### PR TITLE
feat: self-service signup backend (R1)

### DIFF
--- a/packages/backend/src/api/routes/auth.ts
+++ b/packages/backend/src/api/routes/auth.ts
@@ -18,7 +18,12 @@ import { config } from '../../config.js';
 import { InvitationService } from '../../saas/services/invitation.service.js';
 import { sendSuccess, sendCreated } from '../utils/response.js';
 import { findOrThrow, omitFields } from '../utils/resource.js';
-import { PASSWORD, parseTimeString, DEFAULT_TOKEN_EXPIRY_SECONDS } from '../utils/constants.js';
+import { PASSWORD } from '../utils/constants.js';
+import {
+  buildRefreshCookieOptions,
+  buildClearRefreshCookieOptions,
+} from '../utils/auth-cookies.js';
+import { generateAuthTokens } from '../utils/auth-tokens.js';
 import {
   checkLockoutStatus,
   recordFailedAttempt,
@@ -42,36 +47,6 @@ interface RegisterBody {
 
 interface RefreshTokenBody {
   refresh_token: string;
-}
-
-/**
- * Generate JWT tokens for a user
- */
-function generateTokens(fastify: FastifyInstance, user: User) {
-  const payload = { userId: user.id, isPlatformAdmin: isPlatformAdmin(user) };
-
-  const access_token = fastify.jwt.sign(payload, {
-    expiresIn: config.jwt.expiresIn,
-  });
-
-  const refresh_token = fastify.jwt.sign(payload, {
-    expiresIn: config.jwt.refreshExpiresIn,
-  });
-
-  // Calculate expiry time in seconds
-  const expiresIn = parseTimeString(config.jwt.expiresIn, DEFAULT_TOKEN_EXPIRY_SECONDS);
-  const refreshExpiresIn = parseTimeString(
-    config.jwt.refreshExpiresIn,
-    DEFAULT_TOKEN_EXPIRY_SECONDS
-  );
-
-  return {
-    access_token,
-    refresh_token,
-    expires_in: expiresIn,
-    refresh_expires_in: refreshExpiresIn,
-    token_type: 'Bearer' as const,
-  };
 }
 
 /**
@@ -197,16 +172,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       await invitationService.autoAcceptPendingInvitations(email, user.id);
 
       // Generate tokens
-      const tokens = generateTokens(fastify, user);
+      const tokens = generateAuthTokens(fastify, user);
 
       // Set refresh token in httpOnly cookie
-      reply.setCookie('refresh_token', tokens.refresh_token, {
-        httpOnly: true,
-        secure: config.server.env === 'production',
-        sameSite: 'strict',
-        maxAge: tokens.refresh_expires_in,
-        path: '/',
-      });
+      reply.setCookie(
+        'refresh_token',
+        tokens.refresh_token,
+        buildRefreshCookieOptions(tokens.refresh_expires_in)
+      );
 
       // Remove password hash from response
       const userWithoutPassword = omitFields(user, 'password_hash');
@@ -278,16 +251,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       await clearFailedAttempts(email);
 
       // Generate tokens
-      const tokens = generateTokens(fastify, user);
+      const tokens = generateAuthTokens(fastify, user);
 
       // Set refresh token in httpOnly cookie
-      reply.setCookie('refresh_token', tokens.refresh_token, {
-        httpOnly: true,
-        secure: config.server.env === 'production',
-        sameSite: 'strict',
-        maxAge: tokens.refresh_expires_in,
-        path: '/',
-      });
+      reply.setCookie(
+        'refresh_token',
+        tokens.refresh_token,
+        buildRefreshCookieOptions(tokens.refresh_expires_in)
+      );
 
       // Remove password hash from response
       const userWithoutPassword = omitFields(user, 'password_hash');
@@ -335,16 +306,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         const user = await findOrThrow(() => db.users.findById(decoded.userId), 'User');
 
         // Generate new tokens
-        const tokens = generateTokens(fastify, user);
+        const tokens = generateAuthTokens(fastify, user);
 
         // Set new refresh token in httpOnly cookie
-        reply.setCookie('refresh_token', tokens.refresh_token, {
-          httpOnly: true,
-          secure: config.server.env === 'production',
-          sameSite: 'strict',
-          maxAge: tokens.refresh_expires_in,
-          path: '/',
-        });
+        reply.setCookie(
+          'refresh_token',
+          tokens.refresh_token,
+          buildRefreshCookieOptions(tokens.refresh_expires_in)
+        );
 
         return sendSuccess(reply, {
           access_token: tokens.access_token,
@@ -419,16 +388,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         }
 
         // Generate regular access/refresh tokens for the session
-        const tokens = generateTokens(fastify, user);
+        const tokens = generateAuthTokens(fastify, user);
 
         // Set refresh token in httpOnly cookie
-        reply.setCookie('refresh_token', tokens.refresh_token, {
-          httpOnly: true,
-          secure: config.server.env === 'production',
-          sameSite: 'strict',
-          maxAge: tokens.refresh_expires_in,
-          path: '/',
-        });
+        reply.setCookie(
+          'refresh_token',
+          tokens.refresh_token,
+          buildRefreshCookieOptions(tokens.refresh_expires_in)
+        );
 
         // Remove password hash from response
         const userWithoutPassword = omitFields(user, 'password_hash');
@@ -463,12 +430,7 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
     },
     async (_request, reply) => {
       // Clear refresh token cookie
-      reply.clearCookie('refresh_token', {
-        httpOnly: true,
-        secure: config.server.env === 'production',
-        sameSite: 'strict',
-        path: '/',
-      });
+      reply.clearCookie('refresh_token', buildClearRefreshCookieOptions());
 
       return sendSuccess(reply, { message: 'Logged out successfully' });
     }

--- a/packages/backend/src/api/routes/signup.ts
+++ b/packages/backend/src/api/routes/signup.ts
@@ -11,6 +11,14 @@
  *
  * Separate from `/auth/register` (which is user-only and does not create
  * an organization) to keep the invite-flow contract stable.
+ *
+ * Rate limiting: This endpoint overrides the default per-route rate limit
+ * with a stricter 5/minute/IP cap — genuine users never rapid-fire signups.
+ * NOTE: effectiveness depends on `trustProxy` being configured when behind
+ * a reverse proxy (CDN/Vercel/nginx) so `request.ip` reflects the real
+ * client IP rather than the proxy's. That wiring is deployment-topology
+ * config, not code, but is called out in the project plan as a
+ * pre-prod blocker.
  */
 
 import type { FastifyInstance } from 'fastify';
@@ -39,19 +47,31 @@ interface SignupBody {
 }
 
 export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void {
+  // Parse region ONCE at route-registration time. Config is already validated
+  // by `validateConfig('api')` at server boot, so this throw is a belt-and-
+  // braces guard for the theoretical "someone called signupRoutes without
+  // validating config first" case — we still prefer a boot failure to a
+  // per-request 500.
+  const region = parseDataResidencyRegion(config.dataResidency.region);
+  const service = new SignupService(db, region);
+
   fastify.post<{ Body: SignupBody }>(
     '/api/v1/auth/signup',
     {
       schema: signupSchema,
-      config: { public: true },
+      config: {
+        public: true,
+        // Per-IP burst cap — tighter than the global default because this
+        // endpoint creates real tenant data and must resist credential-
+        // stuffing / subdomain-squatting bots. Honeypot and fail-closed
+        // SpamFilter are complementary, not substitutes.
+        rateLimit: { max: 5, timeWindow: '1 minute' },
+      },
     },
     async (request, reply) => {
       if (!config.auth.selfServiceSignupEnabled) {
         throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
       }
-
-      const region = parseDataResidencyRegion(config.dataResidency.region);
-      const service = new SignupService(db, region);
 
       const input: SignupInput = {
         email: request.body.email,

--- a/packages/backend/src/api/routes/signup.ts
+++ b/packages/backend/src/api/routes/signup.ts
@@ -1,0 +1,100 @@
+/**
+ * Self-service signup route
+ *
+ * POST /api/v1/auth/signup
+ *
+ * Sentry-style instant onboarding: one atomic call provisions user +
+ * organization + trial subscription + default project + write-scoped API
+ * key, returns JWTs + plaintext key in a single response. The landing
+ * wizard on `kz.bugspotter.io` calls this; enterprise/admin-approval flow
+ * lives at `/organization-requests` unchanged.
+ *
+ * Separate from `/auth/register` (which is user-only and does not create
+ * an organization) to keep the invite-flow contract stable.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { DatabaseClient } from '../../db/client.js';
+import { config } from '../../config.js';
+import { AppError } from '../middleware/error.js';
+import { omitFields } from '../utils/resource.js';
+import { sendCreated } from '../utils/response.js';
+import { buildRefreshCookieOptions } from '../utils/auth-cookies.js';
+import { generateAuthTokens } from '../utils/auth-tokens.js';
+import { signupSchema } from '../schemas/auth-schema.js';
+import {
+  SignupService,
+  parseDataResidencyRegion,
+  type SignupInput,
+} from '../../saas/services/signup.service.js';
+
+interface SignupBody {
+  email: string;
+  password: string;
+  name?: string;
+  company_name: string;
+  subdomain?: string;
+  /** Honeypot — named `website` in the form to look like a legitimate field to bots. */
+  website?: string;
+}
+
+export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void {
+  fastify.post<{ Body: SignupBody }>(
+    '/api/v1/auth/signup',
+    {
+      schema: signupSchema,
+      config: { public: true },
+    },
+    async (request, reply) => {
+      if (!config.auth.selfServiceSignupEnabled) {
+        throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
+      }
+
+      const region = parseDataResidencyRegion(config.dataResidency.region);
+      const service = new SignupService(db, region);
+
+      const input: SignupInput = {
+        email: request.body.email,
+        password: request.body.password,
+        name: request.body.name,
+        company_name: request.body.company_name,
+        subdomain: request.body.subdomain,
+        ip_address: request.ip,
+        honeypot: request.body.website ?? null,
+      };
+
+      const result = await service.signup(input);
+
+      // Issue session JWTs so the wizard can hand off to the tenant admin UI
+      // without a separate /login round-trip.
+      const tokens = generateAuthTokens(fastify, result.user);
+
+      reply.setCookie(
+        'refresh_token',
+        tokens.refresh_token,
+        buildRefreshCookieOptions(tokens.refresh_expires_in)
+      );
+
+      const userWithoutPassword = omitFields(result.user, 'password_hash');
+
+      return sendCreated(reply, {
+        user: userWithoutPassword,
+        organization: {
+          id: result.organization.id,
+          name: result.organization.name,
+          subdomain: result.organization.subdomain,
+          trial_ends_at: result.organization.trial_ends_at,
+        },
+        project: {
+          id: result.project.id,
+          name: result.project.name,
+        },
+        api_key: result.api_key,
+        api_key_id: result.api_key_id,
+        access_token: tokens.access_token,
+        expires_in: tokens.expires_in,
+        token_type: tokens.token_type,
+      });
+    }
+  );
+}

--- a/packages/backend/src/api/schemas/auth-schema.ts
+++ b/packages/backend/src/api/schemas/auth-schema.ts
@@ -150,6 +150,72 @@ export const magicLoginSchema = {
   },
 } as const;
 
+export const signupSchema = {
+  body: {
+    type: 'object',
+    required: ['email', 'password', 'company_name'],
+    properties: {
+      email: { type: 'string', format: 'email', maxLength: 254 },
+      password: { type: 'string', minLength: 8, maxLength: 128 },
+      name: { type: 'string', minLength: 1, maxLength: 128 },
+      company_name: { type: 'string', minLength: 1, maxLength: 128 },
+      subdomain: { type: 'string', minLength: 3, maxLength: 63 },
+      // Honeypot: must be empty/absent for humans. Bots auto-fill visible
+      // form fields, including ones hidden via CSS.
+      website: { type: 'string', maxLength: 256 },
+    },
+    additionalProperties: false,
+  },
+  response: {
+    201: {
+      type: 'object',
+      required: ['success', 'data', 'timestamp'],
+      properties: {
+        success: { type: 'boolean', enum: [true] },
+        data: {
+          type: 'object',
+          required: [
+            'user',
+            'organization',
+            'project',
+            'api_key',
+            'access_token',
+            'expires_in',
+            'token_type',
+          ],
+          properties: {
+            user: userSchema,
+            organization: {
+              type: 'object',
+              required: ['id', 'name', 'subdomain'],
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                name: { type: 'string' },
+                subdomain: { type: 'string' },
+                trial_ends_at: { type: 'string', format: 'date-time', nullable: true },
+              },
+            },
+            project: {
+              type: 'object',
+              required: ['id', 'name'],
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                name: { type: 'string' },
+              },
+            },
+            api_key: { type: 'string' },
+            api_key_id: { type: 'string', format: 'uuid' },
+            access_token: { type: 'string' },
+            expires_in: { type: 'number' },
+            token_type: { type: 'string', enum: ['Bearer'] },
+          },
+        },
+        timestamp: { type: 'string', format: 'date-time' },
+      },
+    },
+  },
+} as const;
+
 export const registrationStatusSchema = {
   response: {
     200: {

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -29,6 +29,7 @@ import { projectRoutes } from './routes/projects.js';
 import { projectMemberRoutes } from './routes/project-members.js';
 import { projectIntegrationRoutes } from './routes/project-integrations.js';
 import { authRoutes } from './routes/auth.js';
+import { signupRoutes } from './routes/signup.js';
 import { shareTokenRoutes } from './routes/share-tokens.js';
 import { retentionRoutes } from './routes/retention.js';
 import { dataResidencyRoutes } from './routes/data-residency.js';
@@ -419,6 +420,7 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
   projectMemberRoutes(fastify, db);
   projectIntegrationRoutes(fastify, db, options.pluginRegistry);
   authRoutes(fastify, db);
+  signupRoutes(fastify, db);
   await adminRoutes(fastify, db, options.pluginRegistry);
   await adminJobsRoutes(fastify);
   await setupRoutes(fastify, db);

--- a/packages/backend/src/api/utils/auth-cookies.ts
+++ b/packages/backend/src/api/utils/auth-cookies.ts
@@ -1,0 +1,54 @@
+/**
+ * Refresh-token cookie options helper
+ *
+ * Centralizes cookie settings so `/register`, `/login`, `/refresh`,
+ * `/magic-login`, `/logout`, and the self-service `/signup` all emit
+ * identical cookies. Keeping this in one place avoids drift when the
+ * cookie domain or sameSite mode changes per deployment.
+ */
+
+import type { CookieSerializeOptions } from '@fastify/cookie';
+import { config } from '../../config.js';
+
+export interface RefreshCookieOptions extends CookieSerializeOptions {
+  /** Always present — Fastify requires explicit options each call. */
+  httpOnly: true;
+  path: '/';
+}
+
+/**
+ * Build cookie options for setting the refresh_token cookie.
+ *
+ * - When `COOKIE_DOMAIN` is configured (SaaS), the cookie is scoped to the
+ *   parent domain (e.g. `.kz.bugspotter.io`) and uses `sameSite=lax` so
+ *   the wizard on `kz.bugspotter.io` can hand off the session to
+ *   `[org].kz.bugspotter.io` on redirect.
+ * - When `COOKIE_DOMAIN` is empty (self-hosted), the cookie stays
+ *   host-scoped with `sameSite=strict` to match legacy behavior.
+ */
+export function buildRefreshCookieOptions(maxAgeSeconds: number): RefreshCookieOptions {
+  const hasCookieDomain = !!config.auth.cookieDomain;
+  return {
+    httpOnly: true,
+    secure: config.server.env === 'production',
+    sameSite: hasCookieDomain ? 'lax' : 'strict',
+    maxAge: maxAgeSeconds,
+    path: '/',
+    ...(hasCookieDomain ? { domain: config.auth.cookieDomain as string } : {}),
+  };
+}
+
+/**
+ * Build cookie options for clearing the refresh_token cookie.
+ * Must match the attributes used when setting it, or browsers ignore the clear.
+ */
+export function buildClearRefreshCookieOptions(): RefreshCookieOptions {
+  const hasCookieDomain = !!config.auth.cookieDomain;
+  return {
+    httpOnly: true,
+    secure: config.server.env === 'production',
+    sameSite: hasCookieDomain ? 'lax' : 'strict',
+    path: '/',
+    ...(hasCookieDomain ? { domain: config.auth.cookieDomain as string } : {}),
+  };
+}

--- a/packages/backend/src/api/utils/auth-tokens.ts
+++ b/packages/backend/src/api/utils/auth-tokens.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared JWT token generation helper.
+ *
+ * One source of truth for access/refresh token payloads + expiry so
+ * `/auth/register`, `/auth/login`, `/auth/refresh`, `/auth/magic-login`,
+ * and `/auth/signup` cannot drift apart. Per-flow behavior (cookie
+ * attributes, response shape) lives in the route handler.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { config } from '../../config.js';
+import type { User } from '../../db/types.js';
+import { isPlatformAdmin } from '../middleware/auth.js';
+import { parseTimeString, DEFAULT_TOKEN_EXPIRY_SECONDS } from './constants.js';
+
+export interface AuthTokens {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  refresh_expires_in: number;
+  token_type: 'Bearer';
+}
+
+export function generateAuthTokens(fastify: FastifyInstance, user: User): AuthTokens {
+  const payload = { userId: user.id, isPlatformAdmin: isPlatformAdmin(user) };
+
+  const access_token = fastify.jwt.sign(payload, {
+    expiresIn: config.jwt.expiresIn,
+  });
+
+  const refresh_token = fastify.jwt.sign(payload, {
+    expiresIn: config.jwt.refreshExpiresIn,
+  });
+
+  const expiresIn = parseTimeString(config.jwt.expiresIn, DEFAULT_TOKEN_EXPIRY_SECONDS);
+  const refreshExpiresIn = parseTimeString(
+    config.jwt.refreshExpiresIn,
+    DEFAULT_TOKEN_EXPIRY_SECONDS
+  );
+
+  return {
+    access_token,
+    refresh_token,
+    expires_in: expiresIn,
+    refresh_expires_in: refreshExpiresIn,
+    token_type: 'Bearer',
+  };
+}

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -169,6 +169,21 @@ function collectSecurityErrors(): string[] {
   return errors;
 }
 
+const VALID_DATA_RESIDENCY_REGIONS = ['kz', 'rf', 'eu', 'us', 'global'] as const;
+
+function collectDataResidencyErrors(): string[] {
+  // Validate at boot rather than on the first signup. A misconfigured region
+  // otherwise surfaces as a 500 from /api/v1/auth/signup instead of a clear
+  // operator-facing startup failure.
+  const region = config.dataResidency.region;
+  if (!(VALID_DATA_RESIDENCY_REGIONS as readonly string[]).includes(region)) {
+    return [
+      `Invalid DATA_RESIDENCY_REGION: ${region}. Expected one of: ${VALID_DATA_RESIDENCY_REGIONS.join(', ')}`,
+    ];
+  }
+  return [];
+}
+
 function collectStorageErrors(): string[] {
   const errors: string[] = [];
 
@@ -235,6 +250,7 @@ export function validateConfig(context: ValidationContext = 'api'): void {
   errors.push(...collectSecurityErrors());
   if (context === 'api') {
     errors.push(...collectStorageErrors());
+    errors.push(...collectDataResidencyErrors());
   }
 
   throwIfErrors(errors);

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -69,6 +69,10 @@ export const config: AppConfig = {
       parseBooleanEnv(process.env.ALLOW_REGISTRATION) ?? process.env.DEPLOYMENT_MODE === 'saas',
     requireInvitationToRegister:
       parseBooleanEnv(process.env.REQUIRE_INVITATION_TO_REGISTER) ?? true,
+    selfServiceSignupEnabled:
+      parseBooleanEnv(process.env.SELF_SERVICE_SIGNUP_ENABLED) ??
+      process.env.DEPLOYMENT_MODE === 'saas',
+    cookieDomain: process.env.COOKIE_DOMAIN?.trim() || null,
   },
   frontend: {
     url: process.env.FRONTEND_URL ?? '',
@@ -102,6 +106,9 @@ export const config: AppConfig = {
       maxRetries: parseInt(process.env.S3_MAX_RETRIES ?? '3', 10),
       timeout: parseInt(process.env.S3_TIMEOUT_MS ?? '30000', 10),
     },
+  },
+  dataResidency: {
+    region: (process.env.DATA_RESIDENCY_REGION ?? 'kz').toLowerCase(),
   },
 } as const;
 

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -35,6 +35,18 @@ export interface JwtConfig {
 export interface AuthConfig {
   allowRegistration: boolean;
   requireInvitationToRegister: boolean;
+  selfServiceSignupEnabled: boolean;
+  /**
+   * Domain attribute for refresh_token cookie. When set (e.g. `.kz.bugspotter.io`),
+   * enables cross-subdomain SSO between the landing signup wizard and tenant
+   * admin UIs. When null/empty, the cookie is scoped to the emitting host.
+   */
+  cookieDomain: string | null;
+}
+
+export interface DataResidencyConfig {
+  /** Region code for this deployment (e.g. `kz`, `rf`). Used for signup and billing currency. */
+  region: string;
 }
 
 export interface FrontendConfig {
@@ -82,4 +94,5 @@ export interface AppConfig {
   shareToken: ShareTokenConfig;
   rateLimit: RateLimitConfig;
   storage: StorageConfig;
+  dataResidency: DataResidencyConfig;
 }

--- a/packages/backend/src/saas/repositories/organization-request.repository.ts
+++ b/packages/backend/src/saas/repositories/organization-request.repository.ts
@@ -161,6 +161,26 @@ export class OrganizationRequestRepository extends BaseRepository<
   }
 
   /**
+   * Check whether a subdomain is held by a non-terminal organization request
+   * (pending_verification / verified / approved). Rejected and expired
+   * requests are ignored — their subdomain is free to reuse.
+   *
+   * Used by self-service signup to avoid racing an enterprise onboarding
+   * request that hasn't yet materialized into a real organization row.
+   */
+  async isSubdomainReservedByRequest(subdomain: string): Promise<boolean> {
+    const query = `
+      SELECT EXISTS(
+        SELECT 1 FROM ${this.schema}.${this.tableName}
+        WHERE LOWER(subdomain) = $1
+          AND status IN ('pending_verification', 'verified', 'approved')
+      ) AS reserved
+    `;
+    const result = await this.pool.query<{ reserved: boolean }>(query, [subdomain.toLowerCase()]);
+    return result.rows[0]?.reserved ?? false;
+  }
+
+  /**
    * Update request status with audit fields
    */
   async updateStatus(

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -1,0 +1,288 @@
+/**
+ * Signup Service
+ *
+ * Orchestrates self-service tenant creation: a single atomic flow that
+ * provisions user + organization + trial subscription + owner membership +
+ * default project + write-scoped API key for SDK ingestion. Separate from
+ * `/auth/register` (user-only) and from the admin-approved
+ * `/organization-requests` flow (kept for enterprise onboarding).
+ *
+ * The API key uses `PERMISSION_SCOPE.WRITE` (reports:read/write +
+ * sessions:read/write) — the minimum the SDK needs to post reports and
+ * session replays. There is no dedicated `ingest` scope in the
+ * permission enum; adding one would require a DB CHECK-constraint
+ * migration and is out of scope here.
+ *
+ * Atomicity: all six inserts run inside a single `db.transaction`. If any
+ * step fails, nothing is committed — the user can retry without orphan
+ * rows blocking the email/subdomain.
+ */
+
+import bcrypt from 'bcrypt';
+import type { DatabaseClient } from '../../db/client.js';
+import type {
+  Organization,
+  Project,
+  Subscription,
+  User,
+  DataResidencyRegion,
+} from '../../db/types.js';
+import {
+  SUBSCRIPTION_STATUS,
+  BILLING_STATUS,
+  PLAN_NAME,
+  ORG_MEMBER_ROLE,
+  API_KEY_TYPE,
+  API_KEY_AUDIT_ACTION,
+  PERMISSION_SCOPE,
+  DATA_RESIDENCY_REGION,
+} from '../../db/types.js';
+import { AppError } from '../../api/middleware/error.js';
+import { PASSWORD } from '../../api/utils/constants.js';
+import { getQuotaForPlan } from '../plans.js';
+import { SubdomainService } from './subdomain.service.js';
+import { SpamFilterService } from './spam-filter.service.js';
+import {
+  generatePlaintextKey,
+  hashKey,
+  extractKeyMetadata,
+} from '../../services/api-key/key-crypto.js';
+import { resolvePermissions } from '../../services/api-key/key-permissions.js';
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+const TRIAL_DURATION_DAYS = 14;
+const DEFAULT_PROJECT_NAME = 'My First Project';
+
+export interface SignupInput {
+  email: string;
+  password: string;
+  name?: string;
+  company_name: string;
+  /** Optional user-supplied subdomain; auto-derived from company_name when omitted. */
+  subdomain?: string;
+  /** Client IP for rate limiting and abuse tracking. */
+  ip_address: string;
+  /** Honeypot field — must be empty/absent for humans. */
+  honeypot?: string | null;
+}
+
+export interface SignupResult {
+  user: User;
+  organization: Organization;
+  subscription: Subscription;
+  project: Project;
+  /**
+   * Plaintext API key — shown to the user ONCE on the success screen.
+   * Never persisted in plaintext: the DB stores a SHA-256 hex hash only
+   * (see `services/api-key/key-crypto.ts`).
+   */
+  api_key: string;
+  api_key_id: string;
+}
+
+export class SignupService {
+  private readonly subdomainService: SubdomainService;
+  private readonly spamFilter: SpamFilterService;
+
+  constructor(
+    private readonly db: DatabaseClient,
+    private readonly region: DataResidencyRegion
+  ) {
+    this.subdomainService = new SubdomainService(db);
+    this.spamFilter = new SpamFilterService(db);
+  }
+
+  /**
+   * Run the full signup flow. On success, every record is committed.
+   * On any failure, the transaction rolls back — caller can safely retry.
+   */
+  async signup(input: SignupInput): Promise<SignupResult> {
+    const email = input.email.toLowerCase().trim();
+    const companyName = input.company_name.trim();
+
+    if (companyName.length === 0) {
+      throw new AppError('Company name is required', 400, 'ValidationError');
+    }
+
+    await this.runSpamChecks(email, companyName, input);
+
+    const existingUser = await this.db.users.findByEmail(email);
+    if (existingUser) {
+      throw new AppError('User with this email already exists', 409, 'Conflict');
+    }
+
+    const subdomain = await this.resolveSubdomain(companyName, input.subdomain);
+
+    const passwordHash = await bcrypt.hash(input.password, PASSWORD.SALT_ROUNDS);
+
+    // Single timestamp for every row in this signup — avoids microsecond
+    // drift between trial_ends_at / current_period_start / etc.
+    const now = new Date();
+    const trialEnd = addDays(now, TRIAL_DURATION_DAYS);
+
+    const result = await this.db.transaction(async (tx) => {
+      const user = await tx.users.create({
+        email,
+        name: input.name?.trim() || null,
+        password_hash: passwordHash,
+        role: 'user',
+      });
+
+      const organization = await tx.organizations.create({
+        name: companyName,
+        subdomain,
+        data_residency_region: this.region,
+        subscription_status: SUBSCRIPTION_STATUS.TRIAL,
+        trial_ends_at: trialEnd,
+      });
+
+      const subscription = await tx.subscriptions.create({
+        organization_id: organization.id,
+        plan_name: PLAN_NAME.TRIAL,
+        status: BILLING_STATUS.TRIAL,
+        current_period_start: now,
+        current_period_end: trialEnd,
+        quotas: getQuotaForPlan(PLAN_NAME.TRIAL),
+      });
+
+      await tx.organizationMembers.create({
+        organization_id: organization.id,
+        user_id: user.id,
+        role: ORG_MEMBER_ROLE.OWNER,
+      });
+
+      // Fresh org → project count is guaranteed 0, trial quota is 2.
+      // No advisory lock needed (no concurrent project creation possible
+      // on an org that doesn't exist yet outside this transaction).
+      const project = await tx.projects.create({
+        name: DEFAULT_PROJECT_NAME,
+        created_by: user.id,
+        organization_id: organization.id,
+        settings: {},
+      });
+
+      const plaintextKey = generatePlaintextKey();
+      const keyHash = hashKey(plaintextKey);
+      const { prefix, suffix } = extractKeyMetadata(plaintextKey);
+      const scope = PERMISSION_SCOPE.WRITE;
+
+      const apiKey = await tx.apiKeys.create({
+        name: `${DEFAULT_PROJECT_NAME} — SDK key`,
+        description: 'Auto-generated at signup — use this in your SDK init.',
+        type: API_KEY_TYPE.PRODUCTION,
+        permission_scope: scope,
+        permissions: resolvePermissions(scope),
+        allowed_projects: [project.id],
+        key_hash: keyHash,
+        key_prefix: prefix,
+        key_suffix: suffix,
+        created_by: user.id,
+      });
+
+      await tx.apiKeys.logAudit({
+        api_key_id: apiKey.id,
+        action: API_KEY_AUDIT_ACTION.CREATED,
+        performed_by: user.id,
+        changes: {
+          type: apiKey.type,
+          permission_scope: scope,
+          source: 'self-service-signup',
+        },
+      });
+
+      return {
+        user,
+        organization,
+        subscription,
+        project,
+        api_key: plaintextKey,
+        api_key_id: apiKey.id,
+      };
+    });
+
+    // Log AFTER commit — logging inside the tx callback would record
+    // success even if the COMMIT itself fails.
+    logger.info('Self-service signup completed', {
+      userId: result.user.id,
+      organizationId: result.organization.id,
+      subdomain,
+      projectId: result.project.id,
+    });
+
+    return result;
+  }
+
+  /**
+   * Pre-commit spam checks. Runs before any DB writes so a bot submission
+   * never consumes email/subdomain slots or triggers downstream side effects.
+   *
+   * Fails CLOSED: if the spam check itself errors (DB outage, connection
+   * loss), refuse the signup with 503. Letting requests through during a
+   * degraded state would silently disable rate-limit, honeypot, and
+   * duplicate-email protections — exactly the moment abuse is most likely.
+   */
+  private async runSpamChecks(
+    email: string,
+    companyName: string,
+    input: SignupInput
+  ): Promise<void> {
+    // Subdomain value used for SpamFilterService is informational — the real
+    // uniqueness check happens via SubdomainService.assertValidAndAvailable.
+    // Passing the slug here keeps the check input-complete for future rules.
+    const slugForCheck = this.subdomainService.slugify(companyName) || 'pending';
+
+    let result;
+    try {
+      result = await this.spamFilter.check({
+        company_name: companyName,
+        subdomain: slugForCheck,
+        contact_email: email,
+        ip_address: input.ip_address,
+        honeypot: input.honeypot ?? null,
+      });
+    } catch (err) {
+      logger.error('Spam filter check failed during signup', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw new AppError('Unable to process signup at this time', 503, 'ServiceUnavailable');
+    }
+
+    if (result.rejected) {
+      throw new AppError('Signup request rejected', 403, 'Forbidden', {
+        reasons: result.reasons,
+      });
+    }
+  }
+
+  /**
+   * Determine the final subdomain for this tenant. User-supplied values are
+   * validated and must be available; if omitted, auto-generate from the
+   * company name (with numeric suffix on collision).
+   */
+  private async resolveSubdomain(companyName: string, userSupplied?: string): Promise<string> {
+    if (userSupplied && userSupplied.trim().length > 0) {
+      return this.subdomainService.assertValidAndAvailable(userSupplied);
+    }
+    return this.subdomainService.generateUniqueFromName(companyName);
+  }
+}
+
+function addDays(base: Date, days: number): Date {
+  const end = new Date(base);
+  end.setDate(end.getDate() + days);
+  return end;
+}
+
+/** Resolve a region string from config into the DataResidencyRegion enum, or throw. */
+export function parseDataResidencyRegion(region: string): DataResidencyRegion {
+  const normalized = region.toLowerCase().trim();
+  const match = (Object.values(DATA_RESIDENCY_REGION) as string[]).find((r) => r === normalized);
+  if (!match) {
+    throw new Error(
+      `Invalid DATA_RESIDENCY_REGION: ${region}. Expected one of: ${Object.values(DATA_RESIDENCY_REGION).join(', ')}`
+    );
+  }
+  return match as DataResidencyRegion;
+}

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -122,85 +122,100 @@ export class SignupService {
     const now = new Date();
     const trialEnd = addDays(now, TRIAL_DURATION_DAYS);
 
-    const result = await this.db.transaction(async (tx) => {
-      const user = await tx.users.create({
-        email,
-        name: input.name?.trim() || null,
-        password_hash: passwordHash,
-        role: 'user',
-      });
+    let result;
+    try {
+      result = await this.db.transaction(async (tx) => {
+        const user = await tx.users.create({
+          email,
+          name: input.name?.trim() || null,
+          password_hash: passwordHash,
+          role: 'user',
+        });
 
-      const organization = await tx.organizations.create({
-        name: companyName,
-        subdomain,
-        data_residency_region: this.region,
-        subscription_status: SUBSCRIPTION_STATUS.TRIAL,
-        trial_ends_at: trialEnd,
-      });
+        const organization = await tx.organizations.create({
+          name: companyName,
+          subdomain,
+          data_residency_region: this.region,
+          subscription_status: SUBSCRIPTION_STATUS.TRIAL,
+          trial_ends_at: trialEnd,
+        });
 
-      const subscription = await tx.subscriptions.create({
-        organization_id: organization.id,
-        plan_name: PLAN_NAME.TRIAL,
-        status: BILLING_STATUS.TRIAL,
-        current_period_start: now,
-        current_period_end: trialEnd,
-        quotas: getQuotaForPlan(PLAN_NAME.TRIAL),
-      });
+        const subscription = await tx.subscriptions.create({
+          organization_id: organization.id,
+          plan_name: PLAN_NAME.TRIAL,
+          status: BILLING_STATUS.TRIAL,
+          current_period_start: now,
+          current_period_end: trialEnd,
+          quotas: getQuotaForPlan(PLAN_NAME.TRIAL),
+        });
 
-      await tx.organizationMembers.create({
-        organization_id: organization.id,
-        user_id: user.id,
-        role: ORG_MEMBER_ROLE.OWNER,
-      });
+        await tx.organizationMembers.create({
+          organization_id: organization.id,
+          user_id: user.id,
+          role: ORG_MEMBER_ROLE.OWNER,
+        });
 
-      // Fresh org → project count is guaranteed 0, trial quota is 2.
-      // No advisory lock needed (no concurrent project creation possible
-      // on an org that doesn't exist yet outside this transaction).
-      const project = await tx.projects.create({
-        name: DEFAULT_PROJECT_NAME,
-        created_by: user.id,
-        organization_id: organization.id,
-        settings: {},
-      });
+        // Fresh org → project count is guaranteed 0, trial quota is 2.
+        // No advisory lock needed (no concurrent project creation possible
+        // on an org that doesn't exist yet outside this transaction).
+        const project = await tx.projects.create({
+          name: DEFAULT_PROJECT_NAME,
+          created_by: user.id,
+          organization_id: organization.id,
+          settings: {},
+        });
 
-      const plaintextKey = generatePlaintextKey();
-      const keyHash = hashKey(plaintextKey);
-      const { prefix, suffix } = extractKeyMetadata(plaintextKey);
-      const scope = PERMISSION_SCOPE.WRITE;
+        const plaintextKey = generatePlaintextKey();
+        const keyHash = hashKey(plaintextKey);
+        const { prefix, suffix } = extractKeyMetadata(plaintextKey);
+        const scope = PERMISSION_SCOPE.WRITE;
 
-      const apiKey = await tx.apiKeys.create({
-        name: `${DEFAULT_PROJECT_NAME} — SDK key`,
-        description: 'Auto-generated at signup — use this in your SDK init.',
-        type: API_KEY_TYPE.PRODUCTION,
-        permission_scope: scope,
-        permissions: resolvePermissions(scope),
-        allowed_projects: [project.id],
-        key_hash: keyHash,
-        key_prefix: prefix,
-        key_suffix: suffix,
-        created_by: user.id,
-      });
-
-      await tx.apiKeys.logAudit({
-        api_key_id: apiKey.id,
-        action: API_KEY_AUDIT_ACTION.CREATED,
-        performed_by: user.id,
-        changes: {
-          type: apiKey.type,
+        const apiKey = await tx.apiKeys.create({
+          name: `${DEFAULT_PROJECT_NAME} — SDK key`,
+          description: 'Auto-generated at signup — use this in your SDK init.',
+          type: API_KEY_TYPE.PRODUCTION,
           permission_scope: scope,
-          source: 'self-service-signup',
-        },
-      });
+          permissions: resolvePermissions(scope),
+          allowed_projects: [project.id],
+          key_hash: keyHash,
+          key_prefix: prefix,
+          key_suffix: suffix,
+          created_by: user.id,
+        });
 
-      return {
-        user,
-        organization,
-        subscription,
-        project,
-        api_key: plaintextKey,
-        api_key_id: apiKey.id,
-      };
-    });
+        await tx.apiKeys.logAudit({
+          api_key_id: apiKey.id,
+          action: API_KEY_AUDIT_ACTION.CREATED,
+          performed_by: user.id,
+          changes: {
+            type: apiKey.type,
+            permission_scope: scope,
+            source: 'self-service-signup',
+          },
+        });
+
+        return {
+          user,
+          organization,
+          subscription,
+          project,
+          api_key: plaintextKey,
+          api_key_id: apiKey.id,
+        };
+      });
+    } catch (err) {
+      // Race-condition backstop: two concurrent signups can both pass the
+      // read-side checks (findByEmail / isAvailable) and both reach INSERT.
+      // The UNIQUE constraints on users.email and organizations.subdomain
+      // mean one will succeed, the other raises Postgres 23505. Without
+      // this remap, the loser sees a 500 Internal Server Error rather than
+      // the proper 409 Conflict they'd get from the read-side checks.
+      const remapped = remapUniqueViolation(err);
+      if (remapped) {
+        throw remapped;
+      }
+      throw err;
+    }
 
     // Log AFTER commit — logging inside the tx callback would record
     // success even if the COMMIT itself fails.
@@ -273,6 +288,40 @@ function addDays(base: Date, days: number): Date {
   const end = new Date(base);
   end.setDate(end.getDate() + days);
   return end;
+}
+
+/**
+ * Postgres unique_violation SQLSTATE. When a concurrent signup wins the
+ * INSERT race, the loser's transaction raises this code.
+ */
+const PG_UNIQUE_VIOLATION = '23505';
+
+/**
+ * If `err` is a Postgres unique_violation, return a user-facing 409 AppError
+ * with a hint about which field collided; otherwise return null so the
+ * caller can rethrow the original error.
+ *
+ * We inspect `error.constraint` (the PG constraint name) to pick the
+ * message. Unknown constraints fall back to a generic "already exists"
+ * message so we never leak raw SQL identifiers to the client.
+ */
+function remapUniqueViolation(err: unknown): AppError | null {
+  if (!err || typeof err !== 'object') {
+    return null;
+  }
+  const candidate = err as { code?: unknown; constraint?: unknown };
+  if (candidate.code !== PG_UNIQUE_VIOLATION) {
+    return null;
+  }
+
+  const constraint = typeof candidate.constraint === 'string' ? candidate.constraint : '';
+  if (constraint.includes('email') || constraint.includes('users')) {
+    return new AppError('User with this email already exists', 409, 'Conflict');
+  }
+  if (constraint.includes('subdomain') || constraint.includes('organizations')) {
+    return new AppError('This subdomain is already taken', 409, 'Conflict');
+  }
+  return new AppError('A conflicting record already exists', 409, 'Conflict');
 }
 
 /** Resolve a region string from config into the DataResidencyRegion enum, or throw. */

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -1,0 +1,218 @@
+/**
+ * Subdomain Service
+ * Generates and validates tenant subdomains for self-service signup.
+ * Handles slugification, reserved-name blocking, uniqueness across
+ * `organizations` and `organization_requests` (to avoid collision when
+ * a pending enterprise request is later approved).
+ */
+
+import type { DatabaseClient } from '../../db/client.js';
+import { AppError } from '../../api/middleware/error.js';
+
+const SUBDOMAIN_MIN_LENGTH = 3;
+const SUBDOMAIN_MAX_LENGTH = 63;
+const MAX_AUTO_SUFFIX_ATTEMPTS = 50;
+
+/**
+ * DNS-safe subdomain pattern: lowercase alphanumeric + single hyphens,
+ * no leading/trailing hyphen, 3–63 chars (LDH rule minus TLD constraints).
+ */
+const SUBDOMAIN_REGEX = /^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$/;
+
+/**
+ * Subdomains reserved for platform infrastructure. Blocking these prevents
+ * tenants from impersonating api/admin/support surfaces or colliding with
+ * existing DNS records on *.kz.bugspotter.io.
+ */
+const RESERVED_SUBDOMAINS = new Set([
+  // Platform infra
+  'app',
+  'api',
+  'admin',
+  'www',
+  'mail',
+  'static',
+  'cdn',
+  'assets',
+  'media',
+  'uploads',
+  'files',
+  // Environments
+  'staging',
+  'dev',
+  'test',
+  'demo',
+  'preview',
+  'sandbox',
+  'local',
+  // Product surfaces
+  'docs',
+  'blog',
+  'status',
+  'help',
+  'support',
+  'billing',
+  'auth',
+  'login',
+  'signup',
+  'register',
+  'onboarding',
+  // Generic reserved
+  'root',
+  'system',
+  'public',
+  'private',
+  'internal',
+  // Monitoring/ops
+  'grafana',
+  'prometheus',
+  'kibana',
+  'logs',
+  'metrics',
+]);
+
+export class SubdomainService {
+  constructor(private readonly db: DatabaseClient) {}
+
+  /**
+   * Convert an organization name into a DNS-safe subdomain candidate.
+   * Strategy: lowercase → replace non-[a-z0-9] with hyphens → collapse
+   * consecutive hyphens → trim leading/trailing hyphens → truncate to
+   * SUBDOMAIN_MAX_LENGTH → trim edge hyphens again in case the truncation
+   * landed on one.
+   * Returns empty string if nothing usable remains (caller must handle).
+   */
+  slugify(input: string): string {
+    const normalized = input
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+
+    // Truncate first, then re-trim — truncation can land on a `-` and leave
+    // a trailing hyphen that would fail LDH validation.
+    return normalized.slice(0, SUBDOMAIN_MAX_LENGTH).replace(/^-|-$/g, '');
+  }
+
+  /**
+   * Validate subdomain format and reserved-name policy.
+   * Does NOT check uniqueness — use isAvailable() for that.
+   */
+  validateFormat(subdomain: string): void {
+    if (subdomain.length < SUBDOMAIN_MIN_LENGTH) {
+      throw new AppError(
+        `Subdomain must be at least ${SUBDOMAIN_MIN_LENGTH} characters`,
+        400,
+        'ValidationError'
+      );
+    }
+    if (subdomain.length > SUBDOMAIN_MAX_LENGTH) {
+      throw new AppError(
+        `Subdomain must be at most ${SUBDOMAIN_MAX_LENGTH} characters`,
+        400,
+        'ValidationError'
+      );
+    }
+    if (!SUBDOMAIN_REGEX.test(subdomain)) {
+      throw new AppError(
+        'Subdomain must contain only lowercase letters, numbers, and hyphens (no leading/trailing hyphen)',
+        400,
+        'ValidationError'
+      );
+    }
+    if (RESERVED_SUBDOMAINS.has(subdomain)) {
+      throw new AppError('This subdomain is reserved', 400, 'ValidationError');
+    }
+  }
+
+  /**
+   * Check if a subdomain is available across both `organizations` (active
+   * tenants — subdomain stays reserved for soft-deleted rows until hard
+   * delete) and `organization_requests` (non-terminal enterprise flow that
+   * could later approve into a real org).
+   *
+   * The pre-existing `organizationRequests.isSubdomainTaken()` queries the
+   * organizations table despite its name; we use the request-table-specific
+   * method here to get the intended behavior.
+   */
+  async isAvailable(subdomain: string): Promise<boolean> {
+    const normalized = subdomain.toLowerCase();
+
+    const orgTaken = !(await this.db.organizations.isSubdomainAvailable(normalized));
+    if (orgTaken) {
+      return false;
+    }
+
+    const requestReserved =
+      await this.db.organizationRequests.isSubdomainReservedByRequest(normalized);
+    if (requestReserved) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Generate a unique subdomain from a seed (e.g. company name).
+   * If the slugified seed collides, appends numeric suffixes (-2, -3, ...).
+   * Throws if the seed yields no usable slug or suffixes exhaust.
+   *
+   * Used for auto-suggesting a subdomain from company_name at signup.
+   * The caller may still let the user override before commit.
+   */
+  async generateUniqueFromName(name: string): Promise<string> {
+    const base = this.slugify(name);
+    if (base.length < SUBDOMAIN_MIN_LENGTH) {
+      throw new AppError(
+        'Could not derive a valid subdomain from the organization name',
+        400,
+        'ValidationError',
+        { hint: 'Try a name with at least 3 alphanumeric characters' }
+      );
+    }
+
+    // Reserved base → fall through to suffixed attempts, which are not reserved.
+    const baseUsable = !RESERVED_SUBDOMAINS.has(base);
+
+    if (baseUsable && (await this.isAvailable(base))) {
+      return base;
+    }
+
+    for (let i = 2; i <= MAX_AUTO_SUFFIX_ATTEMPTS; i++) {
+      // Leave room for the suffix so total length stays within limit.
+      // Re-trim the sliced base so we don't end up with "foo--2" when the
+      // cut-off character is a hyphen.
+      const suffix = `-${i}`;
+      const maxBase = SUBDOMAIN_MAX_LENGTH - suffix.length;
+      const trimmedBase = base.slice(0, maxBase).replace(/-+$/, '');
+      if (trimmedBase.length < SUBDOMAIN_MIN_LENGTH) {
+        continue;
+      }
+      const candidate = `${trimmedBase}${suffix}`;
+      if (await this.isAvailable(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new AppError(
+      'Could not generate a unique subdomain — please choose one manually',
+      409,
+      'Conflict'
+    );
+  }
+
+  /**
+   * Full validation pipeline for a user-provided subdomain at signup:
+   * normalize → format check → reserved check → uniqueness.
+   * Throws AppError with a specific code on any failure.
+   */
+  async assertValidAndAvailable(subdomain: string): Promise<string> {
+    const normalized = subdomain.toLowerCase().trim();
+    this.validateFormat(normalized);
+    if (!(await this.isAvailable(normalized))) {
+      throw new AppError('This subdomain is already taken', 409, 'Conflict');
+    }
+    return normalized;
+  }
+}

--- a/packages/backend/tests/config.test.ts
+++ b/packages/backend/tests/config.test.ts
@@ -292,6 +292,29 @@ describe('Application Configuration', () => {
       expect(() => validateConfig()).toThrow('Invalid STORAGE_BACKEND');
     });
 
+    it('should throw at startup for an unknown DATA_RESIDENCY_REGION', async () => {
+      // Regression guard: a misconfigured region previously surfaced as a
+      // generic 500 on the first /api/v1/auth/signup call, which is a bad
+      // operational signal. Fail fast at boot instead.
+      process.env.DATABASE_URL = 'postgres://localhost/db';
+      process.env.DATA_RESIDENCY_REGION = 'moon';
+
+      const { validateConfig } = await import('../src/config.js');
+
+      expect(() => validateConfig()).toThrow('Configuration validation failed');
+      expect(() => validateConfig()).toThrow('Invalid DATA_RESIDENCY_REGION');
+    });
+
+    it('should accept all documented DATA_RESIDENCY_REGION values', async () => {
+      for (const region of ['kz', 'rf', 'eu', 'us', 'global']) {
+        vi.resetModules();
+        process.env = { ...originalEnv, DATABASE_URL: 'postgres://localhost/db' };
+        process.env.DATA_RESIDENCY_REGION = region;
+        const { validateConfig } = await import('../src/config.js');
+        expect(() => validateConfig()).not.toThrow(/DATA_RESIDENCY_REGION/);
+      }
+    });
+
     it('should throw error for mismatched S3 credentials', async () => {
       process.env.DATABASE_URL = 'postgres://localhost/db';
       process.env.STORAGE_BACKEND = 's3';

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -1,0 +1,352 @@
+/**
+ * SignupService Unit Tests
+ * Covers the happy path plus the contract boundaries:
+ * - duplicate email → 409 (before any DB writes)
+ * - spam filter rejection → 403
+ * - spam filter error → 503 (fail closed, not fail open)
+ * - invalid subdomain → 409
+ * - atomic transaction: all 6 inserts or none
+ * - API key returned in plaintext; stored as SHA-256 hash
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SignupService } from '../../src/saas/services/signup.service.js';
+import type { DatabaseClient } from '../../src/db/client.js';
+import { DATA_RESIDENCY_REGION } from '../../src/db/types.js';
+import { hashKey } from '../../src/services/api-key/key-crypto.js';
+
+vi.mock('../../src/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+interface InsertLog {
+  users: unknown[];
+  organizations: unknown[];
+  subscriptions: unknown[];
+  organizationMembers: unknown[];
+  projects: unknown[];
+  apiKeys: unknown[];
+  apiKeyAudits: unknown[];
+}
+
+function validInput() {
+  return {
+    email: 'Founder@Acme.com',
+    password: 'correct-horse-battery-staple',
+    name: 'Jane Founder',
+    company_name: 'Acme Corp',
+    ip_address: '203.0.113.7',
+    honeypot: null,
+  };
+}
+
+interface DbOverrides {
+  findByEmail?: () => Promise<unknown>;
+  countRecentByIp?: () => Promise<number>;
+  findPendingByEmail?: () => Promise<unknown>;
+  isSubdomainTaken?: () => Promise<boolean>;
+  isSubdomainReservedByRequest?: () => Promise<boolean>;
+  orgIsSubdomainAvailable?: () => Promise<boolean>;
+  spamFilterThrows?: boolean;
+  transactionThrows?: boolean;
+}
+
+function createMockDb(overrides: DbOverrides = {}): {
+  db: DatabaseClient;
+  log: InsertLog;
+  transactionCalled: { value: number };
+} {
+  const log: InsertLog = {
+    users: [],
+    organizations: [],
+    subscriptions: [],
+    organizationMembers: [],
+    projects: [],
+    apiKeys: [],
+    apiKeyAudits: [],
+  };
+  const transactionCalled = { value: 0 };
+
+  const tx = {
+    users: {
+      create: vi.fn(async (data: unknown) => {
+        const user = { id: 'user-uuid', created_at: new Date(), ...(data as object) };
+        log.users.push(user);
+        return user;
+      }),
+    },
+    organizations: {
+      create: vi.fn(async (data: unknown) => {
+        const org = {
+          id: 'org-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.organizations.push(org);
+        return org;
+      }),
+    },
+    subscriptions: {
+      create: vi.fn(async (data: unknown) => {
+        const sub = {
+          id: 'sub-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.subscriptions.push(sub);
+        return sub;
+      }),
+    },
+    organizationMembers: {
+      create: vi.fn(async (data: unknown) => {
+        log.organizationMembers.push(data);
+        return { id: 'member-uuid', ...(data as object) };
+      }),
+    },
+    projects: {
+      create: vi.fn(async (data: unknown) => {
+        const project = {
+          id: 'project-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.projects.push(project);
+        return project;
+      }),
+    },
+    apiKeys: {
+      create: vi.fn(async (data: unknown) => {
+        const key = {
+          id: 'apikey-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.apiKeys.push(key);
+        return key;
+      }),
+      logAudit: vi.fn(async (data: unknown) => {
+        log.apiKeyAudits.push(data);
+      }),
+    },
+  };
+
+  const db = {
+    users: {
+      findByEmail: vi.fn(overrides.findByEmail ?? (async () => null)),
+    },
+    organizations: {
+      isSubdomainAvailable: vi.fn(overrides.orgIsSubdomainAvailable ?? (async () => true)),
+    },
+    organizationRequests: {
+      countRecentByIp: vi.fn(overrides.countRecentByIp ?? (async () => 0)),
+      findPendingByEmail: vi.fn(overrides.findPendingByEmail ?? (async () => null)),
+      isSubdomainTaken: vi.fn(overrides.isSubdomainTaken ?? (async () => false)),
+      isSubdomainReservedByRequest: vi.fn(
+        overrides.isSubdomainReservedByRequest ?? (async () => false)
+      ),
+    },
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+      transactionCalled.value++;
+      if (overrides.transactionThrows) {
+        throw new Error('simulated commit failure');
+      }
+      return cb(tx);
+    }),
+  } as unknown as DatabaseClient;
+
+  if (overrides.spamFilterThrows) {
+    (db.organizationRequests.countRecentByIp as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('db connection lost')
+    );
+  }
+
+  return { db, log, transactionCalled };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SignupService', () => {
+  let mock: ReturnType<typeof createMockDb>;
+  let service: SignupService;
+
+  beforeEach(() => {
+    mock = createMockDb();
+    service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+  });
+
+  describe('happy path', () => {
+    it('provisions all 6 records in a single transaction', async () => {
+      const result = await service.signup(validInput());
+
+      expect(mock.transactionCalled.value).toBe(1);
+      expect(mock.log.users).toHaveLength(1);
+      expect(mock.log.organizations).toHaveLength(1);
+      expect(mock.log.subscriptions).toHaveLength(1);
+      expect(mock.log.organizationMembers).toHaveLength(1);
+      expect(mock.log.projects).toHaveLength(1);
+      expect(mock.log.apiKeys).toHaveLength(1);
+      expect(mock.log.apiKeyAudits).toHaveLength(1);
+
+      expect(result.user.id).toBe('user-uuid');
+      expect(result.organization.id).toBe('org-uuid');
+      expect(result.project.id).toBe('project-uuid');
+      expect(result.api_key).toMatch(/^bgs_/);
+      expect(result.api_key_id).toBe('apikey-uuid');
+    });
+
+    it('stores the API key as a SHA-256 hex hash (not plaintext, not bcrypt)', async () => {
+      const result = await service.signup(validInput());
+      const storedKey = mock.log.apiKeys[0] as { key_hash: string };
+
+      // SHA-256 hex is always 64 hex chars.
+      expect(storedKey.key_hash).toMatch(/^[0-9a-f]{64}$/);
+      // And it verifiably matches the plaintext via the shared hashKey().
+      expect(storedKey.key_hash).toBe(hashKey(result.api_key));
+    });
+
+    it('hashes the password with bcrypt before storing', async () => {
+      await service.signup(validInput());
+      const storedUser = mock.log.users[0] as { password_hash: string };
+
+      expect(storedUser.password_hash).not.toBe(validInput().password);
+      // bcrypt hashes start with $2a$, $2b$, or $2y$
+      expect(storedUser.password_hash).toMatch(/^\$2[aby]\$/);
+    });
+
+    it('normalizes email to lowercase and trims whitespace', async () => {
+      await service.signup({ ...validInput(), email: '  Founder@Acme.COM  ' });
+      const storedUser = mock.log.users[0] as { email: string };
+      expect(storedUser.email).toBe('founder@acme.com');
+    });
+
+    it('uses the configured data residency region, not anything from input', async () => {
+      const rfService = new SignupService(mock.db, DATA_RESIDENCY_REGION.RF);
+      await rfService.signup(validInput());
+      const storedOrg = mock.log.organizations[0] as { data_residency_region: string };
+      expect(storedOrg.data_residency_region).toBe('rf');
+    });
+
+    it('auto-generates subdomain from company name when not provided', async () => {
+      await service.signup({ ...validInput(), company_name: 'Acme Widgets LLC' });
+      const storedOrg = mock.log.organizations[0] as { subdomain: string };
+      expect(storedOrg.subdomain).toBe('acme-widgets-llc');
+    });
+
+    it('uses the user-supplied subdomain when provided', async () => {
+      await service.signup({ ...validInput(), subdomain: 'my-custom-sub' });
+      const storedOrg = mock.log.organizations[0] as { subdomain: string };
+      expect(storedOrg.subdomain).toBe('my-custom-sub');
+    });
+
+    it('issues a write-scoped API key limited to the new project', async () => {
+      const result = await service.signup(validInput());
+      const storedKey = mock.log.apiKeys[0] as {
+        permission_scope: string;
+        allowed_projects: string[];
+      };
+      expect(storedKey.permission_scope).toBe('write');
+      expect(storedKey.allowed_projects).toEqual([result.project.id]);
+    });
+
+    it('uses the same timestamp for trial_ends_at and current_period_end', async () => {
+      await service.signup(validInput());
+      const storedOrg = mock.log.organizations[0] as { trial_ends_at: Date };
+      const storedSub = mock.log.subscriptions[0] as { current_period_end: Date };
+      expect(storedOrg.trial_ends_at.getTime()).toBe(storedSub.current_period_end.getTime());
+    });
+  });
+
+  describe('validation failures', () => {
+    it('rejects empty company_name with 400', async () => {
+      await expect(service.signup({ ...validInput(), company_name: '   ' })).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects duplicate email with 409 and never opens a transaction', async () => {
+      mock = createMockDb({
+        findByEmail: async () => ({ id: 'existing-user' }),
+      });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects when user-supplied subdomain is taken with 409', async () => {
+      mock = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup({ ...validInput(), subdomain: 'taken' })).rejects.toMatchObject({
+        statusCode: 409,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects when subdomain is held by a pending enterprise request', async () => {
+      mock = createMockDb({ isSubdomainReservedByRequest: async () => true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(
+        service.signup({ ...validInput(), subdomain: 'reserved' })
+      ).rejects.toMatchObject({ statusCode: 409 });
+    });
+  });
+
+  describe('spam filter', () => {
+    it('rejects honeypot-filled submissions with 403 (bot signature)', async () => {
+      await expect(
+        service.signup({ ...validInput(), honeypot: 'spam-bot-filled-this' })
+      ).rejects.toMatchObject({ statusCode: 403 });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects IP rate-limited submissions with 403', async () => {
+      mock = createMockDb({ countRecentByIp: async () => 10 });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 403,
+      });
+    });
+
+    it('fails CLOSED when the spam filter itself errors (503, not allow-through)', async () => {
+      // Regression guard: the first PR revision caught this error and let the
+      // signup proceed, effectively disabling rate-limits during DB outages.
+      mock = createMockDb({ spamFilterThrows: true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 503,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+  });
+
+  describe('transaction atomicity', () => {
+    it('surfaces a commit failure to the caller and does not return a partial result', async () => {
+      mock = createMockDb({ transactionThrows: true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toThrow(/simulated commit failure/);
+    });
+  });
+});

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -4,7 +4,8 @@
  * - duplicate email → 409 (before any DB writes)
  * - spam filter rejection → 403
  * - spam filter error → 503 (fail closed, not fail open)
- * - invalid subdomain → 409
+ * - invalid subdomain format → 400 ValidationError; taken/reserved subdomain → 409
+ * - concurrent-insert race (Postgres 23505) → 409, not 500
  * - atomic transaction: all 6 inserts or none
  * - API key returned in plaintext; stored as SHA-256 hash
  */
@@ -338,6 +339,70 @@ describe('SignupService', () => {
         statusCode: 503,
       });
       expect(mock.transactionCalled.value).toBe(0);
+    });
+  });
+
+  describe('unique-violation race', () => {
+    // Two concurrent signups can both pass the read-side checks (findByEmail,
+    // isAvailable) and both reach INSERT. The Postgres UNIQUE constraints on
+    // users.email and organizations.subdomain ensure one wins and the loser
+    // raises 23505. These tests guard that we remap to 409 (not 500).
+
+    function createMockDbWithUniqueViolation(constraint: string) {
+      const { db, log, transactionCalled } = createMockDb();
+      // Override the tx callback to throw a Postgres-shaped error with the
+      // given constraint name. This simulates the loser of an INSERT race.
+      (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        transactionCalled.value++;
+        const err = new Error('duplicate key value violates unique constraint') as Error & {
+          code: string;
+          constraint: string;
+        };
+        err.code = '23505';
+        err.constraint = constraint;
+        throw err;
+      });
+      return { db, log, transactionCalled };
+    }
+
+    it('maps a users.email UNIQUE violation to 409 Conflict', async () => {
+      const raceMock = createMockDbWithUniqueViolation('users_email_key');
+      service = new SignupService(raceMock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringMatching(/email/i) as unknown as string,
+      });
+    });
+
+    it('maps an organizations.subdomain UNIQUE violation to 409 Conflict', async () => {
+      const raceMock = createMockDbWithUniqueViolation('organizations_subdomain_key');
+      service = new SignupService(raceMock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringMatching(/subdomain/i) as unknown as string,
+      });
+    });
+
+    it('maps an unknown UNIQUE violation to a generic 409 (no SQL identifier leak)', async () => {
+      const raceMock = createMockDbWithUniqueViolation('some_internal_constraint');
+      service = new SignupService(raceMock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+      });
+    });
+
+    it('does NOT swallow unrelated errors (only 23505 is remapped)', async () => {
+      const { db, transactionCalled } = createMockDb();
+      (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        transactionCalled.value++;
+        throw new Error('unrelated internal error');
+      });
+      service = new SignupService(db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toThrow(/unrelated internal error/);
     });
   });
 

--- a/packages/backend/tests/saas/subdomain.service.test.ts
+++ b/packages/backend/tests/saas/subdomain.service.test.ts
@@ -1,0 +1,237 @@
+/**
+ * SubdomainService Unit Tests
+ * Covers slugification (including truncation edge cases), format validation,
+ * reserved-name policy, cross-table availability, and unique-name generation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SubdomainService } from '../../src/saas/services/subdomain.service.js';
+import type { DatabaseClient } from '../../src/db/client.js';
+
+vi.mock('../../src/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+interface MockOverrides {
+  orgIsSubdomainAvailable?: (sd: string) => Promise<boolean>;
+  requestIsReserved?: (sd: string) => Promise<boolean>;
+}
+
+function createMockDb(overrides: MockOverrides = {}) {
+  const orgIsSubdomainAvailable = overrides.orgIsSubdomainAvailable ?? (async () => true);
+  const requestIsReserved = overrides.requestIsReserved ?? (async () => false);
+  return {
+    organizations: {
+      isSubdomainAvailable: vi.fn(orgIsSubdomainAvailable),
+    },
+    organizationRequests: {
+      isSubdomainReservedByRequest: vi.fn(requestIsReserved),
+    },
+  } as unknown as DatabaseClient;
+}
+
+describe('SubdomainService', () => {
+  let db: DatabaseClient;
+  let service: SubdomainService;
+
+  beforeEach(() => {
+    db = createMockDb();
+    service = new SubdomainService(db);
+  });
+
+  describe('slugify()', () => {
+    it('lowercases and hyphenates a normal name', () => {
+      expect(service.slugify('Acme Corp')).toBe('acme-corp');
+    });
+
+    it('collapses consecutive special chars into a single hyphen', () => {
+      expect(service.slugify('Acme & Co., Ltd.')).toBe('acme-co-ltd');
+    });
+
+    it('trims leading and trailing hyphens', () => {
+      expect(service.slugify('  -- Acme --  ')).toBe('acme');
+    });
+
+    it('strips non-ascii alphanumerics', () => {
+      // Cyrillic → replaced by hyphens → collapsed → trimmed → empty
+      expect(service.slugify('ПримерОрг')).toBe('');
+    });
+
+    it('keeps digits', () => {
+      expect(service.slugify('Company 123')).toBe('company-123');
+    });
+
+    it('re-trims after truncation so the result never ends in a hyphen', () => {
+      // Build a 64-char string whose 64th char is a letter, but where the
+      // cut-off at char 63 lands on a hyphen.
+      // Pattern: 62 a's + '-' at index 62 (so slice(0, 63) includes it) + 'b'.
+      const input = 'a'.repeat(62) + '-' + 'b';
+      expect(input.length).toBe(64);
+      const out = service.slugify(input);
+      expect(out.length).toBeLessThanOrEqual(63);
+      expect(out.endsWith('-')).toBe(false);
+      expect(out).toBe('a'.repeat(62));
+    });
+
+    it('returns empty string for input with no usable characters', () => {
+      expect(service.slugify('!!!')).toBe('');
+      expect(service.slugify('')).toBe('');
+    });
+  });
+
+  describe('validateFormat()', () => {
+    it('accepts valid subdomains', () => {
+      expect(() => service.validateFormat('acme')).not.toThrow();
+      expect(() => service.validateFormat('acme-co')).not.toThrow();
+      expect(() => service.validateFormat('a1b')).not.toThrow();
+    });
+
+    it('rejects subdomains shorter than 3 characters', () => {
+      expect(() => service.validateFormat('ab')).toThrow(/at least 3/);
+    });
+
+    it('rejects subdomains longer than 63 characters', () => {
+      expect(() => service.validateFormat('a'.repeat(64))).toThrow(/at most 63/);
+    });
+
+    it('rejects uppercase letters', () => {
+      expect(() => service.validateFormat('Acme')).toThrow(/lowercase/);
+    });
+
+    it('rejects underscores and other non-LDH characters', () => {
+      expect(() => service.validateFormat('acme_co')).toThrow();
+      expect(() => service.validateFormat('acme.co')).toThrow();
+    });
+
+    it('rejects leading or trailing hyphens', () => {
+      expect(() => service.validateFormat('-acme')).toThrow();
+      expect(() => service.validateFormat('acme-')).toThrow();
+    });
+
+    it('rejects reserved names', () => {
+      expect(() => service.validateFormat('api')).toThrow(/reserved/);
+      expect(() => service.validateFormat('admin')).toThrow(/reserved/);
+      expect(() => service.validateFormat('signup')).toThrow(/reserved/);
+    });
+  });
+
+  describe('isAvailable()', () => {
+    it('returns true when neither table holds the subdomain', async () => {
+      expect(await service.isAvailable('new-co')).toBe(true);
+    });
+
+    it('returns false when organizations table already holds it', async () => {
+      db = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SubdomainService(db);
+      expect(await service.isAvailable('taken')).toBe(false);
+    });
+
+    it('returns false when a non-terminal organization request holds it', async () => {
+      // Regression guard for the bug in the first PR revision, where the
+      // second check called `isSubdomainTaken` (which actually queries the
+      // organizations table) and never blocked a pending enterprise request.
+      db = createMockDb({ requestIsReserved: async () => true });
+      service = new SubdomainService(db);
+      expect(await service.isAvailable('reserved-by-request')).toBe(false);
+    });
+
+    it('normalizes the input to lowercase before checking', async () => {
+      const orgFn = vi.fn().mockResolvedValue(true);
+      const reqFn = vi.fn().mockResolvedValue(false);
+      db = {
+        organizations: { isSubdomainAvailable: orgFn },
+        organizationRequests: { isSubdomainReservedByRequest: reqFn },
+      } as unknown as DatabaseClient;
+      service = new SubdomainService(db);
+      await service.isAvailable('Mixed-CASE');
+      expect(orgFn).toHaveBeenCalledWith('mixed-case');
+      expect(reqFn).toHaveBeenCalledWith('mixed-case');
+    });
+  });
+
+  describe('generateUniqueFromName()', () => {
+    it('returns the clean slug when available', async () => {
+      expect(await service.generateUniqueFromName('Acme Corp')).toBe('acme-corp');
+    });
+
+    it('throws a ValidationError when the seed yields too few characters', async () => {
+      await expect(service.generateUniqueFromName('!!')).rejects.toThrow(
+        /Could not derive a valid subdomain/
+      );
+    });
+
+    it('appends a numeric suffix on collision', async () => {
+      let callCount = 0;
+      const orgFn = vi.fn().mockImplementation(async () => {
+        callCount++;
+        // First call (base "acme-corp") collides, all subsequent return available.
+        return callCount !== 1;
+      });
+      db = {
+        organizations: { isSubdomainAvailable: orgFn },
+        organizationRequests: { isSubdomainReservedByRequest: vi.fn().mockResolvedValue(false) },
+      } as unknown as DatabaseClient;
+      service = new SubdomainService(db);
+
+      const result = await service.generateUniqueFromName('Acme Corp');
+      expect(result).toBe('acme-corp-2');
+    });
+
+    it('skips a reserved base and falls through to suffixed attempts', async () => {
+      const result = await service.generateUniqueFromName('api');
+      // 'api' is reserved but 'api-2' is not and isAvailable returns true.
+      expect(result).toBe('api-2');
+    });
+
+    it('throws Conflict when all suffix attempts exhaust', async () => {
+      db = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SubdomainService(db);
+      await expect(service.generateUniqueFromName('Acme Corp')).rejects.toThrow(
+        /Could not generate a unique subdomain/
+      );
+    });
+
+    it('handles base near the 63-char limit without producing "foo--2"', async () => {
+      // Craft a base that would be exactly 63 chars ending in a letter, so
+      // when we slice to make room for '-2' (3 chars), the slice boundary
+      // lands at char 60. Pad so the slice boundary would be a hyphen and
+      // verify we DON'T emit '--2'.
+      const name = 'a'.repeat(60) + '-company'; // slugifies to "aaaa...a-company"
+      // Force collision on the base so it falls into the suffix loop.
+      const orgFn = vi
+        .fn()
+        .mockImplementationOnce(async () => false) // base collides
+        .mockResolvedValue(true);
+      db = {
+        organizations: { isSubdomainAvailable: orgFn },
+        organizationRequests: { isSubdomainReservedByRequest: vi.fn().mockResolvedValue(false) },
+      } as unknown as DatabaseClient;
+      service = new SubdomainService(db);
+
+      const result = await service.generateUniqueFromName(name);
+      expect(result).not.toMatch(/--/);
+      expect(result.endsWith('-2')).toBe(true);
+    });
+  });
+
+  describe('assertValidAndAvailable()', () => {
+    it('returns normalized subdomain on happy path', async () => {
+      expect(await service.assertValidAndAvailable('  AcmeCo ')).toBe('acmeco');
+    });
+
+    it('throws 400 for invalid format', async () => {
+      await expect(service.assertValidAndAvailable('A_B')).rejects.toThrow();
+    });
+
+    it('throws 409 when already taken', async () => {
+      db = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SubdomainService(db);
+      await expect(service.assertValidAndAvailable('taken')).rejects.toThrow(/already taken/);
+    });
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -60,6 +60,8 @@ export default defineConfig({
       'tests/api/utils/enrichment-trigger.test.ts',
       'tests/services/intelligence/dedup-service.test.ts',
       'tests/services/intelligence/self-service.test.ts',
+      // Pure env-var / config validation test, no DB.
+      'tests/config.test.ts',
     ],
     testTimeout: 10000,
     hookTimeout: 10000,

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
       'tests/saas/invitation-email.service.test.ts',
       'tests/saas/plans.test.ts',
       'tests/saas/spam-filter.service.test.ts',
+      'tests/saas/subdomain.service.test.ts',
+      'tests/saas/signup.service.test.ts',
       'tests/saas/tenant-middleware.test.ts',
       // Integration tests that don't require database
       'tests/integrations/plugin-utils-retry.test.ts',


### PR DESCRIPTION
## Summary

Phase 1 of the self-service signup MVP. Adds `POST /api/v1/auth/signup` — a Sentry-style instant onboarding endpoint.

- **One atomic transaction** provisions user + organization + trial subscription + owner membership + default project + write-scoped API key for SDK ingestion. Returns JWTs + plaintext key in a single response.
- **Separate from `/auth/register`** (user-only) and `/organization-requests` (admin-approved enterprise flow) — both preserved unchanged.
- **New config flags**: `SELF_SERVICE_SIGNUP_ENABLED` (default saas-on, self-hosted-off), `COOKIE_DOMAIN` (empty on self-hosted; sets `domain` + `sameSite=lax` for cross-subdomain SSO when set), `DATA_RESIDENCY_REGION` (default `kz`, read from server config — never from request body).
- **Shared `generateAuthTokens` helper** replaces the duplicated token-signing logic across `/register`, `/login`, `/refresh`, `/magic-login`, `/signup`.

## Design notes

**API key scope**: Uses `PERMISSION_SCOPE.WRITE` (reports:read/write + sessions:read/write) — the SDK minimum. No dedicated `ingest` scope exists in the enum; adding one would need a DB CHECK-constraint migration. Flagged in code comments.

**Subdomain uniqueness**: The existing `organizationRequests.isSubdomainTaken()` method is misnamed — it queries the `organizations` table, not `organization_requests`. I added a correctly-named `isSubdomainReservedByRequest()` that queries the actual request table for non-terminal statuses (`pending_verification`, `verified`, `approved`). This prevents a self-service signup from racing an enterprise request that hasn't yet materialized into a real org.

**Fail-closed spam filter**: If the spam check itself errors (DB outage, connection loss), the signup is refused with 503. Letting requests through during a degraded state would silently disable rate-limit/honeypot/duplicate-email protections — exactly the moment abuse is most likely.

**Slugify truncation**: Re-trim edge hyphens after `.slice(0, 63)` — previously a 64th-char hyphen could produce an invalid subdomain. `generateUniqueFromName` also re-trims the sliced base before suffixing so we never emit `foo--2`.

**Single transaction timestamp**: `now` is captured once and reused for `trial_ends_at`, `current_period_start`, `current_period_end` so records don't drift by microseconds. Success log emitted *after* commit, not inside the tx callback.

## Tests

44 new unit tests (all passing):

- **SubdomainService (27 tests)**: slugify happy path + truncation edge cases, format validation (length, case, LDH rule, reserved names), cross-table availability with explicit regression guard for the bug above, unique-name generation (base collision, reserved base fall-through, exhaustion, hyphen-avoidance near length limit), assertValidAndAvailable.
- **SignupService (17 tests)**: happy path (all 6 inserts committed in one tx), SHA-256 API key hashing (not bcrypt, not plaintext), bcrypt password hashing, email normalization, region from config, auto vs explicit subdomain, write-scoped key limited to new project, single-timestamp consistency, validation failures (empty company, duplicate email, subdomain taken, reserved by request), spam rejection (honeypot, rate limit), **fail-closed** spam filter (503 on error — regression guard), commit-failure propagation.

## Review feedback incorporated

This PR incorporates the 4 bug fixes, 2 refactors, and security concern from automated reviews on the initial draft PR in the private repo:

- Corrected module-level and field-level doc comments (`write`-scoped not `ingest`-scoped; DB stores SHA-256 hex not bcrypt hash).
- Fixed the `isAvailable()` redundancy that didn't actually block pending enterprise requests.
- Fixed the slugify trailing-hyphen-after-truncation edge case.
- Switched the spam-filter error path from fail-open to fail-closed (503).
- Extracted duplicated JWT signing into `generateAuthTokens`.
- Moved success logging out of the transaction callback.

## Test plan

- [x] Unit tests: `pnpm test:unit tests/saas/signup.service.test.ts tests/saas/subdomain.service.test.ts` — 44/44 passing.
- [x] Existing auth tests still green: `pnpm test:unit tests/api/auth-handlers.test.ts tests/api/auth-responses.test.ts` — 30/30 passing.
- [x] Source typecheck: `npx tsc --noEmit -p tsconfig.json` — clean.
- [ ] Manual `curl POST /api/v1/auth/signup` on a deployed instance.
- [ ] Verify refresh_token cookie gets `domain=.kz.bugspotter.io` + `SameSite=Lax` when `COOKIE_DOMAIN` is configured.
- [ ] Integration test against real DB (follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)