### PR TITLE
fix: write scope implies read, fix permission display

### DIFF
--- a/apps/admin/src/components/api-keys/api-key-table.tsx
+++ b/apps/admin/src/components/api-keys/api-key-table.tsx
@@ -229,14 +229,20 @@ function TableRow({
       {/* Permissions */}
       <td className="px-6 py-4">
         <div className="flex flex-wrap gap-1">
-          {apiKey.permissions.map((permission) => (
-            <span
-              key={permission}
-              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
-            >
-              {permission}
+          {apiKey.permissions.length > 0 ? (
+            apiKey.permissions.map((permission) => (
+              <span
+                key={permission}
+                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+              >
+                {permission}
+              </span>
+            ))
+          ) : apiKey.permission_scope ? (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+              {apiKey.permission_scope}
             </span>
-          ))}
+          ) : null}
         </div>
       </td>
 

--- a/apps/admin/src/tests/components/api-key-table.test.tsx
+++ b/apps/admin/src/tests/components/api-key-table.test.tsx
@@ -39,6 +39,7 @@ describe('ApiKeyTable', () => {
     type: 'production',
     allowed_projects: ['proj-1'],
     key_prefix: 'bgs_test12',
+    permission_scope: 'custom',
     permissions: ['reports:read', 'reports:write'],
     status: 'active',
     expires_at: null,
@@ -339,6 +340,189 @@ describe('ApiKeyTable', () => {
       // Project column is the 4th cell (0-indexed: 3)
       const projectCell = cells[3];
       expect(projectCell).toHaveTextContent('Unknown');
+    });
+  });
+
+  describe('Permission Display', () => {
+    // Helper to get the permissions cell content for a given key config
+    function renderAndGetPermissionsCell(overrides: Partial<ApiKey>) {
+      const name = overrides.name || 'test-key';
+      const apiKeys = [createMockApiKey({ name, ...overrides })];
+      render(
+        <ApiKeyTable
+          apiKeys={apiKeys}
+          projects={mockProjects}
+          isLoading={false}
+          {...mockHandlers}
+        />
+      );
+      const row = screen.getByRole('row', { name: new RegExp(name, 'i') });
+      const cells = within(row).getAllByRole('cell');
+      return cells[4]; // Permissions column is 5th cell (0-indexed: 4)
+    }
+
+    describe('Predefined scopes (permissions array empty)', () => {
+      it.each([
+        { scope: 'full', label: 'full' },
+        { scope: 'read', label: 'read' },
+        { scope: 'write', label: 'write' },
+      ] as const)(
+        'should display "$scope" badge for permission_scope="$scope"',
+        ({ scope, label }) => {
+          const cell = renderAndGetPermissionsCell({
+            permission_scope: scope,
+            permissions: [],
+            name: `${scope}-scope-key`,
+          });
+          expect(cell).toHaveTextContent(label);
+        }
+      );
+    });
+
+    describe('Custom scope — individual permissions', () => {
+      it.each([
+        'reports:read',
+        'reports:write',
+        'reports:update',
+        'reports:delete',
+        'sessions:read',
+        'sessions:write',
+      ])('should display single custom permission "%s"', (permission) => {
+        const safeName = permission.replace(':', '-');
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: [permission],
+          name: `single-${safeName}`,
+        });
+        expect(cell).toHaveTextContent(permission);
+      });
+    });
+
+    describe('Custom scope — permission combinations', () => {
+      it('should display reports:read + reports:write', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: ['reports:read', 'reports:write'],
+          name: 'combo-rw',
+        });
+        expect(cell).toHaveTextContent('reports:read');
+        expect(cell).toHaveTextContent('reports:write');
+      });
+
+      it('should display all report permissions', () => {
+        const allReportPerms = [
+          'reports:read',
+          'reports:write',
+          'reports:update',
+          'reports:delete',
+        ];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: allReportPerms,
+          name: 'combo-all-reports',
+        });
+        for (const perm of allReportPerms) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display all session permissions', () => {
+        const allSessionPerms = ['sessions:read', 'sessions:write'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: allSessionPerms,
+          name: 'combo-all-sessions',
+        });
+        for (const perm of allSessionPerms) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display mixed reports + sessions permissions', () => {
+        const mixed = ['reports:write', 'sessions:read'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: mixed,
+          name: 'combo-mixed',
+        });
+        for (const perm of mixed) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display all 6 permissions at once', () => {
+        const allPerms = [
+          'reports:read',
+          'reports:write',
+          'reports:update',
+          'reports:delete',
+          'sessions:read',
+          'sessions:write',
+        ];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: allPerms,
+          name: 'combo-all',
+        });
+        for (const perm of allPerms) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display default SDK permissions (reports:write + sessions:write)', () => {
+        const defaults = ['reports:write', 'sessions:write'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: defaults,
+          name: 'combo-defaults',
+        });
+        for (const perm of defaults) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should show nothing when both permissions and permission_scope are empty', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: '' as 'custom',
+          permissions: [],
+          name: 'empty-everything',
+        });
+        expect(cell.textContent).toBe('');
+      });
+
+      it('should prefer permissions array over permission_scope when both present', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'write',
+          permissions: ['reports:read'],
+          name: 'both-present',
+        });
+        // When permissions array has items, those should display (not the scope)
+        expect(cell).toHaveTextContent('reports:read');
+        expect(cell).not.toHaveTextContent('write');
+      });
+
+      it('should render correct badge count matching permissions array length', () => {
+        const perms = ['reports:read', 'reports:write', 'sessions:read'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: perms,
+          name: 'badge-count',
+        });
+        const badges = cell.querySelectorAll('span');
+        expect(badges).toHaveLength(perms.length);
+      });
+
+      it('should render exactly 1 badge for predefined scope with empty permissions', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'write',
+          permissions: [],
+          name: 'single-badge',
+        });
+        const badges = cell.querySelectorAll('span');
+        expect(badges).toHaveLength(1);
+      });
     });
   });
 

--- a/apps/admin/src/tests/components/rbac-ui-gating.test.tsx
+++ b/apps/admin/src/tests/components/rbac-ui-gating.test.tsx
@@ -46,6 +46,7 @@ const mockApiKey: ApiKey = {
   name: 'Test Key',
   key_prefix: 'bgs_test',
   type: 'development',
+  permission_scope: 'custom',
   permissions: ['read', 'write'],
   allowed_projects: ['project-1'],
   status: 'active',

--- a/apps/admin/src/types/api-keys.ts
+++ b/apps/admin/src/types/api-keys.ts
@@ -6,6 +6,7 @@ export interface ApiKey {
   type: ApiKeyType;
   allowed_projects: string[] | null;
   key_prefix: string;
+  permission_scope: PermissionScope;
   permissions: string[];
   status: ApiKeyStatus;
   expires_at: string | null;

--- a/packages/backend/src/services/api-key/key-permissions.ts
+++ b/packages/backend/src/services/api-key/key-permissions.ts
@@ -129,8 +129,14 @@ export function checkPermission(key: ApiKey, requiredScope: string): PermissionC
 
     // Then check if required permission matches the scope pattern
     // E.g., permission_scope 'read' allows 'bugs:read', 'projects:read', etc.
+    // Write scope implies read access (write is a superset of read)
     const scopePattern = `:${key.permission_scope}`;
     if (requiredScope.endsWith(scopePattern) || requiredScope === key.permission_scope) {
+      return { allowed: true };
+    }
+
+    // Write scope also allows read operations
+    if (key.permission_scope === PERMISSION_SCOPE.WRITE && requiredScope.endsWith(':read')) {
       return { allowed: true };
     }
 

--- a/packages/backend/tests/services/api-key/key-permissions.test.ts
+++ b/packages/backend/tests/services/api-key/key-permissions.test.ts
@@ -302,7 +302,7 @@ describe('key-permissions', () => {
     it('should allow read scope for any :read permission (pattern matching)', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.READ,
-        permissions: null,
+        permissions: [],
       });
 
       expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
@@ -313,7 +313,7 @@ describe('key-permissions', () => {
     it('should allow write scope for any :write permission (pattern matching)', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.WRITE,
-        permissions: null,
+        permissions: [],
       });
 
       expect(checkPermission(key, 'bugs:write')).toEqual({ allowed: true });
@@ -324,7 +324,7 @@ describe('key-permissions', () => {
     it('should deny read scope for write operations', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.READ,
-        permissions: null,
+        permissions: [],
       });
 
       const result = checkPermission(key, 'bugs:write');
@@ -334,17 +334,28 @@ describe('key-permissions', () => {
       expect(result.reason).toContain('*:read');
     });
 
-    it('should deny write scope for read operations', () => {
+    it('should allow write scope for read operations (write implies read)', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.WRITE,
-        permissions: null,
+        permissions: [],
       });
 
-      const result = checkPermission(key, 'bugs:read');
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('bugs:read');
-      expect(result.reason).toContain('write');
-      expect(result.reason).toContain('*:write');
+      expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'projects:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'users:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'sessions:read')).toEqual({ allowed: true });
+    });
+
+    it('should deny read scope for write operations (read does NOT imply write)', () => {
+      const key = createApiKey({
+        permission_scope: PERMISSION_SCOPE.READ,
+        permissions: [],
+      });
+
+      expect(checkPermission(key, 'bugs:write').allowed).toBe(false);
+      expect(checkPermission(key, 'projects:write').allowed).toBe(false);
+      expect(checkPermission(key, 'users:write').allowed).toBe(false);
+      expect(checkPermission(key, 'sessions:write').allowed).toBe(false);
     });
 
     it('should prioritize explicit permissions over pattern matching', () => {
@@ -367,7 +378,7 @@ describe('key-permissions', () => {
     it('should handle custom scope without permissions array gracefully', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.CUSTOM,
-        permissions: null,
+        permissions: [],
       });
 
       const result = checkPermission(key, 'bugs:read');
@@ -378,12 +389,103 @@ describe('key-permissions', () => {
     it('should handle unknown permission scope', () => {
       const key = createApiKey({
         permission_scope: 'unknown' as any,
-        permissions: null,
+        permissions: [],
       });
 
       const result = checkPermission(key, 'bugs:read');
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe('Unknown permission scope: unknown');
+    });
+  });
+
+  // ============================================================================
+  // SCOPE ACCESS MATRIX
+  // ============================================================================
+
+  describe('scope access matrix', () => {
+    const RESOURCES = ['reports', 'sessions', 'bugs', 'projects'] as const;
+    const ACTIONS = ['read', 'write'] as const;
+
+    // Expected access for each scope
+    // full: everything allowed
+    // read: only :read
+    // write: :read + :write (write implies read)
+    // custom: only explicit permissions
+
+    describe('full scope — allows everything', () => {
+      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.FULL });
+
+      for (const resource of RESOURCES) {
+        for (const action of ACTIONS) {
+          it(`should allow ${resource}:${action}`, () => {
+            expect(checkPermission(key, `${resource}:${action}`)).toEqual({ allowed: true });
+          });
+        }
+      }
+    });
+
+    describe('read scope — allows only :read', () => {
+      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.READ, permissions: [] });
+
+      for (const resource of RESOURCES) {
+        it(`should allow ${resource}:read`, () => {
+          expect(checkPermission(key, `${resource}:read`)).toEqual({ allowed: true });
+        });
+
+        it(`should deny ${resource}:write`, () => {
+          expect(checkPermission(key, `${resource}:write`).allowed).toBe(false);
+        });
+      }
+    });
+
+    describe('write scope — allows :read and :write', () => {
+      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.WRITE, permissions: [] });
+
+      for (const resource of RESOURCES) {
+        it(`should allow ${resource}:write`, () => {
+          expect(checkPermission(key, `${resource}:write`)).toEqual({ allowed: true });
+        });
+
+        it(`should allow ${resource}:read (write implies read)`, () => {
+          expect(checkPermission(key, `${resource}:read`)).toEqual({ allowed: true });
+        });
+      }
+    });
+
+    describe('custom scope — allows only explicit permissions', () => {
+      it('should allow only listed permissions and deny everything else', () => {
+        const key = createApiKey({
+          permission_scope: PERMISSION_SCOPE.CUSTOM,
+          permissions: ['reports:write', 'sessions:read'],
+        });
+
+        expect(checkPermission(key, 'reports:write')).toEqual({ allowed: true });
+        expect(checkPermission(key, 'sessions:read')).toEqual({ allowed: true });
+        expect(checkPermission(key, 'reports:read').allowed).toBe(false);
+        expect(checkPermission(key, 'sessions:write').allowed).toBe(false);
+        expect(checkPermission(key, 'bugs:read').allowed).toBe(false);
+        expect(checkPermission(key, 'bugs:write').allowed).toBe(false);
+      });
+
+      it.each([
+        'reports:read',
+        'reports:write',
+        'reports:update',
+        'reports:delete',
+        'sessions:read',
+        'sessions:write',
+      ])('should allow single permission "%s" and deny others', (permission) => {
+        const key = createApiKey({
+          permission_scope: PERMISSION_SCOPE.CUSTOM,
+          permissions: [permission],
+        });
+
+        expect(checkPermission(key, permission)).toEqual({ allowed: true });
+
+        // Pick a different permission and verify it's denied
+        const other = permission === 'reports:read' ? 'reports:write' : 'reports:read';
+        expect(checkPermission(key, other).allowed).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- **Backend**: Write-scoped API keys now correctly allow read operations (write implies read). Previously a `permission_scope='write'` key could create reports but was denied listing/viewing them.
- **Frontend**: API key table PERMISSIONS column now shows `permission_scope` (full/read/write) when the `permissions` array is empty (non-custom scopes). Previously showed blank.
- **Types**: Added `permission_scope` to the `ApiKey` frontend interface.

## Tests
- **Backend**: 66 tests in `key-permissions.test.ts` — added full scope access matrix (4 scopes × 4 resources × 2 actions), custom scope individual + combination tests. Fixed `permissions: null` → `[]` for type safety.
- **Frontend**: 41 tests in `api-key-table.test.tsx` — added 19 permission display tests covering all scopes, all individual custom permissions, combinations, and edge cases.
- Verified 5 backend + 4 frontend tests fail against old buggy code.

## Test plan
- [ ] Verify `write`-scoped API key can both create and list reports
- [ ] Verify `read`-scoped API key can list but NOT create reports
- [ ] Verify PERMISSIONS column shows "write"/"read"/"full" for non-custom keys
- [ ] Verify custom permissions still display as individual badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)