### PR TITLE
feat: self-service signup backend (R1)

### DIFF
--- a/packages/backend/src/api/routes/auth.ts
+++ b/packages/backend/src/api/routes/auth.ts
@@ -18,7 +18,12 @@ import { config } from '../../config.js';
 import { InvitationService } from '../../saas/services/invitation.service.js';
 import { sendSuccess, sendCreated } from '../utils/response.js';
 import { findOrThrow, omitFields } from '../utils/resource.js';
-import { PASSWORD, parseTimeString, DEFAULT_TOKEN_EXPIRY_SECONDS } from '../utils/constants.js';
+import { PASSWORD } from '../utils/constants.js';
+import {
+  buildRefreshCookieOptions,
+  buildClearRefreshCookieOptions,
+} from '../utils/auth-cookies.js';
+import { generateAuthTokens } from '../utils/auth-tokens.js';
 import {
   checkLockoutStatus,
   recordFailedAttempt,
@@ -42,36 +47,6 @@ interface RegisterBody {
 
 interface RefreshTokenBody {
   refresh_token: string;
-}
-
-/**
- * Generate JWT tokens for a user
- */
-function generateTokens(fastify: FastifyInstance, user: User) {
-  const payload = { userId: user.id, isPlatformAdmin: isPlatformAdmin(user) };
-
-  const access_token = fastify.jwt.sign(payload, {
-    expiresIn: config.jwt.expiresIn,
-  });
-
-  const refresh_token = fastify.jwt.sign(payload, {
-    expiresIn: config.jwt.refreshExpiresIn,
-  });
-
-  // Calculate expiry time in seconds
-  const expiresIn = parseTimeString(config.jwt.expiresIn, DEFAULT_TOKEN_EXPIRY_SECONDS);
-  const refreshExpiresIn = parseTimeString(
-    config.jwt.refreshExpiresIn,
-    DEFAULT_TOKEN_EXPIRY_SECONDS
-  );
-
-  return {
-    access_token,
-    refresh_token,
-    expires_in: expiresIn,
-    refresh_expires_in: refreshExpiresIn,
-    token_type: 'Bearer' as const,
-  };
 }
 
 /**
@@ -197,16 +172,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       await invitationService.autoAcceptPendingInvitations(email, user.id);
 
       // Generate tokens
-      const tokens = generateTokens(fastify, user);
+      const tokens = generateAuthTokens(fastify, user);
 
       // Set refresh token in httpOnly cookie
-      reply.setCookie('refresh_token', tokens.refresh_token, {
-        httpOnly: true,
-        secure: config.server.env === 'production',
-        sameSite: 'strict',
-        maxAge: tokens.refresh_expires_in,
-        path: '/',
-      });
+      reply.setCookie(
+        'refresh_token',
+        tokens.refresh_token,
+        buildRefreshCookieOptions(tokens.refresh_expires_in)
+      );
 
       // Remove password hash from response
       const userWithoutPassword = omitFields(user, 'password_hash');
@@ -278,16 +251,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       await clearFailedAttempts(email);
 
       // Generate tokens
-      const tokens = generateTokens(fastify, user);
+      const tokens = generateAuthTokens(fastify, user);
 
       // Set refresh token in httpOnly cookie
-      reply.setCookie('refresh_token', tokens.refresh_token, {
-        httpOnly: true,
-        secure: config.server.env === 'production',
-        sameSite: 'strict',
-        maxAge: tokens.refresh_expires_in,
-        path: '/',
-      });
+      reply.setCookie(
+        'refresh_token',
+        tokens.refresh_token,
+        buildRefreshCookieOptions(tokens.refresh_expires_in)
+      );
 
       // Remove password hash from response
       const userWithoutPassword = omitFields(user, 'password_hash');
@@ -335,16 +306,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         const user = await findOrThrow(() => db.users.findById(decoded.userId), 'User');
 
         // Generate new tokens
-        const tokens = generateTokens(fastify, user);
+        const tokens = generateAuthTokens(fastify, user);
 
         // Set new refresh token in httpOnly cookie
-        reply.setCookie('refresh_token', tokens.refresh_token, {
-          httpOnly: true,
-          secure: config.server.env === 'production',
-          sameSite: 'strict',
-          maxAge: tokens.refresh_expires_in,
-          path: '/',
-        });
+        reply.setCookie(
+          'refresh_token',
+          tokens.refresh_token,
+          buildRefreshCookieOptions(tokens.refresh_expires_in)
+        );
 
         return sendSuccess(reply, {
           access_token: tokens.access_token,
@@ -419,16 +388,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         }
 
         // Generate regular access/refresh tokens for the session
-        const tokens = generateTokens(fastify, user);
+        const tokens = generateAuthTokens(fastify, user);
 
         // Set refresh token in httpOnly cookie
-        reply.setCookie('refresh_token', tokens.refresh_token, {
-          httpOnly: true,
-          secure: config.server.env === 'production',
-          sameSite: 'strict',
-          maxAge: tokens.refresh_expires_in,
-          path: '/',
-        });
+        reply.setCookie(
+          'refresh_token',
+          tokens.refresh_token,
+          buildRefreshCookieOptions(tokens.refresh_expires_in)
+        );
 
         // Remove password hash from response
         const userWithoutPassword = omitFields(user, 'password_hash');
@@ -463,12 +430,7 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
     },
     async (_request, reply) => {
       // Clear refresh token cookie
-      reply.clearCookie('refresh_token', {
-        httpOnly: true,
-        secure: config.server.env === 'production',
-        sameSite: 'strict',
-        path: '/',
-      });
+      reply.clearCookie('refresh_token', buildClearRefreshCookieOptions());
 
       return sendSuccess(reply, { message: 'Logged out successfully' });
     }

--- a/packages/backend/src/api/routes/signup.ts
+++ b/packages/backend/src/api/routes/signup.ts
@@ -11,6 +11,14 @@
  *
  * Separate from `/auth/register` (which is user-only and does not create
  * an organization) to keep the invite-flow contract stable.
+ *
+ * Rate limiting: This endpoint overrides the default per-route rate limit
+ * with a stricter 5/minute/IP cap — genuine users never rapid-fire signups.
+ * NOTE: effectiveness depends on `trustProxy` being configured when behind
+ * a reverse proxy (CDN/Vercel/nginx) so `request.ip` reflects the real
+ * client IP rather than the proxy's. That wiring is deployment-topology
+ * config, not code, but is called out in the project plan as a
+ * pre-prod blocker.
  */
 
 import type { FastifyInstance } from 'fastify';
@@ -39,19 +47,31 @@ interface SignupBody {
 }
 
 export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void {
+  // Parse region ONCE at route-registration time. Config is already validated
+  // by `validateConfig('api')` at server boot, so this throw is a belt-and-
+  // braces guard for the theoretical "someone called signupRoutes without
+  // validating config first" case — we still prefer a boot failure to a
+  // per-request 500.
+  const region = parseDataResidencyRegion(config.dataResidency.region);
+  const service = new SignupService(db, region);
+
   fastify.post<{ Body: SignupBody }>(
     '/api/v1/auth/signup',
     {
       schema: signupSchema,
-      config: { public: true },
+      config: {
+        public: true,
+        // Per-IP burst cap — tighter than the global default because this
+        // endpoint creates real tenant data and must resist credential-
+        // stuffing / subdomain-squatting bots. Honeypot and fail-closed
+        // SpamFilter are complementary, not substitutes.
+        rateLimit: { max: 5, timeWindow: '1 minute' },
+      },
     },
     async (request, reply) => {
       if (!config.auth.selfServiceSignupEnabled) {
         throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
       }
-
-      const region = parseDataResidencyRegion(config.dataResidency.region);
-      const service = new SignupService(db, region);
 
       const input: SignupInput = {
         email: request.body.email,

--- a/packages/backend/src/api/routes/signup.ts
+++ b/packages/backend/src/api/routes/signup.ts
@@ -4,10 +4,12 @@
  * POST /api/v1/auth/signup
  *
  * Sentry-style instant onboarding: one atomic call provisions user +
- * organization + trial subscription + default project + write-scoped API
- * key, returns JWTs + plaintext key in a single response. The landing
- * wizard on `kz.bugspotter.io` calls this; enterprise/admin-approval flow
- * lives at `/organization-requests` unchanged.
+ * organization + trial subscription + default project + ingest-only
+ * custom-scope API key (limited to `reports:write` + `sessions:write`,
+ * with no read access). Returns JWTs + plaintext key in a single
+ * response. The landing wizard on `kz.bugspotter.io` calls this;
+ * enterprise/admin-approval flow lives at `/organization-requests`
+ * unchanged.
  *
  * Separate from `/auth/register` (which is user-only and does not create
  * an organization) to keep the invite-flow contract stable.

--- a/packages/backend/src/api/routes/signup.ts
+++ b/packages/backend/src/api/routes/signup.ts
@@ -1,0 +1,100 @@
+/**
+ * Self-service signup route
+ *
+ * POST /api/v1/auth/signup
+ *
+ * Sentry-style instant onboarding: one atomic call provisions user +
+ * organization + trial subscription + default project + write-scoped API
+ * key, returns JWTs + plaintext key in a single response. The landing
+ * wizard on `kz.bugspotter.io` calls this; enterprise/admin-approval flow
+ * lives at `/organization-requests` unchanged.
+ *
+ * Separate from `/auth/register` (which is user-only and does not create
+ * an organization) to keep the invite-flow contract stable.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { DatabaseClient } from '../../db/client.js';
+import { config } from '../../config.js';
+import { AppError } from '../middleware/error.js';
+import { omitFields } from '../utils/resource.js';
+import { sendCreated } from '../utils/response.js';
+import { buildRefreshCookieOptions } from '../utils/auth-cookies.js';
+import { generateAuthTokens } from '../utils/auth-tokens.js';
+import { signupSchema } from '../schemas/auth-schema.js';
+import {
+  SignupService,
+  parseDataResidencyRegion,
+  type SignupInput,
+} from '../../saas/services/signup.service.js';
+
+interface SignupBody {
+  email: string;
+  password: string;
+  name?: string;
+  company_name: string;
+  subdomain?: string;
+  /** Honeypot — named `website` in the form to look like a legitimate field to bots. */
+  website?: string;
+}
+
+export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void {
+  fastify.post<{ Body: SignupBody }>(
+    '/api/v1/auth/signup',
+    {
+      schema: signupSchema,
+      config: { public: true },
+    },
+    async (request, reply) => {
+      if (!config.auth.selfServiceSignupEnabled) {
+        throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
+      }
+
+      const region = parseDataResidencyRegion(config.dataResidency.region);
+      const service = new SignupService(db, region);
+
+      const input: SignupInput = {
+        email: request.body.email,
+        password: request.body.password,
+        name: request.body.name,
+        company_name: request.body.company_name,
+        subdomain: request.body.subdomain,
+        ip_address: request.ip,
+        honeypot: request.body.website ?? null,
+      };
+
+      const result = await service.signup(input);
+
+      // Issue session JWTs so the wizard can hand off to the tenant admin UI
+      // without a separate /login round-trip.
+      const tokens = generateAuthTokens(fastify, result.user);
+
+      reply.setCookie(
+        'refresh_token',
+        tokens.refresh_token,
+        buildRefreshCookieOptions(tokens.refresh_expires_in)
+      );
+
+      const userWithoutPassword = omitFields(result.user, 'password_hash');
+
+      return sendCreated(reply, {
+        user: userWithoutPassword,
+        organization: {
+          id: result.organization.id,
+          name: result.organization.name,
+          subdomain: result.organization.subdomain,
+          trial_ends_at: result.organization.trial_ends_at,
+        },
+        project: {
+          id: result.project.id,
+          name: result.project.name,
+        },
+        api_key: result.api_key,
+        api_key_id: result.api_key_id,
+        access_token: tokens.access_token,
+        expires_in: tokens.expires_in,
+        token_type: tokens.token_type,
+      });
+    }
+  );
+}

--- a/packages/backend/src/api/schemas/auth-schema.ts
+++ b/packages/backend/src/api/schemas/auth-schema.ts
@@ -179,6 +179,7 @@ export const signupSchema = {
             'organization',
             'project',
             'api_key',
+            'api_key_id',
             'access_token',
             'expires_in',
             'token_type',

--- a/packages/backend/src/api/schemas/auth-schema.ts
+++ b/packages/backend/src/api/schemas/auth-schema.ts
@@ -150,6 +150,72 @@ export const magicLoginSchema = {
   },
 } as const;
 
+export const signupSchema = {
+  body: {
+    type: 'object',
+    required: ['email', 'password', 'company_name'],
+    properties: {
+      email: { type: 'string', format: 'email', maxLength: 254 },
+      password: { type: 'string', minLength: 8, maxLength: 128 },
+      name: { type: 'string', minLength: 1, maxLength: 128 },
+      company_name: { type: 'string', minLength: 1, maxLength: 128 },
+      subdomain: { type: 'string', minLength: 3, maxLength: 63 },
+      // Honeypot: must be empty/absent for humans. Bots auto-fill visible
+      // form fields, including ones hidden via CSS.
+      website: { type: 'string', maxLength: 256 },
+    },
+    additionalProperties: false,
+  },
+  response: {
+    201: {
+      type: 'object',
+      required: ['success', 'data', 'timestamp'],
+      properties: {
+        success: { type: 'boolean', enum: [true] },
+        data: {
+          type: 'object',
+          required: [
+            'user',
+            'organization',
+            'project',
+            'api_key',
+            'access_token',
+            'expires_in',
+            'token_type',
+          ],
+          properties: {
+            user: userSchema,
+            organization: {
+              type: 'object',
+              required: ['id', 'name', 'subdomain'],
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                name: { type: 'string' },
+                subdomain: { type: 'string' },
+                trial_ends_at: { type: 'string', format: 'date-time', nullable: true },
+              },
+            },
+            project: {
+              type: 'object',
+              required: ['id', 'name'],
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                name: { type: 'string' },
+              },
+            },
+            api_key: { type: 'string' },
+            api_key_id: { type: 'string', format: 'uuid' },
+            access_token: { type: 'string' },
+            expires_in: { type: 'number' },
+            token_type: { type: 'string', enum: ['Bearer'] },
+          },
+        },
+        timestamp: { type: 'string', format: 'date-time' },
+      },
+    },
+  },
+} as const;
+
 export const registrationStatusSchema = {
   response: {
     200: {

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -29,6 +29,7 @@ import { projectRoutes } from './routes/projects.js';
 import { projectMemberRoutes } from './routes/project-members.js';
 import { projectIntegrationRoutes } from './routes/project-integrations.js';
 import { authRoutes } from './routes/auth.js';
+import { signupRoutes } from './routes/signup.js';
 import { shareTokenRoutes } from './routes/share-tokens.js';
 import { retentionRoutes } from './routes/retention.js';
 import { dataResidencyRoutes } from './routes/data-residency.js';
@@ -419,6 +420,7 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
   projectMemberRoutes(fastify, db);
   projectIntegrationRoutes(fastify, db, options.pluginRegistry);
   authRoutes(fastify, db);
+  signupRoutes(fastify, db);
   await adminRoutes(fastify, db, options.pluginRegistry);
   await adminJobsRoutes(fastify);
   await setupRoutes(fastify, db);

--- a/packages/backend/src/api/utils/auth-cookies.ts
+++ b/packages/backend/src/api/utils/auth-cookies.ts
@@ -1,0 +1,54 @@
+/**
+ * Refresh-token cookie options helper
+ *
+ * Centralizes cookie settings so `/register`, `/login`, `/refresh`,
+ * `/magic-login`, `/logout`, and the self-service `/signup` all emit
+ * identical cookies. Keeping this in one place avoids drift when the
+ * cookie domain or sameSite mode changes per deployment.
+ */
+
+import type { CookieSerializeOptions } from '@fastify/cookie';
+import { config } from '../../config.js';
+
+export interface RefreshCookieOptions extends CookieSerializeOptions {
+  /** Always present — Fastify requires explicit options each call. */
+  httpOnly: true;
+  path: '/';
+}
+
+/**
+ * Build cookie options for setting the refresh_token cookie.
+ *
+ * - When `COOKIE_DOMAIN` is configured (SaaS), the cookie is scoped to the
+ *   parent domain (e.g. `.kz.bugspotter.io`) and uses `sameSite=lax` so
+ *   the wizard on `kz.bugspotter.io` can hand off the session to
+ *   `[org].kz.bugspotter.io` on redirect.
+ * - When `COOKIE_DOMAIN` is empty (self-hosted), the cookie stays
+ *   host-scoped with `sameSite=strict` to match legacy behavior.
+ */
+export function buildRefreshCookieOptions(maxAgeSeconds: number): RefreshCookieOptions {
+  const hasCookieDomain = !!config.auth.cookieDomain;
+  return {
+    httpOnly: true,
+    secure: config.server.env === 'production',
+    sameSite: hasCookieDomain ? 'lax' : 'strict',
+    maxAge: maxAgeSeconds,
+    path: '/',
+    ...(hasCookieDomain ? { domain: config.auth.cookieDomain as string } : {}),
+  };
+}
+
+/**
+ * Build cookie options for clearing the refresh_token cookie.
+ * Must match the attributes used when setting it, or browsers ignore the clear.
+ */
+export function buildClearRefreshCookieOptions(): RefreshCookieOptions {
+  const hasCookieDomain = !!config.auth.cookieDomain;
+  return {
+    httpOnly: true,
+    secure: config.server.env === 'production',
+    sameSite: hasCookieDomain ? 'lax' : 'strict',
+    path: '/',
+    ...(hasCookieDomain ? { domain: config.auth.cookieDomain as string } : {}),
+  };
+}

--- a/packages/backend/src/api/utils/auth-cookies.ts
+++ b/packages/backend/src/api/utils/auth-cookies.ts
@@ -20,11 +20,28 @@ export interface RefreshCookieOptions extends CookieSerializeOptions {
  * Build cookie options for setting the refresh_token cookie.
  *
  * - When `COOKIE_DOMAIN` is configured (SaaS), the cookie is scoped to the
- *   parent domain (e.g. `.kz.bugspotter.io`) and uses `sameSite=lax` so
- *   the wizard on `kz.bugspotter.io` can hand off the session to
- *   `[org].kz.bugspotter.io` on redirect.
+ *   parent domain (e.g. `.kz.bugspotter.io`) and uses `sameSite=lax`.
+ *
+ *   Why `lax` and not `strict` here, given the wizard-to-tenant handoff
+ *   (`kz.bugspotter.io` → `[org].kz.bugspotter.io`) is same-site and
+ *   would work with either:
+ *
+ *   The real concern is *inbound* cross-site navigations — a user
+ *   clicking an email link, following a bookmark, or typing the tenant
+ *   URL directly. `Strict` drops the cookie on every such top-level
+ *   navigation, which means users would be logged out whenever they
+ *   arrive at their tenant from anywhere outside our own origins.
+ *   `Lax` preserves the cookie on top-level GETs from external origins
+ *   while still blocking cross-site sub-resource and POST leakage.
+ *
+ *   The CSRF surface from `Lax` here is minimal: refresh_token is
+ *   `HttpOnly` so JS can't read it, the refresh endpoint is POST-only,
+ *   and the access token still travels via `Authorization` header.
+ *
  * - When `COOKIE_DOMAIN` is empty (self-hosted), the cookie stays
- *   host-scoped with `sameSite=strict` to match legacy behavior.
+ *   host-scoped with `sameSite=strict` to match legacy behavior — no
+ *   cross-subdomain flow exists in self-hosted so the stricter mode
+ *   costs nothing.
  */
 export function buildRefreshCookieOptions(maxAgeSeconds: number): RefreshCookieOptions {
   const hasCookieDomain = !!config.auth.cookieDomain;

--- a/packages/backend/src/api/utils/auth-tokens.ts
+++ b/packages/backend/src/api/utils/auth-tokens.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared JWT token generation helper.
+ *
+ * One source of truth for access/refresh token payloads + expiry so
+ * `/auth/register`, `/auth/login`, `/auth/refresh`, `/auth/magic-login`,
+ * and `/auth/signup` cannot drift apart. Per-flow behavior (cookie
+ * attributes, response shape) lives in the route handler.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { config } from '../../config.js';
+import type { User } from '../../db/types.js';
+import { isPlatformAdmin } from '../middleware/auth.js';
+import { parseTimeString, DEFAULT_TOKEN_EXPIRY_SECONDS } from './constants.js';
+
+export interface AuthTokens {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  refresh_expires_in: number;
+  token_type: 'Bearer';
+}
+
+export function generateAuthTokens(fastify: FastifyInstance, user: User): AuthTokens {
+  const payload = { userId: user.id, isPlatformAdmin: isPlatformAdmin(user) };
+
+  const access_token = fastify.jwt.sign(payload, {
+    expiresIn: config.jwt.expiresIn,
+  });
+
+  const refresh_token = fastify.jwt.sign(payload, {
+    expiresIn: config.jwt.refreshExpiresIn,
+  });
+
+  const expiresIn = parseTimeString(config.jwt.expiresIn, DEFAULT_TOKEN_EXPIRY_SECONDS);
+  const refreshExpiresIn = parseTimeString(
+    config.jwt.refreshExpiresIn,
+    DEFAULT_TOKEN_EXPIRY_SECONDS
+  );
+
+  return {
+    access_token,
+    refresh_token,
+    expires_in: expiresIn,
+    refresh_expires_in: refreshExpiresIn,
+    token_type: 'Bearer',
+  };
+}

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -12,6 +12,7 @@ import {
   type LogLevel,
   type AppConfig,
 } from './config/types.js';
+import { DATA_RESIDENCY_REGION } from './db/types.js';
 import {
   MIN_PORT,
   MAX_PORT,
@@ -108,7 +109,11 @@ export const config: AppConfig = {
     },
   },
   dataResidency: {
-    region: (process.env.DATA_RESIDENCY_REGION ?? 'kz').toLowerCase(),
+    // Trim + lowercase at ingestion so `validateConfig` and
+    // `parseDataResidencyRegion` always agree on what's a valid value.
+    // Without `.trim()` an env like `" kz "` would pass parse() but fail
+    // validate(), causing a confusing boot error.
+    region: (process.env.DATA_RESIDENCY_REGION ?? 'kz').trim().toLowerCase(),
   },
 } as const;
 
@@ -169,16 +174,45 @@ function collectSecurityErrors(): string[] {
   return errors;
 }
 
-const VALID_DATA_RESIDENCY_REGIONS = ['kz', 'rf', 'eu', 'us', 'global'] as const;
+function collectCookieDomainErrors(): string[] {
+  // Skip the check when not configured — a null/empty value means
+  // "host-scoped cookie only" which is the self-hosted default.
+  const raw = config.auth.cookieDomain;
+  if (!raw) {
+    return [];
+  }
+
+  // Reject obvious misconfigurations that would silently break cookie
+  // issuance or expose the refresh cookie to the wrong origin. We don't
+  // try to be a full RFC 1034 hostname validator — just catch the
+  // common env-var mistakes (pasted URL, included port, trailing path,
+  // whitespace, or uppercase).
+  const lower = raw.toLowerCase();
+  const errors: string[] = [];
+  if (raw !== lower) {
+    errors.push(`COOKIE_DOMAIN must be lowercase (got "${raw}")`);
+  }
+  if (/[\s/]/.test(raw) || raw.includes('://') || /:\d+$/.test(raw)) {
+    errors.push(
+      `COOKIE_DOMAIN must be a bare hostname (no scheme, path, port, or whitespace). Got "${raw}"`
+    );
+  }
+  return errors;
+}
 
 function collectDataResidencyErrors(): string[] {
   // Validate at boot rather than on the first signup. A misconfigured region
   // otherwise surfaces as a 500 from /api/v1/auth/signup instead of a clear
   // operator-facing startup failure.
+  //
+  // Source of truth: `DATA_RESIDENCY_REGION` in `db/types.ts` (which is also
+  // mirrored by the DB CHECK constraint in the organizations table). Using
+  // the enum here means adding a region only requires editing one place.
+  const validRegions = Object.values(DATA_RESIDENCY_REGION);
   const region = config.dataResidency.region;
-  if (!(VALID_DATA_RESIDENCY_REGIONS as readonly string[]).includes(region)) {
+  if (!(validRegions as string[]).includes(region)) {
     return [
-      `Invalid DATA_RESIDENCY_REGION: ${region}. Expected one of: ${VALID_DATA_RESIDENCY_REGIONS.join(', ')}`,
+      `Invalid DATA_RESIDENCY_REGION: ${region}. Expected one of: ${validRegions.join(', ')}`,
     ];
   }
   return [];
@@ -251,6 +285,7 @@ export function validateConfig(context: ValidationContext = 'api'): void {
   if (context === 'api') {
     errors.push(...collectStorageErrors());
     errors.push(...collectDataResidencyErrors());
+    errors.push(...collectCookieDomainErrors());
   }
 
   throwIfErrors(errors);

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -169,6 +169,21 @@ function collectSecurityErrors(): string[] {
   return errors;
 }
 
+const VALID_DATA_RESIDENCY_REGIONS = ['kz', 'rf', 'eu', 'us', 'global'] as const;
+
+function collectDataResidencyErrors(): string[] {
+  // Validate at boot rather than on the first signup. A misconfigured region
+  // otherwise surfaces as a 500 from /api/v1/auth/signup instead of a clear
+  // operator-facing startup failure.
+  const region = config.dataResidency.region;
+  if (!(VALID_DATA_RESIDENCY_REGIONS as readonly string[]).includes(region)) {
+    return [
+      `Invalid DATA_RESIDENCY_REGION: ${region}. Expected one of: ${VALID_DATA_RESIDENCY_REGIONS.join(', ')}`,
+    ];
+  }
+  return [];
+}
+
 function collectStorageErrors(): string[] {
   const errors: string[] = [];
 
@@ -235,6 +250,7 @@ export function validateConfig(context: ValidationContext = 'api'): void {
   errors.push(...collectSecurityErrors());
   if (context === 'api') {
     errors.push(...collectStorageErrors());
+    errors.push(...collectDataResidencyErrors());
   }
 
   throwIfErrors(errors);

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -69,6 +69,10 @@ export const config: AppConfig = {
       parseBooleanEnv(process.env.ALLOW_REGISTRATION) ?? process.env.DEPLOYMENT_MODE === 'saas',
     requireInvitationToRegister:
       parseBooleanEnv(process.env.REQUIRE_INVITATION_TO_REGISTER) ?? true,
+    selfServiceSignupEnabled:
+      parseBooleanEnv(process.env.SELF_SERVICE_SIGNUP_ENABLED) ??
+      process.env.DEPLOYMENT_MODE === 'saas',
+    cookieDomain: process.env.COOKIE_DOMAIN?.trim() || null,
   },
   frontend: {
     url: process.env.FRONTEND_URL ?? '',
@@ -102,6 +106,9 @@ export const config: AppConfig = {
       maxRetries: parseInt(process.env.S3_MAX_RETRIES ?? '3', 10),
       timeout: parseInt(process.env.S3_TIMEOUT_MS ?? '30000', 10),
     },
+  },
+  dataResidency: {
+    region: (process.env.DATA_RESIDENCY_REGION ?? 'kz').toLowerCase(),
   },
 } as const;
 

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -35,6 +35,18 @@ export interface JwtConfig {
 export interface AuthConfig {
   allowRegistration: boolean;
   requireInvitationToRegister: boolean;
+  selfServiceSignupEnabled: boolean;
+  /**
+   * Domain attribute for refresh_token cookie. When set (e.g. `.kz.bugspotter.io`),
+   * enables cross-subdomain SSO between the landing signup wizard and tenant
+   * admin UIs. When null/empty, the cookie is scoped to the emitting host.
+   */
+  cookieDomain: string | null;
+}
+
+export interface DataResidencyConfig {
+  /** Region code for this deployment (e.g. `kz`, `rf`). Used for signup and billing currency. */
+  region: string;
 }
 
 export interface FrontendConfig {
@@ -82,4 +94,5 @@ export interface AppConfig {
   shareToken: ShareTokenConfig;
   rateLimit: RateLimitConfig;
   storage: StorageConfig;
+  dataResidency: DataResidencyConfig;
 }

--- a/packages/backend/src/db/migrations/017_org_request_subdomain_index.sql
+++ b/packages/backend/src/db/migrations/017_org_request_subdomain_index.sql
@@ -6,9 +6,11 @@
 -- inside generateUniqueFromName). Without an index, those queries
 -- degrade to a seq scan as the table grows.
 --
--- A partial functional index on non-terminal statuses keeps the index
--- small (terminal rows — rejected/expired — dominate over time and are
--- not queried here).
+-- A partial index on non-terminal statuses keeps the index small
+-- (terminal rows — rejected/expired — dominate over time and are not
+-- queried here). No function expression on the column: the stored
+-- `subdomain` is already normalized to lowercase on insert, so plain
+-- equality is enough.
 
 SET search_path TO saas;
 

--- a/packages/backend/src/db/migrations/017_org_request_subdomain_index.sql
+++ b/packages/backend/src/db/migrations/017_org_request_subdomain_index.sql
@@ -1,0 +1,19 @@
+-- Migration 017: index for organization_requests.subdomain lookups
+--
+-- SubdomainService.isAvailable() calls
+-- OrganizationRequestRepository.isSubdomainReservedByRequest() on every
+-- self-service signup (and up to 50 times per collision-resolution loop
+-- inside generateUniqueFromName). Without an index, those queries
+-- degrade to a seq scan as the table grows.
+--
+-- A partial functional index on non-terminal statuses keeps the index
+-- small (terminal rows — rejected/expired — dominate over time and are
+-- not queried here).
+
+SET search_path TO saas;
+
+CREATE INDEX IF NOT EXISTS idx_org_requests_subdomain_active
+  ON organization_requests (subdomain)
+  WHERE status IN ('pending_verification', 'verified', 'approved');
+
+SET search_path TO application, saas, public;

--- a/packages/backend/src/db/migrations/018_users_email_lower_index.sql
+++ b/packages/backend/src/db/migrations/018_users_email_lower_index.sql
@@ -1,0 +1,19 @@
+-- Migration 018: functional index on LOWER(email) for users
+--
+-- `UserRepository.findByEmail` now matches on `LOWER(email) = LOWER($1)`
+-- to make duplicate-email detection reliable across mixed-case rows.
+-- Without a functional index the query degrades to a seq scan on every
+-- login / registration / signup attempt.
+--
+-- This is NOT a UNIQUE index: prior data may contain case-insensitive
+-- duplicates (the base `users.email` UNIQUE constraint is case-sensitive
+-- and historical `/auth/register` calls didn't always normalize). A
+-- UNIQUE functional index would fail to create. Upgrading to UNIQUE is
+-- a follow-up that requires a data audit and cleanup.
+
+SET search_path TO application;
+
+CREATE INDEX IF NOT EXISTS idx_users_email_lower
+  ON users (LOWER(email));
+
+SET search_path TO application, saas, public;

--- a/packages/backend/src/db/repositories/user.repository.ts
+++ b/packages/backend/src/db/repositories/user.repository.ts
@@ -66,9 +66,14 @@ export class UserRepository extends BaseRepository<User, UserInsert, Partial<Use
     const result = await this.getClient().query<User>(query, [email]);
 
     if (result.rows.length > 1) {
+      // `sampledCount` not `matchedCount`: the query uses `LIMIT 2` as a
+      // cheap "more than one" sentinel, so the actual number of duplicate
+      // rows may be higher than what we logged. Any non-zero value here
+      // still warrants ops cleanup — the exact count requires a separate
+      // COUNT(*) if triage needs it.
       logger.warn('Case-insensitive email lookup matched multiple rows', {
         normalizedEmail: email.toLowerCase(),
-        matchedCount: result.rows.length,
+        sampledCount: result.rows.length,
         oldestId: result.rows[0]?.id,
       });
     }

--- a/packages/backend/src/db/repositories/user.repository.ts
+++ b/packages/backend/src/db/repositories/user.repository.ts
@@ -28,10 +28,27 @@ export class UserRepository extends BaseRepository<User, UserInsert, Partial<Use
   }
 
   /**
-   * Find user by email
+   * Find user by email — case-insensitive.
+   *
+   * Existing rows in the `users` table may have mixed-case emails: the
+   * base UNIQUE constraint is case-sensitive, and historical
+   * `/auth/register` paths did not lowercase before insert. A case-
+   * sensitive lookup of `foo@bar.com` would miss an existing row stored
+   * as `Foo@bar.com`, so duplicate-email checks (in signup/login/invite)
+   * would be unreliable and two accounts could end up sharing an
+   * effective address. See PR #15 review.
+   *
+   * For callers that already normalize (signup service, invitation
+   * service) this is redundant-but-safe. For callers that don't
+   * (existing `/auth/register` — out of scope here), this at least makes
+   * the lookup side correct; a follow-up should also normalize on insert
+   * and add a `LOWER(email)` unique functional index for DB-level
+   * enforcement.
    */
   async findByEmail(email: string): Promise<User | null> {
-    return this.findBy('email', email);
+    const query = `SELECT * FROM ${this.schema}.${this.tableName} WHERE LOWER(email) = LOWER($1)`;
+    const result = await this.getClient().query<User>(query, [email]);
+    return result.rows[0] ?? null;
   }
 
   /**

--- a/packages/backend/src/db/repositories/user.repository.ts
+++ b/packages/backend/src/db/repositories/user.repository.ts
@@ -7,6 +7,9 @@ import { BaseRepository } from './base-repository.js';
 import type { User, UserInsert, PaginatedResult } from '../types.js';
 import { createFilter } from '../filter-builder.js';
 import { createPagination } from '../pagination-builder.js';
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
 
 export class UserRepository extends BaseRepository<User, UserInsert, Partial<User>> {
   constructor(pool: Pool | PoolClient) {
@@ -36,18 +39,40 @@ export class UserRepository extends BaseRepository<User, UserInsert, Partial<Use
    * sensitive lookup of `foo@bar.com` would miss an existing row stored
    * as `Foo@bar.com`, so duplicate-email checks (in signup/login/invite)
    * would be unreliable and two accounts could end up sharing an
-   * effective address. See PR #15 review.
+   * effective address.
    *
    * For callers that already normalize (signup service, invitation
    * service) this is redundant-but-safe. For callers that don't
    * (existing `/auth/register` — out of scope here), this at least makes
-   * the lookup side correct; a follow-up should also normalize on insert
-   * and add a `LOWER(email)` unique functional index for DB-level
-   * enforcement.
+   * the lookup side correct.
+   *
+   * Determinism: multiple rows CAN match today if historical data has
+   * case-insensitive duplicates. We `ORDER BY created_at ASC, id ASC`
+   * and `LIMIT 2` so the caller always sees the oldest row, and we
+   * `logger.warn` when more than one matches so ops can schedule a
+   * cleanup. A follow-up migration should add a `UNIQUE` functional
+   * index on `LOWER(email)` once the data is clean; the current
+   * migration 018 adds a non-unique functional index for the perf side
+   * only.
    */
   async findByEmail(email: string): Promise<User | null> {
-    const query = `SELECT * FROM ${this.schema}.${this.tableName} WHERE LOWER(email) = LOWER($1)`;
+    const query = `
+      SELECT *
+      FROM ${this.schema}.${this.tableName}
+      WHERE LOWER(email) = LOWER($1)
+      ORDER BY created_at ASC, id ASC
+      LIMIT 2
+    `;
     const result = await this.getClient().query<User>(query, [email]);
+
+    if (result.rows.length > 1) {
+      logger.warn('Case-insensitive email lookup matched multiple rows', {
+        normalizedEmail: email.toLowerCase(),
+        matchedCount: result.rows.length,
+        oldestId: result.rows[0]?.id,
+      });
+    }
+
     return result.rows[0] ?? null;
   }
 

--- a/packages/backend/src/saas/repositories/organization-request.repository.ts
+++ b/packages/backend/src/saas/repositories/organization-request.repository.ts
@@ -161,6 +161,26 @@ export class OrganizationRequestRepository extends BaseRepository<
   }
 
   /**
+   * Check whether a subdomain is held by a non-terminal organization request
+   * (pending_verification / verified / approved). Rejected and expired
+   * requests are ignored — their subdomain is free to reuse.
+   *
+   * Used by self-service signup to avoid racing an enterprise onboarding
+   * request that hasn't yet materialized into a real organization row.
+   */
+  async isSubdomainReservedByRequest(subdomain: string): Promise<boolean> {
+    const query = `
+      SELECT EXISTS(
+        SELECT 1 FROM ${this.schema}.${this.tableName}
+        WHERE LOWER(subdomain) = $1
+          AND status IN ('pending_verification', 'verified', 'approved')
+      ) AS reserved
+    `;
+    const result = await this.pool.query<{ reserved: boolean }>(query, [subdomain.toLowerCase()]);
+    return result.rows[0]?.reserved ?? false;
+  }
+
+  /**
    * Update request status with audit fields
    */
   async updateStatus(

--- a/packages/backend/src/saas/repositories/organization-request.repository.ts
+++ b/packages/backend/src/saas/repositories/organization-request.repository.ts
@@ -167,12 +167,17 @@ export class OrganizationRequestRepository extends BaseRepository<
    *
    * Used by self-service signup to avoid racing an enterprise onboarding
    * request that hasn't yet materialized into a real organization row.
+   *
+   * Subdomains are always stored lowercase (see org-request insert paths),
+   * so the WHERE clause uses a plain equality — this lets the partial
+   * index `idx_org_requests_subdomain_active` (migration 017) satisfy
+   * the lookup instead of forcing a seq scan.
    */
   async isSubdomainReservedByRequest(subdomain: string): Promise<boolean> {
     const query = `
       SELECT EXISTS(
         SELECT 1 FROM ${this.schema}.${this.tableName}
-        WHERE LOWER(subdomain) = $1
+        WHERE subdomain = $1
           AND status IN ('pending_verification', 'verified', 'approved')
       ) AS reserved
     `;

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -3,15 +3,16 @@
  *
  * Orchestrates self-service tenant creation: a single atomic flow that
  * provisions user + organization + trial subscription + owner membership +
- * default project + write-scoped API key for SDK ingestion. Separate from
- * `/auth/register` (user-only) and from the admin-approved
+ * default project + ingest-only API key for SDK write access. Separate
+ * from `/auth/register` (user-only) and from the admin-approved
  * `/organization-requests` flow (kept for enterprise onboarding).
  *
- * The API key uses `PERMISSION_SCOPE.WRITE` (reports:read/write +
- * sessions:read/write) — the minimum the SDK needs to post reports and
- * session replays. There is no dedicated `ingest` scope in the
- * permission enum; adding one would require a DB CHECK-constraint
- * migration and is out of scope here.
+ * The API key uses `PERMISSION_SCOPE.CUSTOM` with exactly
+ * `['reports:write', 'sessions:write']` — least privilege for the SDK,
+ * which only POSTs bug reports and session replays. Using the stock
+ * `WRITE` scope would have ALSO granted `reports:read` + `sessions:read`,
+ * which is dangerous for keys customers typically paste into public
+ * front-end SDK code where the key ships to every page visitor.
  *
  * Atomicity: all six inserts run inside a single `db.transaction`. If any
  * step fails, nothing is committed — the user can retry without orphan
@@ -41,7 +42,6 @@ import {
   hashKey,
   extractKeyMetadata,
 } from '../../services/api-key/key-crypto.js';
-import { resolvePermissions } from '../../services/api-key/key-permissions.js';
 import { getLogger } from '../../logger.js';
 
 const logger = getLogger();
@@ -164,14 +164,20 @@ export class SignupService {
         const plaintextKey = generatePlaintextKey();
         const keyHash = hashKey(plaintextKey);
         const { prefix, suffix } = extractKeyMetadata(plaintextKey);
-        const scope = PERMISSION_SCOPE.WRITE;
+
+        // Ingest-only: write access to reports and sessions, NO read.
+        // Intentionally narrower than PERMISSION_SCOPE.WRITE (which also
+        // grants reports:read + sessions:read). SDK-embedded keys must
+        // not be able to exfiltrate data — a public page would leak
+        // everyone else's reports/sessions.
+        const SDK_INGEST_PERMISSIONS = ['reports:write', 'sessions:write'];
 
         const apiKey = await tx.apiKeys.create({
           name: `${DEFAULT_PROJECT_NAME} — SDK key`,
           description: 'Auto-generated at signup — use this in your SDK init.',
           type: API_KEY_TYPE.PRODUCTION,
-          permission_scope: scope,
-          permissions: resolvePermissions(scope),
+          permission_scope: PERMISSION_SCOPE.CUSTOM,
+          permissions: SDK_INGEST_PERMISSIONS,
           allowed_projects: [project.id],
           key_hash: keyHash,
           key_prefix: prefix,
@@ -185,7 +191,8 @@ export class SignupService {
           performed_by: user.id,
           changes: {
             type: apiKey.type,
-            permission_scope: scope,
+            permission_scope: PERMISSION_SCOPE.CUSTOM,
+            permissions: SDK_INGEST_PERMISSIONS,
             source: 'self-service-signup',
           },
         });

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -1,0 +1,288 @@
+/**
+ * Signup Service
+ *
+ * Orchestrates self-service tenant creation: a single atomic flow that
+ * provisions user + organization + trial subscription + owner membership +
+ * default project + write-scoped API key for SDK ingestion. Separate from
+ * `/auth/register` (user-only) and from the admin-approved
+ * `/organization-requests` flow (kept for enterprise onboarding).
+ *
+ * The API key uses `PERMISSION_SCOPE.WRITE` (reports:read/write +
+ * sessions:read/write) — the minimum the SDK needs to post reports and
+ * session replays. There is no dedicated `ingest` scope in the
+ * permission enum; adding one would require a DB CHECK-constraint
+ * migration and is out of scope here.
+ *
+ * Atomicity: all six inserts run inside a single `db.transaction`. If any
+ * step fails, nothing is committed — the user can retry without orphan
+ * rows blocking the email/subdomain.
+ */
+
+import bcrypt from 'bcrypt';
+import type { DatabaseClient } from '../../db/client.js';
+import type {
+  Organization,
+  Project,
+  Subscription,
+  User,
+  DataResidencyRegion,
+} from '../../db/types.js';
+import {
+  SUBSCRIPTION_STATUS,
+  BILLING_STATUS,
+  PLAN_NAME,
+  ORG_MEMBER_ROLE,
+  API_KEY_TYPE,
+  API_KEY_AUDIT_ACTION,
+  PERMISSION_SCOPE,
+  DATA_RESIDENCY_REGION,
+} from '../../db/types.js';
+import { AppError } from '../../api/middleware/error.js';
+import { PASSWORD } from '../../api/utils/constants.js';
+import { getQuotaForPlan } from '../plans.js';
+import { SubdomainService } from './subdomain.service.js';
+import { SpamFilterService } from './spam-filter.service.js';
+import {
+  generatePlaintextKey,
+  hashKey,
+  extractKeyMetadata,
+} from '../../services/api-key/key-crypto.js';
+import { resolvePermissions } from '../../services/api-key/key-permissions.js';
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+const TRIAL_DURATION_DAYS = 14;
+const DEFAULT_PROJECT_NAME = 'My First Project';
+
+export interface SignupInput {
+  email: string;
+  password: string;
+  name?: string;
+  company_name: string;
+  /** Optional user-supplied subdomain; auto-derived from company_name when omitted. */
+  subdomain?: string;
+  /** Client IP for rate limiting and abuse tracking. */
+  ip_address: string;
+  /** Honeypot field — must be empty/absent for humans. */
+  honeypot?: string | null;
+}
+
+export interface SignupResult {
+  user: User;
+  organization: Organization;
+  subscription: Subscription;
+  project: Project;
+  /**
+   * Plaintext API key — shown to the user ONCE on the success screen.
+   * Never persisted in plaintext: the DB stores a SHA-256 hex hash only
+   * (see `services/api-key/key-crypto.ts`).
+   */
+  api_key: string;
+  api_key_id: string;
+}
+
+export class SignupService {
+  private readonly subdomainService: SubdomainService;
+  private readonly spamFilter: SpamFilterService;
+
+  constructor(
+    private readonly db: DatabaseClient,
+    private readonly region: DataResidencyRegion
+  ) {
+    this.subdomainService = new SubdomainService(db);
+    this.spamFilter = new SpamFilterService(db);
+  }
+
+  /**
+   * Run the full signup flow. On success, every record is committed.
+   * On any failure, the transaction rolls back — caller can safely retry.
+   */
+  async signup(input: SignupInput): Promise<SignupResult> {
+    const email = input.email.toLowerCase().trim();
+    const companyName = input.company_name.trim();
+
+    if (companyName.length === 0) {
+      throw new AppError('Company name is required', 400, 'ValidationError');
+    }
+
+    await this.runSpamChecks(email, companyName, input);
+
+    const existingUser = await this.db.users.findByEmail(email);
+    if (existingUser) {
+      throw new AppError('User with this email already exists', 409, 'Conflict');
+    }
+
+    const subdomain = await this.resolveSubdomain(companyName, input.subdomain);
+
+    const passwordHash = await bcrypt.hash(input.password, PASSWORD.SALT_ROUNDS);
+
+    // Single timestamp for every row in this signup — avoids microsecond
+    // drift between trial_ends_at / current_period_start / etc.
+    const now = new Date();
+    const trialEnd = addDays(now, TRIAL_DURATION_DAYS);
+
+    const result = await this.db.transaction(async (tx) => {
+      const user = await tx.users.create({
+        email,
+        name: input.name?.trim() || null,
+        password_hash: passwordHash,
+        role: 'user',
+      });
+
+      const organization = await tx.organizations.create({
+        name: companyName,
+        subdomain,
+        data_residency_region: this.region,
+        subscription_status: SUBSCRIPTION_STATUS.TRIAL,
+        trial_ends_at: trialEnd,
+      });
+
+      const subscription = await tx.subscriptions.create({
+        organization_id: organization.id,
+        plan_name: PLAN_NAME.TRIAL,
+        status: BILLING_STATUS.TRIAL,
+        current_period_start: now,
+        current_period_end: trialEnd,
+        quotas: getQuotaForPlan(PLAN_NAME.TRIAL),
+      });
+
+      await tx.organizationMembers.create({
+        organization_id: organization.id,
+        user_id: user.id,
+        role: ORG_MEMBER_ROLE.OWNER,
+      });
+
+      // Fresh org → project count is guaranteed 0, trial quota is 2.
+      // No advisory lock needed (no concurrent project creation possible
+      // on an org that doesn't exist yet outside this transaction).
+      const project = await tx.projects.create({
+        name: DEFAULT_PROJECT_NAME,
+        created_by: user.id,
+        organization_id: organization.id,
+        settings: {},
+      });
+
+      const plaintextKey = generatePlaintextKey();
+      const keyHash = hashKey(plaintextKey);
+      const { prefix, suffix } = extractKeyMetadata(plaintextKey);
+      const scope = PERMISSION_SCOPE.WRITE;
+
+      const apiKey = await tx.apiKeys.create({
+        name: `${DEFAULT_PROJECT_NAME} — SDK key`,
+        description: 'Auto-generated at signup — use this in your SDK init.',
+        type: API_KEY_TYPE.PRODUCTION,
+        permission_scope: scope,
+        permissions: resolvePermissions(scope),
+        allowed_projects: [project.id],
+        key_hash: keyHash,
+        key_prefix: prefix,
+        key_suffix: suffix,
+        created_by: user.id,
+      });
+
+      await tx.apiKeys.logAudit({
+        api_key_id: apiKey.id,
+        action: API_KEY_AUDIT_ACTION.CREATED,
+        performed_by: user.id,
+        changes: {
+          type: apiKey.type,
+          permission_scope: scope,
+          source: 'self-service-signup',
+        },
+      });
+
+      return {
+        user,
+        organization,
+        subscription,
+        project,
+        api_key: plaintextKey,
+        api_key_id: apiKey.id,
+      };
+    });
+
+    // Log AFTER commit — logging inside the tx callback would record
+    // success even if the COMMIT itself fails.
+    logger.info('Self-service signup completed', {
+      userId: result.user.id,
+      organizationId: result.organization.id,
+      subdomain,
+      projectId: result.project.id,
+    });
+
+    return result;
+  }
+
+  /**
+   * Pre-commit spam checks. Runs before any DB writes so a bot submission
+   * never consumes email/subdomain slots or triggers downstream side effects.
+   *
+   * Fails CLOSED: if the spam check itself errors (DB outage, connection
+   * loss), refuse the signup with 503. Letting requests through during a
+   * degraded state would silently disable rate-limit, honeypot, and
+   * duplicate-email protections — exactly the moment abuse is most likely.
+   */
+  private async runSpamChecks(
+    email: string,
+    companyName: string,
+    input: SignupInput
+  ): Promise<void> {
+    // Subdomain value used for SpamFilterService is informational — the real
+    // uniqueness check happens via SubdomainService.assertValidAndAvailable.
+    // Passing the slug here keeps the check input-complete for future rules.
+    const slugForCheck = this.subdomainService.slugify(companyName) || 'pending';
+
+    let result;
+    try {
+      result = await this.spamFilter.check({
+        company_name: companyName,
+        subdomain: slugForCheck,
+        contact_email: email,
+        ip_address: input.ip_address,
+        honeypot: input.honeypot ?? null,
+      });
+    } catch (err) {
+      logger.error('Spam filter check failed during signup', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw new AppError('Unable to process signup at this time', 503, 'ServiceUnavailable');
+    }
+
+    if (result.rejected) {
+      throw new AppError('Signup request rejected', 403, 'Forbidden', {
+        reasons: result.reasons,
+      });
+    }
+  }
+
+  /**
+   * Determine the final subdomain for this tenant. User-supplied values are
+   * validated and must be available; if omitted, auto-generate from the
+   * company name (with numeric suffix on collision).
+   */
+  private async resolveSubdomain(companyName: string, userSupplied?: string): Promise<string> {
+    if (userSupplied && userSupplied.trim().length > 0) {
+      return this.subdomainService.assertValidAndAvailable(userSupplied);
+    }
+    return this.subdomainService.generateUniqueFromName(companyName);
+  }
+}
+
+function addDays(base: Date, days: number): Date {
+  const end = new Date(base);
+  end.setDate(end.getDate() + days);
+  return end;
+}
+
+/** Resolve a region string from config into the DataResidencyRegion enum, or throw. */
+export function parseDataResidencyRegion(region: string): DataResidencyRegion {
+  const normalized = region.toLowerCase().trim();
+  const match = (Object.values(DATA_RESIDENCY_REGION) as string[]).find((r) => r === normalized);
+  if (!match) {
+    throw new Error(
+      `Invalid DATA_RESIDENCY_REGION: ${region}. Expected one of: ${Object.values(DATA_RESIDENCY_REGION).join(', ')}`
+    );
+  }
+  return match as DataResidencyRegion;
+}

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -20,13 +20,7 @@
 
 import bcrypt from 'bcrypt';
 import type { DatabaseClient } from '../../db/client.js';
-import type {
-  Organization,
-  Project,
-  Subscription,
-  User,
-  DataResidencyRegion,
-} from '../../db/types.js';
+import type { Organization, Project, User, DataResidencyRegion } from '../../db/types.js';
 import {
   SUBSCRIPTION_STATUS,
   BILLING_STATUS,
@@ -71,7 +65,6 @@ export interface SignupInput {
 export interface SignupResult {
   user: User;
   organization: Organization;
-  subscription: Subscription;
   project: Project;
   /**
    * Plaintext API key — shown to the user ONCE on the success screen.
@@ -140,7 +133,10 @@ export class SignupService {
           trial_ends_at: trialEnd,
         });
 
-        const subscription = await tx.subscriptions.create({
+        // Subscription row is created and committed here, but not returned
+        // to the caller — the client has everything it needs via
+        // `organization.trial_ends_at`. See PR #15 review.
+        await tx.subscriptions.create({
           organization_id: organization.id,
           plan_name: PLAN_NAME.TRIAL,
           status: BILLING_STATUS.TRIAL,
@@ -197,7 +193,6 @@ export class SignupService {
         return {
           user,
           organization,
-          subscription,
           project,
           api_key: plaintextKey,
           api_key_id: apiKey.id,
@@ -265,6 +260,20 @@ export class SignupService {
     }
 
     if (result.rejected) {
+      // `duplicate_pending` fires when SpamFilter finds an active row in
+      // `organization_requests` (the enterprise admin-approved flow) for
+      // this email. It's a real user state, not a bot signal — the generic
+      // 403 we return for honeypot/rate-limit/etc. would leave the user with
+      // no idea what to do. Map it to a clearer 409 that support can point
+      // people to.
+      if (result.reasons.includes('duplicate_pending')) {
+        throw new AppError(
+          'An enterprise signup request for this email is already in review. ' +
+            'Please contact support if you need to proceed with self-service instead.',
+          409,
+          'PendingEnterpriseRequest'
+        );
+      }
       throw new AppError('Signup request rejected', 403, 'Forbidden', {
         reasons: result.reasons,
       });
@@ -297,13 +306,25 @@ function addDays(base: Date, days: number): Date {
 const PG_UNIQUE_VIOLATION = '23505';
 
 /**
- * If `err` is a Postgres unique_violation, return a user-facing 409 AppError
- * with a hint about which field collided; otherwise return null so the
- * caller can rethrow the original error.
+ * Map of the exact Postgres constraint names that this signup flow can
+ * plausibly violate, to the user-facing 409 message. Using exact names
+ * (rather than substring matching) keeps us from misclassifying a future
+ * unique constraint — e.g. a hypothetical `users_phone_key` — as "email
+ * already exists". Unknown constraints fall through to a generic message.
  *
- * We inspect `error.constraint` (the PG constraint name) to pick the
- * message. Unknown constraints fall back to a generic "already exists"
- * message so we never leak raw SQL identifiers to the client.
+ * The names `users_email_key` and `organizations_subdomain_key` are the
+ * Postgres defaults from inline `UNIQUE` declarations on those columns
+ * (see `db/migrations/001_initial_schema.sql`).
+ */
+const UNIQUE_CONSTRAINT_MESSAGES: Readonly<Record<string, string>> = Object.freeze({
+  users_email_key: 'User with this email already exists',
+  organizations_subdomain_key: 'This subdomain is already taken',
+});
+
+/**
+ * If `err` is a Postgres unique_violation, return a user-facing 409 AppError
+ * identifying the specific field that collided; otherwise return null so the
+ * caller can rethrow the original error.
  */
 function remapUniqueViolation(err: unknown): AppError | null {
   if (!err || typeof err !== 'object') {
@@ -315,13 +336,8 @@ function remapUniqueViolation(err: unknown): AppError | null {
   }
 
   const constraint = typeof candidate.constraint === 'string' ? candidate.constraint : '';
-  if (constraint.includes('email') || constraint.includes('users')) {
-    return new AppError('User with this email already exists', 409, 'Conflict');
-  }
-  if (constraint.includes('subdomain') || constraint.includes('organizations')) {
-    return new AppError('This subdomain is already taken', 409, 'Conflict');
-  }
-  return new AppError('A conflicting record already exists', 409, 'Conflict');
+  const message = UNIQUE_CONSTRAINT_MESSAGES[constraint] ?? 'A conflicting record already exists';
+  return new AppError(message, 409, 'Conflict');
 }
 
 /** Resolve a region string from config into the DataResidencyRegion enum, or throw. */

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -122,85 +122,100 @@ export class SignupService {
     const now = new Date();
     const trialEnd = addDays(now, TRIAL_DURATION_DAYS);
 
-    const result = await this.db.transaction(async (tx) => {
-      const user = await tx.users.create({
-        email,
-        name: input.name?.trim() || null,
-        password_hash: passwordHash,
-        role: 'user',
-      });
+    let result;
+    try {
+      result = await this.db.transaction(async (tx) => {
+        const user = await tx.users.create({
+          email,
+          name: input.name?.trim() || null,
+          password_hash: passwordHash,
+          role: 'user',
+        });
 
-      const organization = await tx.organizations.create({
-        name: companyName,
-        subdomain,
-        data_residency_region: this.region,
-        subscription_status: SUBSCRIPTION_STATUS.TRIAL,
-        trial_ends_at: trialEnd,
-      });
+        const organization = await tx.organizations.create({
+          name: companyName,
+          subdomain,
+          data_residency_region: this.region,
+          subscription_status: SUBSCRIPTION_STATUS.TRIAL,
+          trial_ends_at: trialEnd,
+        });
 
-      const subscription = await tx.subscriptions.create({
-        organization_id: organization.id,
-        plan_name: PLAN_NAME.TRIAL,
-        status: BILLING_STATUS.TRIAL,
-        current_period_start: now,
-        current_period_end: trialEnd,
-        quotas: getQuotaForPlan(PLAN_NAME.TRIAL),
-      });
+        const subscription = await tx.subscriptions.create({
+          organization_id: organization.id,
+          plan_name: PLAN_NAME.TRIAL,
+          status: BILLING_STATUS.TRIAL,
+          current_period_start: now,
+          current_period_end: trialEnd,
+          quotas: getQuotaForPlan(PLAN_NAME.TRIAL),
+        });
 
-      await tx.organizationMembers.create({
-        organization_id: organization.id,
-        user_id: user.id,
-        role: ORG_MEMBER_ROLE.OWNER,
-      });
+        await tx.organizationMembers.create({
+          organization_id: organization.id,
+          user_id: user.id,
+          role: ORG_MEMBER_ROLE.OWNER,
+        });
 
-      // Fresh org → project count is guaranteed 0, trial quota is 2.
-      // No advisory lock needed (no concurrent project creation possible
-      // on an org that doesn't exist yet outside this transaction).
-      const project = await tx.projects.create({
-        name: DEFAULT_PROJECT_NAME,
-        created_by: user.id,
-        organization_id: organization.id,
-        settings: {},
-      });
+        // Fresh org → project count is guaranteed 0, trial quota is 2.
+        // No advisory lock needed (no concurrent project creation possible
+        // on an org that doesn't exist yet outside this transaction).
+        const project = await tx.projects.create({
+          name: DEFAULT_PROJECT_NAME,
+          created_by: user.id,
+          organization_id: organization.id,
+          settings: {},
+        });
 
-      const plaintextKey = generatePlaintextKey();
-      const keyHash = hashKey(plaintextKey);
-      const { prefix, suffix } = extractKeyMetadata(plaintextKey);
-      const scope = PERMISSION_SCOPE.WRITE;
+        const plaintextKey = generatePlaintextKey();
+        const keyHash = hashKey(plaintextKey);
+        const { prefix, suffix } = extractKeyMetadata(plaintextKey);
+        const scope = PERMISSION_SCOPE.WRITE;
 
-      const apiKey = await tx.apiKeys.create({
-        name: `${DEFAULT_PROJECT_NAME} — SDK key`,
-        description: 'Auto-generated at signup — use this in your SDK init.',
-        type: API_KEY_TYPE.PRODUCTION,
-        permission_scope: scope,
-        permissions: resolvePermissions(scope),
-        allowed_projects: [project.id],
-        key_hash: keyHash,
-        key_prefix: prefix,
-        key_suffix: suffix,
-        created_by: user.id,
-      });
-
-      await tx.apiKeys.logAudit({
-        api_key_id: apiKey.id,
-        action: API_KEY_AUDIT_ACTION.CREATED,
-        performed_by: user.id,
-        changes: {
-          type: apiKey.type,
+        const apiKey = await tx.apiKeys.create({
+          name: `${DEFAULT_PROJECT_NAME} — SDK key`,
+          description: 'Auto-generated at signup — use this in your SDK init.',
+          type: API_KEY_TYPE.PRODUCTION,
           permission_scope: scope,
-          source: 'self-service-signup',
-        },
-      });
+          permissions: resolvePermissions(scope),
+          allowed_projects: [project.id],
+          key_hash: keyHash,
+          key_prefix: prefix,
+          key_suffix: suffix,
+          created_by: user.id,
+        });
 
-      return {
-        user,
-        organization,
-        subscription,
-        project,
-        api_key: plaintextKey,
-        api_key_id: apiKey.id,
-      };
-    });
+        await tx.apiKeys.logAudit({
+          api_key_id: apiKey.id,
+          action: API_KEY_AUDIT_ACTION.CREATED,
+          performed_by: user.id,
+          changes: {
+            type: apiKey.type,
+            permission_scope: scope,
+            source: 'self-service-signup',
+          },
+        });
+
+        return {
+          user,
+          organization,
+          subscription,
+          project,
+          api_key: plaintextKey,
+          api_key_id: apiKey.id,
+        };
+      });
+    } catch (err) {
+      // Race-condition backstop: two concurrent signups can both pass the
+      // read-side checks (findByEmail / isAvailable) and both reach INSERT.
+      // The UNIQUE constraints on users.email and organizations.subdomain
+      // mean one will succeed, the other raises Postgres 23505. Without
+      // this remap, the loser sees a 500 Internal Server Error rather than
+      // the proper 409 Conflict they'd get from the read-side checks.
+      const remapped = remapUniqueViolation(err);
+      if (remapped) {
+        throw remapped;
+      }
+      throw err;
+    }
 
     // Log AFTER commit — logging inside the tx callback would record
     // success even if the COMMIT itself fails.
@@ -273,6 +288,40 @@ function addDays(base: Date, days: number): Date {
   const end = new Date(base);
   end.setDate(end.getDate() + days);
   return end;
+}
+
+/**
+ * Postgres unique_violation SQLSTATE. When a concurrent signup wins the
+ * INSERT race, the loser's transaction raises this code.
+ */
+const PG_UNIQUE_VIOLATION = '23505';
+
+/**
+ * If `err` is a Postgres unique_violation, return a user-facing 409 AppError
+ * with a hint about which field collided; otherwise return null so the
+ * caller can rethrow the original error.
+ *
+ * We inspect `error.constraint` (the PG constraint name) to pick the
+ * message. Unknown constraints fall back to a generic "already exists"
+ * message so we never leak raw SQL identifiers to the client.
+ */
+function remapUniqueViolation(err: unknown): AppError | null {
+  if (!err || typeof err !== 'object') {
+    return null;
+  }
+  const candidate = err as { code?: unknown; constraint?: unknown };
+  if (candidate.code !== PG_UNIQUE_VIOLATION) {
+    return null;
+  }
+
+  const constraint = typeof candidate.constraint === 'string' ? candidate.constraint : '';
+  if (constraint.includes('email') || constraint.includes('users')) {
+    return new AppError('User with this email already exists', 409, 'Conflict');
+  }
+  if (constraint.includes('subdomain') || constraint.includes('organizations')) {
+    return new AppError('This subdomain is already taken', 409, 'Conflict');
+  }
+  return new AppError('A conflicting record already exists', 409, 'Conflict');
 }
 
 /** Resolve a region string from config into the DataResidencyRegion enum, or throw. */

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -115,7 +115,7 @@ export class SignupService {
     const now = new Date();
     const trialEnd = addDays(now, TRIAL_DURATION_DAYS);
 
-    let result;
+    let result: SignupResult;
     try {
       result = await this.db.transaction(async (tx) => {
         const user = await tx.users.create({
@@ -243,7 +243,7 @@ export class SignupService {
     // Passing the slug here keeps the check input-complete for future rules.
     const slugForCheck = this.subdomainService.slugify(companyName) || 'pending';
 
-    let result;
+    let result: Awaited<ReturnType<SpamFilterService['check']>>;
     try {
       result = await this.spamFilter.check({
         company_name: companyName,
@@ -274,9 +274,16 @@ export class SignupService {
           'PendingEnterpriseRequest'
         );
       }
-      throw new AppError('Signup request rejected', 403, 'Forbidden', {
+      // Log the reasons server-side for ops / abuse investigation, but
+      // DON'T echo them to the client — doing so leaks our spam
+      // heuristics and helps bots iterate past whichever rule they
+      // tripped.
+      logger.info('Self-service signup rejected by spam filter', {
+        ip: input.ip_address,
         reasons: result.reasons,
+        score: result.spam_score,
       });
+      throw new AppError('Signup request rejected', 403, 'Forbidden');
     }
   }
 

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -8,6 +8,7 @@
 
 import type { DatabaseClient } from '../../db/client.js';
 import { AppError } from '../../api/middleware/error.js';
+import { RESERVED_SUBDOMAINS as TENANT_RESERVED_SUBDOMAINS } from '../middleware/tenant.js';
 
 const SUBDOMAIN_MIN_LENGTH = 3;
 const SUBDOMAIN_MAX_LENGTH = 63;
@@ -20,20 +21,18 @@ const MAX_AUTO_SUFFIX_ATTEMPTS = 50;
 const SUBDOMAIN_REGEX = /^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$/;
 
 /**
- * Subdomains reserved for platform infrastructure. Blocking these prevents
- * tenants from impersonating api/admin/support surfaces or colliding with
- * existing DNS records on *.kz.bugspotter.io.
+ * Subdomains reserved for platform infrastructure. Blocking these at signup
+ * prevents tenants from impersonating api/admin/support surfaces or
+ * colliding with existing DNS records on *.kz.bugspotter.io.
+ *
+ * This set is a SUPERSET of the tenant resolution middleware's reserved
+ * list — anything the middleware refuses to route to must also be blocked
+ * at signup, otherwise a user could register an org whose admin UI the
+ * router would never serve. Extras here cover environments, monitoring,
+ * and platform-only names that the middleware doesn't need to know about.
  */
-const RESERVED_SUBDOMAINS = new Set([
+const SIGNUP_ONLY_RESERVED = new Set([
   // Platform infra
-  'app',
-  'api',
-  'admin',
-  'www',
-  'mail',
-  'static',
-  'cdn',
-  'assets',
   'media',
   'uploads',
   'files',
@@ -41,20 +40,11 @@ const RESERVED_SUBDOMAINS = new Set([
   'staging',
   'dev',
   'test',
-  'demo',
   'preview',
   'sandbox',
   'local',
-  // Product surfaces
-  'docs',
+  // Product surfaces the tenant middleware doesn't explicitly block
   'blog',
-  'status',
-  'help',
-  'support',
-  'billing',
-  'auth',
-  'login',
-  'signup',
   'register',
   'onboarding',
   // Generic reserved
@@ -69,6 +59,11 @@ const RESERVED_SUBDOMAINS = new Set([
   'kibana',
   'logs',
   'metrics',
+]);
+
+const RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
+  ...TENANT_RESERVED_SUBDOMAINS,
+  ...SIGNUP_ONLY_RESERVED,
 ]);
 
 export class SubdomainService {
@@ -127,14 +122,18 @@ export class SubdomainService {
   }
 
   /**
-   * Check if a subdomain is available across both `organizations` (active
-   * tenants — subdomain stays reserved for soft-deleted rows until hard
-   * delete) and `organization_requests` (non-terminal enterprise flow that
-   * could later approve into a real org).
+   * Check if a subdomain is available across both `organizations` and
+   * `organization_requests`.
    *
-   * The pre-existing `organizationRequests.isSubdomainTaken()` queries the
-   * organizations table despite its name; we use the request-table-specific
-   * method here to get the intended behavior.
+   * The `organizations` side uses `isSubdomainAvailable`, which does NOT
+   * filter `deleted_at IS NULL` — so a soft-deleted org still reserves
+   * its subdomain until a hard delete. That's intentional: if a tenant
+   * is restored or the name is revived by platform admins, the identity
+   * is still unambiguous. (Note: the pre-existing `isSubdomainTaken` on
+   * `organizationRequests` is misnamed and queries the organizations
+   * table with `deleted_at IS NULL` — we don't use it here; we call
+   * `isSubdomainReservedByRequest` which queries the request table
+   * for non-terminal statuses only.)
    */
   async isAvailable(subdomain: string): Promise<boolean> {
     const normalized = subdomain.toLowerCase();

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -139,18 +139,16 @@ export class SubdomainService {
   async isAvailable(subdomain: string): Promise<boolean> {
     const normalized = subdomain.toLowerCase();
 
-    const orgTaken = !(await this.db.organizations.isSubdomainAvailable(normalized));
-    if (orgTaken) {
-      return false;
-    }
+    // Parallelize the two independent reads — `generateUniqueFromName`
+    // calls this up to 50 times in a collision loop, so halving per-iter
+    // latency from 2 sequential round-trips to 1 cuts worst-case suffix
+    // search time materially.
+    const [orgAvailable, requestReserved] = await Promise.all([
+      this.db.organizations.isSubdomainAvailable(normalized),
+      this.db.organizationRequests.isSubdomainReservedByRequest(normalized),
+    ]);
 
-    const requestReserved =
-      await this.db.organizationRequests.isSubdomainReservedByRequest(normalized);
-    if (requestReserved) {
-      return false;
-    }
-
-    return true;
+    return orgAvailable && !requestReserved;
   }
 
   /**

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -1,0 +1,218 @@
+/**
+ * Subdomain Service
+ * Generates and validates tenant subdomains for self-service signup.
+ * Handles slugification, reserved-name blocking, uniqueness across
+ * `organizations` and `organization_requests` (to avoid collision when
+ * a pending enterprise request is later approved).
+ */
+
+import type { DatabaseClient } from '../../db/client.js';
+import { AppError } from '../../api/middleware/error.js';
+
+const SUBDOMAIN_MIN_LENGTH = 3;
+const SUBDOMAIN_MAX_LENGTH = 63;
+const MAX_AUTO_SUFFIX_ATTEMPTS = 50;
+
+/**
+ * DNS-safe subdomain pattern: lowercase alphanumeric + single hyphens,
+ * no leading/trailing hyphen, 3–63 chars (LDH rule minus TLD constraints).
+ */
+const SUBDOMAIN_REGEX = /^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$/;
+
+/**
+ * Subdomains reserved for platform infrastructure. Blocking these prevents
+ * tenants from impersonating api/admin/support surfaces or colliding with
+ * existing DNS records on *.kz.bugspotter.io.
+ */
+const RESERVED_SUBDOMAINS = new Set([
+  // Platform infra
+  'app',
+  'api',
+  'admin',
+  'www',
+  'mail',
+  'static',
+  'cdn',
+  'assets',
+  'media',
+  'uploads',
+  'files',
+  // Environments
+  'staging',
+  'dev',
+  'test',
+  'demo',
+  'preview',
+  'sandbox',
+  'local',
+  // Product surfaces
+  'docs',
+  'blog',
+  'status',
+  'help',
+  'support',
+  'billing',
+  'auth',
+  'login',
+  'signup',
+  'register',
+  'onboarding',
+  // Generic reserved
+  'root',
+  'system',
+  'public',
+  'private',
+  'internal',
+  // Monitoring/ops
+  'grafana',
+  'prometheus',
+  'kibana',
+  'logs',
+  'metrics',
+]);
+
+export class SubdomainService {
+  constructor(private readonly db: DatabaseClient) {}
+
+  /**
+   * Convert an organization name into a DNS-safe subdomain candidate.
+   * Strategy: lowercase → replace non-[a-z0-9] with hyphens → collapse
+   * consecutive hyphens → trim leading/trailing hyphens → truncate to
+   * SUBDOMAIN_MAX_LENGTH → trim edge hyphens again in case the truncation
+   * landed on one.
+   * Returns empty string if nothing usable remains (caller must handle).
+   */
+  slugify(input: string): string {
+    const normalized = input
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+
+    // Truncate first, then re-trim — truncation can land on a `-` and leave
+    // a trailing hyphen that would fail LDH validation.
+    return normalized.slice(0, SUBDOMAIN_MAX_LENGTH).replace(/^-|-$/g, '');
+  }
+
+  /**
+   * Validate subdomain format and reserved-name policy.
+   * Does NOT check uniqueness — use isAvailable() for that.
+   */
+  validateFormat(subdomain: string): void {
+    if (subdomain.length < SUBDOMAIN_MIN_LENGTH) {
+      throw new AppError(
+        `Subdomain must be at least ${SUBDOMAIN_MIN_LENGTH} characters`,
+        400,
+        'ValidationError'
+      );
+    }
+    if (subdomain.length > SUBDOMAIN_MAX_LENGTH) {
+      throw new AppError(
+        `Subdomain must be at most ${SUBDOMAIN_MAX_LENGTH} characters`,
+        400,
+        'ValidationError'
+      );
+    }
+    if (!SUBDOMAIN_REGEX.test(subdomain)) {
+      throw new AppError(
+        'Subdomain must contain only lowercase letters, numbers, and hyphens (no leading/trailing hyphen)',
+        400,
+        'ValidationError'
+      );
+    }
+    if (RESERVED_SUBDOMAINS.has(subdomain)) {
+      throw new AppError('This subdomain is reserved', 400, 'ValidationError');
+    }
+  }
+
+  /**
+   * Check if a subdomain is available across both `organizations` (active
+   * tenants — subdomain stays reserved for soft-deleted rows until hard
+   * delete) and `organization_requests` (non-terminal enterprise flow that
+   * could later approve into a real org).
+   *
+   * The pre-existing `organizationRequests.isSubdomainTaken()` queries the
+   * organizations table despite its name; we use the request-table-specific
+   * method here to get the intended behavior.
+   */
+  async isAvailable(subdomain: string): Promise<boolean> {
+    const normalized = subdomain.toLowerCase();
+
+    const orgTaken = !(await this.db.organizations.isSubdomainAvailable(normalized));
+    if (orgTaken) {
+      return false;
+    }
+
+    const requestReserved =
+      await this.db.organizationRequests.isSubdomainReservedByRequest(normalized);
+    if (requestReserved) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Generate a unique subdomain from a seed (e.g. company name).
+   * If the slugified seed collides, appends numeric suffixes (-2, -3, ...).
+   * Throws if the seed yields no usable slug or suffixes exhaust.
+   *
+   * Used for auto-suggesting a subdomain from company_name at signup.
+   * The caller may still let the user override before commit.
+   */
+  async generateUniqueFromName(name: string): Promise<string> {
+    const base = this.slugify(name);
+    if (base.length < SUBDOMAIN_MIN_LENGTH) {
+      throw new AppError(
+        'Could not derive a valid subdomain from the organization name',
+        400,
+        'ValidationError',
+        { hint: 'Try a name with at least 3 alphanumeric characters' }
+      );
+    }
+
+    // Reserved base → fall through to suffixed attempts, which are not reserved.
+    const baseUsable = !RESERVED_SUBDOMAINS.has(base);
+
+    if (baseUsable && (await this.isAvailable(base))) {
+      return base;
+    }
+
+    for (let i = 2; i <= MAX_AUTO_SUFFIX_ATTEMPTS; i++) {
+      // Leave room for the suffix so total length stays within limit.
+      // Re-trim the sliced base so we don't end up with "foo--2" when the
+      // cut-off character is a hyphen.
+      const suffix = `-${i}`;
+      const maxBase = SUBDOMAIN_MAX_LENGTH - suffix.length;
+      const trimmedBase = base.slice(0, maxBase).replace(/-+$/, '');
+      if (trimmedBase.length < SUBDOMAIN_MIN_LENGTH) {
+        continue;
+      }
+      const candidate = `${trimmedBase}${suffix}`;
+      if (await this.isAvailable(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new AppError(
+      'Could not generate a unique subdomain — please choose one manually',
+      409,
+      'Conflict'
+    );
+  }
+
+  /**
+   * Full validation pipeline for a user-provided subdomain at signup:
+   * normalize → format check → reserved check → uniqueness.
+   * Throws AppError with a specific code on any failure.
+   */
+  async assertValidAndAvailable(subdomain: string): Promise<string> {
+    const normalized = subdomain.toLowerCase().trim();
+    this.validateFormat(normalized);
+    if (!(await this.isAvailable(normalized))) {
+      throw new AppError('This subdomain is already taken', 409, 'Conflict');
+    }
+    return normalized;
+  }
+}

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -187,6 +187,13 @@ export class SubdomainService {
         continue;
       }
       const candidate = `${trimmedBase}${suffix}`;
+      // Defense against future reserved-list growth: if someone later adds
+      // a suffixed name like `api-2` to RESERVED_SUBDOMAINS, this loop
+      // must not mint it. Today's list has no such entries so this is a
+      // guard, not a reachable branch — but zero-cost to check.
+      if (RESERVED_SUBDOMAINS.has(candidate)) {
+        continue;
+      }
       if (await this.isAvailable(candidate)) {
         return candidate;
       }

--- a/packages/backend/tests/api/routes/signup.route.test.ts
+++ b/packages/backend/tests/api/routes/signup.route.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Signup Route Smoke Tests
+ *
+ * Route-level verification that cannot be covered by the service-level
+ * tests in `tests/saas/signup.service.test.ts`: SELF_SERVICE_SIGNUP_ENABLED
+ * gating, `request.ip` → `ip_address` wiring, honeypot field name, and
+ * refresh_token cookie shape (domain + SameSite).
+ *
+ * Uses a minimal Fastify instance with the same plugins the real server
+ * registers (cookie, rate-limit, jwt) but with a mocked DatabaseClient —
+ * so these stay unit tests, runnable without Docker/testcontainers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import cookie from '@fastify/cookie';
+import rateLimit from '@fastify/rate-limit';
+import jwt from '@fastify/jwt';
+import type { DatabaseClient } from '../../../src/db/client.js';
+
+// ---------------------------------------------------------------------------
+// Config mock — uses `vi.hoisted` so the mutable object is available both
+// inside the hoisted vi.mock factory AND to individual tests that need to
+// flip `selfServiceSignupEnabled` / `cookieDomain` per-case.
+// ---------------------------------------------------------------------------
+
+const { mockConfig } = vi.hoisted(() => ({
+  mockConfig: {
+    auth: {
+      allowRegistration: true,
+      requireInvitationToRegister: false,
+      selfServiceSignupEnabled: true,
+      cookieDomain: null as string | null,
+    },
+    dataResidency: { region: 'kz' },
+    jwt: {
+      secret: 'test-secret-exactly-32-characters-xxxx',
+      expiresIn: '1h',
+      refreshExpiresIn: '7d',
+    },
+    server: { env: 'test' },
+  },
+}));
+
+vi.mock('../../../src/config.js', () => ({
+  config: mockConfig,
+}));
+
+vi.mock('../../../src/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Import AFTER mocks so everything resolves to the mocked config.
+import { signupRoutes } from '../../../src/api/routes/signup.js';
+import { errorHandler } from '../../../src/api/middleware/error.js';
+
+// ---------------------------------------------------------------------------
+// Mock DB — reuses the same shape as the service-level tests, without
+// pulling them in directly (keeps the test files independently readable).
+// ---------------------------------------------------------------------------
+
+function createHappyMockDb(): DatabaseClient {
+  const tx = {
+    users: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({
+        id: 'user-uuid',
+        created_at: new Date(),
+        ...d,
+      })),
+    },
+    organizations: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({
+        id: 'org-uuid',
+        created_at: new Date(),
+        updated_at: new Date(),
+        ...d,
+      })),
+    },
+    subscriptions: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({
+        id: 'sub-uuid',
+        created_at: new Date(),
+        updated_at: new Date(),
+        ...d,
+      })),
+    },
+    organizationMembers: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({ id: 'member-uuid', ...d })),
+    },
+    projects: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({
+        id: 'project-uuid',
+        created_at: new Date(),
+        updated_at: new Date(),
+        ...d,
+      })),
+    },
+    apiKeys: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({
+        id: 'apikey-uuid',
+        created_at: new Date(),
+        updated_at: new Date(),
+        ...d,
+      })),
+      logAudit: vi.fn(async () => undefined),
+    },
+  };
+
+  return {
+    users: { findByEmail: vi.fn(async () => null) },
+    organizations: { isSubdomainAvailable: vi.fn(async () => true) },
+    organizationRequests: {
+      countRecentByIp: vi.fn(async () => 0),
+      findPendingByEmail: vi.fn(async () => null),
+      isSubdomainTaken: vi.fn(async () => false),
+      isSubdomainReservedByRequest: vi.fn(async () => false),
+    },
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(tx)),
+  } as unknown as DatabaseClient;
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+async function buildServer(db: DatabaseClient): Promise<FastifyInstance> {
+  const server = Fastify();
+  await server.register(cookie);
+  await server.register(rateLimit, {
+    max: 10_000, // high enough to not affect these tests
+    timeWindow: '1 minute',
+  });
+  await server.register(jwt, { secret: mockConfig.jwt.secret });
+  server.setErrorHandler(errorHandler);
+  signupRoutes(server, db);
+  await server.ready();
+  return server;
+}
+
+function validPayload() {
+  return {
+    email: 'founder@acme.com',
+    password: 'correct-horse-battery-staple',
+    name: 'Jane Founder',
+    company_name: 'Acme Corp',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/auth/signup (route smoke)', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    mockConfig.auth.selfServiceSignupEnabled = true;
+    mockConfig.auth.cookieDomain = null;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+    }
+  });
+
+  it('returns 201 + provisioning payload on happy path', async () => {
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/signup',
+      payload: validPayload(),
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.user.email).toBe('founder@acme.com');
+    expect(body.data.organization.subdomain).toBe('acme-corp');
+    expect(body.data.project.name).toBe('My First Project');
+    expect(body.data.api_key).toMatch(/^bgs_/);
+    expect(body.data.access_token).toBeTruthy();
+  });
+
+  it('returns 403 when SELF_SERVICE_SIGNUP_ENABLED is false', async () => {
+    mockConfig.auth.selfServiceSignupEnabled = false;
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/signup',
+      payload: validPayload(),
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('maps the `website` body field to the honeypot and rejects non-empty values with 403', async () => {
+    // This verifies the handler-level mapping — the service test covers
+    // the honeypot logic itself, but only this test proves the route
+    // correctly names the honeypot field `website` in the JSON body.
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/signup',
+      payload: { ...validPayload(), website: 'https://bot-filled-this.com' },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('emits a host-scoped refresh_token cookie when COOKIE_DOMAIN is unset', async () => {
+    mockConfig.auth.cookieDomain = null;
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/signup',
+      payload: validPayload(),
+    });
+
+    expect(res.statusCode).toBe(201);
+    const setCookie = res.headers['set-cookie'];
+    const cookieStr = Array.isArray(setCookie) ? setCookie.join('\n') : String(setCookie ?? '');
+    expect(cookieStr).toMatch(/refresh_token=/);
+    expect(cookieStr).toMatch(/HttpOnly/);
+    expect(cookieStr).toMatch(/SameSite=Strict/i);
+    expect(cookieStr).not.toMatch(/Domain=/i);
+  });
+
+  it('emits a parent-domain refresh_token cookie with SameSite=Lax when COOKIE_DOMAIN is set', async () => {
+    mockConfig.auth.cookieDomain = '.kz.bugspotter.io';
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/signup',
+      payload: validPayload(),
+    });
+
+    expect(res.statusCode).toBe(201);
+    const setCookie = res.headers['set-cookie'];
+    const cookieStr = Array.isArray(setCookie) ? setCookie.join('\n') : String(setCookie ?? '');
+    expect(cookieStr).toMatch(/refresh_token=/);
+    expect(cookieStr).toMatch(/Domain=\.kz\.bugspotter\.io/);
+    expect(cookieStr).toMatch(/SameSite=Lax/i);
+  });
+
+  it('rejects payloads missing required fields with 400', async () => {
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/signup',
+      payload: { email: 'no-password@example.com' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/backend/tests/api/routes/signup.route.test.ts
+++ b/packages/backend/tests/api/routes/signup.route.test.ts
@@ -3,8 +3,8 @@
  *
  * Route-level verification that cannot be covered by the service-level
  * tests in `tests/saas/signup.service.test.ts`: SELF_SERVICE_SIGNUP_ENABLED
- * gating, `request.ip` → `ip_address` wiring, honeypot field name, and
- * refresh_token cookie shape (domain + SameSite).
+ * gating, honeypot field name, refresh_token cookie shape
+ * (domain + SameSite), and JSON-schema request validation.
  *
  * Uses a minimal Fastify instance with the same plugins the real server
  * registers (cookie, rate-limit, jwt) but with a mocked DatabaseClient —

--- a/packages/backend/tests/config.test.ts
+++ b/packages/backend/tests/config.test.ts
@@ -315,6 +315,57 @@ describe('Application Configuration', () => {
       }
     });
 
+    it('should accept a whitespace-padded DATA_RESIDENCY_REGION (trim at ingestion)', async () => {
+      // Regression guard: config.ts previously only `.toLowerCase()`ed the
+      // env, so `" kz "` (whitespace-padded, common in shell exports) would
+      // fail startup validation even though `parseDataResidencyRegion` later
+      // trimmed and accepted it.
+      process.env.DATABASE_URL = 'postgres://localhost/db';
+      process.env.DATA_RESIDENCY_REGION = '  KZ  ';
+
+      const { validateConfig, config } = await import('../src/config.js');
+      expect(() => validateConfig()).not.toThrow();
+      expect(config.dataResidency.region).toBe('kz');
+    });
+
+    it('should reject COOKIE_DOMAIN with a URL scheme', async () => {
+      process.env.DATABASE_URL = 'postgres://localhost/db';
+      process.env.COOKIE_DOMAIN = 'https://example.com';
+
+      const { validateConfig } = await import('../src/config.js');
+
+      expect(() => validateConfig()).toThrow('Configuration validation failed');
+      expect(() => validateConfig()).toThrow('COOKIE_DOMAIN must be a bare hostname');
+    });
+
+    it('should reject COOKIE_DOMAIN with a port', async () => {
+      process.env.DATABASE_URL = 'postgres://localhost/db';
+      process.env.COOKIE_DOMAIN = 'example.com:3000';
+
+      const { validateConfig } = await import('../src/config.js');
+
+      expect(() => validateConfig()).toThrow('COOKIE_DOMAIN must be a bare hostname');
+    });
+
+    it('should reject COOKIE_DOMAIN with a path', async () => {
+      process.env.DATABASE_URL = 'postgres://localhost/db';
+      process.env.COOKIE_DOMAIN = 'example.com/path';
+
+      const { validateConfig } = await import('../src/config.js');
+
+      expect(() => validateConfig()).toThrow('COOKIE_DOMAIN must be a bare hostname');
+    });
+
+    it('should accept common COOKIE_DOMAIN forms', async () => {
+      for (const domain of ['.kz.bugspotter.io', 'kz.bugspotter.io', 'localhost']) {
+        vi.resetModules();
+        process.env = { ...originalEnv, DATABASE_URL: 'postgres://localhost/db' };
+        process.env.COOKIE_DOMAIN = domain;
+        const { validateConfig } = await import('../src/config.js');
+        expect(() => validateConfig()).not.toThrow(/COOKIE_DOMAIN/);
+      }
+    });
+
     it('should throw error for mismatched S3 credentials', async () => {
       process.env.DATABASE_URL = 'postgres://localhost/db';
       process.env.STORAGE_BACKEND = 's3';

--- a/packages/backend/tests/config.test.ts
+++ b/packages/backend/tests/config.test.ts
@@ -292,6 +292,29 @@ describe('Application Configuration', () => {
       expect(() => validateConfig()).toThrow('Invalid STORAGE_BACKEND');
     });
 
+    it('should throw at startup for an unknown DATA_RESIDENCY_REGION', async () => {
+      // Regression guard: a misconfigured region previously surfaced as a
+      // generic 500 on the first /api/v1/auth/signup call, which is a bad
+      // operational signal. Fail fast at boot instead.
+      process.env.DATABASE_URL = 'postgres://localhost/db';
+      process.env.DATA_RESIDENCY_REGION = 'moon';
+
+      const { validateConfig } = await import('../src/config.js');
+
+      expect(() => validateConfig()).toThrow('Configuration validation failed');
+      expect(() => validateConfig()).toThrow('Invalid DATA_RESIDENCY_REGION');
+    });
+
+    it('should accept all documented DATA_RESIDENCY_REGION values', async () => {
+      for (const region of ['kz', 'rf', 'eu', 'us', 'global']) {
+        vi.resetModules();
+        process.env = { ...originalEnv, DATABASE_URL: 'postgres://localhost/db' };
+        process.env.DATA_RESIDENCY_REGION = region;
+        const { validateConfig } = await import('../src/config.js');
+        expect(() => validateConfig()).not.toThrow(/DATA_RESIDENCY_REGION/);
+      }
+    });
+
     it('should throw error for mismatched S3 credentials', async () => {
       process.env.DATABASE_URL = 'postgres://localhost/db';
       process.env.STORAGE_BACKEND = 's3';

--- a/packages/backend/tests/config.test.ts
+++ b/packages/backend/tests/config.test.ts
@@ -320,11 +320,15 @@ describe('Application Configuration', () => {
       // env, so `" kz "` (whitespace-padded, common in shell exports) would
       // fail startup validation even though `parseDataResidencyRegion` later
       // trimmed and accepted it.
+      //
+      // The assertion is regex-scoped to DATA_RESIDENCY_REGION so this test
+      // does not flake on CI where unrelated env vars (e.g. S3 credentials)
+      // may independently fail validation.
       process.env.DATABASE_URL = 'postgres://localhost/db';
       process.env.DATA_RESIDENCY_REGION = '  KZ  ';
 
       const { validateConfig, config } = await import('../src/config.js');
-      expect(() => validateConfig()).not.toThrow();
+      expect(() => validateConfig()).not.toThrow(/DATA_RESIDENCY_REGION/);
       expect(config.dataResidency.region).toBe('kz');
     });
 

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -1,0 +1,352 @@
+/**
+ * SignupService Unit Tests
+ * Covers the happy path plus the contract boundaries:
+ * - duplicate email → 409 (before any DB writes)
+ * - spam filter rejection → 403
+ * - spam filter error → 503 (fail closed, not fail open)
+ * - invalid subdomain → 409
+ * - atomic transaction: all 6 inserts or none
+ * - API key returned in plaintext; stored as SHA-256 hash
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SignupService } from '../../src/saas/services/signup.service.js';
+import type { DatabaseClient } from '../../src/db/client.js';
+import { DATA_RESIDENCY_REGION } from '../../src/db/types.js';
+import { hashKey } from '../../src/services/api-key/key-crypto.js';
+
+vi.mock('../../src/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+interface InsertLog {
+  users: unknown[];
+  organizations: unknown[];
+  subscriptions: unknown[];
+  organizationMembers: unknown[];
+  projects: unknown[];
+  apiKeys: unknown[];
+  apiKeyAudits: unknown[];
+}
+
+function validInput() {
+  return {
+    email: 'Founder@Acme.com',
+    password: 'correct-horse-battery-staple',
+    name: 'Jane Founder',
+    company_name: 'Acme Corp',
+    ip_address: '203.0.113.7',
+    honeypot: null,
+  };
+}
+
+interface DbOverrides {
+  findByEmail?: () => Promise<unknown>;
+  countRecentByIp?: () => Promise<number>;
+  findPendingByEmail?: () => Promise<unknown>;
+  isSubdomainTaken?: () => Promise<boolean>;
+  isSubdomainReservedByRequest?: () => Promise<boolean>;
+  orgIsSubdomainAvailable?: () => Promise<boolean>;
+  spamFilterThrows?: boolean;
+  transactionThrows?: boolean;
+}
+
+function createMockDb(overrides: DbOverrides = {}): {
+  db: DatabaseClient;
+  log: InsertLog;
+  transactionCalled: { value: number };
+} {
+  const log: InsertLog = {
+    users: [],
+    organizations: [],
+    subscriptions: [],
+    organizationMembers: [],
+    projects: [],
+    apiKeys: [],
+    apiKeyAudits: [],
+  };
+  const transactionCalled = { value: 0 };
+
+  const tx = {
+    users: {
+      create: vi.fn(async (data: unknown) => {
+        const user = { id: 'user-uuid', created_at: new Date(), ...(data as object) };
+        log.users.push(user);
+        return user;
+      }),
+    },
+    organizations: {
+      create: vi.fn(async (data: unknown) => {
+        const org = {
+          id: 'org-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.organizations.push(org);
+        return org;
+      }),
+    },
+    subscriptions: {
+      create: vi.fn(async (data: unknown) => {
+        const sub = {
+          id: 'sub-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.subscriptions.push(sub);
+        return sub;
+      }),
+    },
+    organizationMembers: {
+      create: vi.fn(async (data: unknown) => {
+        log.organizationMembers.push(data);
+        return { id: 'member-uuid', ...(data as object) };
+      }),
+    },
+    projects: {
+      create: vi.fn(async (data: unknown) => {
+        const project = {
+          id: 'project-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.projects.push(project);
+        return project;
+      }),
+    },
+    apiKeys: {
+      create: vi.fn(async (data: unknown) => {
+        const key = {
+          id: 'apikey-uuid',
+          created_at: new Date(),
+          updated_at: new Date(),
+          ...(data as object),
+        };
+        log.apiKeys.push(key);
+        return key;
+      }),
+      logAudit: vi.fn(async (data: unknown) => {
+        log.apiKeyAudits.push(data);
+      }),
+    },
+  };
+
+  const db = {
+    users: {
+      findByEmail: vi.fn(overrides.findByEmail ?? (async () => null)),
+    },
+    organizations: {
+      isSubdomainAvailable: vi.fn(overrides.orgIsSubdomainAvailable ?? (async () => true)),
+    },
+    organizationRequests: {
+      countRecentByIp: vi.fn(overrides.countRecentByIp ?? (async () => 0)),
+      findPendingByEmail: vi.fn(overrides.findPendingByEmail ?? (async () => null)),
+      isSubdomainTaken: vi.fn(overrides.isSubdomainTaken ?? (async () => false)),
+      isSubdomainReservedByRequest: vi.fn(
+        overrides.isSubdomainReservedByRequest ?? (async () => false)
+      ),
+    },
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+      transactionCalled.value++;
+      if (overrides.transactionThrows) {
+        throw new Error('simulated commit failure');
+      }
+      return cb(tx);
+    }),
+  } as unknown as DatabaseClient;
+
+  if (overrides.spamFilterThrows) {
+    (db.organizationRequests.countRecentByIp as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('db connection lost')
+    );
+  }
+
+  return { db, log, transactionCalled };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SignupService', () => {
+  let mock: ReturnType<typeof createMockDb>;
+  let service: SignupService;
+
+  beforeEach(() => {
+    mock = createMockDb();
+    service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+  });
+
+  describe('happy path', () => {
+    it('provisions all 6 records in a single transaction', async () => {
+      const result = await service.signup(validInput());
+
+      expect(mock.transactionCalled.value).toBe(1);
+      expect(mock.log.users).toHaveLength(1);
+      expect(mock.log.organizations).toHaveLength(1);
+      expect(mock.log.subscriptions).toHaveLength(1);
+      expect(mock.log.organizationMembers).toHaveLength(1);
+      expect(mock.log.projects).toHaveLength(1);
+      expect(mock.log.apiKeys).toHaveLength(1);
+      expect(mock.log.apiKeyAudits).toHaveLength(1);
+
+      expect(result.user.id).toBe('user-uuid');
+      expect(result.organization.id).toBe('org-uuid');
+      expect(result.project.id).toBe('project-uuid');
+      expect(result.api_key).toMatch(/^bgs_/);
+      expect(result.api_key_id).toBe('apikey-uuid');
+    });
+
+    it('stores the API key as a SHA-256 hex hash (not plaintext, not bcrypt)', async () => {
+      const result = await service.signup(validInput());
+      const storedKey = mock.log.apiKeys[0] as { key_hash: string };
+
+      // SHA-256 hex is always 64 hex chars.
+      expect(storedKey.key_hash).toMatch(/^[0-9a-f]{64}$/);
+      // And it verifiably matches the plaintext via the shared hashKey().
+      expect(storedKey.key_hash).toBe(hashKey(result.api_key));
+    });
+
+    it('hashes the password with bcrypt before storing', async () => {
+      await service.signup(validInput());
+      const storedUser = mock.log.users[0] as { password_hash: string };
+
+      expect(storedUser.password_hash).not.toBe(validInput().password);
+      // bcrypt hashes start with $2a$, $2b$, or $2y$
+      expect(storedUser.password_hash).toMatch(/^\$2[aby]\$/);
+    });
+
+    it('normalizes email to lowercase and trims whitespace', async () => {
+      await service.signup({ ...validInput(), email: '  Founder@Acme.COM  ' });
+      const storedUser = mock.log.users[0] as { email: string };
+      expect(storedUser.email).toBe('founder@acme.com');
+    });
+
+    it('uses the configured data residency region, not anything from input', async () => {
+      const rfService = new SignupService(mock.db, DATA_RESIDENCY_REGION.RF);
+      await rfService.signup(validInput());
+      const storedOrg = mock.log.organizations[0] as { data_residency_region: string };
+      expect(storedOrg.data_residency_region).toBe('rf');
+    });
+
+    it('auto-generates subdomain from company name when not provided', async () => {
+      await service.signup({ ...validInput(), company_name: 'Acme Widgets LLC' });
+      const storedOrg = mock.log.organizations[0] as { subdomain: string };
+      expect(storedOrg.subdomain).toBe('acme-widgets-llc');
+    });
+
+    it('uses the user-supplied subdomain when provided', async () => {
+      await service.signup({ ...validInput(), subdomain: 'my-custom-sub' });
+      const storedOrg = mock.log.organizations[0] as { subdomain: string };
+      expect(storedOrg.subdomain).toBe('my-custom-sub');
+    });
+
+    it('issues a write-scoped API key limited to the new project', async () => {
+      const result = await service.signup(validInput());
+      const storedKey = mock.log.apiKeys[0] as {
+        permission_scope: string;
+        allowed_projects: string[];
+      };
+      expect(storedKey.permission_scope).toBe('write');
+      expect(storedKey.allowed_projects).toEqual([result.project.id]);
+    });
+
+    it('uses the same timestamp for trial_ends_at and current_period_end', async () => {
+      await service.signup(validInput());
+      const storedOrg = mock.log.organizations[0] as { trial_ends_at: Date };
+      const storedSub = mock.log.subscriptions[0] as { current_period_end: Date };
+      expect(storedOrg.trial_ends_at.getTime()).toBe(storedSub.current_period_end.getTime());
+    });
+  });
+
+  describe('validation failures', () => {
+    it('rejects empty company_name with 400', async () => {
+      await expect(service.signup({ ...validInput(), company_name: '   ' })).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects duplicate email with 409 and never opens a transaction', async () => {
+      mock = createMockDb({
+        findByEmail: async () => ({ id: 'existing-user' }),
+      });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects when user-supplied subdomain is taken with 409', async () => {
+      mock = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup({ ...validInput(), subdomain: 'taken' })).rejects.toMatchObject({
+        statusCode: 409,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects when subdomain is held by a pending enterprise request', async () => {
+      mock = createMockDb({ isSubdomainReservedByRequest: async () => true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(
+        service.signup({ ...validInput(), subdomain: 'reserved' })
+      ).rejects.toMatchObject({ statusCode: 409 });
+    });
+  });
+
+  describe('spam filter', () => {
+    it('rejects honeypot-filled submissions with 403 (bot signature)', async () => {
+      await expect(
+        service.signup({ ...validInput(), honeypot: 'spam-bot-filled-this' })
+      ).rejects.toMatchObject({ statusCode: 403 });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+
+    it('rejects IP rate-limited submissions with 403', async () => {
+      mock = createMockDb({ countRecentByIp: async () => 10 });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 403,
+      });
+    });
+
+    it('fails CLOSED when the spam filter itself errors (503, not allow-through)', async () => {
+      // Regression guard: the first PR revision caught this error and let the
+      // signup proceed, effectively disabling rate-limits during DB outages.
+      mock = createMockDb({ spamFilterThrows: true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 503,
+      });
+      expect(mock.transactionCalled.value).toBe(0);
+    });
+  });
+
+  describe('transaction atomicity', () => {
+    it('surfaces a commit failure to the caller and does not return a partial result', async () => {
+      mock = createMockDb({ transactionThrows: true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toThrow(/simulated commit failure/);
+    });
+  });
+});

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -4,7 +4,8 @@
  * - duplicate email → 409 (before any DB writes)
  * - spam filter rejection → 403
  * - spam filter error → 503 (fail closed, not fail open)
- * - invalid subdomain → 409
+ * - invalid subdomain format → 400 ValidationError; taken/reserved subdomain → 409
+ * - concurrent-insert race (Postgres 23505) → 409, not 500
  * - atomic transaction: all 6 inserts or none
  * - API key returned in plaintext; stored as SHA-256 hash
  */
@@ -338,6 +339,70 @@ describe('SignupService', () => {
         statusCode: 503,
       });
       expect(mock.transactionCalled.value).toBe(0);
+    });
+  });
+
+  describe('unique-violation race', () => {
+    // Two concurrent signups can both pass the read-side checks (findByEmail,
+    // isAvailable) and both reach INSERT. The Postgres UNIQUE constraints on
+    // users.email and organizations.subdomain ensure one wins and the loser
+    // raises 23505. These tests guard that we remap to 409 (not 500).
+
+    function createMockDbWithUniqueViolation(constraint: string) {
+      const { db, log, transactionCalled } = createMockDb();
+      // Override the tx callback to throw a Postgres-shaped error with the
+      // given constraint name. This simulates the loser of an INSERT race.
+      (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        transactionCalled.value++;
+        const err = new Error('duplicate key value violates unique constraint') as Error & {
+          code: string;
+          constraint: string;
+        };
+        err.code = '23505';
+        err.constraint = constraint;
+        throw err;
+      });
+      return { db, log, transactionCalled };
+    }
+
+    it('maps a users.email UNIQUE violation to 409 Conflict', async () => {
+      const raceMock = createMockDbWithUniqueViolation('users_email_key');
+      service = new SignupService(raceMock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringMatching(/email/i) as unknown as string,
+      });
+    });
+
+    it('maps an organizations.subdomain UNIQUE violation to 409 Conflict', async () => {
+      const raceMock = createMockDbWithUniqueViolation('organizations_subdomain_key');
+      service = new SignupService(raceMock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+        message: expect.stringMatching(/subdomain/i) as unknown as string,
+      });
+    });
+
+    it('maps an unknown UNIQUE violation to a generic 409 (no SQL identifier leak)', async () => {
+      const raceMock = createMockDbWithUniqueViolation('some_internal_constraint');
+      service = new SignupService(raceMock.db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({
+        statusCode: 409,
+      });
+    });
+
+    it('does NOT swallow unrelated errors (only 23505 is remapped)', async () => {
+      const { db, transactionCalled } = createMockDb();
+      (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        transactionCalled.value++;
+        throw new Error('unrelated internal error');
+      });
+      service = new SignupService(db, DATA_RESIDENCY_REGION.KZ);
+
+      await expect(service.signup(validInput())).rejects.toThrow(/unrelated internal error/);
     });
   });
 

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -254,13 +254,20 @@ describe('SignupService', () => {
       expect(storedOrg.subdomain).toBe('my-custom-sub');
     });
 
-    it('issues a write-scoped API key limited to the new project', async () => {
+    it('issues an ingest-only API key (write-only, no read) limited to the new project', async () => {
+      // Security regression guard: the key must NOT grant reports:read or
+      // sessions:read. SDK-embedded keys ship to public web pages; granting
+      // read would let anyone with the key exfiltrate all reports/sessions.
       const result = await service.signup(validInput());
       const storedKey = mock.log.apiKeys[0] as {
         permission_scope: string;
+        permissions: string[];
         allowed_projects: string[];
       };
-      expect(storedKey.permission_scope).toBe('write');
+      expect(storedKey.permission_scope).toBe('custom');
+      expect(storedKey.permissions).toEqual(['reports:write', 'sessions:write']);
+      expect(storedKey.permissions).not.toContain('reports:read');
+      expect(storedKey.permissions).not.toContain('sessions:read');
       expect(storedKey.allowed_projects).toEqual([result.project.id]);
     });
 

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -4,7 +4,7 @@
  * - duplicate email → 409 (before any DB writes)
  * - spam filter rejection → 403
  * - spam filter error → 503 (fail closed, not fail open)
- * - invalid subdomain format → 400 ValidationError; taken/reserved subdomain → 409
+ * - invalid or reserved subdomain → 400 ValidationError; taken subdomain → 409 Conflict
  * - concurrent-insert race (Postgres 23505) → 409, not 500
  * - atomic transaction: all 6 inserts or none
  * - API key returned in plaintext; stored as SHA-256 hash

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -329,6 +329,26 @@ describe('SignupService', () => {
       });
     });
 
+    it('returns a clearer 409 (not generic 403) when email has a pending enterprise request', async () => {
+      // `SpamFilterService.findPendingByEmail` queries organization_requests.
+      // When the user previously submitted the admin-approved enterprise
+      // flow, SpamFilter sets reasons: ['duplicate_pending']. The generic
+      // 403 we return for honeypot/etc. gives the user no actionable info;
+      // this case gets a specific 409 with a support-pointer message.
+      mock = createMockDb({
+        findPendingByEmail: async () => ({
+          id: 'existing-request',
+          status: 'pending_verification',
+        }),
+      });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+
+      const err = await service.signup(validInput()).catch((e) => e);
+      expect(err.statusCode).toBe(409);
+      expect(err.error).toBe('PendingEnterpriseRequest');
+      expect(err.message).toMatch(/enterprise/i);
+    });
+
     it('fails CLOSED when the spam filter itself errors (503, not allow-through)', async () => {
       // Regression guard: the first PR revision caught this error and let the
       // signup proceed, effectively disabling rate-limits during DB outages.
@@ -392,6 +412,20 @@ describe('SignupService', () => {
       await expect(service.signup(validInput())).rejects.toMatchObject({
         statusCode: 409,
       });
+    });
+
+    it('does NOT misclassify a hypothetical users_phone_key as an email conflict', async () => {
+      // Regression guard: an earlier revision used `.includes('users')` /
+      // `.includes('email')` substring matching, which would wrongly report
+      // a future users_phone_key collision as "email already exists".
+      // The current implementation uses an exact allow-list.
+      const raceMock = createMockDbWithUniqueViolation('users_phone_key');
+      service = new SignupService(raceMock.db, DATA_RESIDENCY_REGION.KZ);
+
+      const err = await service.signup(validInput()).catch((e) => e);
+      expect(err.statusCode).toBe(409);
+      expect(err.message).not.toMatch(/email/i);
+      expect(err.message).not.toMatch(/subdomain/i);
     });
 
     it('does NOT swallow unrelated errors (only 23505 is remapped)', async () => {

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -329,6 +329,20 @@ describe('SignupService', () => {
       });
     });
 
+    it('does NOT leak the spam filter reasons array to the client (403 is opaque)', async () => {
+      // Security regression guard: echoing `reasons: ['honeypot', ...]`
+      // back to the caller lets bots iterate until they pass each
+      // individual heuristic. The server logs the reasons; the response
+      // stays opaque.
+      const err = await service
+        .signup({ ...validInput(), honeypot: 'spam-bot-filled-this' })
+        .catch((e) => e);
+      expect(err.statusCode).toBe(403);
+      expect(err.details).toBeUndefined();
+      // The public error message is generic — no "honeypot", "rate_limit", etc.
+      expect(err.message).not.toMatch(/honeypot|rate_limit|disposable|suspicious/i);
+    });
+
     it('returns a clearer 409 (not generic 403) when email has a pending enterprise request', async () => {
       // `SpamFilterService.findPendingByEmail` queries organization_requests.
       // When the user previously submitted the admin-approved enterprise

--- a/packages/backend/tests/saas/subdomain.service.test.ts
+++ b/packages/backend/tests/saas/subdomain.service.test.ts
@@ -118,6 +118,16 @@ describe('SubdomainService', () => {
       expect(() => service.validateFormat('admin')).toThrow(/reserved/);
       expect(() => service.validateFormat('signup')).toThrow(/reserved/);
     });
+
+    it('blocks every subdomain the tenant middleware refuses to route', () => {
+      // Regression guard: the reserved list used at signup must be a
+      // superset of the tenant resolution middleware's reserved set.
+      // Otherwise a user could register an org with a subdomain the
+      // router will never serve — an unrecoverable broken state.
+      for (const reserved of ['dashboard', 'payment', 'ftp', 'api', 'admin']) {
+        expect(() => service.validateFormat(reserved)).toThrow(/reserved/);
+      }
+    });
   });
 
   describe('isAvailable()', () => {

--- a/packages/backend/tests/saas/subdomain.service.test.ts
+++ b/packages/backend/tests/saas/subdomain.service.test.ts
@@ -1,0 +1,237 @@
+/**
+ * SubdomainService Unit Tests
+ * Covers slugification (including truncation edge cases), format validation,
+ * reserved-name policy, cross-table availability, and unique-name generation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SubdomainService } from '../../src/saas/services/subdomain.service.js';
+import type { DatabaseClient } from '../../src/db/client.js';
+
+vi.mock('../../src/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+interface MockOverrides {
+  orgIsSubdomainAvailable?: (sd: string) => Promise<boolean>;
+  requestIsReserved?: (sd: string) => Promise<boolean>;
+}
+
+function createMockDb(overrides: MockOverrides = {}) {
+  const orgIsSubdomainAvailable = overrides.orgIsSubdomainAvailable ?? (async () => true);
+  const requestIsReserved = overrides.requestIsReserved ?? (async () => false);
+  return {
+    organizations: {
+      isSubdomainAvailable: vi.fn(orgIsSubdomainAvailable),
+    },
+    organizationRequests: {
+      isSubdomainReservedByRequest: vi.fn(requestIsReserved),
+    },
+  } as unknown as DatabaseClient;
+}
+
+describe('SubdomainService', () => {
+  let db: DatabaseClient;
+  let service: SubdomainService;
+
+  beforeEach(() => {
+    db = createMockDb();
+    service = new SubdomainService(db);
+  });
+
+  describe('slugify()', () => {
+    it('lowercases and hyphenates a normal name', () => {
+      expect(service.slugify('Acme Corp')).toBe('acme-corp');
+    });
+
+    it('collapses consecutive special chars into a single hyphen', () => {
+      expect(service.slugify('Acme & Co., Ltd.')).toBe('acme-co-ltd');
+    });
+
+    it('trims leading and trailing hyphens', () => {
+      expect(service.slugify('  -- Acme --  ')).toBe('acme');
+    });
+
+    it('strips non-ascii alphanumerics', () => {
+      // Cyrillic → replaced by hyphens → collapsed → trimmed → empty
+      expect(service.slugify('ПримерОрг')).toBe('');
+    });
+
+    it('keeps digits', () => {
+      expect(service.slugify('Company 123')).toBe('company-123');
+    });
+
+    it('re-trims after truncation so the result never ends in a hyphen', () => {
+      // Build a 64-char string whose 64th char is a letter, but where the
+      // cut-off at char 63 lands on a hyphen.
+      // Pattern: 62 a's + '-' at index 62 (so slice(0, 63) includes it) + 'b'.
+      const input = 'a'.repeat(62) + '-' + 'b';
+      expect(input.length).toBe(64);
+      const out = service.slugify(input);
+      expect(out.length).toBeLessThanOrEqual(63);
+      expect(out.endsWith('-')).toBe(false);
+      expect(out).toBe('a'.repeat(62));
+    });
+
+    it('returns empty string for input with no usable characters', () => {
+      expect(service.slugify('!!!')).toBe('');
+      expect(service.slugify('')).toBe('');
+    });
+  });
+
+  describe('validateFormat()', () => {
+    it('accepts valid subdomains', () => {
+      expect(() => service.validateFormat('acme')).not.toThrow();
+      expect(() => service.validateFormat('acme-co')).not.toThrow();
+      expect(() => service.validateFormat('a1b')).not.toThrow();
+    });
+
+    it('rejects subdomains shorter than 3 characters', () => {
+      expect(() => service.validateFormat('ab')).toThrow(/at least 3/);
+    });
+
+    it('rejects subdomains longer than 63 characters', () => {
+      expect(() => service.validateFormat('a'.repeat(64))).toThrow(/at most 63/);
+    });
+
+    it('rejects uppercase letters', () => {
+      expect(() => service.validateFormat('Acme')).toThrow(/lowercase/);
+    });
+
+    it('rejects underscores and other non-LDH characters', () => {
+      expect(() => service.validateFormat('acme_co')).toThrow();
+      expect(() => service.validateFormat('acme.co')).toThrow();
+    });
+
+    it('rejects leading or trailing hyphens', () => {
+      expect(() => service.validateFormat('-acme')).toThrow();
+      expect(() => service.validateFormat('acme-')).toThrow();
+    });
+
+    it('rejects reserved names', () => {
+      expect(() => service.validateFormat('api')).toThrow(/reserved/);
+      expect(() => service.validateFormat('admin')).toThrow(/reserved/);
+      expect(() => service.validateFormat('signup')).toThrow(/reserved/);
+    });
+  });
+
+  describe('isAvailable()', () => {
+    it('returns true when neither table holds the subdomain', async () => {
+      expect(await service.isAvailable('new-co')).toBe(true);
+    });
+
+    it('returns false when organizations table already holds it', async () => {
+      db = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SubdomainService(db);
+      expect(await service.isAvailable('taken')).toBe(false);
+    });
+
+    it('returns false when a non-terminal organization request holds it', async () => {
+      // Regression guard for the bug in the first PR revision, where the
+      // second check called `isSubdomainTaken` (which actually queries the
+      // organizations table) and never blocked a pending enterprise request.
+      db = createMockDb({ requestIsReserved: async () => true });
+      service = new SubdomainService(db);
+      expect(await service.isAvailable('reserved-by-request')).toBe(false);
+    });
+
+    it('normalizes the input to lowercase before checking', async () => {
+      const orgFn = vi.fn().mockResolvedValue(true);
+      const reqFn = vi.fn().mockResolvedValue(false);
+      db = {
+        organizations: { isSubdomainAvailable: orgFn },
+        organizationRequests: { isSubdomainReservedByRequest: reqFn },
+      } as unknown as DatabaseClient;
+      service = new SubdomainService(db);
+      await service.isAvailable('Mixed-CASE');
+      expect(orgFn).toHaveBeenCalledWith('mixed-case');
+      expect(reqFn).toHaveBeenCalledWith('mixed-case');
+    });
+  });
+
+  describe('generateUniqueFromName()', () => {
+    it('returns the clean slug when available', async () => {
+      expect(await service.generateUniqueFromName('Acme Corp')).toBe('acme-corp');
+    });
+
+    it('throws a ValidationError when the seed yields too few characters', async () => {
+      await expect(service.generateUniqueFromName('!!')).rejects.toThrow(
+        /Could not derive a valid subdomain/
+      );
+    });
+
+    it('appends a numeric suffix on collision', async () => {
+      let callCount = 0;
+      const orgFn = vi.fn().mockImplementation(async () => {
+        callCount++;
+        // First call (base "acme-corp") collides, all subsequent return available.
+        return callCount !== 1;
+      });
+      db = {
+        organizations: { isSubdomainAvailable: orgFn },
+        organizationRequests: { isSubdomainReservedByRequest: vi.fn().mockResolvedValue(false) },
+      } as unknown as DatabaseClient;
+      service = new SubdomainService(db);
+
+      const result = await service.generateUniqueFromName('Acme Corp');
+      expect(result).toBe('acme-corp-2');
+    });
+
+    it('skips a reserved base and falls through to suffixed attempts', async () => {
+      const result = await service.generateUniqueFromName('api');
+      // 'api' is reserved but 'api-2' is not and isAvailable returns true.
+      expect(result).toBe('api-2');
+    });
+
+    it('throws Conflict when all suffix attempts exhaust', async () => {
+      db = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SubdomainService(db);
+      await expect(service.generateUniqueFromName('Acme Corp')).rejects.toThrow(
+        /Could not generate a unique subdomain/
+      );
+    });
+
+    it('handles base near the 63-char limit without producing "foo--2"', async () => {
+      // Craft a base that would be exactly 63 chars ending in a letter, so
+      // when we slice to make room for '-2' (3 chars), the slice boundary
+      // lands at char 60. Pad so the slice boundary would be a hyphen and
+      // verify we DON'T emit '--2'.
+      const name = 'a'.repeat(60) + '-company'; // slugifies to "aaaa...a-company"
+      // Force collision on the base so it falls into the suffix loop.
+      const orgFn = vi
+        .fn()
+        .mockImplementationOnce(async () => false) // base collides
+        .mockResolvedValue(true);
+      db = {
+        organizations: { isSubdomainAvailable: orgFn },
+        organizationRequests: { isSubdomainReservedByRequest: vi.fn().mockResolvedValue(false) },
+      } as unknown as DatabaseClient;
+      service = new SubdomainService(db);
+
+      const result = await service.generateUniqueFromName(name);
+      expect(result).not.toMatch(/--/);
+      expect(result.endsWith('-2')).toBe(true);
+    });
+  });
+
+  describe('assertValidAndAvailable()', () => {
+    it('returns normalized subdomain on happy path', async () => {
+      expect(await service.assertValidAndAvailable('  AcmeCo ')).toBe('acmeco');
+    });
+
+    it('throws 400 for invalid format', async () => {
+      await expect(service.assertValidAndAvailable('A_B')).rejects.toThrow();
+    });
+
+    it('throws 409 when already taken', async () => {
+      db = createMockDb({ orgIsSubdomainAvailable: async () => false });
+      service = new SubdomainService(db);
+      await expect(service.assertValidAndAvailable('taken')).rejects.toThrow(/already taken/);
+    });
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -60,6 +60,8 @@ export default defineConfig({
       'tests/api/utils/enrichment-trigger.test.ts',
       'tests/services/intelligence/dedup-service.test.ts',
       'tests/services/intelligence/self-service.test.ts',
+      // Pure env-var / config validation test, no DB.
+      'tests/config.test.ts',
     ],
     testTimeout: 10000,
     hookTimeout: 10000,

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
       'tests/saas/invitation-email.service.test.ts',
       'tests/saas/plans.test.ts',
       'tests/saas/spam-filter.service.test.ts',
+      'tests/saas/subdomain.service.test.ts',
+      'tests/saas/signup.service.test.ts',
       'tests/saas/tenant-middleware.test.ts',
       // Integration tests that don't require database
       'tests/integrations/plugin-utils-retry.test.ts',

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       'tests/api/routes/rbac-enforcement.test.ts',
       'tests/api/routes/permissions.test.ts',
       'tests/api/routes/rbac-regression.test.ts',
+      'tests/api/routes/signup.route.test.ts',
       'tests/api/services/**/*.test.ts',
       'tests/cache/**/*.test.ts',
       // Only include pure unit tests from tests/db/ (no database required)


### PR DESCRIPTION
## Summary

Phase 1 of the self-service signup MVP. Adds `POST /api/v1/auth/signup` — one atomic call provisions user + organization + trial subscription + owner membership + default project + **ingest-only** API key (write access to reports/sessions, no read); returns JWTs + plaintext key in a single response.

Separate from `/auth/register` (user-only) and `/organization-requests` (admin-approved enterprise flow) — both preserved unchanged.

Supersedes #16 — same work with four rounds of review feedback incorporated.

## Endpoint behavior

- `SELF_SERVICE_SIGNUP_ENABLED=false` → 403.
- Empty / whitespace `company_name` → 400.
- Honeypot (`website` field) filled → 403, response is **opaque** (reasons logged server-side only, never echoed to the client).
- Per-IP rate limit **5/min** via `@fastify/rate-limit` route override.
- Spam filter fails **closed**: errors in the filter itself refuse signup with 503.
- Email pre-check is **case-insensitive** (`LOWER(email) = LOWER($1)` with deterministic `ORDER BY created_at ASC, id ASC LIMIT 2`; `logger.warn` with `sampledCount` when multiple rows match historical mixed-case data).
- Duplicate email (pre-check) → 409. User had a pending enterprise request → specific 409 with `PendingEnterpriseRequest` error code.
- Invalid or reserved subdomain → 400; taken subdomain (in `organizations` including soft-deleted, or non-terminal rows in `organization_requests`) → 409.
- Concurrent-insert race (Postgres 23505) caught and remapped to 409 with a constraint-specific message (exact allow-list: `users_email_key`, `organizations_subdomain_key`).
- Reserved subdomains are a **superset** of the tenant middleware's list; auto-generated suffixes (`acme-2`, `acme-3`, …) also skip reserved values in case the list expands.
- API key uses `PERMISSION_SCOPE.CUSTOM` with exactly `['reports:write', 'sessions:write']` — NO read. SDK-embedded keys ship to public pages; read access would let page visitors exfiltrate all reports/sessions.

## Config / infra

| env | default | effect |
|---|---|---|
| `SELF_SERVICE_SIGNUP_ENABLED` | `true` in saas, `false` self-hosted | gate the endpoint |
| `COOKIE_DOMAIN` | empty | when set, refresh cookie gets `domain=` + `SameSite=Lax` for cross-subdomain SSO. Validated at boot (rejects scheme, path, port, whitespace, uppercase). |
| `DATA_RESIDENCY_REGION` | `kz` | validated at startup against `Object.values(DATA_RESIDENCY_REGION)`; whitespace-padded values trimmed at ingestion. |

## Migrations

- **017_org_request_subdomain_index.sql** — partial functional index on `organization_requests (subdomain)` for non-terminal statuses. Without it, `isSubdomainReservedByRequest` degrades to a seq scan (called once per signup + up to 50× in the collision loop).
- **018_users_email_lower_index.sql** — non-UNIQUE functional index on `LOWER(email)`. Keeps case-insensitive lookup cheap. Non-UNIQUE deliberately — historical mixed-case duplicates may exist and a UNIQUE index would fail to create. Upgrading to UNIQUE is a follow-up once data is audited.

## Key design decisions

- **Single atomic tx** for 6 inserts. Failures roll back cleanly; timestamps captured once at the top; success log emitted *after* commit, not inside the callback. 23505 remap is a backstop for the loser of a race — normal path goes through the pre-checks.
- **Ingest-only API key** (`custom` scope with `['reports:write', 'sessions:write']`), scoped to `allowed_projects: [project.id]`. No dedicated `ingest` scope in the enum, so `custom` is the least-privilege path without a schema change.
- **Shared `generateAuthTokens`** helper replaces duplicated token-signing logic across `/register`, `/login`, `/refresh`, `/magic-login`, `/signup` — single source of truth.
- **`findByEmail` is now deterministic** even when historical mixed-case duplicates exist: oldest match wins, ops gets a warning with a sampled count.
- **Reserved subdomain set** imports from `saas/middleware/tenant.js` and extends — so signup can never produce a subdomain the router won't serve.
- **Single source of truth** for residency regions: `DATA_RESIDENCY_REGION` in `db/types.ts`. `validateConfig` consumes it via `Object.values(...)`.

## Explicitly deferred

- **Email verification.** Needs `users.email_verified_at` column + email template. Scoped to a follow-up.
- **Persisted spam score.** SpamFilter returns a score; we only use it for reject/not-reject.
- **Subdomain abuse heuristics.** SpamFilter only pattern-checks `company_name`, not `subdomain`.
- **UNIQUE functional index on `LOWER(email)`.** Requires a data audit first; current migration 018 is non-unique for perf only.
- **Integration-level test against real DB.** All tests here are unit-level.

## Tests

**112 unit tests** across the affected suites (all green, typecheck clean, full CI green on preceding commit):

- **SubdomainService (28 tests)**: slugify + truncation edge cases, format validation, reserved set is superset of tenant middleware's list, cross-table availability including soft-delete policy, unique-name generation (base collision, reserved-base fall-through, exhaustion, hyphen-avoidance near length limit, **reserved check inside suffix loop**), `assertValidAndAvailable`.
- **SignupService (24 tests)**: happy path (all 6 inserts in one tx), SHA-256 key hashing, bcrypt password hashing, email normalization, region from config, auto vs explicit subdomain, **ingest-only API key — explicit regression guard that the key does NOT carry `reports:read` or `sessions:read`**, single-timestamp consistency, validation failures, spam rejection, **reasons not leaked to client** (security guard), fail-closed spam filter, **23505 → 409 with exact constraint-name matching** (users.email, organizations.subdomain, unknown → generic, future `users_phone_key` not misclassified, unrelated errors not swallowed), `duplicate_pending` → 409 `PendingEnterpriseRequest`, commit-failure propagation.
- **Route smoke (6 tests via `fastify.inject`)**: happy path, `SELF_SERVICE_SIGNUP_ENABLED=false` → 403, honeypot field name mapping, cookie attrs for `COOKIE_DOMAIN` set and unset, schema rejection of missing required fields.
- **Config validation (40 tests, +6 new)**: unknown `DATA_RESIDENCY_REGION` throws at startup, whitespace-padded accepted (trim), all documented values accepted, `COOKIE_DOMAIN` rejects scheme/port/path/whitespace/uppercase, accepts common forms.
- **Auth handlers (14 tests)** still green — `generateAuthTokens` refactor did not regress `/register`, `/login`, `/refresh`, or `/magic-login`.

## Test plan

- [x] Unit: `pnpm test:unit` on affected suites — 112/112 passing.
- [x] Source typecheck: `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] Full CI green on prior commit (all 10 checks: lint, 4× backend test suites, docker compose, admin E2E, test coverage, build, CI).
- [ ] Manual `curl POST /api/v1/auth/signup` on a deployed instance.
- [ ] Verify cross-subdomain cookie when `COOKIE_DOMAIN=.kz.bugspotter.io`.
- [ ] Verify `trustProxy` wiring for real-IP rate-limit behind CDN (infra; project-plan pre-prod blocker).
- [ ] Integration test against real DB (follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)