### PR TITLE
fix: demo app IBAN regex, inline styles, responsive grid

### DIFF
--- a/apps/demo/buggy-app.html
+++ b/apps/demo/buggy-app.html
@@ -339,6 +339,87 @@
         color: #4a5568;
         line-height: 1.8;
       }
+      /* v2.1 Sensitive Data Protection section */
+      .version-tag {
+        font-size: 0.7em;
+        color: #d35400;
+      }
+      .section-description {
+        color: #a0aec0;
+        font-size: 0.9rem;
+        margin-bottom: 1rem;
+      }
+      .protection-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 1rem;
+        margin-bottom: 2rem;
+      }
+      .card-blockselector {
+        border-left: 3px solid #d35400;
+      }
+      .card-exclude {
+        border-left: 3px solid #2563eb;
+      }
+      .badge-blockselector {
+        background: #d35400;
+        color: #fff;
+      }
+      .badge-exclude {
+        background: #2563eb;
+        color: #fff;
+      }
+      .sensitive-panel {
+        background: #1a1a2e;
+        border-radius: 8px;
+        padding: 1rem;
+        margin-top: 0.5rem;
+      }
+      .stock-row {
+        display: flex;
+        justify-content: space-between;
+        color: #a0aec0;
+        font-size: 0.85rem;
+      }
+      .stock-row + .stock-row {
+        margin-top: 0.5rem;
+      }
+      .stock-gain {
+        color: #48bb78;
+      }
+      .stock-loss {
+        color: #fc8181;
+      }
+      .portfolio-total {
+        margin-top: 0.75rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid #2d3748;
+        color: #fff;
+        font-size: 0.95rem;
+      }
+      .account-field {
+        color: #a0aec0;
+        font-size: 0.85rem;
+        margin-bottom: 0.5rem;
+      }
+      .account-field:last-child {
+        margin-bottom: 0;
+      }
+      .account-value {
+        color: #fff;
+      }
+      .account-value-positive {
+        color: #48bb78;
+      }
+      .card-hint {
+        font-size: 0.75rem;
+        color: #718096;
+        margin-top: 0.5rem;
+      }
+      .block-class-note {
+        font-size: 0.7rem;
+        color: #718096;
+      }
     </style>
   </head>
   <body>
@@ -642,92 +723,51 @@
 
       <!-- v2.1 Feature Demo: Sensitive Data Protection -->
       <h2 class="section-title">
-        Sensitive Data Protection <span style="font-size: 0.7em; color: #d35400">(v2.1)</span>
+        Sensitive Data Protection <span class="version-tag">(v2.1)</span>
       </h2>
-      <p style="color: #a0aec0; font-size: 0.9rem; margin-bottom: 1rem">
+      <p class="section-description">
         BugSpotter v2.1 adds <code>blockSelectors</code> to hide DOM elements from session replay,
         and <code>data-bugspotter-exclude</code> to exclude elements from screenshots. Try
         triggering a bug report — the blocked sections below will appear as placeholders in the
         replay.
       </p>
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 2rem">
-        <div class="bug-card" style="border-left: 3px solid #d35400">
-          <span class="badge" style="background: #d35400; color: #fff">blockSelectors</span>
+      <div class="protection-grid">
+        <div class="bug-card card-blockselector">
+          <span class="badge badge-blockselector">blockSelectors</span>
           <h3>Portfolio (blocked from replay)</h3>
-          <div
-            class="sensitive-portfolio"
-            style="background: #1a1a2e; border-radius: 8px; padding: 1rem; margin-top: 0.5rem"
-          >
-            <div
-              style="
-                display: flex;
-                justify-content: space-between;
-                color: #a0aec0;
-                font-size: 0.85rem;
-                margin-bottom: 0.5rem;
-              "
-            >
-              <span>AAPL</span><span style="color: #48bb78">+2.4%</span><span>$189.50</span>
+          <div class="sensitive-portfolio sensitive-panel">
+            <div class="stock-row">
+              <span>AAPL</span><span class="stock-gain">+2.4%</span><span>$189.50</span>
             </div>
-            <div
-              style="
-                display: flex;
-                justify-content: space-between;
-                color: #a0aec0;
-                font-size: 0.85rem;
-                margin-bottom: 0.5rem;
-              "
-            >
-              <span>GOOGL</span><span style="color: #fc8181">-0.8%</span><span>$142.30</span>
+            <div class="stock-row">
+              <span>GOOGL</span><span class="stock-loss">-0.8%</span><span>$142.30</span>
             </div>
-            <div
-              style="
-                display: flex;
-                justify-content: space-between;
-                color: #a0aec0;
-                font-size: 0.85rem;
-              "
-            >
-              <span>MSFT</span><span style="color: #48bb78">+1.2%</span><span>$415.80</span>
+            <div class="stock-row">
+              <span>MSFT</span><span class="stock-gain">+1.2%</span><span>$415.80</span>
             </div>
-            <div
-              style="
-                margin-top: 0.75rem;
-                padding-top: 0.5rem;
-                border-top: 1px solid #2d3748;
-                color: #fff;
-                font-size: 0.95rem;
-              "
-            >
-              Total: <strong>$12,450.00</strong>
-            </div>
+            <div class="portfolio-total">Total: <strong>$12,450.00</strong></div>
           </div>
-          <p style="font-size: 0.75rem; color: #718096; margin-top: 0.5rem">
+          <p class="card-hint">
             This section uses <code>blockSelectors: ['.sensitive-portfolio']</code> — hidden from
             replay
           </p>
         </div>
-        <div class="bug-card" style="border-left: 3px solid #2563eb">
-          <span class="badge" style="background: #2563eb; color: #fff"
-            >data-bugspotter-exclude</span
-          >
+        <div class="bug-card card-exclude">
+          <span class="badge badge-exclude">data-bugspotter-exclude</span>
           <h3>Account Info (excluded from screenshots)</h3>
-          <div
-            data-bugspotter-exclude
-            style="background: #1a1a2e; border-radius: 8px; padding: 1rem; margin-top: 0.5rem"
-          >
-            <div style="color: #a0aec0; font-size: 0.85rem; margin-bottom: 0.5rem">
-              Account: <strong style="color: #fff">FRH123456789</strong>
+          <div data-bugspotter-exclude class="sensitive-panel">
+            <div class="account-field">
+              Account: <strong class="account-value">FRH123456789</strong>
             </div>
-            <div style="color: #a0aec0; font-size: 0.85rem; margin-bottom: 0.5rem">
-              IBAN: <strong style="color: #fff">KZ861250400601001000</strong>
+            <div class="account-field">
+              IBAN: <strong class="account-value">KZ861250400601001000</strong>
             </div>
-            <div class="bugspotter-block" style="color: #a0aec0; font-size: 0.85rem">
-              Balance: <strong style="color: #48bb78">&#8376; 2,450,000</strong>
-              <span style="font-size: 0.7rem; color: #718096">(blocked via blockClass)</span>
+            <div class="bugspotter-block account-field">
+              Balance: <strong class="account-value-positive">&#8376; 2,450,000</strong>
+              <span class="block-class-note">(blocked via blockClass)</span>
             </div>
           </div>
-          <p style="font-size: 0.75rem; color: #718096; margin-top: 0.5rem">
+          <p class="card-hint">
             This section uses <code>data-bugspotter-exclude</code> — hidden from screenshots
           </p>
         </div>
@@ -902,7 +942,7 @@
           // v2.1: custom PII patterns for industry-specific data
           customPatterns: [
             { name: 'broker-account', regex: /FRH\d{9}/gi },
-            { name: 'iban-kz', regex: /KZ\d{18}/gi },
+            { name: 'iban-kz', regex: /\bKZ\d{2}[A-Z0-9]{16}\b/gi },
           ],
         },
       });

--- a/apps/demo/buggy-app.html
+++ b/apps/demo/buggy-app.html
@@ -351,7 +351,7 @@
       }
       .protection-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
         gap: 1rem;
         margin-bottom: 2rem;
       }


### PR DESCRIPTION
## Summary
- **IBAN regex**: `KZ\d{18}` → `\bKZ\d{2}[A-Z0-9]{16}\b` — word boundaries, correct KZ IBAN format (2 check digits + 16 alphanumeric)
- **Inline styles → CSS classes**: Extracted all inline styles from v2.1 Sensitive Data Protection section into reusable CSS classes
- **Responsive grid**: `repeat(auto-fit, minmax(300px, 1fr))` for mobile
- **Stock-row spacing**: Adjacent sibling selector instead of broken `:last-of-type`

## Test plan
- [ ] Open demo app, verify v2.1 section renders correctly on desktop and mobile
- [ ] Trigger a bug report, verify IBAN is redacted in replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)