### PR TITLE
docs: add CLAUDE.md at monorepo root, backend, admin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ SaaS bug-reporting platform. pnpm + TypeScript, Docker-native dev loop.
 
 - `packages/` — backend (Fastify), billing, types, utils, message-broker, payment-service
 - `apps/` — admin (React/Vite), demo (showcase)
-- `docker-compose*.yml` — dev stack; `./dev.sh up` brings everything up including Postgres + Redis + MinIO
-- **Dozzle** on `:8080` — live log viewer for running containers
+- `docker-compose*.yml` — dev stack; `./dev.sh start` brings everything up including Postgres + Redis + MinIO. `./dev.sh help` lists the other subcommands.
+- **Dozzle** on `http://localhost:9999` — live log viewer for running containers (host port from `docker-compose.override.yml`; container port is 8080).
 
 ## Deployment modes
 
@@ -21,7 +21,7 @@ Flags that depend on mode are declared in `packages/backend/src/config.ts`.
 ## Common commands
 
 ```bash
-./dev.sh up                                      # bring up the stack
+./dev.sh start                                   # bring up the stack
 pnpm --filter @bugspotter/backend dev            # API on :3000
 pnpm --filter @bugspotter/backend typecheck      # src-only typecheck
 pnpm --filter @bugspotter/backend test:unit      # no docker needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# BugSpotter Monorepo
+
+SaaS bug-reporting platform. pnpm + TypeScript, Docker-native dev loop.
+
+## Shape
+
+- `packages/` — backend (Fastify), billing, types, utils, message-broker, payment-service
+- `apps/` — admin (React/Vite), demo (showcase)
+- `docker-compose*.yml` — dev stack; `./dev.sh up` brings everything up including Postgres + Redis + MinIO
+- **Dozzle** on `:8080` — live log viewer for running containers
+
+## Deployment modes
+
+The `DEPLOYMENT_MODE` env toggles major behavior:
+
+- `saas` (prod on `*.kz.bugspotter.io`) — multi-tenancy, billing, quota enforcement, self-service signup, tenant resolution middleware.
+- `selfhosted` (customer-deployable) — single tenant, no billing, no signup endpoint.
+
+Flags that depend on mode are declared in `packages/backend/src/config.ts`.
+
+## Common commands
+
+```bash
+./dev.sh up                                      # bring up the stack
+pnpm --filter @bugspotter/backend dev            # API on :3000
+pnpm --filter @bugspotter/backend typecheck      # src-only typecheck
+pnpm --filter @bugspotter/backend test:unit      # no docker needed
+pnpm --filter @bugspotter/backend migrate        # run DB migrations
+pnpm --filter @bugspotter/admin dev              # admin UI on :5173
+```
+
+## Where things live
+
+- **Backend** — `packages/backend/CLAUDE.md` for the auth model, migration rules, test harness.
+- **Admin UI** — `apps/admin/CLAUDE.md` for routing, i18n, E2E config variants.
+- **Landing signup wizard** is in a _separate_ repo: `bugspotter-landing/` (Astro).
+- **Chrome extension** is in a _separate_ repo: `bugspotter-extension/`.
+
+See also: `LOCAL_DEVELOPMENT.md`, `DOCKER.md`, `CONTRIBUTING.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ SaaS bug-reporting platform. pnpm + TypeScript, Docker-native dev loop.
 - `packages/` — backend (Fastify), billing, types, utils, message-broker, payment-service
 - `apps/` — admin (React/Vite), demo (showcase)
 - `docker-compose*.yml` — dev stack; `./dev.sh start` brings everything up including Postgres + Redis + MinIO. `./dev.sh help` lists the other subcommands.
-- **Dozzle** on `http://localhost:9999` — live log viewer for running containers (host port from `docker-compose.override.yml`; container port is 8080).
+- **Dozzle** (optional live log viewer) is behind the `monitoring` profile — NOT started by `./dev.sh start`. Bring it up with `docker compose --profile monitoring up -d dozzle`; then `http://localhost:9999`.
 
 ## Deployment modes
 

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -2,44 +2,34 @@
 
 Tenant admin dashboard. React 18 + Vite + react-i18next. Deployed behind nginx.
 
-## Tenant routing
+## Tenant routing + cross-subdomain auth
 
-- Prod URL pattern: `https://[org].kz.bugspotter.io/...`
-- The _subdomain_ resolves the tenant; don't hardcode org IDs or embed them in URLs — the backend's tenant middleware attaches `request.organizationId` based on the host.
-- Auth flows through the refresh_token cookie set by `api.kz.bugspotter.io`. Requires `COOKIE_DOMAIN=.kz.bugspotter.io` on the backend env or cross-subdomain SSO doesn't work (see `packages/backend/CLAUDE.md`).
+- Prod URL pattern: `https://[org].kz.bugspotter.io/...`. The _subdomain_ resolves the tenant — don't hardcode org IDs in URLs; the backend's tenant middleware attaches `request.organizationId` based on the host.
+- Auth is JWT in a refresh-token cookie set by `api.kz.bugspotter.io`. For the wizard → tenant UI handoff to work, the backend must run with `COOKIE_DOMAIN=.kz.bugspotter.io` so the cookie carries a `Domain` attribute and `SameSite=Lax`; otherwise it stays host-scoped and each subdomain prompts for login.
 
-## i18n
+## i18n (en / ru / kk, kept in sync)
 
-- `react-i18next` with three locales: `en`, `ru`, `kk`. All JSON under `src/i18n/locales/`.
-- Keep all three files in sync — CI runs `pnpm validate:i18n` and fails on missing keys.
-- `pnpm test:i18n` runs the locale-sync unit test locally.
-- Never inline English strings in JSX — use `t('key')`.
+- `react-i18next`, JSON under `src/i18n/locales/`. Three locales; drift fails CI.
+- `pnpm validate:i18n` (root) or `pnpm test:i18n` (local unit test) checks key sync.
+- Never inline English strings in JSX — always `t('key')`.
 
-## Test configs (not interchangeable)
+## Tests
 
-- `playwright.config.ts` — default E2E run.
-- `playwright.seed.config.ts` — runs `seed-demo-bugs.spec.ts` to populate demo data.
-- `playwright.video.config.ts` / `.video-extension.config.ts` — record walkthrough videos.
-
-Pick the right one for the task:
-
-```bash
-pnpm test:e2e                # default (chromium)
-pnpm test:e2e:ci             # CI preset — chromium only, retries=2
-pnpm test:e2e:ui             # interactive UI mode for debugging
-pnpm test:e2e:notifications  # targeted suite for notification-delivery
-```
-
-## Nginx tests
-
-The admin ships its own nginx config (`nginx.conf.template`). `pnpm test:nginx` validates CORS, cache directives, and general config sanity. Run it when touching `nginx*.conf` or `docker-entrypoint.sh`.
+- Unit (vitest): `pnpm test`.
+- E2E (Playwright) lives in `src/tests/e2e/`, driven by `playwright.config.ts`. Useful commands:
+  ```bash
+  pnpm test:e2e                # full suite, chromium
+  pnpm test:e2e:ci             # CI preset — chromium only, retries=2
+  pnpm test:e2e:ui              # interactive debug mode
+  pnpm test:e2e:notifications   # targeted: notification-delivery spec only
+  ```
+- The admin ships its own nginx config (`nginx.conf.template`); `pnpm test:nginx` validates CORS/cache directives. Run it when editing `nginx*.conf` or `docker-entrypoint.sh`.
 
 ## Commands
 
 ```bash
 pnpm dev             # Vite on :5173
 pnpm build           # tsc + vite build
-pnpm test            # vitest (unit)
 pnpm lint            # eslint, 0 warnings policy
 pnpm validate:i18n   # fails CI if locales drift
 ```

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1,0 +1,45 @@
+# @bugspotter/admin
+
+Tenant admin dashboard. React 18 + Vite + react-i18next. Deployed behind nginx.
+
+## Tenant routing
+
+- Prod URL pattern: `https://[org].kz.bugspotter.io/...`
+- The _subdomain_ resolves the tenant; don't hardcode org IDs or embed them in URLs — the backend's tenant middleware attaches `request.organizationId` based on the host.
+- Auth flows through the refresh_token cookie set by `api.kz.bugspotter.io`. Requires `COOKIE_DOMAIN=.kz.bugspotter.io` on the backend env or cross-subdomain SSO doesn't work (see `packages/backend/CLAUDE.md`).
+
+## i18n
+
+- `react-i18next` with three locales: `en`, `ru`, `kk`. All JSON under `src/i18n/locales/`.
+- Keep all three files in sync — CI runs `pnpm validate:i18n` and fails on missing keys.
+- `pnpm test:i18n` runs the locale-sync unit test locally.
+- Never inline English strings in JSX — use `t('key')`.
+
+## Test configs (not interchangeable)
+
+- `playwright.config.ts` — default E2E run.
+- `playwright.seed.config.ts` — runs `seed-demo-bugs.spec.ts` to populate demo data.
+- `playwright.video.config.ts` / `.video-extension.config.ts` — record walkthrough videos.
+
+Pick the right one for the task:
+
+```bash
+pnpm test:e2e                # default (chromium)
+pnpm test:e2e:ci             # CI preset — chromium only, retries=2
+pnpm test:e2e:ui             # interactive UI mode for debugging
+pnpm test:e2e:notifications  # targeted suite for notification-delivery
+```
+
+## Nginx tests
+
+The admin ships its own nginx config (`nginx.conf.template`). `pnpm test:nginx` validates CORS, cache directives, and general config sanity. Run it when touching `nginx*.conf` or `docker-entrypoint.sh`.
+
+## Commands
+
+```bash
+pnpm dev             # Vite on :5173
+pnpm build           # tsc + vite build
+pnpm test            # vitest (unit)
+pnpm lint            # eslint, 0 warnings policy
+pnpm validate:i18n   # fails CI if locales drift
+```

--- a/packages/backend/CLAUDE.md
+++ b/packages/backend/CLAUDE.md
@@ -4,13 +4,14 @@ Fastify + pg + BullMQ. Most complex package in the monorepo.
 
 ## The auth trio
 
-Every request can carry up to three auth artifacts:
+Every request can carry up to four auth artifacts:
 
-| Field                 | Set by                                                  | Meaning                                 |
-| --------------------- | ------------------------------------------------------- | --------------------------------------- |
-| `request.authUser`    | JWT (`Authorization: Bearer <token>`)                   | Dashboard user                          |
-| `request.apiKey`      | `X-API-Key: bgs_...` header                             | SDK / machine credential                |
-| `request.authProject` | Alongside `apiKey` when `allowed_projects.length === 1` | Convenience flag for single-project key |
+| Field                    | Set by                                                  | Meaning                                       |
+| ------------------------ | ------------------------------------------------------- | --------------------------------------------- |
+| `request.authUser`       | JWT (`Authorization: Bearer <token>`)                   | Dashboard user                                |
+| `request.apiKey`         | `X-API-Key: bgs_...` header                             | SDK / machine credential                      |
+| `request.authProject`    | Alongside `apiKey` when `allowed_projects.length === 1` | Convenience flag for single-project key       |
+| `request.authShareToken` | `handleShareTokenAuth` via share-token query/body param | Public replay-access grant, bug-report-scoped |
 
 **`authProject` is NOT a legacy flag.** It's set inside `handleNewApiKeyAuth` (`src/api/middleware/auth/handlers.ts`), only after `request.apiKey` is set, and only for single-project keys — which includes the self-service-signup-issued ingest-only key. Bypassing on `authProject` would let that key read reports, so don't.
 

--- a/packages/backend/CLAUDE.md
+++ b/packages/backend/CLAUDE.md
@@ -4,48 +4,34 @@ Fastify + pg + BullMQ. Most complex package in the monorepo.
 
 ## The auth trio
 
-Every request can carry up to three auth artifacts. Get these right before writing route-level guards:
+Every request can carry up to three auth artifacts:
 
-| Field                 | Set by                                                            | Meaning                                   |
-| --------------------- | ----------------------------------------------------------------- | ----------------------------------------- |
-| `request.authUser`    | JWT (`Authorization: Bearer <token>`)                             | Dashboard user                            |
-| `request.apiKey`      | `X-API-Key: bgs_...` header                                       | SDK / machine credential                  |
-| `request.authProject` | Alongside `apiKey`, **only** when `allowed_projects.length === 1` | Convenience flag for "single-project key" |
+| Field                 | Set by                                                  | Meaning                                 |
+| --------------------- | ------------------------------------------------------- | --------------------------------------- |
+| `request.authUser`    | JWT (`Authorization: Bearer <token>`)                   | Dashboard user                          |
+| `request.apiKey`      | `X-API-Key: bgs_...` header                             | SDK / machine credential                |
+| `request.authProject` | Alongside `apiKey` when `allowed_projects.length === 1` | Convenience flag for single-project key |
 
-**`authProject` is NOT a legacy flag.** It's the _only_ assignment site at `src/api/middleware/auth/handlers.ts:98`, set right after `request.apiKey = apiKey` (same function). Treating it as a legacy / unrestricted bypass is a recurring misread — the self-service-signup-issued ingest-only key has `authProject` set because it's single-project, and bypassing on `authProject` would let it read reports.
+**`authProject` is NOT a legacy flag.** It's set inside `handleNewApiKeyAuth` (`src/api/middleware/auth/handlers.ts`), only after `request.apiKey` is set, and only for single-project keys — which includes the self-service-signup-issued ingest-only key. Bypassing on `authProject` would let that key read reports, so don't.
 
-## API key permission enforcement (since PR #19)
+## API key permission enforcement
 
-- The key's `permissions` array IS enforced on read routes. Use `requireApiKeyPermission('resource:action')` as a preHandler.
-- Always delegate to the shared `checkPermission` in `src/services/api-key/key-permissions.ts` — it handles `'*'` wildcards and scope fallback for pre-backfill keys. Do not reimplement the check.
-- POSTs today gate on `requireProject` + `allowed_projects` only; declared permissions are not enforced on writes yet (see the follow-up in PR #19 description).
+- Read routes enforce the key's `permissions` via `requireApiKeyPermission('resource:action')` as a preHandler.
+- Delegate to the shared `checkPermission` in `src/services/api-key/key-permissions.ts` — it handles `'*'` wildcards and scope fallback for pre-backfill keys. Don't reimplement.
+- Write routes (POST/PATCH/DELETE on reports) currently gate on `requireProject` + `allowed_projects` only; the permissions array is advisory on writes until the same middleware is applied there.
 
-## Schema split
+## Schema + migrations
 
-- `application.*` — users, projects, bug_reports, api_keys. Everyone uses these.
-- `saas.*` — organizations, subscriptions, organization_requests, invitations. SaaS-mode only.
+- `application.*` — users, projects, bug_reports, api_keys (used in every mode).
+- `saas.*` — organizations, subscriptions, organization_requests, invitations (SaaS-mode only).
+- Migrations in `src/db/migrations/NNN_description.sql`, run via `pnpm migrate`. Never rewrite a merged migration — add a new one.
 
-Migrations live in `src/db/migrations/NNN_description.sql`, run via `pnpm migrate`. Never rewrite a merged migration — add a new one.
+## Repositories + transactions
 
-## Repository pattern
-
-- Every repo extends `BaseRepository<T, TInsert, TUpdate>`. Use `findBy`, `findById`, `create`, `update` — don't hand-write SQL unless there's a specific reason (advisory locks, functional indexes, etc.).
-- Compose filters with `createFilter()`, pagination with `createPagination()`.
-- Transactions: `db.transaction(async tx => ...)` gives you the typed repo object; `db.queryWithTransaction(async client => ...)` gives you a raw `pg.PoolClient` when you need advisory locks.
+- Most CRUD-style repos extend `BaseRepository<T, TInsert, TUpdate>` — prefer `findBy` / `findById` / `create` / `update` and compose filters via `createFilter()`, pagination via `createPagination()`. A few specialized repos (outbox flows, advisory-lock paths) hand-write SQL; that's intentional.
+- `db.transaction(async tx => ...)` for tx-scoped repo calls. `db.queryWithTransaction(async client => ...)` gives you a raw `pg.PoolClient` when you need advisory locks.
 
 ## Test harness
 
-- **Unit** (`pnpm test:unit`, no Docker) — mocks DB; `tests/setup-unit-env.ts` populates `ENCRYPTION_KEY` and `JWT_SECRET`.
-- **Integration** (`pnpm test:integration`, needs Docker) — spins up a real Postgres via testcontainers in `tests/setup.ts`.
-
-CI sets env vars via workflow; locally the setup files match that.
-
-## Commands
-
-```bash
-pnpm dev            # tsx watch
-pnpm typecheck      # src-only, fast
-pnpm test:unit      # ~20s, no Docker
-pnpm test:integration  # slower, needs Docker
-pnpm migrate        # apply DB migrations
-```
+- **Unit** (`pnpm test:unit`, no Docker): mocks DB; `tests/setup-unit-env.ts` populates `ENCRYPTION_KEY` + `JWT_SECRET` so the suite runs standalone.
+- **Integration** (`pnpm test:integration`, needs Docker): spins up real Postgres via testcontainers from `tests/setup.integration.ts`.

--- a/packages/backend/CLAUDE.md
+++ b/packages/backend/CLAUDE.md
@@ -1,0 +1,51 @@
+# @bugspotter/backend
+
+Fastify + pg + BullMQ. Most complex package in the monorepo.
+
+## The auth trio
+
+Every request can carry up to three auth artifacts. Get these right before writing route-level guards:
+
+| Field                 | Set by                                                            | Meaning                                   |
+| --------------------- | ----------------------------------------------------------------- | ----------------------------------------- |
+| `request.authUser`    | JWT (`Authorization: Bearer <token>`)                             | Dashboard user                            |
+| `request.apiKey`      | `X-API-Key: bgs_...` header                                       | SDK / machine credential                  |
+| `request.authProject` | Alongside `apiKey`, **only** when `allowed_projects.length === 1` | Convenience flag for "single-project key" |
+
+**`authProject` is NOT a legacy flag.** It's the _only_ assignment site at `src/api/middleware/auth/handlers.ts:98`, set right after `request.apiKey = apiKey` (same function). Treating it as a legacy / unrestricted bypass is a recurring misread — the self-service-signup-issued ingest-only key has `authProject` set because it's single-project, and bypassing on `authProject` would let it read reports.
+
+## API key permission enforcement (since PR #19)
+
+- The key's `permissions` array IS enforced on read routes. Use `requireApiKeyPermission('resource:action')` as a preHandler.
+- Always delegate to the shared `checkPermission` in `src/services/api-key/key-permissions.ts` — it handles `'*'` wildcards and scope fallback for pre-backfill keys. Do not reimplement the check.
+- POSTs today gate on `requireProject` + `allowed_projects` only; declared permissions are not enforced on writes yet (see the follow-up in PR #19 description).
+
+## Schema split
+
+- `application.*` — users, projects, bug_reports, api_keys. Everyone uses these.
+- `saas.*` — organizations, subscriptions, organization_requests, invitations. SaaS-mode only.
+
+Migrations live in `src/db/migrations/NNN_description.sql`, run via `pnpm migrate`. Never rewrite a merged migration — add a new one.
+
+## Repository pattern
+
+- Every repo extends `BaseRepository<T, TInsert, TUpdate>`. Use `findBy`, `findById`, `create`, `update` — don't hand-write SQL unless there's a specific reason (advisory locks, functional indexes, etc.).
+- Compose filters with `createFilter()`, pagination with `createPagination()`.
+- Transactions: `db.transaction(async tx => ...)` gives you the typed repo object; `db.queryWithTransaction(async client => ...)` gives you a raw `pg.PoolClient` when you need advisory locks.
+
+## Test harness
+
+- **Unit** (`pnpm test:unit`, no Docker) — mocks DB; `tests/setup-unit-env.ts` populates `ENCRYPTION_KEY` and `JWT_SECRET`.
+- **Integration** (`pnpm test:integration`, needs Docker) — spins up a real Postgres via testcontainers in `tests/setup.ts`.
+
+CI sets env vars via workflow; locally the setup files match that.
+
+## Commands
+
+```bash
+pnpm dev            # tsx watch
+pnpm typecheck      # src-only, fast
+pnpm test:unit      # ~20s, no Docker
+pnpm test:integration  # slower, needs Docker
+pnpm migrate        # apply DB migrations
+```


### PR DESCRIPTION
## Summary

Three concise CLAUDE.md files (~35–40 LOC each) placed where they earn their keep — encoding non-obvious things a fresh reader (or agent session) can't derive from the code in 30 seconds. Matches the pattern in [bugspotter-landing/CLAUDE.md](https://github.com/apex-bridge/bugspotter-landing/blob/main/CLAUDE.md).

## Files

- **`CLAUDE.md`** (repo root): monorepo shape, `DEPLOYMENT_MODE=saas` vs `selfhosted` semantics, common dev commands, Dozzle pointer, pointers to the deeper CLAUDE.md files.
- **`packages/backend/CLAUDE.md`**: the auth trio (`authUser` / `apiKey` / `authProject`), with an explicit callout that `authProject` is NOT a legacy-unrestricted flag — bypassing on it re-introduces the bug PR #19 fixed. Also: PR #19 permission-enforcement rule, `application.*` vs `saas.*` schema split, migration convention (append-only), repository pattern, unit vs integration test harness.
- **`apps/admin/CLAUDE.md`**: tenant routing via subdomain, the cross-subdomain cookie requirement (`COOKIE_DOMAIN=.kz.bugspotter.io` on the backend), i18n triple-sync rule (`en`/`ru`/`kk`, enforced by `pnpm validate:i18n`), and which Playwright config to pick for which test scenario (default / seed / video — not interchangeable).

## Not in this PR

- **`bugspotter-extension/CLAUDE.md`**: separate repo, separate PR.
- **`bugspotter-landing/`**: already has a good CLAUDE.md — unchanged.
- **Tier 2 subdirectory files** (backend `saas/`, `db/`): will add if/when the Tier 1 files start linking to conventions deeper than 40 lines can cover.

## Size discipline

Every file kept under 40 lines so it actually gets read. If a CLAUDE.md grows past that, the fix is a deeper CLAUDE.md in the relevant subdir, not bloating the top one.

## Test plan

No code changes — docs only. Safe to merge independently of any feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)