### PR TITLE
ci(admin): run E2E backend in saas mode + bump job timeout to 30m

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -125,7 +125,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     if: ${{ github.event.inputs.skip_tests != 'true' }}
-    timeout-minutes: 20
+    # The E2E suite runs ~289 Playwright tests on a single worker (Postgres +
+    # Redis + MinIO via testcontainers + a live backend + Vite), and on a
+    # fresh GitHub runner the whole job has been timing out at 20 minutes
+    # before the suite finishes. Bumping to 30 gives enough headroom; the
+    # longer-term fix is sharding / parallel workers, which requires the
+    # tests to be safe against shared DB state first.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -281,6 +281,13 @@ export default async function globalSetup() {
         LOG_LEVEL: 'warn', // Only show warnings and errors (reduce log noise)
         CORS_ORIGINS: 'http://localhost:4001,http://localhost:4000',
         FRONTEND_URL: 'http://localhost:4001',
+        // Run the backend in SaaS mode so routes gated by `SaaSRoute` in
+        // the admin (organizations list, retention, billing, etc.) are
+        // reachable during E2E. Without this, the backend defaults to
+        // selfhosted, the admin's /deployment endpoint returns
+        // `selfhosted`, and those routes silently redirect to /projects
+        // — failing any test that navigates to a SaaS-gated page.
+        DEPLOYMENT_MODE: 'saas',
         // Increase database pool size for E2E tests
         DB_POOL_MIN: '5',
         DB_POOL_MAX: '20',


### PR DESCRIPTION
## Summary

Two infrastructure fixes for the admin deploy workflow, which has been failing or getting cancelled on every main push for 2+ weeks. Neither is a feature change — this is only about making the E2E suite actually complete and cover the routes it's supposed to.

## 1. E2E backend runs in saas mode

`global-setup.ts` spawns the backend without `DEPLOYMENT_MODE`, so it defaults to selfhosted. The admin's `DeploymentProvider` fetches `/deployment`, gets `{mode: 'selfhosted'}`, and `SaaSRoute` then silently redirects any SaaS-gated page to `/projects`:

- `/organizations` (platform admin orgs list)
- `/organizations/retention` (new in #23 — hard-delete tab)
- `/organizations/:id` (org detail)
- `/organizations/requests`
- `/billing`
- `/usage`

Any E2E test that navigates to one of those routes hits `/projects` and then fails with a "heading not found" fast-fail. That's exactly the symptom we've been seeing:

- `organizations.spec.ts:55` ("navigate to organizations page from sidebar") — fails on every main run since the file has existed.
- `org-retention.spec.ts:26` / `:39` / `:93` (new in #23) — same fast-fail, three tests × three retries = 9 unnecessary failures per run.

Adding `DEPLOYMENT_MODE: 'saas'` to the spawned backend env is a one-line unblock for all SaaS-gated E2E coverage.

## 2. Workflow timeout 20m → 30m

The suite runs ~289 Playwright tests on `workers: 1` (Postgres + Redis + MinIO testcontainers + live backend + Vite). On a fresh GitHub runner it's been finishing at roughly 18–20m wall time, right at the `timeout-minutes: 20` cutoff. When any upstream step is slightly slow (container pull, migrations, etc.), the whole job gets cancelled mid-suite — which is what happened on `cb16dce` (PR #23's merge), test #272 of 289.

30m gives real headroom without masking a genuine runaway. Longer-term we should shard across multiple workers, but that requires the tests to be safe against shared DB state first — out of scope for this PR.

## Why this is a separate PR

Neither fix belongs in a feature branch. #1 affects every SaaS-gated route across the app; #2 is pure CI config. Landing them together also gives us a clean signal: if the next `main` run is green, we know the chronic failure was config drift, not a code regression.

## Test plan

- [x] YAML + TypeScript lint clean locally.
- [ ] On merge: observe the next `deploy-admin.yml` run on `main`. Expect:
  - E2E suite completes inside 30m.
  - `organizations.spec.ts:55` and the three `org-retention.spec.ts` tests pass.
  - Any *remaining* failures (if any) are now real signals rather than route-gate redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)