### PR TITLE
ci(admin): seed default org + sync worker env for saas-mode E2E

### DIFF
--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -379,6 +379,12 @@ export default async function globalSetup() {
         REDIS_URL: redisUrl,
         NODE_ENV: 'test',
         LOG_LEVEL: 'error',
+        // Match the backend's deployment mode so queue consumers operate
+        // under the same billing / usage-tracking / tenant-resolution
+        // rules as the API they're paired with. Diverging here would
+        // silently drift behavior between sync (API) and async (queue)
+        // paths.
+        DEPLOYMENT_MODE: 'saas',
         // Configure MinIO storage for E2E tests (same as backend)
         STORAGE_BACKEND: 'minio',
         S3_ENDPOINT: minioEndpoint,

--- a/apps/admin/src/tests/fixtures/setup-fixture.ts
+++ b/apps/admin/src/tests/fixtures/setup-fixture.ts
@@ -101,6 +101,50 @@ export const test = base.extend<SetupFixtures>({
         }
 
         console.log('✓ System initialized successfully');
+
+        // SaaS-mode default org.
+        //
+        // The E2E backend runs with `DEPLOYMENT_MODE=saas` so the
+        // `SaaSRoute`-gated pages in the admin (organizations list,
+        // retention, billing, etc.) are reachable. But SaaS mode also
+        // changes project creation semantics: from the hub domain
+        // (no tenant subdomain) the backend requires `organization_id`
+        // in the body — see `resolveOrganizationForProject` in
+        // `packages/backend/src/api/routes/projects.ts`. Tests that
+        // drive the admin's project-create form (audit-logs,
+        // api-keys, bug-reports, etc.) need the admin to own at least
+        // one org so the form's "select organization" flow resolves:
+        // the admin UI auto-selects when exactly one org is present
+        // (see `projects.tsx`), which keeps the existing tests
+        // working without per-test changes.
+        //
+        // Creating the org via the public POST endpoint makes the
+        // admin the owner — no extra membership plumbing needed.
+        const loginResponse = await request.post(`${API_URL}/api/v1/auth/login`, {
+          data: { email: creds.email, password: creds.password },
+        });
+        if (!loginResponse.ok()) {
+          throw new Error(
+            `Failed to log in after init: ${loginResponse.status()} ${await loginResponse.text()}`
+          );
+        }
+        const { data: loginData } = await loginResponse.json();
+        const accessToken: string = loginData.access_token;
+
+        const orgResponse = await request.post(`${API_URL}/api/v1/organizations`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          data: {
+            name: 'E2E Default Org',
+            subdomain: 'e2e-default',
+            data_residency_region: 'global',
+          },
+        });
+        if (!orgResponse.ok()) {
+          throw new Error(
+            `Failed to create default E2E org: ${orgResponse.status()} ${await orgResponse.text()}`
+          );
+        }
+        console.log('✓ Default E2E org created');
       },
 
       /**
@@ -131,13 +175,16 @@ export const test = base.extend<SetupFixtures>({
           }
         }
 
-        // Create a test project if none exists
+        // Create a test project if none exists. Note: the create-project
+        // schema has `additionalProperties: false` and the old `description`
+        // field here was rejected with a 400 — the fixture had been
+        // silently relying on `project` being resolved from the list
+        // call. Keep only the supported fields.
         if (!project) {
           const createResponse = await request.post(`${API_URL}/api/v1/projects`, {
             headers: { Authorization: `Bearer ${token}` },
             data: {
               name: 'E2E Test Project',
-              description: 'Project for E2E testing',
             },
           });
 

--- a/apps/admin/src/tests/fixtures/setup-fixture.ts
+++ b/apps/admin/src/tests/fixtures/setup-fixture.ts
@@ -67,42 +67,63 @@ export const test = base.extend<SetupFixtures>({
         };
         const isInitialized = await setupState.checkStatus();
 
+        let accessToken: string;
+
         if (isInitialized) {
           console.log('✓ System already initialized');
-          return;
+          // We still need a token so the default-org seed below can run
+          // idempotently — earlier setup paths (e.g. the setup-wizard
+          // E2E tests) initialize the system without touching this
+          // fixture and therefore without creating an org. Logging in
+          // here picks up that case.
+          const loginResponse = await request.post(`${API_URL}/api/v1/auth/login`, {
+            data: { email: creds.email, password: creds.password },
+          });
+          if (!loginResponse.ok()) {
+            throw new Error(
+              `Failed to log in after init check: ${loginResponse.status()} ${await loginResponse.text()}`
+            );
+          }
+          const { data: loginData } = await loginResponse.json();
+          accessToken = loginData.access_token;
+        } else {
+          console.log('🔍 Initializing with credentials:', {
+            email: creds.email,
+            name: creds.name,
+          });
+
+          // Initialize the system with local storage for E2E tests
+          // Note: Backend setup route requires S3 credentials even for local storage
+          // These are dummy values that won't be used since STORAGE_BACKEND=local
+          const response = await request.post(`${API_URL}/api/v1/setup/initialize`, {
+            data: {
+              admin_email: creds.email,
+              admin_password: creds.password,
+              admin_name: creds.name,
+              instance_name: 'Test BugSpotter',
+              instance_url: 'http://localhost:4001',
+              storage_type: 'local',
+              // Dummy S3 credentials (required by validation but not used)
+              storage_access_key: 'dummy-access-key',
+              storage_secret_key: 'dummy-secret-key',
+              storage_bucket: 'dummy-bucket',
+            },
+          });
+
+          if (!response.ok()) {
+            const error = await response.json();
+            throw new Error(`Failed to initialize system: ${JSON.stringify(error)}`);
+          }
+
+          // `/setup/initialize` returns the admin's access_token in its
+          // response body — no separate login call needed.
+          const { data: initData } = await response.json();
+          accessToken = initData.access_token;
+
+          console.log('✓ System initialized successfully');
         }
 
-        console.log('🔍 Initializing with credentials:', {
-          email: creds.email,
-          name: creds.name,
-        });
-
-        // Initialize the system with local storage for E2E tests
-        // Note: Backend setup route requires S3 credentials even for local storage
-        // These are dummy values that won't be used since STORAGE_BACKEND=local
-        const response = await request.post(`${API_URL}/api/v1/setup/initialize`, {
-          data: {
-            admin_email: creds.email,
-            admin_password: creds.password,
-            admin_name: creds.name,
-            instance_name: 'Test BugSpotter',
-            instance_url: 'http://localhost:4001',
-            storage_type: 'local',
-            // Dummy S3 credentials (required by validation but not used)
-            storage_access_key: 'dummy-access-key',
-            storage_secret_key: 'dummy-secret-key',
-            storage_bucket: 'dummy-bucket',
-          },
-        });
-
-        if (!response.ok()) {
-          const error = await response.json();
-          throw new Error(`Failed to initialize system: ${JSON.stringify(error)}`);
-        }
-
-        console.log('✓ System initialized successfully');
-
-        // SaaS-mode default org.
+        // SaaS-mode default org (idempotent).
         //
         // The E2E backend runs with `DEPLOYMENT_MODE=saas` so the
         // `SaaSRoute`-gated pages in the admin (organizations list,
@@ -111,40 +132,60 @@ export const test = base.extend<SetupFixtures>({
         // (no tenant subdomain) the backend requires `organization_id`
         // in the body — see `resolveOrganizationForProject` in
         // `packages/backend/src/api/routes/projects.ts`. Tests that
-        // drive the admin's project-create form (audit-logs,
-        // api-keys, bug-reports, etc.) need the admin to own at least
-        // one org so the form's "select organization" flow resolves:
-        // the admin UI auto-selects when exactly one org is present
-        // (see `projects.tsx`), which keeps the existing tests
-        // working without per-test changes.
+        // drive the admin's project-create form (audit-logs, api-keys,
+        // bug-reports, etc.) need the admin to own at least one org so
+        // the form's "select organization" flow resolves: the admin UI
+        // auto-selects when exactly one org is present (see
+        // `projects.tsx`), which keeps existing tests working without
+        // per-test changes.
         //
-        // Creating the org via the public POST endpoint makes the
-        // admin the owner — no extra membership plumbing needed.
-        const loginResponse = await request.post(`${API_URL}/api/v1/auth/login`, {
-          data: { email: creds.email, password: creds.password },
+        // Runs on EVERY call (not just first-time init) so the seed
+        // still happens after setup paths that bypass this fixture
+        // entirely (e.g. the setup-wizard E2E tests).
+        const authHeaders = { Authorization: `Bearer ${accessToken}` };
+        const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
+          headers: authHeaders,
         });
-        if (!loginResponse.ok()) {
-          throw new Error(
-            `Failed to log in after init: ${loginResponse.status()} ${await loginResponse.text()}`
-          );
+        if (myOrgsResponse.ok()) {
+          const { data: existing } = await myOrgsResponse.json();
+          if (Array.isArray(existing) && existing.length > 0) {
+            return;
+          }
         }
-        const { data: loginData } = await loginResponse.json();
-        const accessToken: string = loginData.access_token;
 
         const orgResponse = await request.post(`${API_URL}/api/v1/organizations`, {
-          headers: { Authorization: `Bearer ${accessToken}` },
+          headers: authHeaders,
           data: {
             name: 'E2E Default Org',
             subdomain: 'e2e-default',
             data_residency_region: 'global',
           },
         });
-        if (!orgResponse.ok()) {
-          throw new Error(
-            `Failed to create default E2E org: ${orgResponse.status()} ${await orgResponse.text()}`
-          );
+        if (orgResponse.ok()) {
+          console.log('✓ Default E2E org created');
+          return;
         }
-        console.log('✓ Default E2E org created');
+
+        // 409 = subdomain reserved by a soft-deleted org from a prior
+        // run that didn't fully clean up. Treat as success if the admin
+        // already has an org accessible via /me; otherwise surface the
+        // error so we're not silently papering over broken state.
+        if (orgResponse.status() === 409) {
+          const recheck = await request.get(`${API_URL}/api/v1/organizations/me`, {
+            headers: authHeaders,
+          });
+          if (recheck.ok()) {
+            const { data: existing } = await recheck.json();
+            if (Array.isArray(existing) && existing.length > 0) {
+              console.log('✓ Default E2E org already exists (409)');
+              return;
+            }
+          }
+        }
+
+        throw new Error(
+          `Failed to create default E2E org: ${orgResponse.status()} ${await orgResponse.text()}`
+        );
       },
 
       /**
@@ -180,11 +221,35 @@ export const test = base.extend<SetupFixtures>({
         // field here was rejected with a 400 — the fixture had been
         // silently relying on `project` being resolved from the list
         // call. Keep only the supported fields.
+        //
+        // In SaaS mode on the hub domain (what E2E is), the backend's
+        // `resolveOrganizationForProject` requires `organization_id`
+        // in the body. This helper is a direct API call — it bypasses
+        // the admin UI's auto-select — so we must resolve the org ID
+        // ourselves. `ensureInitialized` seeds exactly one org owned
+        // by the admin, so taking `[0]` is deterministic.
         if (!project) {
+          const orgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (!orgsResponse.ok()) {
+            throw new Error(
+              `Failed to resolve organization for test project: ${orgsResponse.status()} ${await orgsResponse.text()}`
+            );
+          }
+          const { data: myOrgs } = await orgsResponse.json();
+          const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
+          if (!organizationId) {
+            throw new Error(
+              'Failed to resolve organization for test project: admin has no org memberships'
+            );
+          }
+
           const createResponse = await request.post(`${API_URL}/api/v1/projects`, {
             headers: { Authorization: `Bearer ${token}` },
             data: {
               name: 'E2E Test Project',
+              organization_id: organizationId,
             },
           });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #24 to keep the E2E suite passing under `DEPLOYMENT_MODE=saas`. The mode flip correctly unblocked SaaS-gated tests (org-retention, organizations, billing) but broke a wider group of tests that create projects from the hub domain. This PR fixes them without per-test changes.

## Problem

In saas mode, the backend's `/api/v1/projects` POST requires `organization_id` in the body when the request has no tenant subdomain — see `resolveOrganizationForProject` in [packages/backend/src/api/routes/projects.ts](packages/backend/src/api/routes/projects.ts). E2E tests run against `localhost:4001` (no subdomain), so the resolver falls into the hub-domain branch.

The admin UI's project-create form *only* sends `organization_id` when the user has an org. The E2E admin (`admin@bugspotter.io`) comes out of `ensureInitialized` with zero org memberships, so the form submits `{name}` only, backend returns 400, and every test that waits for a 201 on `/api/v1/projects` times out:

- `api-keys.spec.ts:88`
- `audit-logs.spec.ts:117`
- `auth-setup.spec.ts:159`
- `bug-reports-access-control.spec.ts:296`
- `bug-reports.spec.ts:85`
- `integration-rules-auto-create.spec.ts:107`, `:124`
- ... and more downstream of those

## Fixes

### 1. Seed a default E2E org in `ensureInitialized`

After the admin is created, log in and create `E2E Default Org` (subdomain `e2e-default`). The admin becomes the owner. The admin UI already auto-selects the organization when the user has exactly one (see the `useEffect` in [apps/admin/src/pages/projects.tsx](apps/admin/src/pages/projects.tsx)), so the project-create form now submits with a valid `organization_id`. No per-test changes needed.

Tests that explicitly create their own additional orgs (`organizations.spec.ts`, `my-organization.spec.ts`) stay green — their assertions are shape-based (\`rowCount > 0\`, filter matches trial status, etc.) and not affected by an extra org.

### 2. Drop unsupported `description` field

`ensureProjectExists` was sending `{name, description}` to a schema that has `additionalProperties: false`. This has been broken silently — the helper only hit the create path when no project existed and the call returned 400. Keeping only supported fields.

### 3. Worker process inherits `DEPLOYMENT_MODE=saas`

Flagged on Gemini's PR #24 review, valid: the worker process was spawned without `DEPLOYMENT_MODE`, defaulting to selfhosted while the backend ran as saas. Diverging here would silently drift behavior between sync (API) and async (queue) paths — billing, usage tracking, tenant resolution.

On Gemini's second PR #24 comment: the workflow `timeout-minutes` bump *was* in the diff at lines 125–131 of [.github/workflows/deploy-admin.yml](.github/workflows/deploy-admin.yml). That comment was a false positive.

## Test plan

- [x] YAML + TS lint clean.
- [ ] After merge: observe the next `deploy-admin.yml` run on main. Expect:
  - `api-keys.spec.ts:88` → pass
  - `audit-logs.spec.ts:117` → pass
  - `bug-reports*.spec.ts` → pass
  - `org-retention.spec.ts` → still passing (unchanged by this PR)
  - `organizations.spec.ts` → still passing (unchanged; row counts are gte-based)
  - If any test fails, the next iteration addresses that specific test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)