### PR TITLE
ci(admin): resolve residual 9 E2E failures + make ports configurable

### DIFF
--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -21,19 +21,10 @@ dotenv.config({ path: path.resolve(__dirname, '.env.integration') });
 dotenv.config({ path: path.resolve(__dirname, '../../packages/backend/.env.integration') });
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
-// Normalize user-provided URLs through `new URL(...).origin` so a
-// `BASE_URL` / `API_URL` with a trailing slash or path doesn't leak
-// into Playwright's URL resolution (`page.goto('/...')` against a
-// base with a path behaves unexpectedly) or into Vite's proxy config.
-// Mirrors the normalization done in `src/tests/e2e/config.ts` and
-// `global-setup.ts` so every consumer agrees on one canonical origin.
-function normalizeOrigin(raw: string, label: string): string {
-  try {
-    return new URL(raw).origin;
-  } catch {
-    throw new Error(`Invalid ${label}: ${raw}`);
-  }
-}
+// Shared helper — see `src/tests/e2e/helpers/url-helpers.ts` for
+// rationale. Import is relative because `playwright.config.ts` lives
+// outside `src/` but TypeScript resolution still works.
+import { normalizeOrigin } from './src/tests/e2e/helpers/url-helpers';
 
 const ADMIN_BASE_URL = normalizeOrigin(
   process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`,

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -21,6 +21,29 @@ dotenv.config({ path: path.resolve(__dirname, '.env.integration') });
 dotenv.config({ path: path.resolve(__dirname, '../../packages/backend/.env.integration') });
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
+// Normalize user-provided URLs through `new URL(...).origin` so a
+// `BASE_URL` / `API_URL` with a trailing slash or path doesn't leak
+// into Playwright's URL resolution (`page.goto('/...')` against a
+// base with a path behaves unexpectedly) or into Vite's proxy config.
+// Mirrors the normalization done in `src/tests/e2e/config.ts` and
+// `global-setup.ts` so every consumer agrees on one canonical origin.
+function normalizeOrigin(raw: string, label: string): string {
+  try {
+    return new URL(raw).origin;
+  } catch {
+    throw new Error(`Invalid ${label}: ${raw}`);
+  }
+}
+
+const ADMIN_BASE_URL = normalizeOrigin(
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`,
+  'BASE_URL'
+);
+const BACKEND_API_URL = normalizeOrigin(
+  process.env.API_URL || `http://localhost:${process.env.API_PORT || '4000'}`,
+  'API_URL'
+);
+
 export default defineConfig({
   testDir: './src/tests/e2e',
   fullyParallel: false, // Run tests sequentially (can enable after verification)
@@ -37,7 +60,7 @@ export default defineConfig({
     // Port overrides via env so contributors on Windows (where Hyper-V
     // reserves 4000/4001 for its own use via `netsh int ipv4 show
     // excludedportrange`) can pick free ports.
-    baseURL: process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+    baseURL: ADMIN_BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -56,15 +79,15 @@ export default defineConfig({
     : {
         // Use node to run vite directly, bypassing Corepack/pnpm issues
         // This works because vite is installed in node_modules
-        command: `node node_modules/vite/bin/vite.js --port ${process.env.E2E_ADMIN_PORT ?? '4001'}`,
-        url: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+        command: `node node_modules/vite/bin/vite.js --port ${process.env.E2E_ADMIN_PORT || '4001'}`,
+        url: ADMIN_BASE_URL,
         reuseExistingServer: !process.env.CI,
         timeout: 120000,
         stdout: 'pipe',
         stderr: 'pipe',
         env: {
-          PORT: process.env.E2E_ADMIN_PORT ?? '4001',
-          VITE_API_URL: process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`,
+          PORT: process.env.E2E_ADMIN_PORT || '4001',
+          VITE_API_URL: BACKEND_API_URL,
         },
       },
 });

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -34,7 +34,10 @@ export default defineConfig({
   timeout: 120000, // Increase test timeout to 120s (2 minutes) for testcontainer startup
   outputDir: 'e2e-debug/test-results',
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:4001',
+    // Port overrides via env so contributors on Windows (where Hyper-V
+    // reserves 4000/4001 for its own use via `netsh int ipv4 show
+    // excludedportrange`) can pick free ports.
+    baseURL: process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -53,15 +56,15 @@ export default defineConfig({
     : {
         // Use node to run vite directly, bypassing Corepack/pnpm issues
         // This works because vite is installed in node_modules
-        command: 'node node_modules/vite/bin/vite.js --port 4001',
-        url: 'http://localhost:4001',
+        command: `node node_modules/vite/bin/vite.js --port ${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+        url: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
         reuseExistingServer: !process.env.CI,
         timeout: 120000,
         stdout: 'pipe',
         stderr: 'pipe',
         env: {
-          PORT: '4001',
-          VITE_API_URL: process.env.API_URL || 'http://localhost:4000',
+          PORT: process.env.E2E_ADMIN_PORT ?? '4001',
+          VITE_API_URL: process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`,
         },
       },
 });

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -21,17 +21,21 @@ dotenv.config({ path: path.resolve(__dirname, '.env.integration') });
 dotenv.config({ path: path.resolve(__dirname, '../../packages/backend/.env.integration') });
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
-// Shared helper — see `src/tests/e2e/helpers/url-helpers.ts` for
+// Shared helpers — see `src/tests/e2e/helpers/url-helpers.ts` for
 // rationale. Import is relative because `playwright.config.ts` lives
 // outside `src/` but TypeScript resolution still works.
-import { normalizeOrigin } from './src/tests/e2e/helpers/url-helpers';
+import {
+  DEFAULT_ADMIN_PORT,
+  DEFAULT_API_PORT,
+  normalizeOrigin,
+} from './src/tests/e2e/helpers/url-helpers';
 
 const ADMIN_BASE_URL = normalizeOrigin(
-  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`,
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || DEFAULT_ADMIN_PORT}`,
   'BASE_URL'
 );
 const BACKEND_API_URL = normalizeOrigin(
-  process.env.API_URL || `http://localhost:${process.env.API_PORT || '4000'}`,
+  process.env.API_URL || `http://localhost:${process.env.API_PORT || DEFAULT_API_PORT}`,
   'API_URL'
 );
 
@@ -70,14 +74,14 @@ export default defineConfig({
     : {
         // Use node to run vite directly, bypassing Corepack/pnpm issues
         // This works because vite is installed in node_modules
-        command: `node node_modules/vite/bin/vite.js --port ${process.env.E2E_ADMIN_PORT || '4001'}`,
+        command: `node node_modules/vite/bin/vite.js --port ${process.env.E2E_ADMIN_PORT || DEFAULT_ADMIN_PORT}`,
         url: ADMIN_BASE_URL,
         reuseExistingServer: !process.env.CI,
         timeout: 120000,
         stdout: 'pipe',
         stderr: 'pipe',
         env: {
-          PORT: process.env.E2E_ADMIN_PORT || '4001',
+          PORT: process.env.E2E_ADMIN_PORT || DEFAULT_ADMIN_PORT,
           VITE_API_URL: BACKEND_API_URL,
         },
       },

--- a/apps/admin/src/components/dashboard-layout.tsx
+++ b/apps/admin/src/components/dashboard-layout.tsx
@@ -167,8 +167,12 @@ export default function DashboardLayout() {
           {/* Navigation — overflow-y-auto so a long list of items (platform
               admin + org sections together can be 20+) scrolls INSIDE the
               sidebar rather than pushing the user info + logout button
-              below the viewport on shorter screens. */}
-          <nav className="flex-1 overflow-y-auto p-4 space-y-1">
+              below the viewport on shorter screens. `min-h-0` is required
+              on a flex-1 child for `overflow-y-auto` to actually shrink
+              and scroll in a column-flex container — without it the
+              content can still push the sibling footer off-screen in
+              some browsers. */}
+          <nav className="flex-1 min-h-0 overflow-y-auto p-4 space-y-1">
             {NAV_ITEMS.map((item) => {
               if (item.adminOnly && !isAdmin) {
                 return null;

--- a/apps/admin/src/components/dashboard-layout.tsx
+++ b/apps/admin/src/components/dashboard-layout.tsx
@@ -164,8 +164,11 @@ export default function DashboardLayout() {
             <p className="text-sm text-gray-500 mt-1">{t('nav.adminPanel')}</p>
           </div>
 
-          {/* Navigation */}
-          <nav className="flex-1 p-4 space-y-1">
+          {/* Navigation — overflow-y-auto so a long list of items (platform
+              admin + org sections together can be 20+) scrolls INSIDE the
+              sidebar rather than pushing the user info + logout button
+              below the viewport on shorter screens. */}
+          <nav className="flex-1 overflow-y-auto p-4 space-y-1">
             {NAV_ITEMS.map((item) => {
               if (item.adminOnly && !isAdmin) {
                 return null;

--- a/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
+++ b/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
@@ -98,6 +98,31 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     const regularData = await regularLoginResponse.json();
     regularUserToken = regularData.data.access_token;
 
+    // Create a dedicated org for this spec's projects. We can't reuse
+    // the admin's default E2E org because the trial plan caps at 2
+    // projects and earlier specs in the suite (api-keys, audit-logs,
+    // etc.) already consume slots via `ensureProjectExists`. A fresh
+    // org gives us our own 2-project budget.
+    //
+    // Required in SaaS mode anyway: the hub domain's project-create
+    // needs `organization_id` in the body
+    // (see `resolveOrganizationForProject` in
+    // packages/backend/src/api/routes/projects.ts).
+    const bugReportOrgResponse = await request.post(`${API_URL}/api/v1/organizations`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      data: {
+        name: `Bug Reports RBAC ${Date.now()}`,
+        subdomain: `bug-reports-rbac-${Date.now()}`,
+        data_residency_region: 'global',
+      },
+    });
+    if (!bugReportOrgResponse.ok()) {
+      throw new Error(
+        `Failed to create test org: ${bugReportOrgResponse.status()} ${await bugReportOrgResponse.text()}`
+      );
+    }
+    const organizationId = (await bugReportOrgResponse.json()).data.id as string;
+
     // Create two projects
     const project1Response = await request.post(`${API_URL}/api/v1/projects`, {
       headers: {
@@ -105,6 +130,7 @@ test.describe('Bug Reports - Access Control & Filters', () => {
       },
       data: {
         name: 'Project Alpha',
+        organization_id: organizationId,
       },
     });
     const project1Data = await project1Response.json();
@@ -116,6 +142,7 @@ test.describe('Bug Reports - Access Control & Filters', () => {
       },
       data: {
         name: 'Project Beta',
+        organization_id: organizationId,
       },
     });
     const project2Data = await project2Response.json();

--- a/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
+++ b/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
@@ -51,6 +51,7 @@ test.describe('Bug Reports - Access Control & Filters', () => {
   let project1: { id: string; name: string; api_key: string };
   let project2: { id: string; name: string; api_key: string };
   let regularUserId: string;
+  let bugReportOrgId: string | undefined;
 
   test.beforeAll(async ({ request, setupState }) => {
     // Create admin user
@@ -108,11 +109,17 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     // needs `organization_id` in the body
     // (see `resolveOrganizationForProject` in
     // packages/backend/src/api/routes/projects.ts).
+    //
+    // Captured to `bugReportOrgId` so `afterAll` can tear it down —
+    // otherwise this spec leaves the admin with an extra membership
+    // and later specs that pick `myOrgs[0]` could select the wrong
+    // one.
+    const orgTimestamp = Date.now();
     const bugReportOrgResponse = await request.post(`${API_URL}/api/v1/organizations`, {
       headers: { Authorization: `Bearer ${adminToken}` },
       data: {
-        name: `Bug Reports RBAC ${Date.now()}`,
-        subdomain: `bug-reports-rbac-${Date.now()}`,
+        name: `Bug Reports RBAC ${orgTimestamp}`,
+        subdomain: `bug-reports-rbac-${orgTimestamp}`,
         data_residency_region: 'global',
       },
     });
@@ -121,7 +128,8 @@ test.describe('Bug Reports - Access Control & Filters', () => {
         `Failed to create test org: ${bugReportOrgResponse.status()} ${await bugReportOrgResponse.text()}`
       );
     }
-    const organizationId = (await bugReportOrgResponse.json()).data.id as string;
+    bugReportOrgId = (await bugReportOrgResponse.json()).data.id as string;
+    const organizationId = bugReportOrgId;
 
     // Create two projects
     const project1Response = await request.post(`${API_URL}/api/v1/projects`, {
@@ -315,6 +323,22 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     } catch (error) {
       console.log(
         'Failed to delete regular user (backend may be down):',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+
+    try {
+      // Delete the dedicated org this spec created. Without this, the
+      // admin accumulates an extra membership across specs and later
+      // tests that pick `myOrgs[0]` could select the wrong one.
+      if (bugReportOrgId && adminToken) {
+        await request.delete(`${API_URL}/api/v1/organizations/${bugReportOrgId}`, {
+          headers: { Authorization: `Bearer ${adminToken}` },
+        });
+      }
+    } catch (error) {
+      console.log(
+        'Failed to delete bug-reports RBAC org (backend may be down):',
         error instanceof Error ? error.message : String(error)
       );
     }

--- a/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
+++ b/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
@@ -331,10 +331,18 @@ test.describe('Bug Reports - Access Control & Filters', () => {
       // Delete the dedicated org this spec created. Without this, the
       // admin accumulates an extra membership across specs and later
       // tests that pick `myOrgs[0]` could select the wrong one.
+      // Check the response status explicitly — a silently-failing
+      // delete (e.g. 401 from a stale token) would re-introduce the
+      // accumulation this block exists to prevent.
       if (bugReportOrgId && adminToken) {
-        await request.delete(`${API_URL}/api/v1/organizations/${bugReportOrgId}`, {
+        const response = await request.delete(`${API_URL}/api/v1/organizations/${bugReportOrgId}`, {
           headers: { Authorization: `Bearer ${adminToken}` },
         });
+        if (!response.ok()) {
+          console.log(
+            `[Cleanup] Failed to delete bug-reports RBAC org ${bugReportOrgId}: ${response.status()} ${await response.text()}`
+          );
+        }
       }
     } catch (error) {
       console.log(

--- a/apps/admin/src/tests/e2e/config.ts
+++ b/apps/admin/src/tests/e2e/config.ts
@@ -3,11 +3,15 @@
  * Centralized configuration for all E2E tests
  */
 
-// Base URL for the admin panel (Vite dev server)
-export const E2E_BASE_URL = process.env.BASE_URL || 'http://localhost:4001';
+// Base URL for the admin panel (Vite dev server). Honors E2E_ADMIN_PORT
+// so contributors on Windows — where Hyper-V reserves 4000/4001 via
+// `netsh int ipv4 show excludedportrange` — can point at free ports.
+export const E2E_BASE_URL =
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
 
-// API URL for the backend server
-export const E2E_API_URL = process.env.API_URL || 'http://localhost:4000';
+// API URL for the backend server. Honors API_PORT for the same reason.
+export const E2E_API_URL =
+  process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`;
 
 // Extract hostname for URL checks (without protocol)
 export const E2E_BASE_HOSTNAME = E2E_BASE_URL.replace(/^https?:\/\//, '');

--- a/apps/admin/src/tests/e2e/config.ts
+++ b/apps/admin/src/tests/e2e/config.ts
@@ -3,30 +3,22 @@
  * Centralized configuration for all E2E tests
  */
 
-// Resolve the admin + API URLs once, normalizing through `new URL(...).origin`
-// so a user-provided `BASE_URL` / `API_URL` with a trailing slash or path
-// (e.g. `https://host.com/admin`) doesn't leak into downstream consumers
-// — `E2E_BASE_HOSTNAME` would end up as `host.com/admin`, breaking the
-// auth helper's `currentURL.includes(E2E_BASE_HOSTNAME)` short-circuit.
-function normalizeOrigin(raw: string, label: string): string {
-  try {
-    return new URL(raw).origin;
-  } catch {
-    throw new Error(`Invalid ${label}: ${raw}`);
-  }
-}
+import { normalizeOrigin } from './helpers/url-helpers';
 
 // Base URL for the admin panel (Vite dev server). Honors E2E_ADMIN_PORT
 // so contributors on Windows — where Hyper-V reserves 4000/4001 via
 // `netsh int ipv4 show excludedportrange` — can point at free ports.
+// Using `||` (not `??`) so an empty-string env var falls back to the
+// default rather than producing `http://localhost:` and throwing in
+// `normalizeOrigin`.
 export const E2E_BASE_URL = normalizeOrigin(
-  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`,
   'BASE_URL'
 );
 
 // API URL for the backend server. Honors API_PORT for the same reason.
 export const E2E_API_URL = normalizeOrigin(
-  process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`,
+  process.env.API_URL || `http://localhost:${process.env.API_PORT || '4000'}`,
   'API_URL'
 );
 

--- a/apps/admin/src/tests/e2e/config.ts
+++ b/apps/admin/src/tests/e2e/config.ts
@@ -3,7 +3,7 @@
  * Centralized configuration for all E2E tests
  */
 
-import { normalizeOrigin } from './helpers/url-helpers';
+import { DEFAULT_ADMIN_PORT, DEFAULT_API_PORT, normalizeOrigin } from './helpers/url-helpers';
 
 // Base URL for the admin panel (Vite dev server). Honors E2E_ADMIN_PORT
 // so contributors on Windows — where Hyper-V reserves 4000/4001 via
@@ -12,13 +12,13 @@ import { normalizeOrigin } from './helpers/url-helpers';
 // default rather than producing `http://localhost:` and throwing in
 // `normalizeOrigin`.
 export const E2E_BASE_URL = normalizeOrigin(
-  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`,
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || DEFAULT_ADMIN_PORT}`,
   'BASE_URL'
 );
 
 // API URL for the backend server. Honors API_PORT for the same reason.
 export const E2E_API_URL = normalizeOrigin(
-  process.env.API_URL || `http://localhost:${process.env.API_PORT || '4000'}`,
+  process.env.API_URL || `http://localhost:${process.env.API_PORT || DEFAULT_API_PORT}`,
   'API_URL'
 );
 

--- a/apps/admin/src/tests/e2e/config.ts
+++ b/apps/admin/src/tests/e2e/config.ts
@@ -3,15 +3,32 @@
  * Centralized configuration for all E2E tests
  */
 
+// Resolve the admin + API URLs once, normalizing through `new URL(...).origin`
+// so a user-provided `BASE_URL` / `API_URL` with a trailing slash or path
+// (e.g. `https://host.com/admin`) doesn't leak into downstream consumers
+// — `E2E_BASE_HOSTNAME` would end up as `host.com/admin`, breaking the
+// auth helper's `currentURL.includes(E2E_BASE_HOSTNAME)` short-circuit.
+function normalizeOrigin(raw: string, label: string): string {
+  try {
+    return new URL(raw).origin;
+  } catch {
+    throw new Error(`Invalid ${label}: ${raw}`);
+  }
+}
+
 // Base URL for the admin panel (Vite dev server). Honors E2E_ADMIN_PORT
 // so contributors on Windows — where Hyper-V reserves 4000/4001 via
 // `netsh int ipv4 show excludedportrange` — can point at free ports.
-export const E2E_BASE_URL =
-  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
+export const E2E_BASE_URL = normalizeOrigin(
+  process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+  'BASE_URL'
+);
 
 // API URL for the backend server. Honors API_PORT for the same reason.
-export const E2E_API_URL =
-  process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`;
+export const E2E_API_URL = normalizeOrigin(
+  process.env.API_URL || `http://localhost:${process.env.API_PORT ?? '4000'}`,
+  'API_URL'
+);
 
 // Extract hostname for URL checks (without protocol)
 export const E2E_BASE_HOSTNAME = E2E_BASE_URL.replace(/^https?:\/\//, '');

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -258,15 +258,30 @@ export default async function globalSetup() {
       throw error;
     }
 
-    // Set API_URL for both backend and frontend. Precedence:
-    //   1. `API_URL` if explicitly provided (someone pointing tests at a
-    //      non-localhost backend, or a port + host combination that can't
-    //      be captured via `API_PORT` alone).
-    //   2. Otherwise derive from `API_PORT` (default `4000`).
-    const apiPort = process.env.API_PORT || '4000';
-    const apiUrl = process.env.API_URL || `http://localhost:${apiPort}`;
-    process.env.API_URL = apiUrl;
-    process.env.VITE_API_URL = apiUrl; // For Vite proxy configuration
+    // Resolve the API URL once, normalizing to an origin so a user-
+    // provided `API_URL=https://host.com/prefix/` can't leak a path
+    // into CORS matching or downstream consumers that read
+    // `process.env.API_URL` and append `/api/v1/...`.
+    //
+    // Port precedence (critical for consistency — the port used in
+    // the URL must match the port the backend is spawned on):
+    //   1. If `API_URL` is set, derive the port from it.
+    //   2. Else if `API_PORT` is set, use it.
+    //   3. Else default to 4000.
+    // Using `||` (not `??`) so an empty-string env var falls back
+    // cleanly — matches the pattern in `config.ts` and
+    // `playwright.config.ts`.
+    const rawApiUrl = process.env.API_URL || `http://localhost:${process.env.API_PORT || '4000'}`;
+    let apiUrlParsed: URL;
+    try {
+      apiUrlParsed = new URL(rawApiUrl);
+    } catch {
+      throw new Error(`Invalid API_URL / API_PORT combination: ${rawApiUrl}`);
+    }
+    const apiOrigin = apiUrlParsed.origin;
+    const apiPort = apiUrlParsed.port || (apiUrlParsed.protocol === 'https:' ? '443' : '80');
+    process.env.API_URL = apiOrigin;
+    process.env.VITE_API_URL = apiOrigin; // For Vite proxy configuration
 
     // Resolve the admin (frontend) URL once. `BASE_URL` takes precedence
     // when someone is running Playwright against an already-running admin
@@ -275,23 +290,15 @@ export default async function globalSetup() {
     // default to `:4001`. Normalize via `new URL(...).origin` so a
     // `BASE_URL` that includes a path (`https://host.com/admin`) or a
     // trailing slash doesn't leak into CORS matching — the browser's
-    // `Origin` header is always just `scheme://host[:port]`.
+    // `Origin` header is always just `scheme://host[:port]`. Using `||`
+    // (not `??`) so an empty `BASE_URL` falls back to the default.
     const rawAdminUrl =
-      process.env.BASE_URL ?? `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
+      process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`;
     let adminUrl: string;
     try {
       adminUrl = new URL(rawAdminUrl).origin;
     } catch {
       throw new Error(`Invalid BASE_URL / E2E_ADMIN_PORT combination: ${rawAdminUrl}`);
-    }
-
-    // Normalize apiUrl the same way so a user-provided `API_URL` with
-    // a path/trailing slash doesn't leak into CORS matching.
-    let apiOrigin: string;
-    try {
-      apiOrigin = new URL(apiUrl).origin;
-    } catch {
-      throw new Error(`Invalid API_URL / API_PORT combination: ${apiUrl}`);
     }
 
     console.log(`🚀 Starting backend server on port ${apiPort}...`);
@@ -380,7 +387,7 @@ export default async function globalSetup() {
 
     for (let i = 0; i < maxRetries; i++) {
       try {
-        const response = await fetch(`${apiUrl}/health`);
+        const response = await fetch(`${apiOrigin}/health`);
         if (response.ok) {
           console.log('✅ Backend server is ready');
           break;
@@ -470,8 +477,8 @@ export default async function globalSetup() {
 
     // Display loaded configuration
     console.log('\n📋 Test configuration:');
-    console.log(`   API URL: ${apiUrl}`);
-    console.log(`   Base URL: ${process.env.BASE_URL || 'http://localhost:4001'}`);
+    console.log(`   API URL: ${apiOrigin}`);
+    console.log(`   Base URL: ${adminUrl}`);
     console.log(`   Database: Isolated PostgreSQL container`);
     console.log(`   Redis: Isolated Redis container`);
     console.log(`   Storage: MinIO (${minioEndpoint})`);

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -12,7 +12,12 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import * as fs from 'fs/promises';
-import { normalizeOrigin } from './helpers/url-helpers';
+import {
+  DEFAULT_ADMIN_PORT,
+  DEFAULT_API_PORT,
+  DEFAULT_WORKER_PORT,
+  normalizeOrigin,
+} from './helpers/url-helpers';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -275,7 +280,8 @@ export default async function globalSetup() {
     // cleanly — matches the pattern in `config.ts` and
     // `playwright.config.ts`.
     const hasExplicitApiUrl = !!process.env.API_URL;
-    const rawApiUrl = process.env.API_URL || `http://localhost:${process.env.API_PORT || '4000'}`;
+    const rawApiUrl =
+      process.env.API_URL || `http://localhost:${process.env.API_PORT || DEFAULT_API_PORT}`;
     let apiUrlParsed: URL;
     try {
       apiUrlParsed = new URL(rawApiUrl);
@@ -307,7 +313,8 @@ export default async function globalSetup() {
     // `Origin` header is always just `scheme://host[:port]`. Using `||`
     // (not `??`) so an empty `BASE_URL` falls back to the default.
     const rawAdminUrl =
-      process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`;
+      process.env.BASE_URL ||
+      `http://localhost:${process.env.E2E_ADMIN_PORT || DEFAULT_ADMIN_PORT}`;
     const adminUrl = normalizeOrigin(rawAdminUrl, 'BASE_URL / E2E_ADMIN_PORT combination');
 
     console.log(`🚀 Starting backend server on port ${apiPort}...`);
@@ -432,7 +439,7 @@ export default async function globalSetup() {
         // Honor WORKER_HEALTH_PORT override so local runs on Windows
         // (Hyper-V reserves 3001 via `netsh int ipv4 show
         // excludedportrange`) can pick a free port.
-        WORKER_HEALTH_PORT: process.env.WORKER_HEALTH_PORT || '3001',
+        WORKER_HEALTH_PORT: process.env.WORKER_HEALTH_PORT || DEFAULT_WORKER_PORT,
         // Match the backend's deployment mode so queue consumers operate
         // under the same billing / usage-tracking / tenant-resolution
         // rules as the API they're paired with. Diverging here would

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -264,6 +264,15 @@ export default async function globalSetup() {
     process.env.API_URL = apiUrl;
     process.env.VITE_API_URL = apiUrl; // For Vite proxy configuration
 
+    // Resolve the admin (frontend) URL once. `BASE_URL` takes precedence
+    // when someone is running Playwright against an already-running admin
+    // (in that case Playwright's webServer is skipped); otherwise we
+    // honor `E2E_ADMIN_PORT` for Windows/Hyper-V port conflicts; finally
+    // default to `:4001`. Used for both the backend's `FRONTEND_URL`
+    // and its CORS allowlist so the two never disagree.
+    const adminUrl =
+      process.env.BASE_URL ?? `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
+
     // Start backend server on port 4000
     console.log('🚀 Starting backend server on port 4000...');
     const backendPath = path.resolve(__dirname, '../../../../../packages/backend');
@@ -280,9 +289,12 @@ export default async function globalSetup() {
         NODE_ENV: 'test',
         LOG_LEVEL: 'warn', // Only show warnings and errors (reduce log noise)
         // Honor port overrides so local runs on Windows (Hyper-V
-        // reserves 4000/4001) can pick free ports via env vars.
-        CORS_ORIGINS: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'},http://localhost:${apiPort}`,
-        FRONTEND_URL: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
+        // reserves 4000/4001) can pick free ports via env vars. Uses
+        // the shared `adminUrl` resolved above so `FRONTEND_URL` and
+        // the frontend entry in `CORS_ORIGINS` stay in sync even when
+        // the admin is served from a non-localhost `BASE_URL`.
+        CORS_ORIGINS: `${adminUrl},${apiUrl}`,
+        FRONTEND_URL: adminUrl,
         // Run the backend in SaaS mode so routes gated by `SaaSRoute` in
         // the admin (organizations list, retention, billing, etc.) are
         // reachable during E2E. Without this, the backend defaults to

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -12,6 +12,7 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import * as fs from 'fs/promises';
+import { normalizeOrigin } from './helpers/url-helpers';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -265,12 +266,15 @@ export default async function globalSetup() {
     //
     // Port precedence (critical for consistency — the port used in
     // the URL must match the port the backend is spawned on):
-    //   1. If `API_URL` is set, derive the port from it.
+    //   1. If `API_URL` is set, the port MUST come from it (and be
+    //      explicit — otherwise the default 80/443 would try to bind
+    //      privileged ports).
     //   2. Else if `API_PORT` is set, use it.
     //   3. Else default to 4000.
     // Using `||` (not `??`) so an empty-string env var falls back
     // cleanly — matches the pattern in `config.ts` and
     // `playwright.config.ts`.
+    const hasExplicitApiUrl = !!process.env.API_URL;
     const rawApiUrl = process.env.API_URL || `http://localhost:${process.env.API_PORT || '4000'}`;
     let apiUrlParsed: URL;
     try {
@@ -278,8 +282,18 @@ export default async function globalSetup() {
     } catch {
       throw new Error(`Invalid API_URL / API_PORT combination: ${rawApiUrl}`);
     }
+    if (hasExplicitApiUrl && !apiUrlParsed.port) {
+      // The backend spawn below sets `PORT=<apiPort>`. If we let that
+      // be 80/443 from the URL default, the spawn fails immediately
+      // with EACCES on every non-root environment. Fail fast and
+      // clearly instead.
+      throw new Error(
+        `API_URL must include an explicit port for E2E setup (got: ${rawApiUrl}). ` +
+          `The backend process will be spawned listening on that port.`
+      );
+    }
     const apiOrigin = apiUrlParsed.origin;
-    const apiPort = apiUrlParsed.port || (apiUrlParsed.protocol === 'https:' ? '443' : '80');
+    const apiPort = apiUrlParsed.port;
     process.env.API_URL = apiOrigin;
     process.env.VITE_API_URL = apiOrigin; // For Vite proxy configuration
 
@@ -294,12 +308,7 @@ export default async function globalSetup() {
     // (not `??`) so an empty `BASE_URL` falls back to the default.
     const rawAdminUrl =
       process.env.BASE_URL || `http://localhost:${process.env.E2E_ADMIN_PORT || '4001'}`;
-    let adminUrl: string;
-    try {
-      adminUrl = new URL(rawAdminUrl).origin;
-    } catch {
-      throw new Error(`Invalid BASE_URL / E2E_ADMIN_PORT combination: ${rawAdminUrl}`);
-    }
+    const adminUrl = normalizeOrigin(rawAdminUrl, 'BASE_URL / E2E_ADMIN_PORT combination');
 
     console.log(`🚀 Starting backend server on port ${apiPort}...`);
     const backendPath = path.resolve(__dirname, '../../../../../packages/backend');
@@ -423,7 +432,7 @@ export default async function globalSetup() {
         // Honor WORKER_HEALTH_PORT override so local runs on Windows
         // (Hyper-V reserves 3001 via `netsh int ipv4 show
         // excludedportrange`) can pick a free port.
-        WORKER_HEALTH_PORT: process.env.WORKER_HEALTH_PORT ?? '3001',
+        WORKER_HEALTH_PORT: process.env.WORKER_HEALTH_PORT || '3001',
         // Match the backend's deployment mode so queue consumers operate
         // under the same billing / usage-tracking / tenant-resolution
         // rules as the API they're paired with. Diverging here would

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -285,8 +285,16 @@ export default async function globalSetup() {
       throw new Error(`Invalid BASE_URL / E2E_ADMIN_PORT combination: ${rawAdminUrl}`);
     }
 
-    // Start backend server on port 4000
-    console.log('🚀 Starting backend server on port 4000...');
+    // Normalize apiUrl the same way so a user-provided `API_URL` with
+    // a path/trailing slash doesn't leak into CORS matching.
+    let apiOrigin: string;
+    try {
+      apiOrigin = new URL(apiUrl).origin;
+    } catch {
+      throw new Error(`Invalid API_URL / API_PORT combination: ${apiUrl}`);
+    }
+
+    console.log(`🚀 Starting backend server on port ${apiPort}...`);
     const backendPath = path.resolve(__dirname, '../../../../../packages/backend');
 
     // Use npx tsx to avoid Corepack issues (shell: true required on Windows)
@@ -305,7 +313,7 @@ export default async function globalSetup() {
         // the shared `adminUrl` resolved above so `FRONTEND_URL` and
         // the frontend entry in `CORS_ORIGINS` stay in sync even when
         // the admin is served from a non-localhost `BASE_URL`.
-        CORS_ORIGINS: `${adminUrl},${apiUrl}`,
+        CORS_ORIGINS: `${adminUrl},${apiOrigin}`,
         FRONTEND_URL: adminUrl,
         // Run the backend in SaaS mode so routes gated by `SaaSRoute` in
         // the admin (organizations list, retention, billing, etc.) are

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -258,9 +258,13 @@ export default async function globalSetup() {
       throw error;
     }
 
-    // Set API_URL for both backend and frontend
+    // Set API_URL for both backend and frontend. Precedence:
+    //   1. `API_URL` if explicitly provided (someone pointing tests at a
+    //      non-localhost backend, or a port + host combination that can't
+    //      be captured via `API_PORT` alone).
+    //   2. Otherwise derive from `API_PORT` (default `4000`).
     const apiPort = process.env.API_PORT || '4000';
-    const apiUrl = `http://localhost:${apiPort}`;
+    const apiUrl = process.env.API_URL || `http://localhost:${apiPort}`;
     process.env.API_URL = apiUrl;
     process.env.VITE_API_URL = apiUrl; // For Vite proxy configuration
 
@@ -268,10 +272,18 @@ export default async function globalSetup() {
     // when someone is running Playwright against an already-running admin
     // (in that case Playwright's webServer is skipped); otherwise we
     // honor `E2E_ADMIN_PORT` for Windows/Hyper-V port conflicts; finally
-    // default to `:4001`. Used for both the backend's `FRONTEND_URL`
-    // and its CORS allowlist so the two never disagree.
-    const adminUrl =
+    // default to `:4001`. Normalize via `new URL(...).origin` so a
+    // `BASE_URL` that includes a path (`https://host.com/admin`) or a
+    // trailing slash doesn't leak into CORS matching — the browser's
+    // `Origin` header is always just `scheme://host[:port]`.
+    const rawAdminUrl =
       process.env.BASE_URL ?? `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`;
+    let adminUrl: string;
+    try {
+      adminUrl = new URL(rawAdminUrl).origin;
+    } catch {
+      throw new Error(`Invalid BASE_URL / E2E_ADMIN_PORT combination: ${rawAdminUrl}`);
+    }
 
     // Start backend server on port 4000
     console.log('🚀 Starting backend server on port 4000...');

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -279,8 +279,10 @@ export default async function globalSetup() {
         PORT: apiPort,
         NODE_ENV: 'test',
         LOG_LEVEL: 'warn', // Only show warnings and errors (reduce log noise)
-        CORS_ORIGINS: 'http://localhost:4001,http://localhost:4000',
-        FRONTEND_URL: 'http://localhost:4001',
+        // Honor port overrides so local runs on Windows (Hyper-V
+        // reserves 4000/4001) can pick free ports via env vars.
+        CORS_ORIGINS: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'},http://localhost:${apiPort}`,
+        FRONTEND_URL: `http://localhost:${process.env.E2E_ADMIN_PORT ?? '4001'}`,
         // Run the backend in SaaS mode so routes gated by `SaaSRoute` in
         // the admin (organizations list, retention, billing, etc.) are
         // reachable during E2E. Without this, the backend defaults to
@@ -379,6 +381,10 @@ export default async function globalSetup() {
         REDIS_URL: redisUrl,
         NODE_ENV: 'test',
         LOG_LEVEL: 'error',
+        // Honor WORKER_HEALTH_PORT override so local runs on Windows
+        // (Hyper-V reserves 3001 via `netsh int ipv4 show
+        // excludedportrange`) can pick a free port.
+        WORKER_HEALTH_PORT: process.env.WORKER_HEALTH_PORT ?? '3001',
         // Match the backend's deployment mode so queue consumers operate
         // under the same billing / usage-tracking / tenant-resolution
         // rules as the API they're paired with. Diverging here would

--- a/apps/admin/src/tests/e2e/helpers/url-helpers.ts
+++ b/apps/admin/src/tests/e2e/helpers/url-helpers.ts
@@ -14,6 +14,17 @@
  */
 
 /**
+ * Default ports for the E2E harness. Shared across
+ * `playwright.config.ts`, `config.ts`, and `global-setup.ts` so the
+ * three consumers can never disagree on the fallback. Strings rather
+ * than numbers because `process.env.*` is always a string and the
+ * places that use these concatenate them into URLs.
+ */
+export const DEFAULT_ADMIN_PORT = '4001';
+export const DEFAULT_API_PORT = '4000';
+export const DEFAULT_WORKER_PORT = '3001';
+
+/**
  * Reduce a URL-like string to its bare origin (`scheme://host[:port]`).
  * Throws a descriptive error if the input can't be parsed.
  */

--- a/apps/admin/src/tests/e2e/helpers/url-helpers.ts
+++ b/apps/admin/src/tests/e2e/helpers/url-helpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared URL helpers for the E2E test harness.
+ *
+ * Used from three places that all need a single, consistent
+ * interpretation of the frontend/backend base URLs:
+ *   - `playwright.config.ts` (webServer + baseURL wiring)
+ *   - `src/tests/e2e/config.ts` (E2E_BASE_URL / E2E_API_URL)
+ *   - `src/tests/e2e/global-setup.ts` (backend spawn env)
+ *
+ * Without shared normalization a user-provided `BASE_URL` / `API_URL`
+ * with a trailing slash or path (e.g. `https://host.com/admin`) would
+ * leak into CORS matching, Vite's proxy target, and the auth helper's
+ * hostname check — each failure mode subtly different.
+ */
+
+/**
+ * Reduce a URL-like string to its bare origin (`scheme://host[:port]`).
+ * Throws a descriptive error if the input can't be parsed.
+ */
+export function normalizeOrigin(raw: string, label: string): string {
+  try {
+    return new URL(raw).origin;
+  } catch {
+    throw new Error(`Invalid ${label}: ${raw}`);
+  }
+}

--- a/apps/admin/src/tests/e2e/my-organization.spec.ts
+++ b/apps/admin/src/tests/e2e/my-organization.spec.ts
@@ -116,10 +116,13 @@ test.describe('Org Self-Service: My Organization', () => {
     await addButton.waitFor({ state: 'visible', timeout: 10000 });
     await addButton.click();
 
-    // Should show the add form with email input and role select
-    const emailInput = page.getByLabel(/email/i);
+    // Should show the add form with email input and role select.
+    // Use the form's own stable IDs (see `invite-member-form.tsx`) so
+    // the locator doesn't match unrelated email/role-labeled elements
+    // elsewhere on the page (e.g. member-row emails in the table).
+    const emailInput = page.locator('#invite-email');
     await expect(emailInput).toBeVisible({ timeout: 5000 });
-    const roleSelect = page.getByLabel(/role/i);
+    const roleSelect = page.locator('#invite-role');
     await expect(roleSelect).toBeVisible();
   });
 

--- a/apps/admin/src/tests/e2e/organizations.spec.ts
+++ b/apps/admin/src/tests/e2e/organizations.spec.ts
@@ -99,8 +99,11 @@ test.describe('Platform Admin: Organizations', () => {
     // Filter by trial status
     await statusSelect.selectOption('trial');
 
-    // Wait for filtered results to render (use semantic role query)
-    const statusBadges = page.getByRole('status');
+    // Scope the status-badge check to the table body. Without this,
+    // `getByRole('status')` also picks up unrelated badges elsewhere on
+    // the page — e.g. the "role: platform admin" badge in the admin
+    // header — and fails the "every badge says trial" assertion.
+    const statusBadges = page.locator('table tbody').getByRole('status');
     await expect(statusBadges.first().or(page.locator('text=/no organizations/i'))).toBeVisible({
       timeout: 10000,
     });

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -61,35 +61,10 @@ test.describe('Project Integrations Navigation', () => {
 
     // Create a test project. In SaaS mode, the hub domain requires
     // `organization_id` in the body (see `resolveOrganizationForProject`
-    // in packages/backend/src/api/routes/projects.ts). Select the
-    // seeded default org explicitly by subdomain — `myOrgs[0]` is NOT
-    // stable because the backend's `OrganizationRepository.findByUserId`
-    // orders by name and other specs (organizations, my-organization,
-    // role-based-access) create orgs of their own that could sort ahead.
-    const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
-      headers: { Authorization: `Bearer ${adminToken}` },
-    });
-    if (!myOrgsResponse.ok()) {
-      // Include status + body so a 401 (adminToken never populated
-      // because login failed) doesn't masquerade as "admin has no
-      // org memberships".
-      throw new Error(
-        `Failed to fetch /organizations/me: ${myOrgsResponse.status()} ${await myOrgsResponse.text()}`
-      );
-    }
-    const myOrgs = (await myOrgsResponse.json()).data as
-      | Array<{ id: string; subdomain: string }>
-      | undefined;
-    const defaultOrg = Array.isArray(myOrgs)
-      ? myOrgs.find((o) => o.subdomain === 'e2e-default')
-      : undefined;
-    const organizationId = defaultOrg?.id;
-    if (!organizationId) {
-      throw new Error(
-        'Failed to resolve organization_id for test project: ' +
-          "admin is not a member of the seeded 'e2e-default' org"
-      );
-    }
+    // in packages/backend/src/api/routes/projects.ts). Use the shared
+    // `setupState.getDefaultOrgId` so this lookup can't drift from
+    // other specs / fixtures.
+    const organizationId = await setupState.getDefaultOrgId(adminToken);
 
     const projectResponse = await request.post(`${API_URL}/api/v1/projects`, {
       data: { name: 'E2E Navigation Test Project', organization_id: organizationId },

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect, type Page } from '../fixtures/setup-fixture';
 import { waitForI18nReady } from './helpers/i18n-helpers';
+import { E2E_API_URL } from './config';
 
-const API_URL = process.env.API_URL || 'http://localhost:4000';
+// Use the shared helper so `API_PORT` / `API_URL` overrides (see
+// `src/tests/e2e/config.ts`) actually apply here too.
+const API_URL = E2E_API_URL;
 
 // Test credentials
 const TEST_ADMIN = {

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -61,9 +61,11 @@ test.describe('Project Integrations Navigation', () => {
 
     // Create a test project. In SaaS mode, the hub domain requires
     // `organization_id` in the body (see `resolveOrganizationForProject`
-    // in packages/backend/src/api/routes/projects.ts). The admin user is
-    // seeded into a single default org by `ensureInitialized`, so
-    // taking `[0]` is deterministic.
+    // in packages/backend/src/api/routes/projects.ts). Select the
+    // seeded default org explicitly by subdomain — `myOrgs[0]` is NOT
+    // stable because the backend's `OrganizationRepository.findByUserId`
+    // orders by name and other specs (organizations, my-organization,
+    // role-based-access) create orgs of their own that could sort ahead.
     const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     });
@@ -75,10 +77,18 @@ test.describe('Project Integrations Navigation', () => {
         `Failed to fetch /organizations/me: ${myOrgsResponse.status()} ${await myOrgsResponse.text()}`
       );
     }
-    const myOrgs = (await myOrgsResponse.json()).data as Array<{ id: string }> | undefined;
-    const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
+    const myOrgs = (await myOrgsResponse.json()).data as
+      | Array<{ id: string; subdomain: string }>
+      | undefined;
+    const defaultOrg = Array.isArray(myOrgs)
+      ? myOrgs.find((o) => o.subdomain === 'e2e-default')
+      : undefined;
+    const organizationId = defaultOrg?.id;
     if (!organizationId) {
-      throw new Error('Failed to resolve organization_id for test project');
+      throw new Error(
+        'Failed to resolve organization_id for test project: ' +
+          "admin is not a member of the seeded 'e2e-default' org"
+      );
     }
 
     const projectResponse = await request.post(`${API_URL}/api/v1/projects`, {

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -64,6 +64,14 @@ test.describe('Project Integrations Navigation', () => {
     const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
       headers: { Authorization: `Bearer ${adminToken}` },
     });
+    if (!myOrgsResponse.ok()) {
+      // Include status + body so a 401 (adminToken never populated
+      // because login failed) doesn't masquerade as "admin has no
+      // org memberships".
+      throw new Error(
+        `Failed to fetch /organizations/me: ${myOrgsResponse.status()} ${await myOrgsResponse.text()}`
+      );
+    }
     const myOrgs = (await myOrgsResponse.json()).data as Array<{ id: string }> | undefined;
     const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
     if (!organizationId) {

--- a/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
+++ b/apps/admin/src/tests/e2e/project-integrations-navigation.spec.ts
@@ -56,9 +56,22 @@ test.describe('Project Integrations Navigation', () => {
       }
     }
 
-    // Create a test project
+    // Create a test project. In SaaS mode, the hub domain requires
+    // `organization_id` in the body (see `resolveOrganizationForProject`
+    // in packages/backend/src/api/routes/projects.ts). The admin user is
+    // seeded into a single default org by `ensureInitialized`, so
+    // taking `[0]` is deterministic.
+    const myOrgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const myOrgs = (await myOrgsResponse.json()).data as Array<{ id: string }> | undefined;
+    const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
+    if (!organizationId) {
+      throw new Error('Failed to resolve organization_id for test project');
+    }
+
     const projectResponse = await request.post(`${API_URL}/api/v1/projects`, {
-      data: { name: 'E2E Navigation Test Project' },
+      data: { name: 'E2E Navigation Test Project', organization_id: organizationId },
       headers: { Authorization: `Bearer ${adminToken}` },
     });
 

--- a/apps/admin/src/tests/e2e/replay-direct-storage.spec.ts
+++ b/apps/admin/src/tests/e2e/replay-direct-storage.spec.ts
@@ -225,15 +225,24 @@ test.describe('Replay Direct Storage Access', () => {
 
     console.log('✅ Replay file uploaded successfully');
 
-    // Update upload status to 'completed'
-    await request.patch(`${API_URL}/api/v1/reports/${bugReportId}`, {
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
-      data: {
-        replay_upload_status: 'completed',
-      },
-    });
+    // Mark upload complete via the dedicated confirm-upload endpoint.
+    // The general PATCH /reports/:id schema has `additionalProperties: false`
+    // and intentionally doesn't expose `replay_upload_status` as a
+    // user-writable field — upload state transitions go through
+    // POST /reports/:id/confirm-upload (same fix as the fixture in
+    // setup-fixture.ts::createBugReportWithReplay).
+    const confirmResponse = await request.post(
+      `${API_URL}/api/v1/reports/${bugReportId}/confirm-upload`,
+      {
+        headers: { Authorization: `Bearer ${authToken}` },
+        data: { fileType: 'replay' },
+      }
+    );
+    if (!confirmResponse.ok()) {
+      throw new Error(
+        `Failed to mark replay upload complete: ${confirmResponse.status()} ${await confirmResponse.text()}`
+      );
+    }
 
     console.log('✅ Marked replay upload as completed');
 

--- a/apps/admin/src/tests/e2e/role-based-access.spec.ts
+++ b/apps/admin/src/tests/e2e/role-based-access.spec.ts
@@ -28,20 +28,29 @@ const NO_ORG_USER = {
   name: 'No Org User',
 };
 
-/** Admin-only sidebar labels (from en.json nav.*) */
+/** Admin-only sidebar labels (from en.json nav.*).
+ *
+ * These items are gated by `adminOnly: true` in `NAV_ITEMS` inside
+ * `dashboard-layout.tsx` and render only for platform admins.
+ *
+ * Note: 'Audit Logs' and 'API Keys' are intentionally NOT here — the
+ * sidebar renders them for every authenticated user, with the backend
+ * enforcing access control per-route (e.g. `requireAuditAccess` lets
+ * org owners view their org's audit trail, and api-keys are scoped to
+ * projects the user is a member of). They appear in GENERAL_LABELS
+ * instead.
+ */
 const ADMIN_ONLY_LABELS = [
   'Dashboard',
   'User Management',
   'Organizations',
   'System Health',
-  'Audit Logs',
-  'API Keys',
   'Integrations',
   'Settings',
 ];
 
-/** Sidebar labels visible to all authenticated users */
-const GENERAL_LABELS = ['Projects', 'Bug Reports', 'Notifications'];
+/** Sidebar labels visible to all authenticated users (no gates in NAV_ITEMS) */
+const GENERAL_LABELS = ['Projects', 'Bug Reports', 'Notifications', 'Audit Logs', 'API Keys'];
 
 /** Organization section sidebar labels */
 const ORG_LABELS = ['My Organization', 'Team', 'Usage & Quotas', 'Billing'];

--- a/apps/admin/src/tests/e2e/role-based-access.spec.ts
+++ b/apps/admin/src/tests/e2e/role-based-access.spec.ts
@@ -32,6 +32,9 @@ const NO_ORG_USER = {
  *
  * These items are gated by `adminOnly: true` in `NAV_ITEMS` inside
  * `dashboard-layout.tsx` and render only for platform admins.
+ * Keep this list in sync with every `NAV_ITEMS` entry that carries
+ * `adminOnly: true` — if they drift, the "regular user cannot see
+ * admin items" assertions silently stop catching regressions.
  *
  * Note: 'Audit Logs' and 'API Keys' are intentionally NOT here — the
  * sidebar renders them for every authenticated user, with the backend
@@ -44,6 +47,8 @@ const ADMIN_ONLY_LABELS = [
   'Dashboard',
   'User Management',
   'Organizations',
+  'Requests', // organization-requests, adminOnly + saasOnly
+  'Retention', // organizations/retention, adminOnly + saasOnly
   'System Health',
   'Integrations',
   'Settings',

--- a/apps/admin/src/tests/fixtures/setup-fixture.ts
+++ b/apps/admin/src/tests/fixtures/setup-fixture.ts
@@ -18,6 +18,14 @@ type SetupFixtures = {
     checkStatus: () => Promise<boolean>;
     reset: () => Promise<void>;
     ensureProjectExists: (token: string) => Promise<{ id: string; name: string; api_key: string }>;
+    /**
+     * Resolve the id of the seeded `e2e-default` org for the given
+     * admin token. Safer than `myOrgs[0]` because the backend's
+     * `findByUserId` orders by name, and other specs (organizations,
+     * my-organization, role-based-access) create orgs that can sort
+     * ahead alphabetically.
+     */
+    getDefaultOrgId: (token: string) => Promise<string>;
     createSampleBugReports: (apiKey: string, projectId: string) => Promise<void>;
     createBugReportWithReplay: (apiKey: string, projectId: string) => Promise<string>;
   };
@@ -197,6 +205,40 @@ export const test = base.extend<SetupFixtures>({
       },
 
       /**
+       * Resolve the seeded default E2E org's id for the given admin
+       * token. Looks up by `subdomain === 'e2e-default'` — NOT by
+       * `myOrgs[0]` — because the backend's
+       * `OrganizationRepository.findByUserId` orders by name and
+       * other specs can create orgs that sort ahead alphabetically.
+       *
+       * Extracted so specs that need a raw `organization_id` for a
+       * direct-API project create (project-integrations-navigation,
+       * etc.) share one lookup with `ensureProjectExists` below.
+       */
+      getDefaultOrgId: async (token: string): Promise<string> => {
+        const response = await request.get(`${API_URL}/api/v1/organizations/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok()) {
+          throw new Error(
+            `Failed to fetch /organizations/me: ${response.status()} ${await response.text()}`
+          );
+        }
+        const { data: myOrgs } = (await response.json()) as {
+          data: Array<{ id: string; subdomain: string }>;
+        };
+        const defaultOrg = Array.isArray(myOrgs)
+          ? myOrgs.find((o) => o.subdomain === 'e2e-default')
+          : undefined;
+        if (!defaultOrg?.id) {
+          throw new Error(
+            "admin is not a member of the seeded 'e2e-default' org — did ensureInitialized run?"
+          );
+        }
+        return defaultOrg.id;
+      },
+
+      /**
        * Ensure a test project exists (needed for API keys, bug reports, etc.)
        * Returns existing project or creates a new one with an API key
        */
@@ -224,33 +266,10 @@ export const test = base.extend<SetupFixtures>({
         //
         // In SaaS mode on the hub domain (what E2E is), the backend's
         // `resolveOrganizationForProject` requires `organization_id`
-        // in the body. This helper is a direct API call — it bypasses
-        // the admin UI's auto-select — so we must resolve the org ID
-        // ourselves. Select by subdomain rather than `[0]`: the
-        // backend's `findByUserId` orders by name, and other specs
-        // may have created additional orgs (e.g. role-based-access,
-        // my-organization) that sort ahead of 'E2E Default Org'.
+        // in the body. Resolve via `getDefaultOrgId` so this lookup
+        // stays in sync with other specs that need the same raw id.
         if (!project) {
-          const orgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          if (!orgsResponse.ok()) {
-            throw new Error(
-              `Failed to resolve organization for test project: ${orgsResponse.status()} ${await orgsResponse.text()}`
-            );
-          }
-          const { data: myOrgs } = (await orgsResponse.json()) as {
-            data: Array<{ id: string; subdomain: string }>;
-          };
-          const defaultOrg = Array.isArray(myOrgs)
-            ? myOrgs.find((o) => o.subdomain === 'e2e-default')
-            : undefined;
-          const organizationId = defaultOrg?.id;
-          if (!organizationId) {
-            throw new Error(
-              "Failed to resolve organization for test project: admin is not a member of the seeded 'e2e-default' org"
-            );
-          }
+          const organizationId = await setupState.getDefaultOrgId(token);
 
           const createResponse = await request.post(`${API_URL}/api/v1/projects`, {
             headers: { Authorization: `Bearer ${token}` },

--- a/apps/admin/src/tests/fixtures/setup-fixture.ts
+++ b/apps/admin/src/tests/fixtures/setup-fixture.ts
@@ -226,8 +226,10 @@ export const test = base.extend<SetupFixtures>({
         // `resolveOrganizationForProject` requires `organization_id`
         // in the body. This helper is a direct API call — it bypasses
         // the admin UI's auto-select — so we must resolve the org ID
-        // ourselves. `ensureInitialized` seeds exactly one org owned
-        // by the admin, so taking `[0]` is deterministic.
+        // ourselves. Select by subdomain rather than `[0]`: the
+        // backend's `findByUserId` orders by name, and other specs
+        // may have created additional orgs (e.g. role-based-access,
+        // my-organization) that sort ahead of 'E2E Default Org'.
         if (!project) {
           const orgsResponse = await request.get(`${API_URL}/api/v1/organizations/me`, {
             headers: { Authorization: `Bearer ${token}` },
@@ -237,11 +239,16 @@ export const test = base.extend<SetupFixtures>({
               `Failed to resolve organization for test project: ${orgsResponse.status()} ${await orgsResponse.text()}`
             );
           }
-          const { data: myOrgs } = await orgsResponse.json();
-          const organizationId = Array.isArray(myOrgs) ? myOrgs[0]?.id : undefined;
+          const { data: myOrgs } = (await orgsResponse.json()) as {
+            data: Array<{ id: string; subdomain: string }>;
+          };
+          const defaultOrg = Array.isArray(myOrgs)
+            ? myOrgs.find((o) => o.subdomain === 'e2e-default')
+            : undefined;
+          const organizationId = defaultOrg?.id;
           if (!organizationId) {
             throw new Error(
-              'Failed to resolve organization for test project: admin has no org memberships'
+              "Failed to resolve organization for test project: admin is not a member of the seeded 'e2e-default' org"
             );
           }
 


### PR DESCRIPTION
## Summary

After the saas-mode pivot (#25) + h1 fix (#26), the next `deploy-admin.yml` run on main dropped to **237 passed / 9 failed**. This PR fixes all 9. Every fix — including the four review rounds folded in here — was validated against a real testcontainer stack locally before push.

Supersedes #28.

## What landed

### 9 test fixes (7 spec changes + 1 product change + 1 fixture change)

| Test | Root cause | Fix |
|---|---|---|
| `replay-direct-storage.spec.ts:170` | Inline duplicate of the `PATCH /reports/:id { replay_upload_status }` pattern fixed in the fixture in #26 | Switch to `POST /:id/confirm-upload { fileType: 'replay' }` |
| `project-integrations-navigation.spec.ts:84` | Own `POST /projects` without `organization_id` (400 on hub domain) | Resolve seeded default org by `subdomain === 'e2e-default'` (not `myOrgs[0]` — `findByUserId` orders by name, unstable once admin has multiple orgs) |
| `bug-reports-access-control.spec.ts:296` | Missing `organization_id` + trial plan's 2-project cap already consumed | Spec creates its own org in `beforeAll`, uses it for projects, deletes it in `afterAll` (so admin doesn't accumulate memberships across specs) |
| `organizations.spec.ts:91` | `getByRole('status')` matched the sidebar "Role: platform admin" badge | Scope to `table tbody` |
| `my-organization.spec.ts:110` | `getByLabel(/email/i)` resolved to 3 elements once the member table had rows | Use the invite form's stable `#invite-email` / `#invite-role` IDs |
| `role-based-access.spec.ts:241` | 'Audit Logs' and 'API Keys' in `ADMIN_ONLY_LABELS` but items have no `adminOnly` flag; backend allows org owners | Moved to `GENERAL_LABELS`; added 'Requests' + 'Retention' so the list matches every `adminOnly: true` entry in `NAV_ITEMS` |
| `auth-setup.spec.ts:159` + `setup-comprehensive.spec.ts:349` (both logout) | Sidebar `<nav className="flex-1">` had no overflow rule → 20+ nav items pushed the logout button off-viewport. Playwright can't scroll in a `position: fixed` container. | **Product fix**: `flex-1 min-h-0 overflow-y-auto` on the nav. (Also fixes a real UX regression on short viewports.) `min-h-0` is required for `overflow-y-auto` to actually shrink in a column-flex container. |
| `ensureProjectExists` fixture | Same `myOrgs[0]` instability + `description` field rejected by schema | Select by subdomain; drop the unsupported `description` field |

### Test-harness port configurability

E2E hardcoded ports 4000 (backend), 4001 (Vite), 3001 (worker health). On Windows those all fall inside Hyper-V's reserved ranges (`netsh int ipv4 show excludedportrange`), so local runs failed with `EACCES`. That's why earlier rounds of fixes had to go through CI — there was no local iteration loop.

Added env overrides with the existing defaults preserved:

- `E2E_ADMIN_PORT` — Vite (default `4001`)
- `API_PORT` — backend (default `4000`)
- `API_URL` — backend full URL (takes precedence; port is derived from it)
- `BASE_URL` — admin panel origin (takes precedence)
- `WORKER_HEALTH_PORT` — worker health server (default `3001`)

All user-facing URLs (`BASE_URL`, `API_URL`, derived `adminUrl`, derived `apiOrigin`) are normalized through `new URL(...).origin` in `playwright.config.ts`, `src/tests/e2e/config.ts`, and `src/tests/e2e/global-setup.ts` — a path / trailing slash / empty string can't silently break CORS, Vite proxy, or the auth helper's hostname check. CI is unchanged because none of the variables are set there.

Locally:
```bash
E2E_ADMIN_PORT=5534 API_URL=http://localhost:5535 \
  WORKER_HEALTH_PORT=5536 pnpm --filter @bugspotter/admin test:e2e
```

(Note: `API_PORT` is optional — if only `API_URL` is set the port is parsed from it, so backend and tests always agree.)

### Review rounds folded in

- **Round 1**: `Date.now()` captured once; created org cleaned up in `afterAll`; `FRONTEND_URL` / `CORS_ORIGINS` derived from a single `adminUrl` resolver honoring `BASE_URL`; `/organizations/me` response now `.ok()`-checked with status + body in the error.
- **Round 2**: shared `E2E_API_URL` replacing a hardcoded fallback; user-provided `API_URL` honored (was silently overwritten); `new URL(...).origin` normalization on CORS; 'Requests' + 'Retention' added to `ADMIN_ONLY_LABELS`.
- **Round 3**: `apiUrl` normalized too (not just `adminUrl`); log message uses resolved port; `config.ts` URLs go through a shared `normalizeOrigin` helper; seeded default org selected by subdomain (not `[0]`).
- **Round 4**: `apiPort` now derived from parsed `API_URL` when set (fixing the "backend on 4000 but tests hit 5535" footgun); `process.env.API_URL` stored as `apiOrigin` rather than raw; `||` instead of `??` for fallback consistency; `playwright.config.ts` `baseURL` / `webServer.url` / `webServer.env.VITE_API_URL` all normalized via shared helper; `min-h-0` added to the sidebar nav for the logout-click fix to be robust across browsers.

## Test plan

- [x] All affected specs pass locally against a real testcontainer stack.
- [x] Validated with `API_URL=…:5535` + no `API_PORT` (port derived from URL).
- [x] Validated with both `API_URL` and `API_PORT` set (regression check).
- [ ] After merge: observe the next `deploy-admin.yml` run on main. Expect 0 failures in this PR's scope.

## Not in scope

A handful of other specs still hardcode `const API_BASE_URL = 'http://localhost:4000'` (integration-edit, integration-rules*, integrations, jira-service-specific, project-integration-config). They pass in CI with default ports and would fail only under local `API_PORT` overrides. Cleaning that up is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)