### PR TITLE
ci(admin): fix h1 strict-mode violations + replay upload confirm

### DIFF
--- a/apps/admin/src/tests/e2e/my-organization.spec.ts
+++ b/apps/admin/src/tests/e2e/my-organization.spec.ts
@@ -64,8 +64,10 @@ test.describe('Org Self-Service: My Organization', () => {
     await loginAsAdmin(page);
     await page.goto('/my-organization');
 
-    // Should show org name heading
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15000 });
+    // Should show org name heading (scoped to <main> to avoid the sidebar brand h1).
+    await expect(page.getByRole('main').getByRole('heading', { level: 1 })).toBeVisible({
+      timeout: 15000,
+    });
 
     // Should show stats cards (Plan, Team Members, Billing Status)
     const cards = page.locator('a[href*="my-organization"], div').filter({
@@ -87,8 +89,10 @@ test.describe('Org Self-Service: My Organization', () => {
     await loginAsAdmin(page);
     await page.goto('/my-organization/members');
 
-    // Should show team heading
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15000 });
+    // Should show team heading (scoped to <main> to avoid the sidebar brand h1).
+    await expect(page.getByRole('main').getByRole('heading', { level: 1 })).toBeVisible({
+      timeout: 15000,
+    });
 
     // Should show members table with at least the owner
     const table = page.locator('table');
@@ -123,8 +127,10 @@ test.describe('Org Self-Service: My Organization', () => {
     await loginAsAdmin(page);
     await page.goto('/my-organization/usage');
 
-    // Should show usage heading
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 15000 });
+    // Should show usage heading (scoped to <main> to avoid the sidebar brand h1).
+    await expect(page.getByRole('main').getByRole('heading', { level: 1 })).toBeVisible({
+      timeout: 15000,
+    });
 
     // Should show plan badge
     const planBadge = page.getByTestId('plan-badge');

--- a/apps/admin/src/tests/e2e/org-retention.spec.ts
+++ b/apps/admin/src/tests/e2e/org-retention.spec.ts
@@ -27,7 +27,12 @@ test.describe('Platform Admin: Org Retention', () => {
     await loginAsAdmin(page);
     await page.goto('/organizations/retention');
 
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10000 });
+    // Scope the heading check to <main> — the dashboard layout has a
+    // sidebar brand <h1>BugSpotter</h1> that would otherwise make
+    // `getByRole('heading', { level: 1 })` a strict-mode violation.
+    await expect(page.getByRole('main').getByRole('heading', { level: 1 })).toBeVisible({
+      timeout: 10000,
+    });
     expect(page.url()).toContain('/organizations/retention');
     // Either the empty-state message or the table is rendered — both
     // confirm the page loaded past the loading state.

--- a/apps/admin/src/tests/e2e/organizations.spec.ts
+++ b/apps/admin/src/tests/e2e/organizations.spec.ts
@@ -56,7 +56,10 @@ test.describe('Platform Admin: Organizations', () => {
     await loginAsAdmin(page);
     await page.goto('/organizations');
 
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10000 });
+    // Scope to <main> to avoid matching the sidebar brand <h1>BugSpotter</h1>.
+    await expect(page.getByRole('main').getByRole('heading', { level: 1 })).toBeVisible({
+      timeout: 10000,
+    });
     expect(page.url()).toContain('/organizations');
   });
 
@@ -142,8 +145,10 @@ test.describe('Platform Admin: Organizations', () => {
     await loginAsAdmin(page);
     await page.goto(`/organizations/${createdOrgId}`);
 
-    // Should show org name
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10000 });
+    // Should show org name (scoped to <main> to avoid the sidebar brand h1).
+    await expect(page.getByRole('main').getByRole('heading', { level: 1 })).toBeVisible({
+      timeout: 10000,
+    });
 
     // Should show subdomain badge
     const subdomainBadge = page.getByTestId('subdomain-badge');

--- a/apps/admin/src/tests/fixtures/setup-fixture.ts
+++ b/apps/admin/src/tests/fixtures/setup-fixture.ts
@@ -457,14 +457,20 @@ export const test = base.extend<SetupFixtures>({
         const loginData = await loginResponse.json();
         const authToken = loginData.data.access_token;
 
-        // Use the storageKey from presignedUrls (already in database as replay_key from prepareUploadUrls)
-        // We just need to mark upload as completed
-        const updateResponse = await request.patch(`${API_URL}/api/v1/reports/${bugReportId}`, {
-          headers: { Authorization: `Bearer ${authToken}` },
-          data: {
-            replay_upload_status: 'completed',
-          },
-        });
+        // Mark the upload as completed via the dedicated confirm-upload
+        // endpoint. The general PATCH /reports/:id schema has
+        // `additionalProperties: false` and intentionally doesn't expose
+        // `replay_upload_status` as a user-writable field — upload state
+        // transitions go through POST /reports/:id/confirm-upload
+        // instead, which also handles the storage headObject check and
+        // queues the replay-processing job.
+        const updateResponse = await request.post(
+          `${API_URL}/api/v1/reports/${bugReportId}/confirm-upload`,
+          {
+            headers: { Authorization: `Bearer ${authToken}` },
+            data: { fileType: 'replay' },
+          }
+        );
 
         if (!updateResponse.ok()) {
           const body = await updateResponse.text();


### PR DESCRIPTION
## Summary

Follow-up to #25. After that merged, the next E2E run on main (commit `f7ecadb`) completed in 17.8m / 30m but still had 22 test failures. Inspection of the log shows two mechanical patterns behind the majority of them — both fixed here.

## Pattern A — sidebar brand `<h1>` collides with page `<h1>`

`dashboard-layout.tsx` renders the brand as `<h1>BugSpotter</h1>`, and every page also has a level-1 heading. Playwright strict-mode rejects `page.getByRole('heading', { level: 1 })` as ambiguous — "resolved to 2 elements".

Fixed by scoping the locator to `page.getByRole('main')` in six places across three specs:

- `org-retention.spec.ts:30`
- `organizations.spec.ts:59`, `:146`
- `my-organization.spec.ts:68`, `:91`, `:127`

## Pattern B — upload confirmation hit the wrong endpoint

`createBugReportWithReplay` in `setup-fixture.ts` was doing:

```
PATCH /api/v1/reports/:id  { replay_upload_status: 'completed' }
```

But the update-bug-report schema has `additionalProperties: false` and intentionally doesn't expose `replay_upload_status` as a user-writable field. Upload state transitions go through:

```
POST /api/v1/reports/:id/confirm-upload  { fileType: 'replay' }
```

which also runs the storage `headObject` check and queues the replay-processing job. Switching to the right endpoint unblocks ~11 tests: `public-replay-sharing` (10 tests), `replay-direct-storage:170`, and `shared-replay-viewer:190`.

## Remaining failures (out of scope for this PR)

~7 tests that aren't covered by either pattern and need individual investigation once the signal is cleaner:

- `auth-setup.spec.ts:159` and `setup-comprehensive.spec.ts:349` — both logout flows
- `bug-reports-access-control.spec.ts:296` and `jira-integration.spec.ts:195` — 0ms precondition failures (likely fixture chaining)
- `project-integrations-navigation.spec.ts:84`
- `role-based-access.spec.ts:241`

## Test plan

- [x] All edits are test-layer only — no production code touched.
- [ ] After merge: observe the next `deploy-admin.yml` run on main. Expect ~6 h1-violation failures and ~11 confirm-upload failures to flip to green, leaving ~7 residual failures to triage next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)