### PR TITLE
feat(backend): trust proxy — rate-limit on real client IP

### DIFF
--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -218,11 +218,13 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
     // Global body size limit - protects against DoS attacks via large JSON payloads
     // Multipart uploads use separate limit (config.server.maxUploadSize)
     bodyLimit: REQUEST_BODY_LIMIT,
-    // With `trustProxy: true`, Fastify reads `X-Forwarded-For` /
-    // `X-Forwarded-Proto` so `request.ip` and `request.protocol`
-    // reflect the real client rather than the immediate proxy hop.
-    // Critical for `@fastify/rate-limit` keying on real IP behind
-    // CDN/NLB/nginx. See `config.server.trustProxy` for the rationale.
+    // When `trustProxy` is truthy (`true` or a hop count), Fastify
+    // reads `X-Forwarded-For` / `X-Forwarded-Proto` so `request.ip`
+    // and `request.protocol` reflect the real client rather than the
+    // immediate proxy hop. Critical for `@fastify/rate-limit` keying
+    // on real IP behind CDN/NLB/nginx. See the comment at
+    // `config.server.trustProxy` for the trust-model rationale and
+    // the full list of consumers (spam filter, audit log, etc.).
     trustProxy: config.server.trustProxy,
     genReqId: () => {
       return `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -218,10 +218,12 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
     // Global body size limit - protects against DoS attacks via large JSON payloads
     // Multipart uploads use separate limit (config.server.maxUploadSize)
     bodyLimit: REQUEST_BODY_LIMIT,
-    // When `trustProxy` is truthy (`true` or a hop count), Fastify
+    // When `trustProxy` is `true` or a non-negative integer, Fastify
     // reads `X-Forwarded-For` / `X-Forwarded-Proto` so `request.ip`
     // and `request.protocol` reflect the real client rather than the
-    // immediate proxy hop. Critical for `@fastify/rate-limit` keying
+    // immediate proxy hop. (Note: `trustProxy: 0` is accepted as a
+    // hop count but tells Fastify to trust zero hops — effectively
+    // the same as `false`.) Critical for `@fastify/rate-limit` keying
     // on real IP behind CDN/NLB/nginx. See the comment at
     // `config.server.trustProxy` for the trust-model rationale and
     // the full list of consumers (spam filter, audit log, etc.).

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -218,6 +218,12 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
     // Global body size limit - protects against DoS attacks via large JSON payloads
     // Multipart uploads use separate limit (config.server.maxUploadSize)
     bodyLimit: REQUEST_BODY_LIMIT,
+    // With `trustProxy: true`, Fastify reads `X-Forwarded-For` /
+    // `X-Forwarded-Proto` so `request.ip` and `request.protocol`
+    // reflect the real client rather than the immediate proxy hop.
+    // Critical for `@fastify/rate-limit` keying on real IP behind
+    // CDN/NLB/nginx. See `config.server.trustProxy` for the rationale.
+    trustProxy: config.server.trustProxy,
     genReqId: () => {
       return `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
     },

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -72,7 +72,8 @@ export const config: AppConfig = {
     // assumption:
     //   - signup spam filter (`SpamFilterService`) keys velocity
     //     checks on IP and persists `ip_address` on signup rows
-    //     (`auth/signup.ts`, `organization-requests.ts`)
+    //     (`src/api/routes/signup.ts`,
+    //     `src/api/routes/organization-requests.ts`)
     //   - API-key usage tracking
     //     (`api/middleware/auth/handlers.ts:112`)
     //   - data-residency compliance audit log
@@ -204,6 +205,17 @@ function collectServerErrors(): string[] {
 
   errors.push(...numericChecks.filter((error): error is string => error !== null));
   errors.push(...validateDatabasePoolConfig(config.database.poolMin, config.database.poolMax));
+
+  // `parseTrustProxy` returns `NaN` for garbage like `TRUST_PROXY=yes`
+  // or `TRUST_PROXY=-3`; surface that here rather than at parse time
+  // so it collects into the single "configuration validation failed"
+  // message alongside every other config error.
+  const tp = config.server.trustProxy;
+  if (typeof tp === 'number' && !Number.isFinite(tp)) {
+    errors.push(
+      `TRUST_PROXY must be 'true', 'false', or a non-negative integer (got "${process.env.TRUST_PROXY}")`
+    );
+  }
 
   return errors;
 }

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -30,6 +30,7 @@ import {
   validateS3ForcePathStyle,
   validateLocalStorageConfig,
   parseBooleanEnv,
+  parseTrustProxy,
 } from './config/validators.js';
 
 const logger = getLogger();
@@ -59,20 +60,38 @@ export const config: AppConfig = {
       'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net',
     ],
     logLevel: (process.env.LOG_LEVEL ?? 'info') as LogLevel,
-    // When true, Fastify reads `X-Forwarded-For` / `X-Forwarded-Proto`
-    // for `request.ip` / `request.protocol`. Required in prod so
-    // rate-limit keys on real client IPs rather than the NLB / CDN /
-    // nginx hop — without it every public request looks the same to
+    // Controls whether Fastify reads `X-Forwarded-For` / `X-Forwarded-Proto`
+    // for `request.ip` / `request.protocol`. Required so rate-limit
+    // keys on real client IPs rather than the NLB / CDN / nginx hop
+    // — without it every public request looks the same to
     // `@fastify/rate-limit`, which defeats the `/auth/signup` spam
     // throttle (plan lists this as a pre-prod blocker).
     //
+    // `request.ip` also flows into several other paths beyond
+    // rate-limit — all of which become spoofable under the same
+    // assumption:
+    //   - signup spam filter (`SpamFilterService`) keys velocity
+    //     checks on IP and persists `ip_address` on signup rows
+    //     (`auth/signup.ts`, `organization-requests.ts`)
+    //   - API-key usage tracking
+    //     (`api/middleware/auth/handlers.ts:112`)
+    //   - data-residency compliance audit log
+    //     (`data-residency/middleware.ts:151`)
+    // TRUST REQUIREMENT: every upstream proxy in the request path
+    // MUST sanitize `X-Forwarded-*` headers coming from the public
+    // (either overwrite or validate — appending alone is NOT enough
+    // because the client-supplied prefix remains in the chain and
+    // `trustProxy: true` returns the leftmost entry). If that
+    // assumption can't hold for your deployment, set
+    // `TRUST_PROXY=false` or use a hop-count (e.g. `TRUST_PROXY=1`
+    // for a single trusted reverse-proxy in front); Fastify then
+    // skips the last N entries in the XFF chain as "ours."
+    //
     // Default `true`: harmless in dev (no XFF header present means
-    // `request.ip` still comes from the socket); correct in prod.
-    // Override with `TRUST_PROXY=false` for the rare topology that
-    // exposes the backend directly to untrusted clients — in that
-    // case a client could spoof XFF to affect their own rate-limit
-    // key (not a confidentiality leak, but worth opting out of).
-    trustProxy: parseBooleanEnv(process.env.TRUST_PROXY) ?? true,
+    // `request.ip` still comes from the socket); correct for
+    // deployments behind a trusted, header-sanitizing proxy.
+    // Accepts `true` / `false` / `<integer>` (hop count).
+    trustProxy: parseTrustProxy(process.env.TRUST_PROXY),
   },
   jwt: {
     secret: process.env.JWT_SECRET ?? '',

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -59,6 +59,20 @@ export const config: AppConfig = {
       'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net',
     ],
     logLevel: (process.env.LOG_LEVEL ?? 'info') as LogLevel,
+    // When true, Fastify reads `X-Forwarded-For` / `X-Forwarded-Proto`
+    // for `request.ip` / `request.protocol`. Required in prod so
+    // rate-limit keys on real client IPs rather than the NLB / CDN /
+    // nginx hop — without it every public request looks the same to
+    // `@fastify/rate-limit`, which defeats the `/auth/signup` spam
+    // throttle (plan lists this as a pre-prod blocker).
+    //
+    // Default `true`: harmless in dev (no XFF header present means
+    // `request.ip` still comes from the socket); correct in prod.
+    // Override with `TRUST_PROXY=false` for the rare topology that
+    // exposes the backend directly to untrusted clients — in that
+    // case a client could spoof XFF to affect their own rate-limit
+    // key (not a confidentiality leak, but worth opting out of).
+    trustProxy: parseBooleanEnv(process.env.TRUST_PROXY) ?? true,
   },
   jwt: {
     secret: process.env.JWT_SECRET ?? '',

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -24,6 +24,7 @@ export interface ServerConfig {
   corsOrigins: string[];
   cspImgSrc: string[];
   logLevel: LogLevel;
+  trustProxy: boolean;
 }
 
 export interface JwtConfig {

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -24,7 +24,7 @@ export interface ServerConfig {
   corsOrigins: string[];
   cspImgSrc: string[];
   logLevel: LogLevel;
-  trustProxy: boolean;
+  trustProxy: boolean | number;
 }
 
 export interface JwtConfig {

--- a/packages/backend/src/config/validators.ts
+++ b/packages/backend/src/config/validators.ts
@@ -181,6 +181,38 @@ export function parseBooleanEnv(value: string | undefined): boolean | undefined 
   return undefined;
 }
 
+/**
+ * Parse Fastify's `trustProxy` config from the `TRUST_PROXY` env.
+ *
+ * Accepts:
+ *   - `true` / `false` — trust all hops / trust none
+ *   - `<non-negative integer>` — trust the last N hops in XFF
+ *     (e.g. `1` for "single trusted reverse-proxy in front")
+ *   - unset / empty — default `true` (safe for dev where no XFF is
+ *     present; correct in prod behind a header-sanitizing proxy)
+ *
+ * `<CIDR list>` and arbitrary strings are not accepted here — add if
+ * a deployment needs it. Fastify supports them in principle.
+ */
+export function parseTrustProxy(value: string | undefined): boolean | number {
+  if (value === undefined || value === '') {
+    return true;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  const n = Number(value);
+  if (Number.isInteger(n) && n >= 0) {
+    return n;
+  }
+  throw new Error(
+    `Invalid TRUST_PROXY: "${value}". Expected "true", "false", or a non-negative integer (hop count).`
+  );
+}
+
 // ============================================================================
 // HOSTNAME VALIDATORS (Network Security)
 // ============================================================================

--- a/packages/backend/src/config/validators.ts
+++ b/packages/backend/src/config/validators.ts
@@ -188,29 +188,34 @@ export function parseBooleanEnv(value: string | undefined): boolean | undefined 
  *   - `true` / `false` — trust all hops / trust none
  *   - `<non-negative integer>` — trust the last N hops in XFF
  *     (e.g. `1` for "single trusted reverse-proxy in front")
- *   - unset / empty — default `true` (safe for dev where no XFF is
- *     present; correct in prod behind a header-sanitizing proxy)
+ *   - unset / empty / whitespace — default `true` (safe for dev where
+ *     no XFF is present; correct in prod behind a header-sanitizing
+ *     proxy)
  *
  * `<CIDR list>` and arbitrary strings are not accepted here — add if
  * a deployment needs it. Fastify supports them in principle.
+ *
+ * Does NOT throw on invalid input — returns `NaN` as a sentinel,
+ * mirroring the `Number(ORG_RETENTION_DAYS)` pattern. Validation is
+ * done later in `collectServerErrors`, so operators see every bad
+ * config value in one error message instead of one at a time.
  */
 export function parseTrustProxy(value: string | undefined): boolean | number {
-  if (value === undefined || value === '') {
+  const trimmed = value?.trim();
+  if (trimmed === undefined || trimmed === '') {
     return true;
   }
-  if (value === 'true') {
+  if (trimmed === 'true') {
     return true;
   }
-  if (value === 'false') {
+  if (trimmed === 'false') {
     return false;
   }
-  const n = Number(value);
+  const n = Number(trimmed);
   if (Number.isInteger(n) && n >= 0) {
     return n;
   }
-  throw new Error(
-    `Invalid TRUST_PROXY: "${value}". Expected "true", "false", or a non-negative integer (hop count).`
-  );
+  return NaN;
 }
 
 // ============================================================================

--- a/packages/backend/tests/api/trust-proxy.test.ts
+++ b/packages/backend/tests/api/trust-proxy.test.ts
@@ -13,7 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import Fastify from 'fastify';
 
-async function buildApp(trustProxy: boolean) {
+async function buildApp(trustProxy: boolean | number) {
   const app = Fastify({ trustProxy });
   app.get('/whoami', async (request) => ({ ip: request.ip, protocol: request.protocol }));
   await app.ready();
@@ -28,8 +28,9 @@ describe('Fastify trustProxy', () => {
         method: 'GET',
         url: '/whoami',
         headers: {
-          // Chain: <real client>, <proxy1>, <proxy2 = us>. With
-          // trustProxy on, the leftmost un-trusted hop is returned.
+          // Chain: <real client>, <proxy1>. With `trustProxy: true`,
+          // Fastify trusts the entire proxy chain and returns the
+          // leftmost address from `X-Forwarded-For` as `request.ip`.
           'x-forwarded-for': '203.0.113.7, 10.0.0.1',
           'x-forwarded-proto': 'https',
         },
@@ -60,6 +61,34 @@ describe('Fastify trustProxy', () => {
       // (which for `.inject` is `127.0.0.1`) — never 203.0.113.7.
       expect(body.ip).not.toBe('203.0.113.7');
       expect(body.protocol).toBe('http');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('with trustProxy=1, treats only the rightmost hop as trusted', async () => {
+    const app = await buildApp(1);
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/whoami',
+        headers: {
+          // Chain: <client-claimed-spoof>, <attacker-real>. With hop
+          // count = 1, Fastify skips the last entry (what our direct
+          // upstream appended, representing the source of the TCP
+          // connection) and treats the remaining chain as untrusted,
+          // returning the rightmost of THOSE entries. Under
+          // `Fastify.inject`, the socket address is '127.0.0.1', so
+          // the hop-count-1 resolution returns the spoofed value the
+          // test sends in XFF. This is expected for the inject harness
+          // — the test's job is to confirm the mode is configurable,
+          // not that it's spoof-proof against a single nginx layer.
+          'x-forwarded-for': '203.0.113.7',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload) as { ip: string };
+      expect(body.ip).toBe('203.0.113.7');
     } finally {
       await app.close();
     }

--- a/packages/backend/tests/api/trust-proxy.test.ts
+++ b/packages/backend/tests/api/trust-proxy.test.ts
@@ -1,0 +1,87 @@
+/**
+ * trustProxy wiring test.
+ *
+ * Verifies that when Fastify is constructed with `trustProxy: true`,
+ * `request.ip` reflects the `X-Forwarded-For` header rather than the
+ * socket's remote address. This is load-bearing for `@fastify/rate-limit`
+ * keying on real client IPs behind the Yandex NLB / admin-nginx / CDN —
+ * without it every public request looks like the same proxy IP and
+ * the `/auth/signup` spam throttle is effectively shared across all
+ * traffic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Fastify from 'fastify';
+
+async function buildApp(trustProxy: boolean) {
+  const app = Fastify({ trustProxy });
+  app.get('/whoami', async (request) => ({ ip: request.ip, protocol: request.protocol }));
+  await app.ready();
+  return app;
+}
+
+describe('Fastify trustProxy', () => {
+  it('reads request.ip from X-Forwarded-For when trustProxy is true', async () => {
+    const app = await buildApp(true);
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/whoami',
+        headers: {
+          // Chain: <real client>, <proxy1>, <proxy2 = us>. With
+          // trustProxy on, the leftmost un-trusted hop is returned.
+          'x-forwarded-for': '203.0.113.7, 10.0.0.1',
+          'x-forwarded-proto': 'https',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload) as { ip: string; protocol: string };
+      expect(body.ip).toBe('203.0.113.7');
+      expect(body.protocol).toBe('https');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('ignores X-Forwarded-For when trustProxy is false', async () => {
+    const app = await buildApp(false);
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/whoami',
+        headers: {
+          'x-forwarded-for': '203.0.113.7',
+          'x-forwarded-proto': 'https',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload) as { ip: string; protocol: string };
+      // With trustProxy off, ip is whatever Fastify sees on the socket
+      // (which for `.inject` is `127.0.0.1`) — never 203.0.113.7.
+      expect(body.ip).not.toBe('203.0.113.7');
+      expect(body.protocol).toBe('http');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('request.ip falls back to socket address when no XFF header is present', async () => {
+    const app = await buildApp(true);
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/whoami',
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.payload) as { ip: string };
+      // Even with trustProxy enabled, an absent XFF header leaves us
+      // reading the socket — so dev environments (no proxy, no XFF)
+      // behave as if trustProxy was off. Makes `trustProxy: true` a
+      // safe default.
+      expect(body.ip).toBeTruthy();
+      expect(body.ip).toMatch(/^(127\.0\.0\.1|::1|::ffff:127\.0\.0\.1)$/);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/backend/tests/config.test.ts
+++ b/packages/backend/tests/config.test.ts
@@ -144,6 +144,25 @@ describe('Application Configuration', () => {
       // parseInt will return NaN, which should be caught by validation
       expect(isNaN(config.server.port)).toBe(true);
     });
+
+    it('should default trustProxy to true', async () => {
+      delete process.env.TRUST_PROXY;
+
+      const { config } = await import('../src/config.js');
+
+      // Default `true` because every supported deployment topology
+      // (Yandex NLB → Docker, admin-nginx → api, CDN → backend) sits
+      // behind at least one proxy hop; rate-limit needs real client IP.
+      expect(config.server.trustProxy).toBe(true);
+    });
+
+    it('should honor TRUST_PROXY=false opt-out', async () => {
+      process.env.TRUST_PROXY = 'false';
+
+      const { config } = await import('../src/config.js');
+
+      expect(config.server.trustProxy).toBe(false);
+    });
   });
 
   describe('JWT configuration', () => {

--- a/packages/backend/tests/config.test.ts
+++ b/packages/backend/tests/config.test.ts
@@ -163,6 +163,24 @@ describe('Application Configuration', () => {
 
       expect(config.server.trustProxy).toBe(false);
     });
+
+    it('should accept TRUST_PROXY as an integer hop count', async () => {
+      process.env.TRUST_PROXY = '1';
+
+      const { config } = await import('../src/config.js');
+
+      // Numeric form lets deployments behind exactly one trusted
+      // reverse-proxy skip the last hop and return the next one in
+      // the XFF chain — tighter than `true` (which trusts the whole
+      // chain and returns the leftmost, potentially-spoofed entry).
+      expect(config.server.trustProxy).toBe(1);
+    });
+
+    it('should reject invalid TRUST_PROXY values at startup', async () => {
+      process.env.TRUST_PROXY = 'yes';
+
+      await expect(import('../src/config.js')).rejects.toThrow(/Invalid TRUST_PROXY/);
+    });
   });
 
   describe('JWT configuration', () => {

--- a/packages/backend/tests/config.test.ts
+++ b/packages/backend/tests/config.test.ts
@@ -176,10 +176,33 @@ describe('Application Configuration', () => {
       expect(config.server.trustProxy).toBe(1);
     });
 
-    it('should reject invalid TRUST_PROXY values at startup', async () => {
+    it('should reject invalid TRUST_PROXY values via validateConfig', async () => {
+      // `parseTrustProxy` returns NaN for garbage; `validateConfig`
+      // surfaces it in the single "Configuration validation failed"
+      // block alongside any other config issues, rather than throwing
+      // at module-eval time (which would mask other errors).
+      process.env.DATABASE_URL = 'postgres://localhost/db';
       process.env.TRUST_PROXY = 'yes';
 
-      await expect(import('../src/config.js')).rejects.toThrow(/Invalid TRUST_PROXY/);
+      const { validateConfig, config } = await import('../src/config.js');
+
+      expect(config.server.trustProxy).toBeNaN();
+      expect(() => validateConfig()).toThrow('Configuration validation failed');
+      expect(() => validateConfig()).toThrow(
+        /TRUST_PROXY must be 'true', 'false', or a non-negative integer/
+      );
+    });
+
+    it('should treat whitespace-only TRUST_PROXY as default (true)', async () => {
+      // Matches the `??` / empty-string semantics: a user env export
+      // like `TRUST_PROXY=" "` (trailing whitespace, common in shell
+      // pipelines) should fall back to the default, not silently
+      // parse to `Number(" ") === 0` (= false).
+      process.env.TRUST_PROXY = '   ';
+
+      const { config } = await import('../src/config.js');
+
+      expect(config.server.trustProxy).toBe(true);
     });
   });
 

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'tests/integrations/base-integration-helpers.test.ts',
       'tests/api/auth-responses.test.ts',
       'tests/api/auth-handlers.test.ts',
+      'tests/api/trust-proxy.test.ts',
       // Only include pure unit tests from middleware (no database/server)
       'tests/api/middleware/authorization.test.ts',
       'tests/api/middleware/require-project-role.test.ts',


### PR DESCRIPTION
## Summary

The self-service signup plan flagged `trustProxy` wiring as a pre-prod blocker. Fastify was being constructed without it, so `request.ip` was the immediate proxy hop (Yandex NLB → Docker, admin-nginx → api:3000, or CDN → backend). `@fastify/rate-limit` keys on `request.ip` by default, which meant:

- Every public request looked like one of a small handful of proxy IPs
- The `/auth/signup` 5/min/IP spam throttle was effectively one global bucket across all traffic
- Same problem for every other rate-limited endpoint

Single-line Fastify config plus a new env knob with three modes. Validated: 2290/2290 backend unit tests pass, +8 new.

## Change

- `config.server.trustProxy` — `boolean | number`, default `true`, overridable via `TRUST_PROXY`.
- `TRUST_PROXY` accepts three forms:
  - `true` / unset / empty / whitespace — trust all hops (current default)
  - `false` — trust none; `request.ip` stays on the socket
  - non-negative integer (e.g. `TRUST_PROXY=1`) — hop count; trust the last N entries in XFF. Use this when you know exactly how many reverse-proxies sit in front of the app.
- Wired into `Fastify({ trustProxy: config.server.trustProxy })` in [server.ts](packages/backend/src/api/server.ts).
- Default `true` because every supported deployment topology sits behind at least one proxy hop. Dev is unaffected — with no `X-Forwarded-For` header present, `request.ip` still comes from the socket.

## Trust model (beyond rate-limit)

`request.ip` also feeds several other code paths, so the trust requirement is broader than rate-limit alone. All of the following assume the proxy layer strips client-supplied XFF before appending the real peer address:

- signup spam filter (`SpamFilterService`) — velocity checks and `ip_address` persistence (`src/api/routes/signup.ts`, `src/api/routes/organization-requests.ts`)
- API-key usage tracking (`src/api/middleware/auth/handlers.ts:112`)
- data-residency compliance audit log (`src/data-residency/middleware.ts:151`)

Both the `config.ts` field and the `server.ts` constructor comment document this.

## Validation error handling

`parseTrustProxy` returns `NaN` as a sentinel for invalid input (e.g. `TRUST_PROXY=yes`) instead of throwing at module-eval time. `collectServerErrors` surfaces the sentinel so operators see every bad config value in one error message — same pattern as the rest of the validators. Whitespace-only values are trimmed and treated as unset.

## Tests

[tests/api/trust-proxy.test.ts](packages/backend/tests/api/trust-proxy.test.ts) — four focused scenarios against a minimal `Fastify.inject()`, no DB:

1. `trustProxy: true`, `request.ip` reads from XFF chain (`"203.0.113.7, 10.0.0.1"` → `203.0.113.7`).
2. `trustProxy: false`, XFF is ignored.
3. `trustProxy: 1`, hop-count mode returns the rightmost un-trusted entry.
4. `trustProxy: true` with no XFF header — `request.ip` falls back to the socket.

[tests/config.test.ts](packages/backend/tests/config.test.ts) — four new assertions:

- Default `trustProxy === true` when `TRUST_PROXY` is unset.
- `TRUST_PROXY=false` is honored.
- `TRUST_PROXY=1` is parsed as integer hop count.
- `TRUST_PROXY=yes` is caught by `validateConfig()` (collect-errors path, not throw-at-parse).

## Test plan

- [x] `pnpm test:unit` — 2290/2290 pass (1 pre-existing flaky HTTP fetch test in `rpc-bridge-security.test.ts` unrelated to this change).
- [x] `pnpm typecheck` — no new errors.
- [ ] After merge + deploy to prod: hit `/api/v1/auth/signup` 6× in <60s from one client IP, confirm the 6th returns 429. Previously this would not trigger because each request would key on a shared proxy IP.

## Ops

No runtime config change needed on the VM. `TRUST_PROXY` is optional and defaults correctly for saas prod. Set `TRUST_PROXY=1` in deployments where the app is reached through exactly one reverse proxy and operators want to lock down the hop count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
