### PR TITLE
refactor: single source of truth for API key permissions

### DIFF
--- a/apps/admin/src/components/api-keys/api-key-table.tsx
+++ b/apps/admin/src/components/api-keys/api-key-table.tsx
@@ -229,14 +229,20 @@ function TableRow({
       {/* Permissions */}
       <td className="px-6 py-4">
         <div className="flex flex-wrap gap-1">
-          {apiKey.permissions.map((permission) => (
-            <span
-              key={permission}
-              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
-            >
-              {permission}
+          {apiKey.permissions.length > 0 ? (
+            apiKey.permissions.map((permission) => (
+              <span
+                key={permission}
+                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+              >
+                {permission}
+              </span>
+            ))
+          ) : apiKey.permission_scope ? (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+              {apiKey.permission_scope}
             </span>
-          ))}
+          ) : null}
         </div>
       </td>
 

--- a/apps/admin/src/components/api-keys/api-key-table.tsx
+++ b/apps/admin/src/components/api-keys/api-key-table.tsx
@@ -229,20 +229,14 @@ function TableRow({
       {/* Permissions */}
       <td className="px-6 py-4">
         <div className="flex flex-wrap gap-1">
-          {apiKey.permissions.length > 0 ? (
-            apiKey.permissions.map((permission) => (
-              <span
-                key={permission}
-                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
-              >
-                {permission}
-              </span>
-            ))
-          ) : apiKey.permission_scope ? (
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
-              {apiKey.permission_scope}
+          {apiKey.permissions.map((permission) => (
+            <span
+              key={permission}
+              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+            >
+              {permission}
             </span>
-          ) : null}
+          ))}
         </div>
       </td>
 

--- a/apps/admin/src/tests/components/api-key-table.test.tsx
+++ b/apps/admin/src/tests/components/api-key-table.test.tsx
@@ -39,6 +39,7 @@ describe('ApiKeyTable', () => {
     type: 'production',
     allowed_projects: ['proj-1'],
     key_prefix: 'bgs_test12',
+    permission_scope: 'custom',
     permissions: ['reports:read', 'reports:write'],
     status: 'active',
     expires_at: null,
@@ -339,6 +340,189 @@ describe('ApiKeyTable', () => {
       // Project column is the 4th cell (0-indexed: 3)
       const projectCell = cells[3];
       expect(projectCell).toHaveTextContent('Unknown');
+    });
+  });
+
+  describe('Permission Display', () => {
+    // Helper to get the permissions cell content for a given key config
+    function renderAndGetPermissionsCell(overrides: Partial<ApiKey>) {
+      const name = overrides.name || 'test-key';
+      const apiKeys = [createMockApiKey({ name, ...overrides })];
+      render(
+        <ApiKeyTable
+          apiKeys={apiKeys}
+          projects={mockProjects}
+          isLoading={false}
+          {...mockHandlers}
+        />
+      );
+      const row = screen.getByRole('row', { name: new RegExp(name, 'i') });
+      const cells = within(row).getAllByRole('cell');
+      return cells[4]; // Permissions column is 5th cell (0-indexed: 4)
+    }
+
+    describe('Predefined scopes (permissions array empty)', () => {
+      it.each([
+        { scope: 'full', label: 'full' },
+        { scope: 'read', label: 'read' },
+        { scope: 'write', label: 'write' },
+      ] as const)(
+        'should display "$scope" badge for permission_scope="$scope"',
+        ({ scope, label }) => {
+          const cell = renderAndGetPermissionsCell({
+            permission_scope: scope,
+            permissions: [],
+            name: `${scope}-scope-key`,
+          });
+          expect(cell).toHaveTextContent(label);
+        }
+      );
+    });
+
+    describe('Custom scope — individual permissions', () => {
+      it.each([
+        'reports:read',
+        'reports:write',
+        'reports:update',
+        'reports:delete',
+        'sessions:read',
+        'sessions:write',
+      ])('should display single custom permission "%s"', (permission) => {
+        const safeName = permission.replace(':', '-');
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: [permission],
+          name: `single-${safeName}`,
+        });
+        expect(cell).toHaveTextContent(permission);
+      });
+    });
+
+    describe('Custom scope — permission combinations', () => {
+      it('should display reports:read + reports:write', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: ['reports:read', 'reports:write'],
+          name: 'combo-rw',
+        });
+        expect(cell).toHaveTextContent('reports:read');
+        expect(cell).toHaveTextContent('reports:write');
+      });
+
+      it('should display all report permissions', () => {
+        const allReportPerms = [
+          'reports:read',
+          'reports:write',
+          'reports:update',
+          'reports:delete',
+        ];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: allReportPerms,
+          name: 'combo-all-reports',
+        });
+        for (const perm of allReportPerms) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display all session permissions', () => {
+        const allSessionPerms = ['sessions:read', 'sessions:write'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: allSessionPerms,
+          name: 'combo-all-sessions',
+        });
+        for (const perm of allSessionPerms) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display mixed reports + sessions permissions', () => {
+        const mixed = ['reports:write', 'sessions:read'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: mixed,
+          name: 'combo-mixed',
+        });
+        for (const perm of mixed) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display all 6 permissions at once', () => {
+        const allPerms = [
+          'reports:read',
+          'reports:write',
+          'reports:update',
+          'reports:delete',
+          'sessions:read',
+          'sessions:write',
+        ];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: allPerms,
+          name: 'combo-all',
+        });
+        for (const perm of allPerms) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+
+      it('should display default SDK permissions (reports:write + sessions:write)', () => {
+        const defaults = ['reports:write', 'sessions:write'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: defaults,
+          name: 'combo-defaults',
+        });
+        for (const perm of defaults) {
+          expect(cell).toHaveTextContent(perm);
+        }
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should show nothing when both permissions and permission_scope are empty', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: '' as 'custom',
+          permissions: [],
+          name: 'empty-everything',
+        });
+        expect(cell.textContent).toBe('');
+      });
+
+      it('should prefer permissions array over permission_scope when both present', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'write',
+          permissions: ['reports:read'],
+          name: 'both-present',
+        });
+        // When permissions array has items, those should display (not the scope)
+        expect(cell).toHaveTextContent('reports:read');
+        expect(cell).not.toHaveTextContent('write');
+      });
+
+      it('should render correct badge count matching permissions array length', () => {
+        const perms = ['reports:read', 'reports:write', 'sessions:read'];
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'custom',
+          permissions: perms,
+          name: 'badge-count',
+        });
+        const badges = cell.querySelectorAll('span');
+        expect(badges).toHaveLength(perms.length);
+      });
+
+      it('should render exactly 1 badge for predefined scope with empty permissions', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'write',
+          permissions: [],
+          name: 'single-badge',
+        });
+        const badges = cell.querySelectorAll('span');
+        expect(badges).toHaveLength(1);
+      });
     });
   });
 

--- a/apps/admin/src/tests/components/api-key-table.test.tsx
+++ b/apps/admin/src/tests/components/api-key-table.test.tsx
@@ -361,22 +361,37 @@ describe('ApiKeyTable', () => {
       return cells[4]; // Permissions column is 5th cell (0-indexed: 4)
     }
 
-    describe('Predefined scopes (permissions array empty)', () => {
-      it.each([
-        { scope: 'full', label: 'full' },
-        { scope: 'read', label: 'read' },
-        { scope: 'write', label: 'write' },
-      ] as const)(
-        'should display "$scope" badge for permission_scope="$scope"',
-        ({ scope, label }) => {
-          const cell = renderAndGetPermissionsCell({
-            permission_scope: scope,
-            permissions: [],
-            name: `${scope}-scope-key`,
-          });
-          expect(cell).toHaveTextContent(label);
-        }
-      );
+    describe('Resolved scope permissions (permissions always populated)', () => {
+      it('should display wildcard for full scope key', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'full',
+          permissions: ['*'],
+          name: 'full-scope-key',
+        });
+        expect(cell).toHaveTextContent('*');
+      });
+
+      it('should display read permissions for read scope key', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'read',
+          permissions: ['reports:read', 'sessions:read'],
+          name: 'read-scope-key',
+        });
+        expect(cell).toHaveTextContent('reports:read');
+        expect(cell).toHaveTextContent('sessions:read');
+      });
+
+      it('should display read + write permissions for write scope key', () => {
+        const cell = renderAndGetPermissionsCell({
+          permission_scope: 'write',
+          permissions: ['reports:read', 'reports:write', 'sessions:read', 'sessions:write'],
+          name: 'write-scope-key',
+        });
+        expect(cell).toHaveTextContent('reports:read');
+        expect(cell).toHaveTextContent('reports:write');
+        expect(cell).toHaveTextContent('sessions:read');
+        expect(cell).toHaveTextContent('sessions:write');
+      });
     });
 
     describe('Custom scope — individual permissions', () => {
@@ -399,57 +414,6 @@ describe('ApiKeyTable', () => {
     });
 
     describe('Custom scope — permission combinations', () => {
-      it('should display reports:read + reports:write', () => {
-        const cell = renderAndGetPermissionsCell({
-          permission_scope: 'custom',
-          permissions: ['reports:read', 'reports:write'],
-          name: 'combo-rw',
-        });
-        expect(cell).toHaveTextContent('reports:read');
-        expect(cell).toHaveTextContent('reports:write');
-      });
-
-      it('should display all report permissions', () => {
-        const allReportPerms = [
-          'reports:read',
-          'reports:write',
-          'reports:update',
-          'reports:delete',
-        ];
-        const cell = renderAndGetPermissionsCell({
-          permission_scope: 'custom',
-          permissions: allReportPerms,
-          name: 'combo-all-reports',
-        });
-        for (const perm of allReportPerms) {
-          expect(cell).toHaveTextContent(perm);
-        }
-      });
-
-      it('should display all session permissions', () => {
-        const allSessionPerms = ['sessions:read', 'sessions:write'];
-        const cell = renderAndGetPermissionsCell({
-          permission_scope: 'custom',
-          permissions: allSessionPerms,
-          name: 'combo-all-sessions',
-        });
-        for (const perm of allSessionPerms) {
-          expect(cell).toHaveTextContent(perm);
-        }
-      });
-
-      it('should display mixed reports + sessions permissions', () => {
-        const mixed = ['reports:write', 'sessions:read'];
-        const cell = renderAndGetPermissionsCell({
-          permission_scope: 'custom',
-          permissions: mixed,
-          name: 'combo-mixed',
-        });
-        for (const perm of mixed) {
-          expect(cell).toHaveTextContent(perm);
-        }
-      });
-
       it('should display all 6 permissions at once', () => {
         const allPerms = [
           'reports:read',
@@ -469,41 +433,21 @@ describe('ApiKeyTable', () => {
         }
       });
 
-      it('should display default SDK permissions (reports:write + sessions:write)', () => {
-        const defaults = ['reports:write', 'sessions:write'];
+      it('should display mixed reports + sessions permissions', () => {
+        const mixed = ['reports:write', 'sessions:read'];
         const cell = renderAndGetPermissionsCell({
           permission_scope: 'custom',
-          permissions: defaults,
-          name: 'combo-defaults',
+          permissions: mixed,
+          name: 'combo-mixed',
         });
-        for (const perm of defaults) {
+        for (const perm of mixed) {
           expect(cell).toHaveTextContent(perm);
         }
       });
     });
 
-    describe('Edge cases', () => {
-      it('should show nothing when both permissions and permission_scope are empty', () => {
-        const cell = renderAndGetPermissionsCell({
-          permission_scope: '' as 'custom',
-          permissions: [],
-          name: 'empty-everything',
-        });
-        expect(cell.textContent).toBe('');
-      });
-
-      it('should prefer permissions array over permission_scope when both present', () => {
-        const cell = renderAndGetPermissionsCell({
-          permission_scope: 'write',
-          permissions: ['reports:read'],
-          name: 'both-present',
-        });
-        // When permissions array has items, those should display (not the scope)
-        expect(cell).toHaveTextContent('reports:read');
-        expect(cell).not.toHaveTextContent('write');
-      });
-
-      it('should render correct badge count matching permissions array length', () => {
+    describe('Badge rendering', () => {
+      it('should render one badge per permission', () => {
         const perms = ['reports:read', 'reports:write', 'sessions:read'];
         const cell = renderAndGetPermissionsCell({
           permission_scope: 'custom',
@@ -514,14 +458,14 @@ describe('ApiKeyTable', () => {
         expect(badges).toHaveLength(perms.length);
       });
 
-      it('should render exactly 1 badge for predefined scope with empty permissions', () => {
+      it('should render no badges for empty permissions', () => {
         const cell = renderAndGetPermissionsCell({
-          permission_scope: 'write',
+          permission_scope: 'custom',
           permissions: [],
-          name: 'single-badge',
+          name: 'empty-perms',
         });
         const badges = cell.querySelectorAll('span');
-        expect(badges).toHaveLength(1);
+        expect(badges).toHaveLength(0);
       });
     });
   });

--- a/apps/admin/src/tests/components/api-key-table.test.tsx
+++ b/apps/admin/src/tests/components/api-key-table.test.tsx
@@ -356,9 +356,14 @@ describe('ApiKeyTable', () => {
           {...mockHandlers}
         />
       );
+      // Find permissions column index from headers (not hardcoded)
+      const headers = screen.getAllByRole('columnheader');
+      const permissionsColumnIndex = headers.findIndex((header) =>
+        /permissions/i.test(header.textContent || '')
+      );
       const row = screen.getByRole('row', { name: new RegExp(name, 'i') });
       const cells = within(row).getAllByRole('cell');
-      return cells[4]; // Permissions column is 5th cell (0-indexed: 4)
+      return cells[permissionsColumnIndex];
     }
 
     describe('Resolved scope permissions (permissions always populated)', () => {

--- a/apps/admin/src/tests/components/api-key-table.test.tsx
+++ b/apps/admin/src/tests/components/api-key-table.test.tsx
@@ -361,6 +361,7 @@ describe('ApiKeyTable', () => {
       const permissionsColumnIndex = headers.findIndex((header) =>
         /permissions/i.test(header.textContent || '')
       );
+      expect(permissionsColumnIndex).toBeGreaterThanOrEqual(0);
       const row = screen.getByRole('row', { name: new RegExp(name, 'i') });
       const cells = within(row).getAllByRole('cell');
       return cells[permissionsColumnIndex];

--- a/apps/admin/src/tests/components/rbac-ui-gating.test.tsx
+++ b/apps/admin/src/tests/components/rbac-ui-gating.test.tsx
@@ -46,6 +46,7 @@ const mockApiKey: ApiKey = {
   name: 'Test Key',
   key_prefix: 'bgs_test',
   type: 'development',
+  permission_scope: 'custom',
   permissions: ['read', 'write'],
   allowed_projects: ['project-1'],
   status: 'active',

--- a/apps/admin/src/tests/components/show-api-key-dialog.test.tsx
+++ b/apps/admin/src/tests/components/show-api-key-dialog.test.tsx
@@ -27,6 +27,7 @@ describe('ShowApiKeyDialog', () => {
     api_key: 'bgs_test1234567890abcdefghijklmnopqrstuvwxyz',
     key_prefix: 'bgs_test12',
     allowed_projects: ['proj-1'],
+    permission_scope: 'custom',
     permissions: ['reports:read', 'reports:write', 'sessions:read'],
     type: 'development',
     created_at: '2025-10-30T12:00:00Z',

--- a/apps/admin/src/types/api-keys.ts
+++ b/apps/admin/src/types/api-keys.ts
@@ -37,6 +37,7 @@ export interface ApiKeyResponse {
   allowed_projects: string[] | null;
   api_key: string;
   key_prefix: string;
+  permission_scope: PermissionScope;
   permissions: string[];
   created_at: string;
 }

--- a/apps/admin/src/types/api-keys.ts
+++ b/apps/admin/src/types/api-keys.ts
@@ -6,6 +6,7 @@ export interface ApiKey {
   type: ApiKeyType;
   allowed_projects: string[] | null;
   key_prefix: string;
+  permission_scope: PermissionScope;
   permissions: string[];
   status: ApiKeyStatus;
   expires_at: string | null;

--- a/packages/backend/src/api/utils/api-key-helpers.ts
+++ b/packages/backend/src/api/utils/api-key-helpers.ts
@@ -6,7 +6,6 @@
 import type { ApiKeyUpdate, PermissionScope, ApiKey } from '../../db/types.js';
 import type { ApiKeyService } from '../../services/api-key/index.js';
 import { RATE_LIMITS } from './constants.js';
-import { resolvePermissions } from '../../services/api-key/key-permissions.js';
 
 /**
  * Update request body interface
@@ -56,20 +55,13 @@ export function mapUpdateFields(body: ApiKeyUpdateBody): Partial<ApiKeyUpdate> {
   if (body.name !== undefined) {
     updates.name = body.name;
   }
+  // Permission resolution and consistency (scope ↔ permissions sync)
+  // is handled in ApiKeyService.updateKey, not here.
   if (body.permission_scope !== undefined) {
     updates.permission_scope = body.permission_scope;
-    // For preset scopes, permissions are derived from the scope.
-    // For custom scope on PATCH, only update permissions when explicitly provided
-    // so existing custom permissions are not silently cleared.
-    if (body.permission_scope !== 'custom') {
-      updates.permissions = resolvePermissions(body.permission_scope, body.permissions);
-    } else if (body.permissions !== undefined) {
-      updates.permissions = body.permissions;
-    }
-  } else if (body.permissions !== undefined) {
-    // Updating permissions directly without changing scope → mark as custom
+  }
+  if (body.permissions !== undefined) {
     updates.permissions = body.permissions;
-    updates.permission_scope = 'custom';
   }
   if (body.allowed_projects !== undefined) {
     updates.allowed_projects = body.allowed_projects;

--- a/packages/backend/src/api/utils/api-key-helpers.ts
+++ b/packages/backend/src/api/utils/api-key-helpers.ts
@@ -58,7 +58,7 @@ export function mapUpdateFields(body: ApiKeyUpdateBody): Partial<ApiKeyUpdate> {
   // Permission resolution and consistency (scope ↔ permissions sync)
   // is handled in ApiKeyService.updateKey, not here.
   if (body.permission_scope !== undefined) {
-    updates.permission_scope = body.permission_scope;
+    updates.permission_scope = body.permission_scope ?? undefined;
   }
   if (body.permissions !== undefined) {
     updates.permissions = body.permissions;

--- a/packages/backend/src/api/utils/api-key-helpers.ts
+++ b/packages/backend/src/api/utils/api-key-helpers.ts
@@ -58,9 +58,18 @@ export function mapUpdateFields(body: ApiKeyUpdateBody): Partial<ApiKeyUpdate> {
   }
   if (body.permission_scope !== undefined) {
     updates.permission_scope = body.permission_scope;
-    updates.permissions = resolvePermissions(body.permission_scope, body.permissions);
+    // For preset scopes, permissions are derived from the scope.
+    // For custom scope on PATCH, only update permissions when explicitly provided
+    // so existing custom permissions are not silently cleared.
+    if (body.permission_scope !== 'custom') {
+      updates.permissions = resolvePermissions(body.permission_scope, body.permissions);
+    } else if (body.permissions !== undefined) {
+      updates.permissions = body.permissions;
+    }
   } else if (body.permissions !== undefined) {
+    // Updating permissions directly without changing scope → mark as custom
     updates.permissions = body.permissions;
+    updates.permission_scope = 'custom';
   }
   if (body.allowed_projects !== undefined) {
     updates.allowed_projects = body.allowed_projects;

--- a/packages/backend/src/api/utils/api-key-helpers.ts
+++ b/packages/backend/src/api/utils/api-key-helpers.ts
@@ -61,7 +61,7 @@ export function mapUpdateFields(body: ApiKeyUpdateBody): Partial<ApiKeyUpdate> {
     updates.permission_scope = body.permission_scope ?? undefined;
   }
   if (body.permissions !== undefined) {
-    updates.permissions = body.permissions;
+    updates.permissions = body.permissions ?? undefined;
   }
   if (body.allowed_projects !== undefined) {
     updates.allowed_projects = body.allowed_projects;

--- a/packages/backend/src/api/utils/api-key-helpers.ts
+++ b/packages/backend/src/api/utils/api-key-helpers.ts
@@ -6,6 +6,7 @@
 import type { ApiKeyUpdate, PermissionScope, ApiKey } from '../../db/types.js';
 import type { ApiKeyService } from '../../services/api-key/index.js';
 import { RATE_LIMITS } from './constants.js';
+import { resolvePermissions } from '../../services/api-key/key-permissions.js';
 
 /**
  * Update request body interface
@@ -57,8 +58,8 @@ export function mapUpdateFields(body: ApiKeyUpdateBody): Partial<ApiKeyUpdate> {
   }
   if (body.permission_scope !== undefined) {
     updates.permission_scope = body.permission_scope;
-  }
-  if (body.permissions !== undefined) {
+    updates.permissions = resolvePermissions(body.permission_scope, body.permissions);
+  } else if (body.permissions !== undefined) {
     updates.permissions = body.permissions;
   }
   if (body.allowed_projects !== undefined) {

--- a/packages/backend/src/db/migrations/016_backfill_api_key_permissions.sql
+++ b/packages/backend/src/db/migrations/016_backfill_api_key_permissions.sql
@@ -1,0 +1,25 @@
+-- Migration: Backfill API key permissions from permission_scope
+--
+-- Previously, permission_scope (full/read/write) was checked at runtime
+-- and the permissions array was only populated for 'custom' scope keys.
+-- Now, permissions are resolved at creation time, so we backfill existing keys.
+
+-- Full scope: wildcard access
+UPDATE application.api_keys
+SET permissions = '["*"]'::jsonb
+WHERE permission_scope = 'full'
+  AND (permissions = '[]'::jsonb OR permissions IS NULL);
+
+-- Read scope: read-only access to reports and sessions
+UPDATE application.api_keys
+SET permissions = '["reports:read", "sessions:read"]'::jsonb
+WHERE permission_scope = 'read'
+  AND (permissions = '[]'::jsonb OR permissions IS NULL);
+
+-- Write scope: read + write access to reports and sessions
+UPDATE application.api_keys
+SET permissions = '["reports:read", "reports:write", "sessions:read", "sessions:write"]'::jsonb
+WHERE permission_scope = 'write'
+  AND (permissions = '[]'::jsonb OR permissions IS NULL);
+
+-- Custom scope keys already have their permissions populated — no change needed.

--- a/packages/backend/src/db/migrations/016_backfill_api_key_permissions.sql
+++ b/packages/backend/src/db/migrations/016_backfill_api_key_permissions.sql
@@ -3,23 +3,25 @@
 -- Previously, permission_scope (full/read/write) was checked at runtime
 -- and the permissions array was only populated for 'custom' scope keys.
 -- Now, permissions are resolved at creation time, so we backfill existing keys.
+-- Uses IS DISTINCT FROM to ensure all non-custom keys get correct permissions
+-- regardless of their current permissions state.
 
 -- Full scope: wildcard access
 UPDATE application.api_keys
 SET permissions = '["*"]'::jsonb
 WHERE permission_scope = 'full'
-  AND (permissions = '[]'::jsonb OR permissions IS NULL);
+  AND permissions IS DISTINCT FROM '["*"]'::jsonb;
 
 -- Read scope: read-only access to reports and sessions
 UPDATE application.api_keys
 SET permissions = '["reports:read", "sessions:read"]'::jsonb
 WHERE permission_scope = 'read'
-  AND (permissions = '[]'::jsonb OR permissions IS NULL);
+  AND permissions IS DISTINCT FROM '["reports:read", "sessions:read"]'::jsonb;
 
 -- Write scope: read + write access to reports and sessions
 UPDATE application.api_keys
 SET permissions = '["reports:read", "reports:write", "sessions:read", "sessions:write"]'::jsonb
 WHERE permission_scope = 'write'
-  AND (permissions = '[]'::jsonb OR permissions IS NULL);
+  AND permissions IS DISTINCT FROM '["reports:read", "reports:write", "sessions:read", "sessions:write"]'::jsonb;
 
 -- Custom scope keys already have their permissions populated — no change needed.

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -48,6 +48,7 @@ import {
   buildRotatedKeyData,
 } from './key-lifecycle-helpers.js';
 import { formatErrorForLog } from '../../utils/error-formatter.js';
+import { resolvePermissions } from './key-permissions.js';
 
 const logger = getLogger();
 
@@ -195,6 +196,11 @@ export class ApiKeyService {
         throw new Error('Name is required');
       }
 
+      // Resolve permission scope into concrete permissions array
+      const resolvedPermissions = data.permission_scope
+        ? resolvePermissions(data.permission_scope, data.permissions)
+        : data.permissions;
+
       // Generate plaintext key and hash
       const plaintextKey = generatePlaintextKey();
       const keyHash = hashKey(plaintextKey);
@@ -206,6 +212,7 @@ export class ApiKeyService {
       const key = await this.db.apiKeys.create({
         ...data,
         name: sanitizedName,
+        permissions: resolvedPermissions,
         key_hash: keyHash,
         key_prefix: prefix,
         key_suffix: suffix,

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -231,7 +231,7 @@ export class ApiKeyService {
         performed_by: data.created_by || null,
         changes: {
           type: data.type,
-          permission_scope: data.permission_scope,
+          permission_scope: effectiveScope,
         },
       });
 
@@ -376,7 +376,36 @@ export class ApiKeyService {
    */
   async updateKey(keyId: string, data: ApiKeyUpdate, actorId: string): Promise<ApiKey | null> {
     try {
-      const updated = await this.db.apiKeys.update(keyId, data);
+      // Ensure permissions stay in sync with permission_scope
+      const normalizedData = { ...data };
+      if (normalizedData.permission_scope !== undefined) {
+        if (normalizedData.permission_scope !== 'custom') {
+          normalizedData.permissions = resolvePermissions(
+            normalizedData.permission_scope,
+            normalizedData.permissions
+          );
+        }
+        // For custom scope, only update permissions if explicitly provided
+        // (don't silently clear existing custom permissions)
+      } else if (normalizedData.permissions !== undefined) {
+        // Updating permissions directly → mark as custom
+        normalizedData.permission_scope = 'custom';
+      }
+
+      // Validate non-empty permissions for custom scope
+      if (
+        normalizedData.permission_scope === 'custom' &&
+        normalizedData.permissions !== undefined &&
+        normalizedData.permissions.length === 0
+      ) {
+        throw new AppError(
+          'Permissions array cannot be empty for custom scope',
+          400,
+          'ValidationError'
+        );
+      }
+
+      const updated = await this.db.apiKeys.update(keyId, normalizedData);
 
       if (updated) {
         // Invalidate cache for updated key

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -199,9 +199,8 @@ export class ApiKeyService {
       // Resolve permission scope into concrete permissions array
       // If permissions are explicitly provided without a scope, treat as 'custom'
       // to avoid unintended privilege escalation (defaulting to 'full' would override them)
-      const effectiveScope =
-        data.permission_scope ||
-        (data.permissions && data.permissions.length > 0 ? 'custom' : 'full');
+      const effectiveScope = data.permission_scope || (data.permissions ? 'custom' : 'full');
+      this.validatePermissions(effectiveScope, data.permissions);
       const resolvedPermissions = resolvePermissions(effectiveScope, data.permissions);
 
       // Generate plaintext key and hash
@@ -215,6 +214,7 @@ export class ApiKeyService {
       const key = await this.db.apiKeys.create({
         ...data,
         name: sanitizedName,
+        permission_scope: effectiveScope,
         permissions: resolvedPermissions,
         key_hash: keyHash,
         key_prefix: prefix,

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -235,6 +235,7 @@ export class ApiKeyService {
         changes: {
           type: data.type,
           permission_scope: effectiveScope,
+          permissions: resolvedPermissions,
         },
       });
 

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -197,8 +197,11 @@ export class ApiKeyService {
       }
 
       // Resolve permission scope into concrete permissions array
-      // Always resolve — DB defaults permission_scope to 'full' when omitted
-      const effectiveScope = data.permission_scope || 'full';
+      // If permissions are explicitly provided without a scope, treat as 'custom'
+      // to avoid unintended privilege escalation (defaulting to 'full' would override them)
+      const effectiveScope =
+        data.permission_scope ||
+        (data.permissions && data.permissions.length > 0 ? 'custom' : 'full');
       const resolvedPermissions = resolvePermissions(effectiveScope, data.permissions);
 
       // Generate plaintext key and hash

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -407,7 +407,7 @@ export class ApiKeyService {
       // Validate non-empty permissions for custom scope
       if (
         normalizedData.permission_scope === 'custom' &&
-        normalizedData.permissions !== undefined &&
+        normalizedData.permissions != null &&
         normalizedData.permissions.length === 0
       ) {
         throw new AppError(

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -197,9 +197,9 @@ export class ApiKeyService {
       }
 
       // Resolve permission scope into concrete permissions array
-      const resolvedPermissions = data.permission_scope
-        ? resolvePermissions(data.permission_scope, data.permissions)
-        : data.permissions;
+      // Always resolve — DB defaults permission_scope to 'full' when omitted
+      const effectiveScope = data.permission_scope ?? 'full';
+      const resolvedPermissions = resolvePermissions(effectiveScope, data.permissions);
 
       // Generate plaintext key and hash
       const plaintextKey = generatePlaintextKey();

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -198,7 +198,7 @@ export class ApiKeyService {
 
       // Resolve permission scope into concrete permissions array
       // Always resolve — DB defaults permission_scope to 'full' when omitted
-      const effectiveScope = data.permission_scope ?? 'full';
+      const effectiveScope = data.permission_scope || 'full';
       const resolvedPermissions = resolvePermissions(effectiveScope, data.permissions);
 
       // Generate plaintext key and hash
@@ -391,10 +391,14 @@ export class ApiKeyService {
             400,
             'ValidationError'
           );
+        } else {
+          // Defensive copy of caller-provided custom permissions
+          normalizedData.permissions = [...normalizedData.permissions];
         }
       } else if (normalizedData.permissions !== undefined) {
         // Updating permissions directly → mark as custom
         normalizedData.permission_scope = 'custom';
+        normalizedData.permissions = [...normalizedData.permissions];
       }
 
       // Validate non-empty permissions for custom scope

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -315,6 +315,7 @@ export class ApiKeyService {
             rotated_from: oldKeyId,
             type: newKey.type,
             permission_scope: newKey.permission_scope,
+            permissions: newKey.permissions,
           },
         });
 

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -384,9 +384,14 @@ export class ApiKeyService {
             normalizedData.permission_scope,
             normalizedData.permissions
           );
+        } else if (normalizedData.permissions === undefined) {
+          // Switching to custom scope requires explicit permissions
+          throw new AppError(
+            'Permissions array is required when switching to custom scope',
+            400,
+            'ValidationError'
+          );
         }
-        // For custom scope, only update permissions if explicitly provided
-        // (don't silently clear existing custom permissions)
       } else if (normalizedData.permissions !== undefined) {
         // Updating permissions directly → mark as custom
         normalizedData.permission_scope = 'custom';
@@ -417,7 +422,7 @@ export class ApiKeyService {
           action: API_KEY_AUDIT_ACTION.UPDATED,
           performed_by: actorId,
           changes: {
-            fields: Object.keys(data),
+            fields: Object.keys(normalizedData),
           },
         });
 

--- a/packages/backend/src/services/api-key/key-lifecycle-helpers.ts
+++ b/packages/backend/src/services/api-key/key-lifecycle-helpers.ts
@@ -7,6 +7,7 @@ import type { DatabaseClient } from '../../db/client.js';
 import type { ApiKey, ApiKeyInsert } from '../../db/types.js';
 import { getCacheService } from '../../cache/index.js';
 import { getLogger } from '../../logger.js';
+import { resolvePermissions } from './key-permissions.js';
 
 const logger = getLogger();
 
@@ -82,11 +83,14 @@ export function buildRotatedKeyData(
   oldKey: ApiKey,
   actorId: string
 ): Omit<ApiKeyInsert, 'key_hash' | 'key_prefix' | 'key_suffix'> {
+  const effectiveScope = oldKey.permission_scope ?? 'full';
   return {
     name: `${oldKey.name} (rotated)`,
     type: oldKey.type,
-    permission_scope: oldKey.permission_scope,
-    permissions: oldKey.permissions,
+    permission_scope: effectiveScope,
+    // Re-resolve permissions to ensure rotated key is consistent,
+    // especially for pre-migration keys with stale/empty permissions
+    permissions: resolvePermissions(effectiveScope, oldKey.permissions),
     created_by: actorId,
     allowed_projects: oldKey.allowed_projects,
     allowed_origins: oldKey.allowed_origins,

--- a/packages/backend/src/services/api-key/key-lifecycle-helpers.ts
+++ b/packages/backend/src/services/api-key/key-lifecycle-helpers.ts
@@ -83,7 +83,7 @@ export function buildRotatedKeyData(
   oldKey: ApiKey,
   actorId: string
 ): Omit<ApiKeyInsert, 'key_hash' | 'key_prefix' | 'key_suffix'> {
-  const effectiveScope = oldKey.permission_scope ?? 'full';
+  const effectiveScope = oldKey.permission_scope || 'full';
   return {
     name: `${oldKey.name} (rotated)`,
     type: oldKey.type,

--- a/packages/backend/src/services/api-key/key-permissions.ts
+++ b/packages/backend/src/services/api-key/key-permissions.ts
@@ -30,9 +30,9 @@ export const SCOPE_PERMISSIONS: Record<PermissionScope, string[]> = {
  */
 export function resolvePermissions(scope: PermissionScope, customPermissions?: string[]): string[] {
   if (scope === PERMISSION_SCOPE.CUSTOM) {
-    return customPermissions ?? [];
+    return customPermissions ? [...customPermissions] : [];
   }
-  return SCOPE_PERMISSIONS[scope] ?? [];
+  return [...(SCOPE_PERMISSIONS[scope] ?? [])];
 }
 
 /**
@@ -136,7 +136,7 @@ export function checkPermission(key: ApiKey, requiredPermission: string): Permis
 
   return {
     allowed: false,
-    reason: `Missing permission: ${requiredPermission}. Key has: [${permissions.join(', ')}]`,
+    reason: `Missing permission: ${requiredPermission}`,
   };
 }
 

--- a/packages/backend/src/services/api-key/key-permissions.ts
+++ b/packages/backend/src/services/api-key/key-permissions.ts
@@ -12,12 +12,13 @@ import type { PermissionScope } from '../../db/types.js';
  * Used at key creation time to resolve scope into permissions array.
  * 'custom' maps to empty — user provides their own permissions.
  */
-export const SCOPE_PERMISSIONS: Record<PermissionScope, string[]> = {
-  full: ['*'],
-  read: ['reports:read', 'sessions:read'],
-  write: ['reports:read', 'reports:write', 'sessions:read', 'sessions:write'],
-  custom: [],
-};
+export const SCOPE_PERMISSIONS: Readonly<Record<PermissionScope, readonly string[]>> =
+  Object.freeze({
+    full: Object.freeze(['*']),
+    read: Object.freeze(['reports:read', 'sessions:read']),
+    write: Object.freeze(['reports:read', 'reports:write', 'sessions:read', 'sessions:write']),
+    custom: Object.freeze([]),
+  });
 
 /**
  * Resolve a permission scope into concrete permissions.
@@ -137,7 +138,11 @@ export function checkPermission(key: ApiKey, requiredPermission: string): Permis
   // Defensive fallback: if permissions array is empty but a non-custom scope is set,
   // resolve on the fly. This handles pre-migration keys and cached keys fetched
   // before the backfill migration ran.
-  if (permissions.length === 0 && key.permission_scope && key.permission_scope !== 'custom') {
+  if (
+    permissions.length === 0 &&
+    key.permission_scope &&
+    key.permission_scope !== PERMISSION_SCOPE.CUSTOM
+  ) {
     permissions = resolvePermissions(key.permission_scope);
   }
 

--- a/packages/backend/src/services/api-key/key-permissions.ts
+++ b/packages/backend/src/services/api-key/key-permissions.ts
@@ -32,7 +32,11 @@ export function resolvePermissions(scope: PermissionScope, customPermissions?: s
   if (scope === PERMISSION_SCOPE.CUSTOM) {
     return customPermissions ? [...customPermissions] : [];
   }
-  return [...(SCOPE_PERMISSIONS[scope] ?? [])];
+  const permissions = SCOPE_PERMISSIONS[scope];
+  if (!permissions) {
+    throw new Error(`Unknown permission scope: ${scope}`);
+  }
+  return [...permissions];
 }
 
 /**

--- a/packages/backend/src/services/api-key/key-permissions.ts
+++ b/packages/backend/src/services/api-key/key-permissions.ts
@@ -129,8 +129,14 @@ export function checkPermission(key: ApiKey, requiredScope: string): PermissionC
 
     // Then check if required permission matches the scope pattern
     // E.g., permission_scope 'read' allows 'bugs:read', 'projects:read', etc.
+    // Write scope implies read access (write is a superset of read)
     const scopePattern = `:${key.permission_scope}`;
     if (requiredScope.endsWith(scopePattern) || requiredScope === key.permission_scope) {
+      return { allowed: true };
+    }
+
+    // Write scope also allows read operations
+    if (key.permission_scope === PERMISSION_SCOPE.WRITE && requiredScope.endsWith(':read')) {
       return { allowed: true };
     }
 

--- a/packages/backend/src/services/api-key/key-permissions.ts
+++ b/packages/backend/src/services/api-key/key-permissions.ts
@@ -132,7 +132,14 @@ export function isKeyUsable(key: ApiKey, gracePeriodMs: number): boolean {
  * @returns Permission check result
  */
 export function checkPermission(key: ApiKey, requiredPermission: string): PermissionCheckResult {
-  const permissions = key.permissions ?? [];
+  let permissions = key.permissions ?? [];
+
+  // Defensive fallback: if permissions array is empty but a non-custom scope is set,
+  // resolve on the fly. This handles pre-migration keys and cached keys fetched
+  // before the backfill migration ran.
+  if (permissions.length === 0 && key.permission_scope && key.permission_scope !== 'custom') {
+    permissions = resolvePermissions(key.permission_scope);
+  }
 
   if (permissions.includes('*') || permissions.includes(requiredPermission)) {
     return { allowed: true };

--- a/packages/backend/src/services/api-key/key-permissions.ts
+++ b/packages/backend/src/services/api-key/key-permissions.ts
@@ -5,6 +5,35 @@
 
 import type { ApiKey } from '../../db/types.js';
 import { PERMISSION_SCOPE } from '../../db/types.js';
+import type { PermissionScope } from '../../db/types.js';
+
+/**
+ * Maps each permission scope to the concrete permissions it grants.
+ * Used at key creation time to resolve scope into permissions array.
+ * 'custom' maps to empty — user provides their own permissions.
+ */
+export const SCOPE_PERMISSIONS: Record<PermissionScope, string[]> = {
+  full: ['*'],
+  read: ['reports:read', 'sessions:read'],
+  write: ['reports:read', 'reports:write', 'sessions:read', 'sessions:write'],
+  custom: [],
+};
+
+/**
+ * Resolve a permission scope into concrete permissions.
+ * For 'custom' scope, returns the provided permissions array.
+ * For predefined scopes, returns the mapped permissions.
+ *
+ * @param scope - Permission scope (full, read, write, custom)
+ * @param customPermissions - Explicit permissions (used only for 'custom' scope)
+ * @returns Resolved permissions array
+ */
+export function resolvePermissions(scope: PermissionScope, customPermissions?: string[]): string[] {
+  if (scope === PERMISSION_SCOPE.CUSTOM) {
+    return customPermissions ?? [];
+  }
+  return SCOPE_PERMISSIONS[scope] ?? [];
+}
 
 /**
  * Permission check result
@@ -88,67 +117,26 @@ export function isKeyUsable(key: ApiKey, gracePeriodMs: number): boolean {
 }
 
 /**
- * Check if API key has required permission scope
+ * Check if API key has the required permission.
  *
- * Permission scopes:
- * - PERMISSION_SCOPE.FULL: Allows all operations
- * - PERMISSION_SCOPE.CUSTOM: Requires explicit permission in permissions array
- * - PERMISSION_SCOPE.READ: Allows all read operations (permissions ending with ':read')
- * - PERMISSION_SCOPE.WRITE: Allows all write operations (permissions ending with ':write')
+ * Permissions are resolved at key creation time into the `permissions` array.
+ * This function simply checks if the required permission is in that array,
+ * or if the key has wildcard access ('*').
  *
  * @param key - API key to check
- * @param requiredScope - Required permission (e.g., 'bugs:read', 'projects:write')
+ * @param requiredPermission - Required permission (e.g., 'reports:read', 'sessions:write')
  * @returns Permission check result
  */
-export function checkPermission(key: ApiKey, requiredScope: string): PermissionCheckResult {
-  // Full access keys can do anything
-  if (key.permission_scope === PERMISSION_SCOPE.FULL) {
+export function checkPermission(key: ApiKey, requiredPermission: string): PermissionCheckResult {
+  const permissions = key.permissions ?? [];
+
+  if (permissions.includes('*') || permissions.includes(requiredPermission)) {
     return { allowed: true };
-  }
-
-  // For custom scope, check if permission is in the allowed list
-  if (key.permission_scope === PERMISSION_SCOPE.CUSTOM) {
-    if (key.permissions && key.permissions.includes(requiredScope)) {
-      return { allowed: true };
-    }
-    return {
-      allowed: false,
-      reason: `Missing required permission: ${requiredScope}`,
-    };
-  }
-
-  // For read/write scopes, check if permission matches the scope pattern
-  if (
-    key.permission_scope === PERMISSION_SCOPE.READ ||
-    key.permission_scope === PERMISSION_SCOPE.WRITE
-  ) {
-    // First check explicit permissions array (if provided)
-    if (key.permissions && key.permissions.includes(requiredScope)) {
-      return { allowed: true };
-    }
-
-    // Then check if required permission matches the scope pattern
-    // E.g., permission_scope 'read' allows 'bugs:read', 'projects:read', etc.
-    // Write scope implies read access (write is a superset of read)
-    const scopePattern = `:${key.permission_scope}`;
-    if (requiredScope.endsWith(scopePattern) || requiredScope === key.permission_scope) {
-      return { allowed: true };
-    }
-
-    // Write scope also allows read operations
-    if (key.permission_scope === PERMISSION_SCOPE.WRITE && requiredScope.endsWith(':read')) {
-      return { allowed: true };
-    }
-
-    return {
-      allowed: false,
-      reason: `Required permission: ${requiredScope}, key scope: ${key.permission_scope} (allows *:${key.permission_scope})`,
-    };
   }
 
   return {
     allowed: false,
-    reason: `Unknown permission scope: ${key.permission_scope}`,
+    reason: `Missing permission: ${requiredPermission}. Key has: [${permissions.join(', ')}]`,
   };
 }
 

--- a/packages/backend/tests/services/api-key-service.test.ts
+++ b/packages/backend/tests/services/api-key-service.test.ts
@@ -1124,6 +1124,101 @@ describe('ApiKeyService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should resolve permissions when updating to preset scope', async () => {
+      const updatedKey = { id: 'key-123' } as ApiKey;
+      mockDb.apiKeys.update.mockResolvedValue(updatedKey);
+
+      await service.updateKey('key-123', { permission_scope: 'write' }, 'user-123');
+
+      expect(mockDb.apiKeys.update).toHaveBeenCalledWith(
+        'key-123',
+        expect.objectContaining({
+          permission_scope: 'write',
+          permissions: ['reports:read', 'reports:write', 'sessions:read', 'sessions:write'],
+        })
+      );
+    });
+
+    it('should resolve full scope to wildcard on update', async () => {
+      const updatedKey = { id: 'key-123' } as ApiKey;
+      mockDb.apiKeys.update.mockResolvedValue(updatedKey);
+
+      await service.updateKey('key-123', { permission_scope: 'full' }, 'user-123');
+
+      expect(mockDb.apiKeys.update).toHaveBeenCalledWith(
+        'key-123',
+        expect.objectContaining({
+          permissions: ['*'],
+        })
+      );
+    });
+
+    it('should pass through custom scope with explicit permissions', async () => {
+      const updatedKey = { id: 'key-123' } as ApiKey;
+      mockDb.apiKeys.update.mockResolvedValue(updatedKey);
+
+      await service.updateKey(
+        'key-123',
+        { permission_scope: 'custom', permissions: ['reports:read'] },
+        'user-123'
+      );
+
+      expect(mockDb.apiKeys.update).toHaveBeenCalledWith(
+        'key-123',
+        expect.objectContaining({
+          permission_scope: 'custom',
+          permissions: ['reports:read'],
+        })
+      );
+    });
+
+    it('should reject custom scope without permissions', async () => {
+      await expect(
+        service.updateKey('key-123', { permission_scope: 'custom' }, 'user-123')
+      ).rejects.toThrow('Permissions array is required when switching to custom scope');
+    });
+
+    it('should reject custom scope with empty permissions array', async () => {
+      await expect(
+        service.updateKey('key-123', { permission_scope: 'custom', permissions: [] }, 'user-123')
+      ).rejects.toThrow('Permissions array cannot be empty for custom scope');
+    });
+
+    it('should auto-set permission_scope to custom when only permissions are updated', async () => {
+      const updatedKey = { id: 'key-123' } as ApiKey;
+      mockDb.apiKeys.update.mockResolvedValue(updatedKey);
+
+      await service.updateKey(
+        'key-123',
+        { permissions: ['sessions:read', 'sessions:write'] },
+        'user-123'
+      );
+
+      expect(mockDb.apiKeys.update).toHaveBeenCalledWith(
+        'key-123',
+        expect.objectContaining({
+          permission_scope: 'custom',
+          permissions: ['sessions:read', 'sessions:write'],
+        })
+      );
+    });
+
+    it('should log normalized fields in audit (including implicit scope changes)', async () => {
+      const updatedKey = { id: 'key-123' } as ApiKey;
+      mockDb.apiKeys.update.mockResolvedValue(updatedKey);
+
+      await service.updateKey('key-123', { permissions: ['reports:read'] }, 'user-123');
+
+      // Audit should include permission_scope even though caller only sent permissions
+      expect(mockDb.apiKeys.logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          changes: {
+            fields: expect.arrayContaining(['permissions', 'permission_scope']),
+          },
+        })
+      );
+    });
   });
 
   describe('deleteKey', () => {

--- a/packages/backend/tests/services/api-key-service.test.ts
+++ b/packages/backend/tests/services/api-key-service.test.ts
@@ -258,12 +258,14 @@ describe('ApiKeyService', () => {
       expect(mockDb.transaction).toHaveBeenCalledWith(expect.any(Function));
 
       // Verify new key created within transaction
+      // Rotation re-resolves permissions from scope, so write scope
+      // expands to full read+write permissions
       expect(mockTx.apiKeys.create).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'Original Key (rotated)',
           type: 'development',
           permission_scope: 'write',
-          permissions: ['bugs:write'],
+          permissions: ['reports:read', 'reports:write', 'sessions:read', 'sessions:write'],
           created_by: 'user-123',
         })
       );

--- a/packages/backend/tests/services/api-key-service.test.ts
+++ b/packages/backend/tests/services/api-key-service.test.ts
@@ -297,6 +297,7 @@ describe('ApiKeyService', () => {
       });
 
       // Second audit: new key creation
+      // newKey.permissions comes from DB mock (which returns what create stored)
       expect(mockTx.apiKeys.logAudit).toHaveBeenNthCalledWith(2, {
         api_key_id: 'new-key',
         action: 'created',
@@ -305,7 +306,7 @@ describe('ApiKeyService', () => {
           rotated_from: 'old-key',
           type: 'development',
           permission_scope: 'write',
-          permissions: ['reports:read', 'reports:write', 'sessions:read', 'sessions:write'],
+          permissions: ['bugs:write'],
         },
       });
     });

--- a/packages/backend/tests/services/api-key-service.test.ts
+++ b/packages/backend/tests/services/api-key-service.test.ts
@@ -749,11 +749,11 @@ describe('ApiKeyService', () => {
   // ============================================================================
 
   describe('checkPermission', () => {
-    it('should allow full scope with permissions', () => {
+    it('should allow full scope with wildcard permission', () => {
       const key = {
         id: 'key-123',
         permission_scope: 'full',
-        permissions: ['bugs:read'], // Need at least one permission
+        permissions: ['*'], // Resolved from full scope at creation time
       } as unknown as ApiKey;
 
       const result = service.checkPermission(key, 'bugs:delete');
@@ -771,7 +771,7 @@ describe('ApiKeyService', () => {
       const result = service.checkPermission(key, 'bugs:delete');
 
       expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('Missing required permission');
+      expect(result.reason).toContain('Missing permission');
     });
 
     it('should check specific permissions for read scope', () => {

--- a/packages/backend/tests/services/api-key-service.test.ts
+++ b/packages/backend/tests/services/api-key-service.test.ts
@@ -169,6 +169,7 @@ describe('ApiKeyService', () => {
         changes: {
           type: 'production',
           permission_scope: 'read',
+          permissions: ['reports:read', 'sessions:read'],
         },
       });
     });
@@ -304,6 +305,7 @@ describe('ApiKeyService', () => {
           rotated_from: 'old-key',
           type: 'development',
           permission_scope: 'write',
+          permissions: ['reports:read', 'reports:write', 'sessions:read', 'sessions:write'],
         },
       });
     });

--- a/packages/backend/tests/services/api-key/integration.test.ts
+++ b/packages/backend/tests/services/api-key/integration.test.ts
@@ -50,7 +50,7 @@ function createApiKey(overrides: Partial<ApiKey> = {}): ApiKey {
     type: 'production',
     status: 'active',
     permission_scope: 'full',
-    permissions: [],
+    permissions: ['*'],
     allowed_projects: null,
     allowed_environments: null,
     rate_limit_per_minute: 60,
@@ -325,10 +325,18 @@ describe('API Key Module Integration', () => {
     it('should check multiple rate limit windows', async () => {
       mockDb.apiKeys.incrementRateLimit.mockImplementation((_keyId: string, window: string) => {
         // Return count after increment
-        if (window === RATE_LIMIT_WINDOW.BURST) return Promise.resolve(3);
-        if (window === RATE_LIMIT_WINDOW.MINUTE) return Promise.resolve(11);
-        if (window === RATE_LIMIT_WINDOW.HOUR) return Promise.resolve(51);
-        if (window === RATE_LIMIT_WINDOW.DAY) return Promise.resolve(501);
+        if (window === RATE_LIMIT_WINDOW.BURST) {
+          return Promise.resolve(3);
+        }
+        if (window === RATE_LIMIT_WINDOW.MINUTE) {
+          return Promise.resolve(11);
+        }
+        if (window === RATE_LIMIT_WINDOW.HOUR) {
+          return Promise.resolve(51);
+        }
+        if (window === RATE_LIMIT_WINDOW.DAY) {
+          return Promise.resolve(501);
+        }
         return Promise.resolve(1);
       });
 
@@ -355,8 +363,12 @@ describe('API Key Module Integration', () => {
     it('should enforce strictest window limit', async () => {
       mockDb.apiKeys.incrementRateLimit.mockImplementation((_keyId: string, window: string) => {
         // Burst window exceeds limit after increment
-        if (window === RATE_LIMIT_WINDOW.BURST) return Promise.resolve(6); // Exceeds limit of 5
-        if (window === RATE_LIMIT_WINDOW.MINUTE) return Promise.resolve(11); // Under limit of 60
+        if (window === RATE_LIMIT_WINDOW.BURST) {
+          return Promise.resolve(6);
+        } // Exceeds limit of 5
+        if (window === RATE_LIMIT_WINDOW.MINUTE) {
+          return Promise.resolve(11);
+        } // Under limit of 60
         return Promise.resolve(1);
       });
 

--- a/packages/backend/tests/services/api-key/key-permissions.test.ts
+++ b/packages/backend/tests/services/api-key/key-permissions.test.ts
@@ -339,13 +339,15 @@ describe('key-permissions', () => {
       expect(checkPermission(key, 'reports:write').allowed).toBe(false);
     });
 
-    it('should include key permissions in denial reason', () => {
+    it('should include missing permission in denial reason without leaking granted permissions', () => {
       const key = createApiKey({ permissions: ['reports:read', 'sessions:read'] });
 
       const result = checkPermission(key, 'reports:write');
       expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('reports:read');
-      expect(result.reason).toContain('sessions:read');
+      expect(result.reason).toContain('reports:write');
+      // Should NOT leak granted permissions
+      expect(result.reason).not.toContain('reports:read');
+      expect(result.reason).not.toContain('sessions:read');
     });
   });
 

--- a/packages/backend/tests/services/api-key/key-permissions.test.ts
+++ b/packages/backend/tests/services/api-key/key-permissions.test.ts
@@ -10,6 +10,8 @@ import {
   isKeyUsable,
   checkPermission,
   checkProjectPermission,
+  resolvePermissions,
+  SCOPE_PERMISSIONS,
 } from '../../../src/services/api-key/key-permissions.js';
 import type { ApiKey } from '../../../src/db/types.js';
 import { PERMISSION_SCOPE } from '../../../src/db/types.js';
@@ -228,192 +230,135 @@ describe('key-permissions', () => {
   });
 
   // ============================================================================
-  // PERMISSION CHECKING
+  // RESOLVE PERMISSIONS
   // ============================================================================
 
-  describe('checkPermission', () => {
-    it('should allow full scope for any permission', () => {
-      const key = createApiKey();
-
-      expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'bugs:write')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'projects:delete')).toEqual({ allowed: true });
+  describe('resolvePermissions', () => {
+    it('should resolve full scope to wildcard', () => {
+      expect(resolvePermissions('full')).toEqual(['*']);
     });
 
-    it('should allow custom scope with specific permission', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.CUSTOM,
-        permissions: ['bugs:read', 'bugs:write'],
-      });
-
-      expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'bugs:write')).toEqual({ allowed: true });
+    it('should resolve read scope to read permissions', () => {
+      expect(resolvePermissions('read')).toEqual(['reports:read', 'sessions:read']);
     });
 
-    it('should deny custom scope without specific permission', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.CUSTOM,
-        permissions: ['bugs:read'],
-      });
-
-      const result = checkPermission(key, 'bugs:write');
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe('Missing required permission: bugs:write');
+    it('should resolve write scope to read + write permissions', () => {
+      expect(resolvePermissions('write')).toEqual([
+        'reports:read',
+        'reports:write',
+        'sessions:read',
+        'sessions:write',
+      ]);
     });
 
-    it('should allow read scope for read permission in permissions array', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.READ,
-        permissions: ['bugs:read', 'projects:read'],
-      });
-
-      expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
+    it('should resolve custom scope with provided permissions', () => {
+      expect(resolvePermissions('custom', ['reports:read', 'sessions:write'])).toEqual([
+        'reports:read',
+        'sessions:write',
+      ]);
     });
 
-    it('should allow write scope for write permission in permissions array', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.WRITE,
-        permissions: ['bugs:write', 'bugs:update'],
-      });
-
-      expect(checkPermission(key, 'bugs:write')).toEqual({ allowed: true });
+    it('should resolve custom scope to empty array when no permissions provided', () => {
+      expect(resolvePermissions('custom')).toEqual([]);
+      expect(resolvePermissions('custom', undefined)).toEqual([]);
     });
 
-    it('should deny read scope for write permission', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.READ,
-        permissions: ['bugs:read'],
-      });
-
-      const result = checkPermission(key, 'bugs:write');
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('Required permission: bugs:write');
-    });
-
-    it('should allow matching scope name as permission', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.READ,
-        permissions: [],
-      });
-
-      expect(checkPermission(key, 'read')).toEqual({ allowed: true });
-    });
-
-    it('should allow read scope for any :read permission (pattern matching)', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.READ,
-        permissions: [],
-      });
-
-      expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'projects:read')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'users:read')).toEqual({ allowed: true });
-    });
-
-    it('should allow write scope for any :write permission (pattern matching)', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.WRITE,
-        permissions: [],
-      });
-
-      expect(checkPermission(key, 'bugs:write')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'projects:write')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'users:write')).toEqual({ allowed: true });
-    });
-
-    it('should deny read scope for write operations', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.READ,
-        permissions: [],
-      });
-
-      const result = checkPermission(key, 'bugs:write');
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('bugs:write');
-      expect(result.reason).toContain('read');
-      expect(result.reason).toContain('*:read');
-    });
-
-    it('should allow write scope for read operations (write implies read)', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.WRITE,
-        permissions: [],
-      });
-
-      expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'projects:read')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'users:read')).toEqual({ allowed: true });
-      expect(checkPermission(key, 'sessions:read')).toEqual({ allowed: true });
-    });
-
-    it('should deny read scope for write operations (read does NOT imply write)', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.READ,
-        permissions: [],
-      });
-
-      expect(checkPermission(key, 'bugs:write').allowed).toBe(false);
-      expect(checkPermission(key, 'projects:write').allowed).toBe(false);
-      expect(checkPermission(key, 'users:write').allowed).toBe(false);
-      expect(checkPermission(key, 'sessions:write').allowed).toBe(false);
-    });
-
-    it('should prioritize explicit permissions over pattern matching', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.READ,
-        permissions: ['bugs:write'], // Explicit override
-      });
-
-      // Explicit permission takes precedence
-      expect(checkPermission(key, 'bugs:write')).toEqual({ allowed: true });
-
-      // Pattern matching still works for other permissions
-      expect(checkPermission(key, 'projects:read')).toEqual({ allowed: true });
-
-      // But not for write operations not in explicit list
-      const result = checkPermission(key, 'projects:write');
-      expect(result.allowed).toBe(false);
-    });
-
-    it('should handle custom scope without permissions array gracefully', () => {
-      const key = createApiKey({
-        permission_scope: PERMISSION_SCOPE.CUSTOM,
-        permissions: [],
-      });
-
-      const result = checkPermission(key, 'bugs:read');
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe('Missing required permission: bugs:read');
-    });
-
-    it('should handle unknown permission scope', () => {
-      const key = createApiKey({
-        permission_scope: 'unknown' as any,
-        permissions: [],
-      });
-
-      const result = checkPermission(key, 'bugs:read');
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toBe('Unknown permission scope: unknown');
+    it('should ignore customPermissions for non-custom scopes', () => {
+      // Non-custom scopes always return their mapped permissions
+      expect(resolvePermissions('full', ['reports:read'])).toEqual(['*']);
+      expect(resolvePermissions('read', ['reports:write'])).toEqual([
+        'reports:read',
+        'sessions:read',
+      ]);
     });
   });
 
   // ============================================================================
-  // SCOPE ACCESS MATRIX
+  // SCOPE_PERMISSIONS MAPPING
+  // ============================================================================
+
+  describe('SCOPE_PERMISSIONS', () => {
+    it('should have entries for all 4 scopes', () => {
+      expect(Object.keys(SCOPE_PERMISSIONS)).toEqual(['full', 'read', 'write', 'custom']);
+    });
+
+    it('should map full to wildcard', () => {
+      expect(SCOPE_PERMISSIONS.full).toEqual(['*']);
+    });
+
+    it('should map read to read-only permissions', () => {
+      for (const perm of SCOPE_PERMISSIONS.read) {
+        expect(perm).toMatch(/:read$/);
+      }
+    });
+
+    it('should map write to include both read and write permissions', () => {
+      const readPerms = SCOPE_PERMISSIONS.write.filter((p) => p.endsWith(':read'));
+      const writePerms = SCOPE_PERMISSIONS.write.filter((p) => p.endsWith(':write'));
+      expect(readPerms.length).toBeGreaterThan(0);
+      expect(writePerms.length).toBeGreaterThan(0);
+    });
+
+    it('should map custom to empty array', () => {
+      expect(SCOPE_PERMISSIONS.custom).toEqual([]);
+    });
+  });
+
+  // ============================================================================
+  // PERMISSION CHECKING (array-based)
+  // ============================================================================
+
+  describe('checkPermission', () => {
+    it('should allow wildcard key for any permission', () => {
+      const key = createApiKey({ permissions: ['*'] });
+
+      expect(checkPermission(key, 'reports:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'reports:write')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'anything:here')).toEqual({ allowed: true });
+    });
+
+    it('should allow specific permission in array', () => {
+      const key = createApiKey({ permissions: ['reports:read', 'reports:write'] });
+
+      expect(checkPermission(key, 'reports:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'reports:write')).toEqual({ allowed: true });
+    });
+
+    it('should deny permission not in array', () => {
+      const key = createApiKey({ permissions: ['reports:read'] });
+
+      const result = checkPermission(key, 'reports:write');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Missing permission: reports:write');
+    });
+
+    it('should deny all permissions for empty array', () => {
+      const key = createApiKey({ permissions: [] });
+
+      expect(checkPermission(key, 'reports:read').allowed).toBe(false);
+      expect(checkPermission(key, 'reports:write').allowed).toBe(false);
+    });
+
+    it('should include key permissions in denial reason', () => {
+      const key = createApiKey({ permissions: ['reports:read', 'sessions:read'] });
+
+      const result = checkPermission(key, 'reports:write');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('reports:read');
+      expect(result.reason).toContain('sessions:read');
+    });
+  });
+
+  // ============================================================================
+  // SCOPE ACCESS MATRIX (using resolved permissions)
   // ============================================================================
 
   describe('scope access matrix', () => {
-    const RESOURCES = ['reports', 'sessions', 'bugs', 'projects'] as const;
+    const RESOURCES = ['reports', 'sessions'] as const;
     const ACTIONS = ['read', 'write'] as const;
 
-    // Expected access for each scope
-    // full: everything allowed
-    // read: only :read
-    // write: :read + :write (write implies read)
-    // custom: only explicit permissions
-
-    describe('full scope — allows everything', () => {
-      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.FULL });
+    describe('full scope — wildcard allows everything', () => {
+      const key = createApiKey({ permissions: resolvePermissions('full') });
 
       for (const resource of RESOURCES) {
         for (const action of ACTIONS) {
@@ -425,7 +370,7 @@ describe('key-permissions', () => {
     });
 
     describe('read scope — allows only :read', () => {
-      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.READ, permissions: [] });
+      const key = createApiKey({ permissions: resolvePermissions('read') });
 
       for (const resource of RESOURCES) {
         it(`should allow ${resource}:read`, () => {
@@ -439,7 +384,7 @@ describe('key-permissions', () => {
     });
 
     describe('write scope — allows :read and :write', () => {
-      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.WRITE, permissions: [] });
+      const key = createApiKey({ permissions: resolvePermissions('write') });
 
       for (const resource of RESOURCES) {
         it(`should allow ${resource}:write`, () => {
@@ -455,16 +400,13 @@ describe('key-permissions', () => {
     describe('custom scope — allows only explicit permissions', () => {
       it('should allow only listed permissions and deny everything else', () => {
         const key = createApiKey({
-          permission_scope: PERMISSION_SCOPE.CUSTOM,
-          permissions: ['reports:write', 'sessions:read'],
+          permissions: resolvePermissions('custom', ['reports:write', 'sessions:read']),
         });
 
         expect(checkPermission(key, 'reports:write')).toEqual({ allowed: true });
         expect(checkPermission(key, 'sessions:read')).toEqual({ allowed: true });
         expect(checkPermission(key, 'reports:read').allowed).toBe(false);
         expect(checkPermission(key, 'sessions:write').allowed).toBe(false);
-        expect(checkPermission(key, 'bugs:read').allowed).toBe(false);
-        expect(checkPermission(key, 'bugs:write').allowed).toBe(false);
       });
 
       it.each([
@@ -476,13 +418,11 @@ describe('key-permissions', () => {
         'sessions:write',
       ])('should allow single permission "%s" and deny others', (permission) => {
         const key = createApiKey({
-          permission_scope: PERMISSION_SCOPE.CUSTOM,
-          permissions: [permission],
+          permissions: resolvePermissions('custom', [permission]),
         });
 
         expect(checkPermission(key, permission)).toEqual({ allowed: true });
 
-        // Pick a different permission and verify it's denied
         const other = permission === 'reports:read' ? 'reports:write' : 'reports:read';
         expect(checkPermission(key, other).allowed).toBe(false);
       });

--- a/packages/backend/tests/services/api-key/key-permissions.test.ts
+++ b/packages/backend/tests/services/api-key/key-permissions.test.ts
@@ -271,6 +271,21 @@ describe('key-permissions', () => {
         'sessions:read',
       ]);
     });
+
+    it('should throw on unknown scope', () => {
+      expect(() => resolvePermissions('unknown' as any)).toThrow(
+        'Unknown permission scope: unknown'
+      );
+    });
+
+    it('should return defensive copies (not shared references)', () => {
+      const a = resolvePermissions('full');
+      const b = resolvePermissions('full');
+      expect(a).toEqual(b);
+      expect(a).not.toBe(b); // Different array instances
+      a.push('mutated');
+      expect(resolvePermissions('full')).toEqual(['*']); // Original unaffected
+    });
   });
 
   // ============================================================================

--- a/packages/backend/tests/services/api-key/key-permissions.test.ts
+++ b/packages/backend/tests/services/api-key/key-permissions.test.ts
@@ -302,7 +302,7 @@ describe('key-permissions', () => {
     it('should allow read scope for any :read permission (pattern matching)', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.READ,
-        permissions: null,
+        permissions: [],
       });
 
       expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
@@ -313,7 +313,7 @@ describe('key-permissions', () => {
     it('should allow write scope for any :write permission (pattern matching)', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.WRITE,
-        permissions: null,
+        permissions: [],
       });
 
       expect(checkPermission(key, 'bugs:write')).toEqual({ allowed: true });
@@ -324,7 +324,7 @@ describe('key-permissions', () => {
     it('should deny read scope for write operations', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.READ,
-        permissions: null,
+        permissions: [],
       });
 
       const result = checkPermission(key, 'bugs:write');
@@ -334,17 +334,28 @@ describe('key-permissions', () => {
       expect(result.reason).toContain('*:read');
     });
 
-    it('should deny write scope for read operations', () => {
+    it('should allow write scope for read operations (write implies read)', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.WRITE,
-        permissions: null,
+        permissions: [],
       });
 
-      const result = checkPermission(key, 'bugs:read');
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain('bugs:read');
-      expect(result.reason).toContain('write');
-      expect(result.reason).toContain('*:write');
+      expect(checkPermission(key, 'bugs:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'projects:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'users:read')).toEqual({ allowed: true });
+      expect(checkPermission(key, 'sessions:read')).toEqual({ allowed: true });
+    });
+
+    it('should deny read scope for write operations (read does NOT imply write)', () => {
+      const key = createApiKey({
+        permission_scope: PERMISSION_SCOPE.READ,
+        permissions: [],
+      });
+
+      expect(checkPermission(key, 'bugs:write').allowed).toBe(false);
+      expect(checkPermission(key, 'projects:write').allowed).toBe(false);
+      expect(checkPermission(key, 'users:write').allowed).toBe(false);
+      expect(checkPermission(key, 'sessions:write').allowed).toBe(false);
     });
 
     it('should prioritize explicit permissions over pattern matching', () => {
@@ -367,7 +378,7 @@ describe('key-permissions', () => {
     it('should handle custom scope without permissions array gracefully', () => {
       const key = createApiKey({
         permission_scope: PERMISSION_SCOPE.CUSTOM,
-        permissions: null,
+        permissions: [],
       });
 
       const result = checkPermission(key, 'bugs:read');
@@ -378,12 +389,103 @@ describe('key-permissions', () => {
     it('should handle unknown permission scope', () => {
       const key = createApiKey({
         permission_scope: 'unknown' as any,
-        permissions: null,
+        permissions: [],
       });
 
       const result = checkPermission(key, 'bugs:read');
       expect(result.allowed).toBe(false);
       expect(result.reason).toBe('Unknown permission scope: unknown');
+    });
+  });
+
+  // ============================================================================
+  // SCOPE ACCESS MATRIX
+  // ============================================================================
+
+  describe('scope access matrix', () => {
+    const RESOURCES = ['reports', 'sessions', 'bugs', 'projects'] as const;
+    const ACTIONS = ['read', 'write'] as const;
+
+    // Expected access for each scope
+    // full: everything allowed
+    // read: only :read
+    // write: :read + :write (write implies read)
+    // custom: only explicit permissions
+
+    describe('full scope — allows everything', () => {
+      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.FULL });
+
+      for (const resource of RESOURCES) {
+        for (const action of ACTIONS) {
+          it(`should allow ${resource}:${action}`, () => {
+            expect(checkPermission(key, `${resource}:${action}`)).toEqual({ allowed: true });
+          });
+        }
+      }
+    });
+
+    describe('read scope — allows only :read', () => {
+      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.READ, permissions: [] });
+
+      for (const resource of RESOURCES) {
+        it(`should allow ${resource}:read`, () => {
+          expect(checkPermission(key, `${resource}:read`)).toEqual({ allowed: true });
+        });
+
+        it(`should deny ${resource}:write`, () => {
+          expect(checkPermission(key, `${resource}:write`).allowed).toBe(false);
+        });
+      }
+    });
+
+    describe('write scope — allows :read and :write', () => {
+      const key = createApiKey({ permission_scope: PERMISSION_SCOPE.WRITE, permissions: [] });
+
+      for (const resource of RESOURCES) {
+        it(`should allow ${resource}:write`, () => {
+          expect(checkPermission(key, `${resource}:write`)).toEqual({ allowed: true });
+        });
+
+        it(`should allow ${resource}:read (write implies read)`, () => {
+          expect(checkPermission(key, `${resource}:read`)).toEqual({ allowed: true });
+        });
+      }
+    });
+
+    describe('custom scope — allows only explicit permissions', () => {
+      it('should allow only listed permissions and deny everything else', () => {
+        const key = createApiKey({
+          permission_scope: PERMISSION_SCOPE.CUSTOM,
+          permissions: ['reports:write', 'sessions:read'],
+        });
+
+        expect(checkPermission(key, 'reports:write')).toEqual({ allowed: true });
+        expect(checkPermission(key, 'sessions:read')).toEqual({ allowed: true });
+        expect(checkPermission(key, 'reports:read').allowed).toBe(false);
+        expect(checkPermission(key, 'sessions:write').allowed).toBe(false);
+        expect(checkPermission(key, 'bugs:read').allowed).toBe(false);
+        expect(checkPermission(key, 'bugs:write').allowed).toBe(false);
+      });
+
+      it.each([
+        'reports:read',
+        'reports:write',
+        'reports:update',
+        'reports:delete',
+        'sessions:read',
+        'sessions:write',
+      ])('should allow single permission "%s" and deny others', (permission) => {
+        const key = createApiKey({
+          permission_scope: PERMISSION_SCOPE.CUSTOM,
+          permissions: [permission],
+        });
+
+        expect(checkPermission(key, permission)).toEqual({ allowed: true });
+
+        // Pick a different permission and verify it's denied
+        const other = permission === 'reports:read' ? 'reports:write' : 'reports:read';
+        expect(checkPermission(key, other).allowed).toBe(false);
+      });
     });
   });
 

--- a/packages/backend/tests/services/api-key/key-permissions.test.ts
+++ b/packages/backend/tests/services/api-key/key-permissions.test.ts
@@ -347,11 +347,28 @@ describe('key-permissions', () => {
       expect(result.reason).toContain('Missing permission: reports:write');
     });
 
-    it('should deny all permissions for empty array', () => {
-      const key = createApiKey({ permissions: [] });
+    it('should deny all permissions for empty array with custom scope', () => {
+      const key = createApiKey({ permissions: [], permission_scope: 'custom' });
 
       expect(checkPermission(key, 'reports:read').allowed).toBe(false);
       expect(checkPermission(key, 'reports:write').allowed).toBe(false);
+    });
+
+    it('should fallback to scope resolution for pre-migration keys with empty permissions', () => {
+      // Key has permission_scope 'full' but empty permissions (pre-migration state)
+      const key = createApiKey({ permissions: [], permission_scope: 'full' });
+
+      // Defensive fallback resolves 'full' → ['*'] on the fly
+      expect(checkPermission(key, 'reports:read').allowed).toBe(true);
+      expect(checkPermission(key, 'anything:here').allowed).toBe(true);
+    });
+
+    it('should fallback to scope resolution for write scope with empty permissions', () => {
+      const key = createApiKey({ permissions: [], permission_scope: 'write' });
+
+      expect(checkPermission(key, 'reports:read').allowed).toBe(true);
+      expect(checkPermission(key, 'reports:write').allowed).toBe(true);
+      expect(checkPermission(key, 'reports:delete').allowed).toBe(false);
     });
 
     it('should include missing permission in denial reason without leaking granted permissions', () => {

--- a/packages/backend/tests/utils/api-key-helpers.test.ts
+++ b/packages/backend/tests/utils/api-key-helpers.test.ts
@@ -64,7 +64,8 @@ describe('API Key Helpers', () => {
 
       expect(result.name).toBe('Updated Key');
       expect(result.permission_scope).toBe(PERMISSION_SCOPE.FULL);
-      expect(result.permissions).toEqual(['read', 'write']);
+      // permission_scope 'full' resolves to ['*'] regardless of provided permissions
+      expect(result.permissions).toEqual(['*']);
       expect(result.allowed_projects).toEqual(['proj-1', 'proj-2']);
     });
 

--- a/packages/backend/tests/utils/api-key-helpers.test.ts
+++ b/packages/backend/tests/utils/api-key-helpers.test.ts
@@ -52,7 +52,7 @@ function createMockApiKey(overrides: Partial<ApiKey> = {}): ApiKey {
 
 describe('API Key Helpers', () => {
   describe('mapUpdateFields', () => {
-    it('should map simple fields', () => {
+    it('should map simple fields (resolution happens in service layer)', () => {
       const body = {
         name: 'Updated Key',
         permission_scope: PERMISSION_SCOPE.FULL,
@@ -64,8 +64,8 @@ describe('API Key Helpers', () => {
 
       expect(result.name).toBe('Updated Key');
       expect(result.permission_scope).toBe(PERMISSION_SCOPE.FULL);
-      // permission_scope 'full' resolves to ['*'] regardless of provided permissions
-      expect(result.permissions).toEqual(['*']);
+      // mapUpdateFields is a passthrough — resolution happens in ApiKeyService.updateKey
+      expect(result.permissions).toEqual(['read', 'write']);
       expect(result.allowed_projects).toEqual(['proj-1', 'proj-2']);
     });
 
@@ -163,55 +163,17 @@ describe('API Key Helpers', () => {
       expect(Object.keys(result)).toHaveLength(0);
     });
 
-    it('should set permission_scope to custom when only permissions are updated', () => {
+    it('should pass through permission_scope and permissions separately', () => {
       const body = {
-        permissions: ['reports:read', 'sessions:write'],
-      };
-
-      const result = mapUpdateFields(body);
-
-      expect(result.permissions).toEqual(['reports:read', 'sessions:write']);
-      expect(result.permission_scope).toBe('custom');
-    });
-
-    it('should not clear permissions when switching to custom scope without providing permissions', () => {
-      const body = {
-        permission_scope: PERMISSION_SCOPE.CUSTOM,
-        // No permissions field — should NOT wipe existing permissions
-      };
-
-      const result = mapUpdateFields(body);
-
-      expect(result.permission_scope).toBe('custom');
-      expect(result.permissions).toBeUndefined();
-    });
-
-    it('should resolve permissions when switching to custom scope with explicit permissions', () => {
-      const body = {
-        permission_scope: PERMISSION_SCOPE.CUSTOM,
+        permission_scope: PERMISSION_SCOPE.WRITE,
         permissions: ['reports:read'],
       };
 
       const result = mapUpdateFields(body);
 
-      expect(result.permission_scope).toBe('custom');
-      expect(result.permissions).toEqual(['reports:read']);
-    });
-
-    it('should resolve write scope to read + write permissions on PATCH', () => {
-      const body = {
-        permission_scope: PERMISSION_SCOPE.WRITE,
-      };
-
-      const result = mapUpdateFields(body);
-
+      // mapUpdateFields is a passthrough — resolution/sync happens in service
       expect(result.permission_scope).toBe('write');
-      expect(result.permissions).toEqual([
-        'reports:read',
-        'reports:write',
-        'sessions:read',
-        'sessions:write',
-      ]);
+      expect(result.permissions).toEqual(['reports:read']);
     });
 
     it('should handle all fields at once', () => {

--- a/packages/backend/tests/utils/api-key-helpers.test.ts
+++ b/packages/backend/tests/utils/api-key-helpers.test.ts
@@ -163,6 +163,57 @@ describe('API Key Helpers', () => {
       expect(Object.keys(result)).toHaveLength(0);
     });
 
+    it('should set permission_scope to custom when only permissions are updated', () => {
+      const body = {
+        permissions: ['reports:read', 'sessions:write'],
+      };
+
+      const result = mapUpdateFields(body);
+
+      expect(result.permissions).toEqual(['reports:read', 'sessions:write']);
+      expect(result.permission_scope).toBe('custom');
+    });
+
+    it('should not clear permissions when switching to custom scope without providing permissions', () => {
+      const body = {
+        permission_scope: PERMISSION_SCOPE.CUSTOM,
+        // No permissions field — should NOT wipe existing permissions
+      };
+
+      const result = mapUpdateFields(body);
+
+      expect(result.permission_scope).toBe('custom');
+      expect(result.permissions).toBeUndefined();
+    });
+
+    it('should resolve permissions when switching to custom scope with explicit permissions', () => {
+      const body = {
+        permission_scope: PERMISSION_SCOPE.CUSTOM,
+        permissions: ['reports:read'],
+      };
+
+      const result = mapUpdateFields(body);
+
+      expect(result.permission_scope).toBe('custom');
+      expect(result.permissions).toEqual(['reports:read']);
+    });
+
+    it('should resolve write scope to read + write permissions on PATCH', () => {
+      const body = {
+        permission_scope: PERMISSION_SCOPE.WRITE,
+      };
+
+      const result = mapUpdateFields(body);
+
+      expect(result.permission_scope).toBe('write');
+      expect(result.permissions).toEqual([
+        'reports:read',
+        'reports:write',
+        'sessions:read',
+        'sessions:write',
+      ]);
+    });
+
     it('should handle all fields at once', () => {
       const body = {
         name: 'Complete Update',


### PR DESCRIPTION
## Summary

`permission_scope` (full/read/write) is now a UI preset resolved into concrete `permissions[]` at creation time. Runtime checks use only the permissions array — one source of truth.

### Changes
- **`resolvePermissions()`** maps scopes to concrete permissions (`full→['*']`, `write→['reports:read','reports:write','sessions:read','sessions:write']`, etc.)
- **`checkPermission()`** simplified to array lookup with defensive fallback for pre-migration/cached keys
- **`createKey()`** resolves permissions before storing; defaults to `'full'` when scope omitted
- **`updateKey()`** resolves permissions on scope change, auto-sets `'custom'` on direct permission update, validates non-empty for custom scope (400)
- **`buildRotatedKeyData()`** re-resolves permissions during rotation to normalize stale keys
- **DB migration** backfills existing keys using `IS DISTINCT FROM`
- **Frontend** displays populated permissions array directly

### Security
- Denial messages no longer leak granted permissions
- `resolvePermissions()` returns defensive copies (prevents mutation of mapping)
- Unknown scopes throw instead of silently returning empty array

## Test plan
- [x] 59 backend tests (key-permissions, api-key-service, integration, helpers)
- [x] 35 frontend tests (api-key-table with header-based column lookup)
- [x] TypeScript compilation clean
- [x] ESLint + Prettier clean
- [ ] Create API keys with each scope in admin UI, verify DB permissions populated
- [ ] Verify write-scoped key can both create and list reports
- [ ] Rotate a pre-migration key, verify permissions normalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)