### PR TITLE
ci(admin): resolve residual 9 E2E failures + make ports configurable

### DIFF
--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -34,7 +34,10 @@ export default defineConfig({
   timeout: 120000, // Increase test timeout to 120s (2 minutes) for testcontainer startup
   outputDir: 'e2e-debug/test-results',
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:4001',
+    // Port overrides via env so contributors on Windows (where Hyper-V
+    // reserves 4000/4001 for its own use via `netsh int ipv4 show
+    // excludedportrange`) can pick free ports.
+    baseURL: process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -53,15 +56,15 @@ export default defineConfig({
     : {
         // Use node to run vite directly, bypassing Corepack/pnpm issues
         // This works because vite is installed in node_modules
-        command: 'node node_modules/vite/bin/vite.js --port 4001',
-        url: 'http://localhost:4001',
+        command: `node node_modules/vite/bin/vite.js --port ${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+        url: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
         reuseExistingServer: !process.env.CI,
         timeout: 120000,
         stdout: 'pipe',
         stderr: 'pipe',
         env: {
-          PORT: '4001',
-          VITE_API_URL: process.env.API_URL || 'http://localhost:4000',
+          PORT: process.env.E2E_ADMIN_PORT ?? '4001',
+          VITE_API_URL: process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`,
         },
       },
 });

--- a/apps/admin/src/components/dashboard-layout.tsx
+++ b/apps/admin/src/components/dashboard-layout.tsx
@@ -164,8 +164,11 @@ export default function DashboardLayout() {
             <p className="text-sm text-gray-500 mt-1">{t('nav.adminPanel')}</p>
           </div>
 
-          {/* Navigation */}
-          <nav className="flex-1 p-4 space-y-1">
+          {/* Navigation — overflow-y-auto so a long list of items (platform
+              admin + org sections together can be 20+) scrolls INSIDE the
+              sidebar rather than pushing the user info + logout button
+              below the viewport on shorter screens. */}
+          <nav className="flex-1 overflow-y-auto p-4 space-y-1">
             {NAV_ITEMS.map((item) => {
               if (item.adminOnly && !isAdmin) {
                 return null;

--- a/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
+++ b/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
@@ -98,6 +98,31 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     const regularData = await regularLoginResponse.json();
     regularUserToken = regularData.data.access_token;
 
+    // Create a dedicated org for this spec's projects. We can't reuse
+    // the admin's default E2E org because the trial plan caps at 2
+    // projects and earlier specs in the suite (api-keys, audit-logs,
+    // etc.) already consume slots via `ensureProjectExists`. A fresh
+    // org gives us our own 2-project budget.
+    //
+    // Required in SaaS mode anyway: the hub domain's project-create
+    // needs `organization_id` in the body
+    // (see `resolveOrganizationForProject` in
+    // packages/backend/src/api/routes/projects.ts).
+    const bugReportOrgResponse = await request.post(`${API_URL}/api/v1/organizations`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      data: {
+        name: `Bug Reports RBAC ${Date.now()}`,
+        subdomain: `bug-reports-rbac-${Date.now()}`,
+        data_residency_region: 'global',
+      },
+    });
+    if (!bugReportOrgResponse.ok()) {
+      throw new Error(
+        `Failed to create test org: ${bugReportOrgResponse.status()} ${await bugReportOrgResponse.text()}`
+      );
+    }
+    const organizationId = (await bugReportOrgResponse.json()).data.id as string;
+
     // Create two projects
     const project1Response = await request.post(`${API_URL}/api/v1/projects`, {
       headers: {
@@ -105,6 +130,7 @@ test.describe('Bug Reports - Access Control & Filters', () => {
       },
       data: {
         name: 'Project Alpha',
+        organization_id: organizationId,
       },
     });
     const project1Data = await project1Response.json();
@@ -116,6 +142,7 @@ test.describe('Bug Reports - Access Control & Filters', () => {
       },
       data: {
         name: 'Project Beta',
+        organization_id: organizationId,
       },
     });
     const project2Data = await project2Response.json();

--- a/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
+++ b/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
@@ -51,6 +51,7 @@ test.describe('Bug Reports - Access Control & Filters', () => {
   let project1: { id: string; name: string; api_key: string };
   let project2: { id: string; name: string; api_key: string };
   let regularUserId: string;
+  let bugReportOrgId: string | undefined;
 
   test.beforeAll(async ({ request, setupState }) => {
     // Create admin user
@@ -108,11 +109,17 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     // needs `organization_id` in the body
     // (see `resolveOrganizationForProject` in
     // packages/backend/src/api/routes/projects.ts).
+    //
+    // Captured to `bugReportOrgId` so `afterAll` can tear it down —
+    // otherwise this spec leaves the admin with an extra membership
+    // and later specs that pick `myOrgs[0]` could select the wrong
+    // one.
+    const orgTimestamp = Date.now();
     const bugReportOrgResponse = await request.post(`${API_URL}/api/v1/organizations`, {
       headers: { Authorization: `Bearer ${adminToken}` },
       data: {
-        name: `Bug Reports RBAC ${Date.now()}`,
-        subdomain: `bug-reports-rbac-${Date.now()}`,
+        name: `Bug Reports RBAC ${orgTimestamp}`,
+        subdomain: `bug-reports-rbac-${orgTimestamp}`,
         data_residency_region: 'global',
       },
     });
@@ -121,7 +128,8 @@ test.describe('Bug Reports - Access Control & Filters', () => {
         `Failed to create test org: ${bugReportOrgResponse.status()} ${await bugReportOrgResponse.text()}`
       );
     }
-    const organizationId = (await bugReportOrgResponse.json()).data.id as string;
+    bugReportOrgId = (await bugReportOrgResponse.json()).data.id as string;
+    const organizationId = bugReportOrgId;
 
     // Create two projects
     const project1Response = await request.post(`${API_URL}/api/v1/projects`, {
@@ -315,6 +323,22 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     } catch (error) {
       console.log(
         'Failed to delete regular user (backend may be down):',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+
+    try {
+      // Delete the dedicated org this spec created. Without this, the
+      // admin accumulates an extra membership across specs and later
+      // tests that pick `myOrgs[0]` could select the wrong one.
+      if (bugReportOrgId && adminToken) {
+        await request.delete(`${API_URL}/api/v1/organizations/${bugReportOrgId}`, {
+          headers: { Authorization: `Bearer ${adminToken}` },
+        });
+      }
+    } catch (error) {
+      console.log(
+        'Failed to delete bug-reports RBAC org (backend may be down):',
         error instanceof Error ? error.message : String(error)
       );
     }

--- a/apps/admin/src/tests/e2e/config.ts
+++ b/apps/admin/src/tests/e2e/config.ts
@@ -3,11 +3,15 @@
  * Centralized configuration for all E2E tests
  */
 
-// Base URL for the admin panel (Vite dev server)
-export const E2E_BASE_URL = process.env.BASE_URL || 'http://localhost:4001';
+// Base URL for the admin panel (Vite dev server). Honors E2E_ADMIN_PORT
+// so contributors on Windows — where Hyper-V reserves 4000/4001 via
+// `netsh int ipv4 show excludedportrange` — can point at free ports.
+export const E2E_BASE_URL =
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
 
-// API URL for the backend server
-export const E2E_API_URL = process.env.API_URL || 'http://localhost:4000';
+// API URL for the backend server. Honors API_PORT for the same reason.
+export const E2E_API_URL =
+  process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`;
 
 // Extract hostname for URL checks (without protocol)
 export const E2E_BASE_HOSTNAME = E2E_BASE_URL.replace(/^https?:\/\//, '');

--- a/apps/admin/src/tests/e2e/config.ts
+++ b/apps/admin/src/tests/e2e/config.ts
@@ -3,15 +3,32 @@
  * Centralized configuration for all E2E tests
  */
 
+// Resolve the admin + API URLs once, normalizing through `new URL(...).origin`
+// so a user-provided `BASE_URL` / `API_URL` with a trailing slash or path
+// (e.g. `https://host.com/admin`) doesn't leak into downstream consumers
+// — `E2E_BASE_HOSTNAME` would end up as `host.com/admin`, breaking the
+// auth helper's `currentURL.includes(E2E_BASE_HOSTNAME)` short-circuit.
+function normalizeOrigin(raw: string, label: string): string {
+  try {
+    return new URL(raw).origin;
+  } catch {
+    throw new Error(`Invalid ${label}: ${raw}`);
+  }
+}
+
 // Base URL for the admin panel (Vite dev server). Honors E2E_ADMIN_PORT
 // so contributors on Windows — where Hyper-V reserves 4000/4001 via
 // `netsh int ipv4 show excludedportrange` — can point at free ports.
-export const E2E_BASE_URL =
-  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
+export const E2E_BASE_URL = normalizeOrigin(
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+  'BASE_URL'
+);
 
 // API URL for the backend server. Honors API_PORT for the same reason.
-export const E2E_API_URL =
-  process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`;
+export const E2E_API_URL = normalizeOrigin(
+  process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`,
+  'API_URL'
+);
 
 // Extract hostname for URL checks (without protocol)
 export const E2E_BASE_HOSTNAME = E2E_BASE_URL.replace(/^https?:\/\//, '');

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -264,6 +264,15 @@ export default async function globalSetup() {
     process.env.API_URL = apiUrl;
     process.env.VITE_API_URL = apiUrl; // For Vite proxy configuration
 
+    // Resolve the admin (frontend) URL once. `BASE_URL` takes precedence
+    // when someone is running Playwright against an already-running admin
+    // (in that case Playwright's webServer is skipped); otherwise we
+    // honor `E2E_ADMIN_PORT` for Windows/Hyper-V port conflicts; finally
+    // default to `:4001`. Used for both the backend's `FRONTEND_URL`
+    // and its CORS allowlist so the two never disagree.
+    const adminUrl =
+      process.env.BASE_URL ?? `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
+
     // Start backend server on port 4000
     console.log('🚀 Starting backend server on port 4000...');
     const backendPath = path.resolve(__dirname, '../../../../../packages/backend');
@@ -280,9 +289,12 @@ export default async function globalSetup() {
         NODE_ENV: 'test',
         LOG_LEVEL: 'warn', // Only show warnings and errors (reduce log noise)
         // Honor port overrides so local runs on Windows (Hyper-V
-        // reserves 4000/4001) can pick free ports via env vars.
-        CORS_ORIGINS: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'},http://localhost:${apiPort}`,
-        FRONTEND_URL: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+        // reserves 4000/4001) can pick free ports via env vars. Uses
+        // the shared `adminUrl` resolved above so `FRONTEND_URL` and
+        // the frontend entry in `CORS_ORIGINS` stay in sync even when
+        // the admin is served from a non-localhost `BASE_URL`.
+        CORS_ORIGINS: `${adminUrl},${apiUrl}`,
+        FRONTEND_URL: adminUrl,
         // Run the backend in SaaS mode so routes gated by `SaaSRoute` in
         // the admin (organizations list, retention, billing, etc.) are
         // reachable during E2E. Without this, the backend defaults to

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -285,8 +285,16 @@ export default async function globalSetup() {
       throw new Error(`Invalid BASE_URL / E2E_ADMIN_PORT combination: ${rawAdminUrl}`);
     }
 
-    // Start backend server on port 4000
-    console.log('🚀 Starting backend server on port 4000...');
+    // Normalize apiUrl the same way so a user-provided `API_URL` with
+    // a path/trailing slash doesn't leak into CORS matching.
+    let apiOrigin: string;
+    try {
+      apiOrigin = new URL(apiUrl).origin;
+    } catch {
+      throw new Error(`Invalid API_URL / API_PORT combination: ${apiUrl}`);
+    }
+
+    console.log(`🚀 Starting backend server on port ${apiPort}...`);
     const backendPath = path.resolve(__dirname, '../../../../../packages/backend');
 
     // Use npx tsx to avoid Corepack issues (shell: true required on Windows)
@@ -305,7 +313,7 @@ export default async function globalSetup() {
         // the shared `adminUrl` resolved above so `FRONTEND_URL` and
         // the frontend entry in `CORS_ORIGINS` stay in sync even when
         // the admin is served from a non-localhost `BASE_URL`.
-        CORS_ORIGINS: `${adminUrl},${apiUrl}`,
+        CORS_ORIGINS: `${adminUrl},${apiOrigin}`,
         FRONTEND_URL: adminUrl,
         // Run the backend in SaaS mode so routes gated by `SaaSRoute` in
         // the admin (organizations list, retention, billing, etc.) are

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -258,9 +258,13 @@ export default async function globalSetup() {
       throw error;
     }
 
-    // Set API_URL for both backend and frontend
+    // Set API_URL for both backend and frontend. Precedence:
+    //   1. `API_URL` if explicitly provided (someone pointing tests at a
+    //      non-localhost backend, or a port + host combination that can't
+    //      be captured via `API_PORT` alone).
+    //   2. Otherwise derive from `API_PORT` (default `4000`).
     const apiPort = process.env.API_PORT || '4000';
-    const apiUrl = `http://localhost:${apiPort}`;
+    const apiUrl = process.env.API_URL || `http://localhost:${apiPort}`;
     process.env.API_URL = apiUrl;
     process.env.VITE_API_URL = apiUrl; // For Vite proxy configuration
 
@@ -268,10 +272,18 @@ export default async function globalSetup() {
     // when someone is running Playwright against an already-running admin
     // (in that case Playwright's webServer is skipped); otherwise we
     // honor `E2E_ADMIN_PORT` for Windows/Hyper-V port conflicts; finally
-    // default to `:4001`. Used for both the backend's `FRONTEND_URL`
-    // and its CORS allowlist so the two never disagree.
-    const adminUrl =
+    // default to `:4001`. Normalize via `new URL(...).origin` so a
+    // `BASE_URL` that includes a path (`https://host.com/admin`) or a
+    // trailing slash doesn't leak into CORS matching — the browser's
+    // `Origin` header is always just `scheme://host[:port]`.
+    const rawAdminUrl =
       process.env.BASE_URL ?? `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
+    let adminUrl: string;
+    try {
+      adminUrl = new URL(rawAdminUrl).origin;
+    } catch {
+      throw new Error(`Invalid BASE_URL / E2E_ADMIN_PORT combination: ${rawAdminUrl}`);
+    }
 
     // Start backend server on port 4000
     console.log('🚀 Starting backend server on port 4000...');

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -279,8 +279,10 @@ export default async function globalSetup() {
         PORT: apiPort,
         NODE_ENV: 'test',
         LOG_LEVEL: 'warn', // Only show warnings and errors (reduce log noise)
-        CORS_ORIGINS: 'http://localhost:4001,http://localhost:4000',
-        FRONTEND_URL: 'http://localhost:4001',
+        // Honor port overrides so local runs on Windows (Hyper-V
+        // reserves 4000/4001) can pick free ports via env vars.
+        CORS_ORIGINS: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'},http://localhost:${apiPort}`,
+        FRONTEND_URL: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
         // Run the backend in SaaS mode so routes gated by `SaaSRoute` in
         // the admin (organizations list, retention, billing, etc.) are
         // reachable during E2E. Without this, the backend defaults to
@@ -379,6 +381,10 @@ export default async function globalSetup() {
         REDIS_URL: redisUrl,
         NODE_ENV: 'test',
         LOG_LEVEL: 'error',
+        // Honor WORKER_HEALTH_PORT override so local runs on Windows
+        // (Hyper-V reserves 3001 via `netsh int ipv4 show
+        // excludedportrange`) can pick a free port.
+        WORKER_HEALTH_PORT: process.env.WORKER_HEALTH_PORT ?? '3001',
         // Match the backend's deployment mode so queue consumers operate
         // under the same billing / usage-tracking / tenant-resolution
         // rules as the API they're paired with. Diverging here would

--- a/apps/admin/src/tests/e2e/my-organization.spec.ts
+++ b/apps/admin/src/tests/e2e/my-organization.spec.ts
@@ -116,10 +116,13 @@ test.describe('Org Self-Service: My Organization', () => {
     await addButton.waitFor({ state: 'visible', timeout: 10000 });
     await addButton.click();
 
-    // Should show the add form with email input and role select
-    const emailInput = page.getByLabel(/email/i);
+    // Should show the add form with email input and role select.
+    // Use the form's own stable IDs (see `invite-member-form.tsx`) so
+    // the locator doesn't match unrelated email/role-labeled elements
+    // elsewhere on the page (e.g. member-row emails in the table).
+    const emailInput = page.locator('#invite-email');
     await expect(emailInput).toBeVisible({ timeout: 5000 });
-    const roleSelect = page.getByLabel(/role/i);
+    const roleSelect = page.locator('#invite-role');
     await expect(roleSelect).toBeVisible();
   });
 

--- a/apps/admin/src/tests/e2e/organizations.spec.ts
+++ b/apps/admin/src/tests/e2e/organizations.spec.ts
@@ -99,8 +99,11 @@ test.describe('Platform Admin: Organizations', () => {
     // Filter by trial status
     await statusSelect.selectOption('trial');
 
-    // Wait for filtered results to render (use semantic role query)
-    const statusBadges = page.getByRole('status');
+    // Scope the status-badge check to the table body. Without this,
+    // `getByRole('status')` also picks up unrelated badges elsewhere on
+    // the page — e.g. the "role: platform admin" badge in the admin
+    // header — and fails the "every badge says trial" assertion.
+    const statusBadges = page.locator('table tbody').getByRole('status');
     await expect(statusBadges.first().or(page.locator('text=/no organizations/i'))).toBeVisible({
       timeout: 10000,
     });

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect, type Page } from '../fixtures/setup-fixture';
 import { waitForI18nReady } from './helpers/i18n-helpers';
+import { E2E_API_URL } from './config';
 
-const API_URL = process.env.API_URL || 'http://localhost:4000';
+// Use the shared helper so `API_PORT` / `API_URL` overrides (see
+// `src/tests/e2e/config.ts`) actually apply here too.
+const API_URL = E2E_API_URL;
 
 // Test credentials
 const TEST_ADMIN = {

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -61,9 +61,11 @@ test.describe('Project Integrations Navigation', () => {
 
     // Create a test project. In SaaS mode, the hub domain requires
     // `organization_id` in the body (see `resolveOrganizationForProject`
-    // in packages/backend/src/api/routes/projects.ts). The admin user is
-    // seeded into a single default org by `ensureInitialized`, so
-    // taking `[0]` is deterministic.
+    // in packages/backend/src/api/routes/projects.ts). Select the
+    // seeded default org explicitly by subdomain — `myOrgs[0]` is NOT
+    // stable because the backend's `OrganizationRepository.findByUserId`
+    // orders by name and other specs (organizations, my-organization,
+    // role-based-access) create orgs of their own that could sort ahead.
     const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     });
@@ -75,10 +77,18 @@ test.describe('Project Integrations Navigation', () => {
         `Failed to fetch /organizations/me: ${myOrgsResponse.status()} ${await myOrgsResponse.text()}`
       );
     }
-    const myOrgs = (await myOrgsResponse.json()).data as Array<{ id: string }> | undefined;
-    const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
+    const myOrgs = (await myOrgsResponse.json()).data as
+      | Array<{ id: string; subdomain: string }>
+      | undefined;
+    const defaultOrg = Array.isArray(myOrgs)
+      ? myOrgs.find((o) => o.subdomain === 'e2e-default')
+      : undefined;
+    const organizationId = defaultOrg?.id;
     if (!organizationId) {
-      throw new Error('Failed to resolve organization_id for test project');
+      throw new Error(
+        'Failed to resolve organization_id for test project: ' +
+          "admin is not a member of the seeded 'e2e-default' org"
+      );
     }
 
     const projectResponse = await request.post(`${API_URL}/api/v1/projects`, {

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -64,6 +64,14 @@ test.describe('Project Integrations Navigation', () => {
     const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     });
+    if (!myOrgsResponse.ok()) {
+      // Include status + body so a 401 (adminToken never populated
+      // because login failed) doesn't masquerade as "admin has no
+      // org memberships".
+      throw new Error(
+        `Failed to fetch /organizations/me: ${myOrgsResponse.status()} ${await myOrgsResponse.text()}`
+      );
+    }
     const myOrgs = (await myOrgsResponse.json()).data as Array<{ id: string }> | undefined;
     const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
     if (!organizationId) {

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -56,9 +56,22 @@ test.describe('Project Integrations Navigation', () => {
       }
     }
 
-    // Create a test project
+    // Create a test project. In SaaS mode, the hub domain requires
+    // `organization_id` in the body (see `resolveOrganizationForProject`
+    // in packages/backend/src/api/routes/projects.ts). The admin user is
+    // seeded into a single default org by `ensureInitialized`, so
+    // taking `[0]` is deterministic.
+    const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const myOrgs = (await myOrgsResponse.json()).data as Array<{ id: string }> | undefined;
+    const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
+    if (!organizationId) {
+      throw new Error('Failed to resolve organization_id for test project');
+    }
+
     const projectResponse = await request.post(`${API_URL}/api/v1/projects`, {
-      data: { name: 'E2E Navigation Test Project' },
+      data: { name: 'E2E Navigation Test Project', organization_id: organizationId },
       headers: { Authorization: `Bearer ${adminToken}` },
     });
 

--- a/apps/admin/src/tests/e2e/replay-direct-storage.spec.ts
+++ b/apps/admin/src/tests/e2e/replay-direct-storage.spec.ts
@@ -225,15 +225,24 @@ test.describe('Replay Direct Storage Access', () => {
 
     console.log('✅ Replay file uploaded successfully');
 
-    // Update upload status to 'completed'
-    await request.patch(`${API_URL}/api/v1/reports/${bugReportId}`, {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
-      data: {
-        replay_upload_status: 'completed',
-      },
-    });
+    // Mark upload complete via the dedicated confirm-upload endpoint.
+    // The general PATCH /reports/:id schema has `additionalProperties: false`
+    // and intentionally doesn't expose `replay_upload_status` as a
+    // user-writable field — upload state transitions go through
+    // POST /reports/:id/confirm-upload (same fix as the fixture in
+    // setup-fixture.ts::createBugReportWithReplay).
+    const confirmResponse = await request.post(
+      `${API_URL}/api/v1/reports/${bugReportId}/confirm-upload`,
+      {
+        headers: { Authorization: `Bearer ${authToken}` },
+        data: { fileType: 'replay' },
+      }
+    );
+    if (!confirmResponse.ok()) {
+      throw new Error(
+        `Failed to mark replay upload complete: ${confirmResponse.status()} ${await confirmResponse.text()}`
+      );
+    }
 
     console.log('✅ Marked replay upload as completed');
 

--- a/apps/admin/src/tests/e2e/role-based-access.spec.ts
+++ b/apps/admin/src/tests/e2e/role-based-access.spec.ts
@@ -28,20 +28,29 @@ const NO_ORG_USER = {
   name: 'No Org User',
 };
 
-/** Admin-only sidebar labels (from en.json nav.*) */
+/** Admin-only sidebar labels (from en.json nav.*).
+ *
+ * These items are gated by `adminOnly: true` in `NAV_ITEMS` inside
+ * `dashboard-layout.tsx` and render only for platform admins.
+ *
+ * Note: 'Audit Logs' and 'API Keys' are intentionally NOT here — the
+ * sidebar renders them for every authenticated user, with the backend
+ * enforcing access control per-route (e.g. `requireAuditAccess` lets
+ * org owners view their org's audit trail, and api-keys are scoped to
+ * projects the user is a member of). They appear in GENERAL_LABELS
+ * instead.
+ */
 const ADMIN_ONLY_LABELS = [
   'Dashboard',
   'User Management',
   'Organizations',
   'System Health',
-  'Audit Logs',
-  'API Keys',
   'Integrations',
   'Settings',
 ];
 
-/** Sidebar labels visible to all authenticated users */
-const GENERAL_LABELS = ['Projects', 'Bug Reports', 'Notifications'];
+/** Sidebar labels visible to all authenticated users (no gates in NAV_ITEMS) */
+const GENERAL_LABELS = ['Projects', 'Bug Reports', 'Notifications', 'Audit Logs', 'API Keys'];
 
 /** Organization section sidebar labels */
 const ORG_LABELS = ['My Organization', 'Team', 'Usage & Quotas', 'Billing'];

--- a/apps/admin/src/tests/e2e/role-based-access.spec.ts
+++ b/apps/admin/src/tests/e2e/role-based-access.spec.ts
@@ -32,6 +32,9 @@ const NO_ORG_USER = {
  *
  * These items are gated by `adminOnly: true` in `NAV_ITEMS` inside
  * `dashboard-layout.tsx` and render only for platform admins.
+ * Keep this list in sync with every `NAV_ITEMS` entry that carries
+ * `adminOnly: true` — if they drift, the "regular user cannot see
+ * admin items" assertions silently stop catching regressions.
  *
  * Note: 'Audit Logs' and 'API Keys' are intentionally NOT here — the
  * sidebar renders them for every authenticated user, with the backend
@@ -44,6 +47,8 @@ const ADMIN_ONLY_LABELS = [
   'Dashboard',
   'User Management',
   'Organizations',
+  'Requests', // organization-requests, adminOnly + saasOnly
+  'Retention', // organizations/retention, adminOnly + saasOnly
   'System Health',
   'Integrations',
   'Settings',

--- a/apps/admin/src/tests/fixtures/setup-fixture.ts
+++ b/apps/admin/src/tests/fixtures/setup-fixture.ts
@@ -226,8 +226,10 @@ export const test = base.extend<SetupFixtures>({
         // `resolveOrganizationForProject` requires `organization_id`
         // in the body. This helper is a direct API call — it bypasses
         // the admin UI's auto-select — so we must resolve the org ID
-        // ourselves. `ensureInitialized` seeds exactly one org owned
-        // by the admin, so taking `[0]` is deterministic.
+        // ourselves. Select by subdomain rather than `[0]`: the
+        // backend's `findByUserId` orders by name, and other specs
+        // may have created additional orgs (e.g. role-based-access,
+        // my-organization) that sort ahead of 'E2E Default Org'.
         if (!project) {
           const orgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
             headers: { Authorization: `Bearer ${token}` },
@@ -237,11 +239,16 @@ export const test = base.extend<SetupFixtures>({
               `Failed to resolve organization for test project: ${orgsResponse.status()} ${await orgsResponse.text()}`
             );
           }
-          const { data: myOrgs } = await orgsResponse.json();
-          const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
+          const { data: myOrgs } = (await orgsResponse.json()) as {
+            data: Array<{ id: string; subdomain: string }>;
+          };
+          const defaultOrg = Array.isArray(myOrgs)
+            ? myOrgs.find((o) => o.subdomain === 'e2e-default')
+            : undefined;
+          const organizationId = defaultOrg?.id;
           if (!organizationId) {
             throw new Error(
-              'Failed to resolve organization for test project: admin has no org memberships'
+              "Failed to resolve organization for test project: admin is not a member of the seeded 'e2e-default' org"
             );
           }
 


### PR DESCRIPTION
## Summary

After the saas-mode pivot (#25) + h1 fix (#26), the next `deploy-admin.yml` run on main dropped to **237 passed / 9 failed**. This PR fixes all 9. Unlike the previous iterations, **every fix here was validated against a real testcontainer stack locally before push** — the 43 tests I changed all pass.

## Fixes, in order

| Test | Root cause | Fix |
|---|---|---|
| `replay-direct-storage.spec.ts:170` | Inline duplicate of the `PATCH /reports/:id { replay_upload_status }` pattern fixed in the fixture in #26 | Switch to `POST /:id/confirm-upload { fileType: 'replay' }` (same as the fixture) |
| `project-integrations-navigation.spec.ts:84` | Test's own `POST /projects` didn't include `organization_id` (400 in SaaS mode on the hub domain) | Resolve org via `/organizations/me`, include `organization_id` |
| `bug-reports-access-control.spec.ts:296` | Same missing `organization_id` *plus* the trial plan's 2-project cap was already consumed by earlier specs using the seeded default org | Spec creates a dedicated org in `beforeAll` so its 2-project budget is fresh |
| `organizations.spec.ts:91` | `getByRole('status')` matched the sidebar "Role: platform admin" badge, not just status badges in the org table | Scope to `table tbody` |
| `my-organization.spec.ts:110` | `getByLabel(/email/i)` resolved to 3 elements once the member table had rows | Use the invite form's stable `#invite-email` / `#invite-role` IDs |
| `role-based-access.spec.ts:241` | 'Audit Logs' and 'API Keys' in `ADMIN_ONLY_LABELS` but the sidebar items have no `adminOnly` flag and backend allows org owners to access them | Move to `GENERAL_LABELS` with a comment explaining why |
| `auth-setup.spec.ts:159` + `setup-comprehensive.spec.ts:349` | Logout button off-viewport: the sidebar `<nav className="flex-1">` had no overflow rule, so with 20+ nav items (platform admin + org sections) the user-info footer got pushed past the viewport bottom. Playwright can't scroll-into-view inside a `position: fixed` container. | **Product fix:** added `overflow-y-auto` to the nav. Fixes a real UX regression too — real users on short viewports had the same issue. |

## Test-harness port configurability

The E2E stack hardcoded ports 4000 (backend), 4001 (Vite), 3001 (worker health). On Windows those all fall inside Hyper-V's reserved port ranges (`netsh int ipv4 show excludedportrange`), so local runs immediately fail with `EACCES: permission denied` or `ERR_CONNECTION_REFUSED`. This is why I kept pushing fixes blind through CI — I literally couldn't run the suite locally.

Added env overrides with the existing defaults preserved:

- `E2E_ADMIN_PORT` — Vite dev server (default `4001`)
- `API_PORT` / `API_URL` — backend (default `4000`)
- `WORKER_HEALTH_PORT` — worker health server (default `3001`)

`playwright.config.ts`, `config.ts`, and `global-setup.ts` all honor these now. CI is unchanged because none of the variables are set there. Locally:

\`\`\`bash
E2E_ADMIN_PORT=5534 API_PORT=5535 API_URL=http://localhost:5535 \
  WORKER_HEALTH_PORT=5536 pnpm --filter @bugspotter/admin test:e2e
\`\`\`

## Test plan

- [x] 43 tests across the specs I modified pass locally against a real testcontainer stack.
- [ ] After merge: observe the next `deploy-admin.yml` run on main. Expect 0 failures in this PR's scope; any residual failures are in tests I didn't touch (and I'd be able to iterate locally now that ports are configurable).

## Not in scope

A handful of other specs still hardcode `const API_BASE_URL = 'http://localhost:4000'` (integration-edit, integration-rules*, integrations, jira-service-specific, project-integration-config). They pass in CI with default ports, and would fail only if someone overrides `API_PORT` locally. Cleaning that up is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)