### PR TITLE
feat(backend): list Jira projects for signup wizard picker

### DIFF
--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -105,15 +105,31 @@ export async function registerIntegrationRoutes(
 
     const { platform } = request.params;
     const config = request.body;
-    const { query, maxResults: maxResultsRaw } = request.query;
+    const { query: queryRaw, maxResults: maxResultsRaw } = request.query;
+
+    // Fastify's default querystring parser returns an array when the
+    // same key appears more than once (`?maxResults=10&maxResults=20`).
+    // Pick the first entry so `.trim()` doesn't throw TypeError and
+    // bubble up as a 500 on what should be a request-shape error.
+    const firstString = (raw: unknown): string | undefined => {
+      if (typeof raw === 'string') {
+        return raw;
+      }
+      if (Array.isArray(raw) && typeof raw[0] === 'string') {
+        return raw[0];
+      }
+      return undefined;
+    };
+    const query = firstString(queryRaw);
+    const maxResultsStr = firstString(maxResultsRaw);
 
     let maxResults: number | undefined;
-    if (maxResultsRaw !== undefined && maxResultsRaw.trim() !== '') {
+    if (maxResultsStr !== undefined && maxResultsStr.trim() !== '') {
       // Trim so `?maxResults= 10` doesn't 400 on a stray space. Then
       // require whole-digits-only — `parseInt` is too permissive and
       // would accept `"10.5"` (→ 10) or `"10abc"` (→ 10), making the
       // "must be a positive integer" error message misleading.
-      const trimmed = maxResultsRaw.trim();
+      const trimmed = maxResultsStr.trim();
       if (!/^\d+$/.test(trimmed)) {
         throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
       }

--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -18,6 +18,32 @@ import { validateSSRFProtection } from '../../integrations/security/ssrf-validat
 const logger = getLogger();
 
 /**
+ * Coerce a Fastify querystring value to a single string.
+ *
+ * Fastify's default parser returns an array when the same key appears
+ * twice (`?maxResults=10&maxResults=20`). We pick the first string so
+ * downstream `.trim()` / regex calls don't throw TypeError and bubble
+ * as 500 on what should be a request-shape issue.
+ */
+function firstString(raw: unknown): string | undefined {
+  if (typeof raw === 'string') {
+    return raw;
+  }
+  if (Array.isArray(raw) && typeof raw[0] === 'string') {
+    return raw[0];
+  }
+  return undefined;
+}
+
+/**
+ * Reasonable upper bound on `?maxResults=`. The Jira client clamps to
+ * 50 per page anyway, but rejecting absurd inputs at the API edge
+ * keeps the error contract honest and avoids silently accepting
+ * values past `Number.MAX_SAFE_INTEGER`.
+ */
+const MAX_LIST_PROJECTS_RESULTS = 1000;
+
+/**
  * Helper function to load a plugin and throw appropriate error if not found
  */
 async function loadPluginOrThrow(registry: PluginRegistry, platform: string) {
@@ -97,7 +123,11 @@ export async function registerIntegrationRoutes(
   server.post<{
     Params: { platform: string };
     Body: Record<string, unknown>;
-    Querystring: { query?: string; maxResults?: string };
+    // Widen to `string | string[]` so the type matches the runtime
+    // behavior of Fastify's default parser for repeated keys — and so
+    // the `firstString` coercion below isn't seen as dead code by
+    // future maintainers.
+    Querystring: { query?: string | string[]; maxResults?: string | string[] };
   }>('/api/v1/integrations/:platform/projects', async (request, reply) => {
     if (!request.authUser && !request.apiKey) {
       throw new AppError('Authentication required', 401, 'Unauthorized');
@@ -105,37 +135,32 @@ export async function registerIntegrationRoutes(
 
     const { platform } = request.params;
     const config = request.body;
-    const { query: queryRaw, maxResults: maxResultsRaw } = request.query;
-
-    // Fastify's default querystring parser returns an array when the
-    // same key appears more than once (`?maxResults=10&maxResults=20`).
-    // Pick the first entry so `.trim()` doesn't throw TypeError and
-    // bubble up as a 500 on what should be a request-shape error.
-    const firstString = (raw: unknown): string | undefined => {
-      if (typeof raw === 'string') {
-        return raw;
-      }
-      if (Array.isArray(raw) && typeof raw[0] === 'string') {
-        return raw[0];
-      }
-      return undefined;
-    };
-    const query = firstString(queryRaw);
-    const maxResultsStr = firstString(maxResultsRaw);
+    const query = firstString(request.query.query);
+    const maxResultsStr = firstString(request.query.maxResults);
 
     let maxResults: number | undefined;
     if (maxResultsStr !== undefined && maxResultsStr.trim() !== '') {
       // Trim so `?maxResults= 10` doesn't 400 on a stray space. Then
       // require whole-digits-only — `parseInt` is too permissive and
       // would accept `"10.5"` (→ 10) or `"10abc"` (→ 10), making the
-      // "must be a positive integer" error message misleading.
+      // "must be a positive integer" error message misleading. Cap
+      // string length so values past `Number.MAX_SAFE_INTEGER` don't
+      // sneak past `Number.isInteger` and get silently clamped.
       const trimmed = maxResultsStr.trim();
-      if (!/^\d+$/.test(trimmed)) {
-        throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
+      if (!/^\d+$/.test(trimmed) || trimmed.length > String(MAX_LIST_PROJECTS_RESULTS).length) {
+        throw new AppError(
+          `\`maxResults\` must be a positive integer between 1 and ${MAX_LIST_PROJECTS_RESULTS}`,
+          400,
+          'BadRequest'
+        );
       }
       const parsed = Number(trimmed);
-      if (!Number.isInteger(parsed) || parsed < 1) {
-        throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
+      if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_LIST_PROJECTS_RESULTS) {
+        throw new AppError(
+          `\`maxResults\` must be a positive integer between 1 and ${MAX_LIST_PROJECTS_RESULTS}`,
+          400,
+          'BadRequest'
+        );
       }
       maxResults = parsed;
     }

--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -109,8 +109,14 @@ export async function registerIntegrationRoutes(
 
     let maxResults: number | undefined;
     if (maxResultsRaw !== undefined && maxResultsRaw !== '') {
-      const parsed = Number.parseInt(maxResultsRaw, 10);
-      if (!Number.isFinite(parsed) || parsed < 1) {
+      // `parseInt` is too permissive — it accepts `"10.5"` (→ 10) and
+      // `"10abc"` (→ 10). Match whole strings of digits only so the
+      // error message "must be a positive integer" stays honest.
+      if (!/^\d+$/.test(maxResultsRaw)) {
+        throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
+      }
+      const parsed = Number(maxResultsRaw);
+      if (!Number.isInteger(parsed) || parsed < 1) {
         throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
       }
       maxResults = parsed;

--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -108,14 +108,16 @@ export async function registerIntegrationRoutes(
     const { query, maxResults: maxResultsRaw } = request.query;
 
     let maxResults: number | undefined;
-    if (maxResultsRaw !== undefined && maxResultsRaw !== '') {
-      // `parseInt` is too permissive — it accepts `"10.5"` (→ 10) and
-      // `"10abc"` (→ 10). Match whole strings of digits only so the
-      // error message "must be a positive integer" stays honest.
-      if (!/^\d+$/.test(maxResultsRaw)) {
+    if (maxResultsRaw !== undefined && maxResultsRaw.trim() !== '') {
+      // Trim so `?maxResults= 10` doesn't 400 on a stray space. Then
+      // require whole-digits-only — `parseInt` is too permissive and
+      // would accept `"10.5"` (→ 10) or `"10abc"` (→ 10), making the
+      // "must be a positive integer" error message misleading.
+      const trimmed = maxResultsRaw.trim();
+      if (!/^\d+$/.test(trimmed)) {
         throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
       }
-      const parsed = Number(maxResultsRaw);
+      const parsed = Number(trimmed);
       if (!Number.isInteger(parsed) || parsed < 1) {
         throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
       }

--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -94,36 +94,49 @@ export async function registerIntegrationRoutes(
    * request, not from decryption. Authenticated users only — the route
    * performs an outbound HTTPS call to the platform.
    */
-  server.post<{ Params: { platform: string }; Body: Record<string, unknown> }>(
-    '/api/v1/integrations/:platform/projects',
-    async (request, reply) => {
-      if (!request.authUser && !request.apiKey) {
-        throw new AppError('Authentication required', 401, 'Unauthorized');
-      }
-
-      const { platform } = request.params;
-      const config = request.body;
-
-      const service = await loadPluginOrThrow(registry, platform);
-
-      if (!service.listProjects || typeof service.listProjects !== 'function') {
-        throw new AppError(
-          `Project listing not supported for ${platform} integration`,
-          400,
-          'BadRequest'
-        );
-      }
-
-      logger.info('Listing projects for integration', {
-        platform,
-        userId: request.authUser?.id || 'api-key',
-      });
-
-      const projects = await service.listProjects(config);
-
-      return sendSuccess(reply, { projects });
+  server.post<{
+    Params: { platform: string };
+    Body: Record<string, unknown>;
+    Querystring: { query?: string; maxResults?: string };
+  }>('/api/v1/integrations/:platform/projects', async (request, reply) => {
+    if (!request.authUser && !request.apiKey) {
+      throw new AppError('Authentication required', 401, 'Unauthorized');
     }
-  );
+
+    const { platform } = request.params;
+    const config = request.body;
+    const { query, maxResults: maxResultsRaw } = request.query;
+
+    let maxResults: number | undefined;
+    if (maxResultsRaw !== undefined && maxResultsRaw !== '') {
+      const parsed = Number.parseInt(maxResultsRaw, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new AppError('`maxResults` must be a positive integer', 400, 'BadRequest');
+      }
+      maxResults = parsed;
+    }
+
+    const service = await loadPluginOrThrow(registry, platform);
+
+    if (!service.listProjects || typeof service.listProjects !== 'function') {
+      throw new AppError(
+        `Project listing not supported for ${platform} integration`,
+        400,
+        'BadRequest'
+      );
+    }
+
+    logger.info('Listing projects for integration', {
+      platform,
+      userId: request.authUser?.id || 'api-key',
+      hasQuery: !!query,
+      maxResults,
+    });
+
+    const projects = await service.listProjects(config, query, maxResults);
+
+    return sendSuccess(reply, { projects });
+  });
 
   /**
    * Save integration configuration for project

--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -85,6 +85,47 @@ export async function registerIntegrationRoutes(
   );
 
   /**
+   * List projects on the external platform using caller-provided credentials.
+   * POST /api/v1/integrations/:platform/projects
+   *
+   * Mirrors `/test` shape (flat config in body, no projectId): the signup
+   * wizard calls this after "Test Connection" passes but before the
+   * integration row exists in the DB, so credentials come from the
+   * request, not from decryption. Authenticated users only — the route
+   * performs an outbound HTTPS call to the platform.
+   */
+  server.post<{ Params: { platform: string }; Body: Record<string, unknown> }>(
+    '/api/v1/integrations/:platform/projects',
+    async (request, reply) => {
+      if (!request.authUser && !request.apiKey) {
+        throw new AppError('Authentication required', 401, 'Unauthorized');
+      }
+
+      const { platform } = request.params;
+      const config = request.body;
+
+      const service = await loadPluginOrThrow(registry, platform);
+
+      if (!service.listProjects || typeof service.listProjects !== 'function') {
+        throw new AppError(
+          `Project listing not supported for ${platform} integration`,
+          400,
+          'BadRequest'
+        );
+      }
+
+      logger.info('Listing projects for integration', {
+        platform,
+        userId: request.authUser?.id || 'api-key',
+      });
+
+      const projects = await service.listProjects(config);
+
+      return sendSuccess(reply, { projects });
+    }
+  );
+
+  /**
    * Save integration configuration for project
    * POST /api/v1/integrations/:platform/:projectId
    */

--- a/packages/backend/src/integrations/base-integration.service.ts
+++ b/packages/backend/src/integrations/base-integration.service.ts
@@ -95,4 +95,21 @@ export interface IntegrationService {
    * @returns Array of allowed hostnames (e.g., ['secure.gravatar.com', '*.atlassian.net'])
    */
   getAllowedAvatarDomains?(config: Record<string, unknown>): string[];
+
+  /**
+   * List projects available on the external platform (optional).
+   *
+   * Used by the signup wizard's project picker after the user has
+   * passed the "Test Connection" step but before the integration is
+   * persisted. Credentials come from the caller, not from DB.
+   *
+   * @param config     Flat configuration including credentials.
+   * @param query      Optional substring filter (platform-dependent).
+   * @param maxResults Max entries to return; platform-dependent cap.
+   */
+  listProjects?(
+    config: Record<string, unknown>,
+    query?: string,
+    maxResults?: number
+  ): Promise<Array<{ id: string; key: string; name: string }>>;
 }

--- a/packages/backend/src/integrations/jira/client.ts
+++ b/packages/backend/src/integrations/jira/client.ts
@@ -16,6 +16,8 @@ import type {
   JiraError,
   JiraConnectionTestResult,
   JiraUser,
+  JiraProject,
+  JiraProjectSearchResponse,
 } from './types.js';
 
 const logger = getLogger();
@@ -31,7 +33,15 @@ const JIRA_ENDPOINTS = {
   GET_PROJECT: (projectKey: string) => `${JIRA_API_BASE}/project/${projectKey}`,
   GET_MYSELF: `${JIRA_API_BASE}/myself`,
   SEARCH_USERS: `${JIRA_API_BASE}/user/search`,
+  SEARCH_PROJECTS: `${JIRA_API_BASE}/project/search`,
 } as const;
+
+/**
+ * Jira caps `/project/search` at 50 results per page. Requesting more is
+ * silently truncated server-side, so mirror the cap here to keep the
+ * wizard's expectations honest.
+ */
+const JIRA_PROJECT_SEARCH_MAX_RESULTS = 50;
 
 /**
  * HTTP request options
@@ -495,6 +505,58 @@ export class JiraClient {
     });
 
     return response;
+  }
+
+  /**
+   * List Jira projects the authenticated user can see.
+   *
+   * Backs the signup wizard's project picker after "Test Connection"
+   * passes but before the integration is saved to the DB. Uses
+   * `/rest/api/3/project/search` — paginated; we return only the first
+   * page (≤ 50 entries) because the wizard's picker is designed for
+   * tenants with a handful of projects, not thousands. Callers that
+   * need to narrow the list should pass `query`.
+   *
+   * @param query      Optional substring filter (Jira matches name/key).
+   * @param maxResults 1..50 inclusive; values above 50 are clamped.
+   */
+  async listProjects(query?: string, maxResults?: number): Promise<JiraProject[]> {
+    const clamped = Math.min(
+      Math.max(1, maxResults ?? JIRA_PROJECT_SEARCH_MAX_RESULTS),
+      JIRA_PROJECT_SEARCH_MAX_RESULTS
+    );
+
+    const params = new URLSearchParams({
+      maxResults: String(clamped),
+      orderBy: 'name',
+    });
+    if (query && query.trim().length > 0) {
+      params.set('query', query.trim());
+    }
+
+    const path = `${JIRA_ENDPOINTS.SEARCH_PROJECTS}?${params.toString()}`;
+
+    logger.debug('Listing Jira projects', {
+      host: this.host,
+      hasQuery: !!query,
+      maxResults: clamped,
+    });
+
+    const response = await this.request<JiraProjectSearchResponse>({
+      method: 'GET',
+      path,
+      headers: {},
+    });
+
+    const values = Array.isArray(response?.values) ? response.values : [];
+
+    logger.debug('Jira project list returned', {
+      count: values.length,
+      total: response?.total,
+      isLast: response?.isLast,
+    });
+
+    return values;
   }
 
   /**

--- a/packages/backend/src/integrations/jira/client.ts
+++ b/packages/backend/src/integrations/jira/client.ts
@@ -521,10 +521,14 @@ export class JiraClient {
    * @param maxResults 1..50 inclusive; values above 50 are clamped.
    */
   async listProjects(query?: string, maxResults?: number): Promise<JiraProject[]> {
-    const clamped = Math.min(
-      Math.max(1, maxResults ?? JIRA_PROJECT_SEARCH_MAX_RESULTS),
-      JIRA_PROJECT_SEARCH_MAX_RESULTS
-    );
+    // Default when unset OR non-finite (e.g. caller passed parseInt of
+    // a non-numeric querystring). Nullish coalescing alone would let
+    // NaN through and produce `maxResults=NaN` on the wire.
+    const requested =
+      typeof maxResults === 'number' && Number.isFinite(maxResults)
+        ? maxResults
+        : JIRA_PROJECT_SEARCH_MAX_RESULTS;
+    const clamped = Math.min(Math.max(1, Math.floor(requested)), JIRA_PROJECT_SEARCH_MAX_RESULTS);
 
     const params = new URLSearchParams({
       maxResults: String(clamped),

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -664,6 +664,72 @@ export class JiraIntegrationService implements IntegrationService {
   }
 
   /**
+   * List Jira projects visible to the authenticated user.
+   *
+   * Called by `POST /api/v1/integrations/jira/projects` to populate
+   * the signup wizard's project picker once "Test Connection" has
+   * validated the creds. No projectId is needed — the integration
+   * has not been saved yet.
+   */
+  async listProjects(
+    config: Record<string, unknown>,
+    query?: string,
+    maxResults?: number
+  ): Promise<{ id: string; key: string; name: string }[]> {
+    const rawConfig = config as RawJiraConfig;
+    const host = rawConfig.instanceUrl;
+
+    const missingFields: string[] = [];
+    const invalidFields: string[] = [];
+
+    if (!host) {
+      missingFields.push('instanceUrl');
+    } else if (typeof host !== 'string' || host.trim().length === 0) {
+      invalidFields.push('instanceUrl (must be non-empty string)');
+    }
+
+    if (!rawConfig.email) {
+      missingFields.push('email');
+    } else if (typeof rawConfig.email !== 'string' || rawConfig.email.trim().length === 0) {
+      invalidFields.push('email (must be non-empty string)');
+    }
+
+    if (!rawConfig.apiToken) {
+      missingFields.push('apiToken');
+    } else if (typeof rawConfig.apiToken !== 'string' || rawConfig.apiToken.trim().length === 0) {
+      invalidFields.push('apiToken (must be non-empty string)');
+    }
+
+    if (missingFields.length > 0 || invalidFields.length > 0) {
+      const errors = [
+        ...(missingFields.length > 0 ? [`missing: ${missingFields.join(', ')}`] : []),
+        ...(invalidFields.length > 0 ? [`invalid: ${invalidFields.join(', ')}`] : []),
+      ];
+      throw new ValidationError(`Jira configuration incomplete: ${errors.join('; ')}.`);
+    }
+
+    const normalizedConfig: JiraConfig = {
+      host: host!,
+      email: rawConfig.email!,
+      apiToken: rawConfig.apiToken!,
+      projectKey: rawConfig.projectKey || 'TEMP', // Not used for project listing
+      issueType: rawConfig.issueType,
+      enabled: rawConfig.enabled ?? true,
+    };
+
+    const client = new JiraClient(normalizedConfig);
+    const projects = await client.listProjects(query, maxResults);
+
+    logger.info('Jira project list fetched', {
+      host: host!.substring(0, MAX_HOST_LOG_LENGTH) + '...',
+      count: projects.length,
+      hasQuery: !!query,
+    });
+
+    return projects.map((p) => ({ id: p.id, key: p.key, name: p.name }));
+  }
+
+  /**
    * Get allowed avatar domains for Jira integration
    * Jira can return avatars from multiple trusted sources
    */

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -47,6 +47,16 @@ const DEFAULT_TICKET_STATUS: TicketStatus = TICKET_STATUS.OPEN;
 const DEFAULT_SCREENSHOT_FILENAME = 'screenshot.png';
 
 /**
+ * `JiraClient`'s constructor requires a non-empty `projectKey`, but
+ * `searchUsers` and `listProjects` both hit endpoints that ignore it
+ * (`/user/search`, `/project/search`). This placeholder satisfies
+ * the constructor contract without fabricating a misleading real key.
+ * Do NOT use for ticket creation — `createIssue` sends the key to
+ * Jira and will 404.
+ */
+const CONFIG_ONLY_PROJECT_KEY_PLACEHOLDER = 'TEMP';
+
+/**
  * Trusted domains for Jira avatar URLs
  * These domains are allowed for avatar proxy requests in addition to the configured instanceUrl
  */
@@ -565,8 +575,10 @@ export class JiraIntegrationService implements IntegrationService {
    * leading/trailing whitespace can't sneak past validation and
    * surface as a 500 from `new URL()` inside `JiraClient`.
    *
-   * @throws {ValidationError} with a field-by-field diagnostic on the
-   *   first validation failure.
+   * @throws {ValidationError} with a single combined diagnostic
+   *   covering every missing and invalid field detected in this call.
+   *   Callers see the full picture instead of having to fix-and-retry
+   *   one field at a time.
    */
   private validateAndNormalizeCredentials(config: Record<string, unknown>): JiraConfig {
     const rawConfig = config as RawJiraConfig;
@@ -635,9 +647,7 @@ export class JiraIntegrationService implements IntegrationService {
       host: trimmedHost!,
       email: trimmedEmail!,
       apiToken: trimmedToken!,
-      // `searchUsers` / `listProjects` don't need a real project key,
-      // but `JiraClient` won't construct without one.
-      projectKey: rawConfig.projectKey || 'TEMP',
+      projectKey: rawConfig.projectKey || CONFIG_ONLY_PROJECT_KEY_PLACEHOLDER,
       issueType: rawConfig.issueType,
       enabled: rawConfig.enabled ?? true,
     };

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -559,16 +559,16 @@ export class JiraIntegrationService implements IntegrationService {
    * Validate caller-supplied Jira credentials and build a trimmed
    * `JiraConfig` ready for `JiraClient`.
    *
-   * Shared by `searchUsers` and `listProjects` (and future wizard-flow
-   * endpoints) so the missing/invalid/whitespace handling stays
-   * consistent. Trims the three string fields so that leading/trailing
-   * whitespace can't sneak past validation and surface as a 500 from
-   * `new URL()` inside `JiraClient`.
+   * Shared by `searchUsers` (admin edit flow) and `listProjects`
+   * (signup wizard flow) so the missing/invalid/whitespace handling
+   * stays consistent. Trims all three string fields so that
+   * leading/trailing whitespace can't sneak past validation and
+   * surface as a 500 from `new URL()` inside `JiraClient`.
    *
    * @throws {ValidationError} with a field-by-field diagnostic on the
    *   first validation failure.
    */
-  private validateAndNormalizeWizardConfig(config: Record<string, unknown>): JiraConfig {
+  private validateAndNormalizeCredentials(config: Record<string, unknown>): JiraConfig {
     const rawConfig = config as RawJiraConfig;
 
     const missingFields: string[] = [];
@@ -582,32 +582,42 @@ export class JiraIntegrationService implements IntegrationService {
       return t.length > 0 ? t : undefined;
     };
 
-    // Accept both `instanceUrl` (used by the admin wizard and the new
-    // signup wizard) and `host` (legacy field name still in some stored
-    // integration rows — see `JiraIntegrationService.normalizeConfig`).
-    // Without this fallback, `searchUsers` on a legacy integration fails
-    // with "instanceUrl missing" even though `host` is populated.
-    const host = rawConfig.instanceUrl ?? rawConfig.host;
-    const email = rawConfig.email;
-    const apiToken = rawConfig.apiToken;
+    // Accept both `instanceUrl` (used by the admin wizard and the
+    // signup wizard) and `host` (legacy field name still in some
+    // stored integration rows — see
+    // `JiraIntegrationService.normalizeConfig`). Use the first
+    // non-empty trimmed value so a blank `instanceUrl` doesn't
+    // block a valid legacy `host`.
+    const trimmedInstanceUrl = trimString(rawConfig.instanceUrl);
+    const trimmedLegacyHost = trimString(rawConfig.host);
+    const trimmedHost = trimmedInstanceUrl ?? trimmedLegacyHost;
+    const trimmedEmail = trimString(rawConfig.email);
+    const trimmedToken = trimString(rawConfig.apiToken);
 
-    const trimmedHost = trimString(host);
-    const trimmedEmail = trimString(email);
-    const trimmedToken = trimString(apiToken);
+    const hostFieldProvided =
+      rawConfig.instanceUrl !== undefined &&
+      rawConfig.instanceUrl !== null &&
+      rawConfig.instanceUrl !== '';
+    const legacyHostFieldProvided =
+      rawConfig.host !== undefined && rawConfig.host !== null && rawConfig.host !== '';
 
-    if (host === undefined || host === null || host === '') {
+    if (!hostFieldProvided && !legacyHostFieldProvided) {
       missingFields.push('instanceUrl');
     } else if (!trimmedHost) {
       invalidFields.push('instanceUrl (must be non-empty string)');
     }
 
-    if (email === undefined || email === null || email === '') {
+    if (rawConfig.email === undefined || rawConfig.email === null || rawConfig.email === '') {
       missingFields.push('email');
     } else if (!trimmedEmail) {
       invalidFields.push('email (must be non-empty string)');
     }
 
-    if (apiToken === undefined || apiToken === null || apiToken === '') {
+    if (
+      rawConfig.apiToken === undefined ||
+      rawConfig.apiToken === null ||
+      rawConfig.apiToken === ''
+    ) {
       missingFields.push('apiToken');
     } else if (!trimmedToken) {
       invalidFields.push('apiToken (must be non-empty string)');
@@ -655,7 +665,7 @@ export class JiraIntegrationService implements IntegrationService {
       configKeys: Object.keys(config),
     });
 
-    const normalizedConfig: JiraConfig = this.validateAndNormalizeWizardConfig(config);
+    const normalizedConfig: JiraConfig = this.validateAndNormalizeCredentials(config);
 
     logger.debug('Creating Jira client for user search', {
       host: normalizedConfig.host.substring(0, MAX_HOST_LOG_LENGTH) + '...',
@@ -694,7 +704,7 @@ export class JiraIntegrationService implements IntegrationService {
     query?: string,
     maxResults?: number
   ): Promise<{ id: string; key: string; name: string }[]> {
-    const normalizedConfig: JiraConfig = this.validateAndNormalizeWizardConfig(config);
+    const normalizedConfig: JiraConfig = this.validateAndNormalizeCredentials(config);
 
     const client = new JiraClient(normalizedConfig);
     const projects = await client.listProjects(query, maxResults);

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -556,10 +556,6 @@ export class JiraIntegrationService implements IntegrationService {
   }
 
   /**
-   * Search for Jira users by query (email, name, etc.)
-   * Used for user autocomplete in admin UI
-   */
-  /**
    * Validate caller-supplied Jira credentials and build a trimmed
    * `JiraConfig` ready for `JiraClient`.
    *
@@ -586,7 +582,12 @@ export class JiraIntegrationService implements IntegrationService {
       return t.length > 0 ? t : undefined;
     };
 
-    const host = rawConfig.instanceUrl;
+    // Accept both `instanceUrl` (used by the admin wizard and the new
+    // signup wizard) and `host` (legacy field name still in some stored
+    // integration rows — see `JiraIntegrationService.normalizeConfig`).
+    // Without this fallback, `searchUsers` on a legacy integration fails
+    // with "instanceUrl missing" even though `host` is populated.
+    const host = rawConfig.instanceUrl ?? rawConfig.host;
     const email = rawConfig.email;
     const apiToken = rawConfig.apiToken;
 
@@ -632,6 +633,10 @@ export class JiraIntegrationService implements IntegrationService {
     };
   }
 
+  /**
+   * Search for Jira users by query (email, name, etc.)
+   * Used for user autocomplete in admin UI
+   */
   async searchUsers(
     config: Record<string, unknown>,
     query: string,

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -559,6 +559,79 @@ export class JiraIntegrationService implements IntegrationService {
    * Search for Jira users by query (email, name, etc.)
    * Used for user autocomplete in admin UI
    */
+  /**
+   * Validate caller-supplied Jira credentials and build a trimmed
+   * `JiraConfig` ready for `JiraClient`.
+   *
+   * Shared by `searchUsers` and `listProjects` (and future wizard-flow
+   * endpoints) so the missing/invalid/whitespace handling stays
+   * consistent. Trims the three string fields so that leading/trailing
+   * whitespace can't sneak past validation and surface as a 500 from
+   * `new URL()` inside `JiraClient`.
+   *
+   * @throws {ValidationError} with a field-by-field diagnostic on the
+   *   first validation failure.
+   */
+  private validateAndNormalizeWizardConfig(config: Record<string, unknown>): JiraConfig {
+    const rawConfig = config as RawJiraConfig;
+
+    const missingFields: string[] = [];
+    const invalidFields: string[] = [];
+
+    const trimString = (value: unknown): string | undefined => {
+      if (typeof value !== 'string') {
+        return undefined;
+      }
+      const t = value.trim();
+      return t.length > 0 ? t : undefined;
+    };
+
+    const host = rawConfig.instanceUrl;
+    const email = rawConfig.email;
+    const apiToken = rawConfig.apiToken;
+
+    const trimmedHost = trimString(host);
+    const trimmedEmail = trimString(email);
+    const trimmedToken = trimString(apiToken);
+
+    if (host === undefined || host === null || host === '') {
+      missingFields.push('instanceUrl');
+    } else if (!trimmedHost) {
+      invalidFields.push('instanceUrl (must be non-empty string)');
+    }
+
+    if (email === undefined || email === null || email === '') {
+      missingFields.push('email');
+    } else if (!trimmedEmail) {
+      invalidFields.push('email (must be non-empty string)');
+    }
+
+    if (apiToken === undefined || apiToken === null || apiToken === '') {
+      missingFields.push('apiToken');
+    } else if (!trimmedToken) {
+      invalidFields.push('apiToken (must be non-empty string)');
+    }
+
+    if (missingFields.length > 0 || invalidFields.length > 0) {
+      const errors = [
+        ...(missingFields.length > 0 ? [`missing: ${missingFields.join(', ')}`] : []),
+        ...(invalidFields.length > 0 ? [`invalid: ${invalidFields.join(', ')}`] : []),
+      ];
+      throw new ValidationError(`Jira configuration incomplete: ${errors.join('; ')}.`);
+    }
+
+    return {
+      host: trimmedHost!,
+      email: trimmedEmail!,
+      apiToken: trimmedToken!,
+      // `searchUsers` / `listProjects` don't need a real project key,
+      // but `JiraClient` won't construct without one.
+      projectKey: rawConfig.projectKey || 'TEMP',
+      issueType: rawConfig.issueType,
+      enabled: rawConfig.enabled ?? true,
+    };
+  }
+
   async searchUsers(
     config: Record<string, unknown>,
     query: string,
@@ -577,72 +650,12 @@ export class JiraIntegrationService implements IntegrationService {
       configKeys: Object.keys(config),
     });
 
-    // Extract Jira instance URL from config
-    const rawConfig = config as RawJiraConfig;
-    const host = rawConfig.instanceUrl;
-
-    logger.debug('Normalized Jira config for user search', {
-      hasInstanceUrl: !!rawConfig.instanceUrl,
-      hasEmail: !!rawConfig.email,
-      hasApiToken: !!rawConfig.apiToken,
-      resolvedHost: host ? host.substring(0, MAX_HOST_LOG_LENGTH) + '...' : undefined,
-    });
-
-    // Validate required Jira configuration fields (existence + type checks)
-    const missingFields: string[] = [];
-    const invalidFields: string[] = [];
-
-    if (!host) {
-      missingFields.push('instanceUrl');
-    } else if (typeof host !== 'string' || host.trim().length === 0) {
-      invalidFields.push('instanceUrl (must be non-empty string)');
-    }
-
-    if (!rawConfig.email) {
-      missingFields.push('email');
-    } else if (typeof rawConfig.email !== 'string' || rawConfig.email.trim().length === 0) {
-      invalidFields.push('email (must be non-empty string)');
-    }
-
-    if (!rawConfig.apiToken) {
-      missingFields.push('apiToken');
-    } else if (typeof rawConfig.apiToken !== 'string' || rawConfig.apiToken.trim().length === 0) {
-      invalidFields.push('apiToken (must be non-empty string)');
-    }
-
-    if (missingFields.length > 0 || invalidFields.length > 0) {
-      const errors = [
-        ...(missingFields.length > 0 ? [`missing: ${missingFields.join(', ')}`] : []),
-        ...(invalidFields.length > 0 ? [`invalid: ${invalidFields.join(', ')}`] : []),
-      ];
-
-      logger.error('Jira user search failed: configuration validation error', {
-        missingFields,
-        invalidFields,
-        availableConfigKeys: Object.keys(config),
-      });
-
-      throw new ValidationError(
-        `Jira configuration incomplete: ${errors.join('; ')}. ` +
-          'Please check that credentials are properly encrypted and stored in the database.'
-      );
-    }
-
-    // Create normalized config with 'host' field for JiraClient
-    // Non-null assertions safe here because validation above ensures these fields exist
-    const normalizedConfig: JiraConfig = {
-      host: host!,
-      email: rawConfig.email!,
-      apiToken: rawConfig.apiToken!,
-      projectKey: rawConfig.projectKey || 'TEMP', // User search doesn't need real project key
-      issueType: rawConfig.issueType,
-      enabled: rawConfig.enabled ?? true,
-    };
+    const normalizedConfig: JiraConfig = this.validateAndNormalizeWizardConfig(config);
 
     logger.debug('Creating Jira client for user search', {
-      host: host!.substring(0, MAX_HOST_LOG_LENGTH) + '...',
-      email: rawConfig.email,
-      hasProjectKey: !!rawConfig.projectKey,
+      host: normalizedConfig.host.substring(0, MAX_HOST_LOG_LENGTH) + '...',
+      email: normalizedConfig.email,
+      hasProjectKey: !!(config as RawJiraConfig).projectKey,
     });
 
     const client = new JiraClient(normalizedConfig);
@@ -676,52 +689,13 @@ export class JiraIntegrationService implements IntegrationService {
     query?: string,
     maxResults?: number
   ): Promise<{ id: string; key: string; name: string }[]> {
-    const rawConfig = config as RawJiraConfig;
-    const host = rawConfig.instanceUrl;
-
-    const missingFields: string[] = [];
-    const invalidFields: string[] = [];
-
-    if (!host) {
-      missingFields.push('instanceUrl');
-    } else if (typeof host !== 'string' || host.trim().length === 0) {
-      invalidFields.push('instanceUrl (must be non-empty string)');
-    }
-
-    if (!rawConfig.email) {
-      missingFields.push('email');
-    } else if (typeof rawConfig.email !== 'string' || rawConfig.email.trim().length === 0) {
-      invalidFields.push('email (must be non-empty string)');
-    }
-
-    if (!rawConfig.apiToken) {
-      missingFields.push('apiToken');
-    } else if (typeof rawConfig.apiToken !== 'string' || rawConfig.apiToken.trim().length === 0) {
-      invalidFields.push('apiToken (must be non-empty string)');
-    }
-
-    if (missingFields.length > 0 || invalidFields.length > 0) {
-      const errors = [
-        ...(missingFields.length > 0 ? [`missing: ${missingFields.join(', ')}`] : []),
-        ...(invalidFields.length > 0 ? [`invalid: ${invalidFields.join(', ')}`] : []),
-      ];
-      throw new ValidationError(`Jira configuration incomplete: ${errors.join('; ')}.`);
-    }
-
-    const normalizedConfig: JiraConfig = {
-      host: host!,
-      email: rawConfig.email!,
-      apiToken: rawConfig.apiToken!,
-      projectKey: rawConfig.projectKey || 'TEMP', // Not used for project listing
-      issueType: rawConfig.issueType,
-      enabled: rawConfig.enabled ?? true,
-    };
+    const normalizedConfig: JiraConfig = this.validateAndNormalizeWizardConfig(config);
 
     const client = new JiraClient(normalizedConfig);
     const projects = await client.listProjects(query, maxResults);
 
     logger.info('Jira project list fetched', {
-      host: host!.substring(0, MAX_HOST_LOG_LENGTH) + '...',
+      host: normalizedConfig.host.substring(0, MAX_HOST_LOG_LENGTH) + '...',
       count: projects.length,
       hasQuery: !!query,
     });

--- a/packages/backend/src/integrations/jira/types.ts
+++ b/packages/backend/src/integrations/jira/types.ts
@@ -187,6 +187,33 @@ export interface JiraIntegrationResult {
 }
 
 /**
+ * Jira project (from /rest/api/3/project/search).
+ * Narrower than the full API shape — just what the wizard picker needs.
+ */
+export interface JiraProject {
+  id: string;
+  key: string;
+  name: string;
+  avatarUrls?: {
+    '48x48'?: string;
+    '24x24'?: string;
+    '16x16'?: string;
+    '32x32'?: string;
+  };
+}
+
+/**
+ * Paginated response envelope from `/rest/api/3/project/search`.
+ */
+export interface JiraProjectSearchResponse {
+  isLast: boolean;
+  maxResults: number;
+  startAt: number;
+  total: number;
+  values: JiraProject[];
+}
+
+/**
  * Jira user (from user search API)
  */
 export interface JiraUser {

--- a/packages/backend/tests/api/project-integration-config.test.ts
+++ b/packages/backend/tests/api/project-integration-config.test.ts
@@ -437,8 +437,8 @@ describe('Project Integration Config API', () => {
       expect(response.json().message).toMatch(/maxResults/);
     });
 
-    it.each([['10.5'], ['10abc'], ['-5'], ['+10'], ['0']])(
-      'should 400 when maxResults is %s (rejects non-integer / non-positive inputs)',
+    it.each([['10.5'], ['10abc'], ['-5'], ['+10'], ['0'], ['9999999'], ['1001']])(
+      'should 400 when maxResults is %s (rejects non-integer / non-positive / oversized inputs)',
       async (bad) => {
         const response = await server.inject({
           method: 'POST',

--- a/packages/backend/tests/api/project-integration-config.test.ts
+++ b/packages/backend/tests/api/project-integration-config.test.ts
@@ -49,9 +49,41 @@ describe('Project Integration Config API', () => {
         async createFromBugReport() {
           return { externalId: 'JIRA-123', externalUrl: 'https://jira.example.com/JIRA-123' };
         },
+        async listProjects(config: Record<string, unknown>) {
+          // Echo back whether creds were received, so tests can assert
+          // the route forwarded the body. Real plugin proxies to the
+          // Jira REST API; mock keeps the assertion surface small.
+          if (!config.instanceUrl || !config.email || !config.apiToken) {
+            throw new Error('Jira configuration incomplete');
+          }
+          return [
+            { id: '10000', key: 'ALPHA', name: 'Alpha' },
+            { id: '10001', key: 'BETA', name: 'Beta' },
+          ];
+        },
       }),
     };
     await pluginRegistry.register(mockJiraPlugin as any);
+
+    // A second plugin that does NOT implement listProjects, so we can
+    // assert the route returns a helpful 400 rather than crashing for
+    // non-Jira platforms.
+    const mockNoListPlugin = {
+      metadata: {
+        platform: 'mock-no-list',
+        version: '1.0.0',
+        name: 'Mock plugin without project listing',
+      },
+      factory: (_context: any) => ({
+        async validateConfig() {
+          return { valid: true };
+        },
+        async createFromBugReport() {
+          return { externalId: 'MOCK-1', externalUrl: 'https://mock.example.com/1' };
+        },
+      }),
+    };
+    await pluginRegistry.register(mockNoListPlugin as any);
 
     server = await createServer({
       db,
@@ -229,6 +261,98 @@ describe('Project Integration Config API', () => {
       });
 
       expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe('POST /api/v1/integrations/:platform/projects (wizard project picker)', () => {
+    it('should return projects shaped as { projects: [...] }', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/jira/projects',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          instanceUrl: 'https://test.atlassian.net',
+          email: 'user@example.com',
+          apiToken: 'secret-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const data = response.json().data;
+      expect(data.projects).toEqual([
+        { id: '10000', key: 'ALPHA', name: 'Alpha' },
+        { id: '10001', key: 'BETA', name: 'Beta' },
+      ]);
+    });
+
+    it('should NOT collide with POST /:platform/:projectId (UUID segment)', async () => {
+      // Static-segment `/projects` must win over the parametric
+      // `/:projectId` route for a path like `/integrations/jira/projects`,
+      // otherwise the wizard would accidentally hit the save-config
+      // endpoint with projectId="projects".
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/jira/projects',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          instanceUrl: 'https://test.atlassian.net',
+          email: 'user@example.com',
+          apiToken: 'secret-token',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data.projects).toBeDefined();
+    });
+
+    it('should require authentication', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/jira/projects',
+        payload: {
+          instanceUrl: 'https://test.atlassian.net',
+          email: 'user@example.com',
+          apiToken: 'secret-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('should return 400 for unsupported platform', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/unsupported_platform/projects',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when platform does not support listProjects', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/mock-no-list/projects',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.message).toMatch(/not supported|listing/i);
+    });
+
+    it('should surface plugin errors from invalid credentials', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/jira/projects',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          // Missing email + apiToken — mock plugin rejects.
+          instanceUrl: 'https://test.atlassian.net',
+        },
+      });
+
+      expect(response.statusCode).toBe(500);
     });
   });
 

--- a/packages/backend/tests/api/project-integration-config.test.ts
+++ b/packages/backend/tests/api/project-integration-config.test.ts
@@ -406,7 +406,7 @@ describe('Project Integration Config API', () => {
       expect(response.json().message).toMatch(/maxResults/);
     });
 
-    it.each([['10.5'], ['10abc'], ['-5'], [' 10'], ['+10'], ['0']])(
+    it.each([['10.5'], ['10abc'], ['-5'], ['+10'], ['0']])(
       'should 400 when maxResults is %s (rejects non-integer / non-positive inputs)',
       async (bad) => {
         const response = await server.inject({
@@ -423,6 +423,21 @@ describe('Project Integration Config API', () => {
         expect(response.statusCode).toBe(400);
       }
     );
+
+    it('should accept maxResults wrapped in whitespace after trimming', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/jira/projects?maxResults=%2010%20',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          instanceUrl: 'https://test.atlassian.net',
+          email: 'user@example.com',
+          apiToken: 'secret-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
   });
 
   describe('GET /api/v1/integrations/:platform/:projectId', () => {

--- a/packages/backend/tests/api/project-integration-config.test.ts
+++ b/packages/backend/tests/api/project-integration-config.test.ts
@@ -341,18 +341,69 @@ describe('Project Integration Config API', () => {
       expect(response.json().message).toMatch(/not supported|listing/i);
     });
 
-    it('should surface plugin errors from invalid credentials', async () => {
+    it('should surface plugin errors when required fields are missing from config', async () => {
       const response = await server.inject({
         method: 'POST',
         url: '/api/v1/integrations/jira/projects',
         headers: { authorization: `Bearer ${authToken}` },
         payload: {
-          // Missing email + apiToken — mock plugin rejects.
+          // Missing email + apiToken — mock plugin rejects with a
+          // generic Error, which the error middleware maps to 500.
           instanceUrl: 'https://test.atlassian.net',
         },
       });
 
       expect(response.statusCode).toBe(500);
+    });
+
+    it('should forward query and parsed maxResults to the plugin', async () => {
+      // Swap the Jira plugin's listProjects stub for a spy that
+      // captures the args the route passes, then restore it.
+      const registeredService = await pluginRegistry.loadDynamicPlugin('jira');
+      const originalListProjects = registeredService.listProjects!.bind(registeredService);
+      const captured: Array<{ query?: string; maxResults?: number }> = [];
+      registeredService.listProjects = async (
+        _config: Record<string, unknown>,
+        q?: string,
+        m?: number
+      ) => {
+        captured.push({ query: q, maxResults: m });
+        return [{ id: '10000', key: 'ALPHA', name: 'Alpha' }];
+      };
+
+      try {
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/v1/integrations/jira/projects?query=alp&maxResults=10',
+          headers: { authorization: `Bearer ${authToken}` },
+          payload: {
+            instanceUrl: 'https://test.atlassian.net',
+            email: 'user@example.com',
+            apiToken: 'secret-token',
+          },
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(captured).toEqual([{ query: 'alp', maxResults: 10 }]);
+      } finally {
+        registeredService.listProjects = originalListProjects;
+      }
+    });
+
+    it('should 400 when maxResults is not a positive integer', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/jira/projects?maxResults=abc',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          instanceUrl: 'https://test.atlassian.net',
+          email: 'user@example.com',
+          apiToken: 'secret-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().message).toMatch(/maxResults/);
     });
   });
 

--- a/packages/backend/tests/api/project-integration-config.test.ts
+++ b/packages/backend/tests/api/project-integration-config.test.ts
@@ -405,6 +405,24 @@ describe('Project Integration Config API', () => {
       expect(response.statusCode).toBe(400);
       expect(response.json().message).toMatch(/maxResults/);
     });
+
+    it.each([['10.5'], ['10abc'], ['-5'], [' 10'], ['+10'], ['0']])(
+      'should 400 when maxResults is %s (rejects non-integer / non-positive inputs)',
+      async (bad) => {
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/v1/integrations/jira/projects?maxResults=${encodeURIComponent(bad)}`,
+          headers: { authorization: `Bearer ${authToken}` },
+          payload: {
+            instanceUrl: 'https://test.atlassian.net',
+            email: 'user@example.com',
+            apiToken: 'secret-token',
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+      }
+    );
   });
 
   describe('GET /api/v1/integrations/:platform/:projectId', () => {

--- a/packages/backend/tests/api/project-integration-config.test.ts
+++ b/packages/backend/tests/api/project-integration-config.test.ts
@@ -338,7 +338,7 @@ describe('Project Integration Config API', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(response.json().error.message).toMatch(/not supported|listing/i);
+      expect(response.json().message).toMatch(/not supported|listing/i);
     });
 
     it('should surface plugin errors from invalid credentials', async () => {

--- a/packages/backend/tests/api/project-integration-config.test.ts
+++ b/packages/backend/tests/api/project-integration-config.test.ts
@@ -341,19 +341,50 @@ describe('Project Integration Config API', () => {
       expect(response.json().message).toMatch(/not supported|listing/i);
     });
 
-    it('should surface plugin errors when required fields are missing from config', async () => {
+    it('should surface generic plugin errors as 500', async () => {
+      // Mock plugin throws `new Error(...)` (not AppError/ValidationError)
+      // when required fields are missing — confirms the error middleware
+      // maps unknown throws to 500. Real Jira plugin throws
+      // ValidationError from the shared credential helper and would
+      // reach the client as 400; see the next test for that path.
       const response = await server.inject({
         method: 'POST',
         url: '/api/v1/integrations/jira/projects',
         headers: { authorization: `Bearer ${authToken}` },
         payload: {
-          // Missing email + apiToken — mock plugin rejects with a
-          // generic Error, which the error middleware maps to 500.
           instanceUrl: 'https://test.atlassian.net',
         },
       });
 
       expect(response.statusCode).toBe(500);
+    });
+
+    it('should return 400 when the plugin throws ValidationError', async () => {
+      // The Jira plugin's real validator throws `ValidationError` for
+      // missing/blank credentials. Swap the plugin's listProjects for
+      // one that simulates that behavior, then restore it.
+      const { ValidationError } = await import('../../src/api/middleware/error.js');
+      const registeredService = await pluginRegistry.loadDynamicPlugin('jira');
+      const originalListProjects = registeredService.listProjects!.bind(registeredService);
+      registeredService.listProjects = async () => {
+        throw new ValidationError('Jira configuration incomplete: missing: email, apiToken.');
+      };
+
+      try {
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/v1/integrations/jira/projects',
+          headers: { authorization: `Bearer ${authToken}` },
+          payload: {
+            instanceUrl: 'https://test.atlassian.net',
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json().message).toMatch(/Jira configuration incomplete/);
+      } finally {
+        registeredService.listProjects = originalListProjects;
+      }
     });
 
     it('should forward query and parsed maxResults to the plugin', async () => {
@@ -423,6 +454,27 @@ describe('Project Integration Config API', () => {
         expect(response.statusCode).toBe(400);
       }
     );
+
+    it('should tolerate duplicate maxResults querystring entries without 500', async () => {
+      // Fastify's default parser returns an array for repeated keys.
+      // The route must pick a single entry instead of crashing with
+      // `TypeError: maxResultsRaw.trim is not a function`.
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/integrations/jira/projects?maxResults=5&maxResults=20',
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          instanceUrl: 'https://test.atlassian.net',
+          email: 'user@example.com',
+          apiToken: 'secret-token',
+        },
+      });
+
+      // Either accepted as the first value (200) or rejected as malformed
+      // (400) — the exact choice is up to the route. What matters is that
+      // we don't crash with a 500.
+      expect(response.statusCode).not.toBe(500);
+    });
 
     it('should accept maxResults wrapped in whitespace after trimming', async () => {
       const response = await server.inject({

--- a/packages/backend/tests/integrations/jira/service-list-projects.test.ts
+++ b/packages/backend/tests/integrations/jira/service-list-projects.test.ts
@@ -145,6 +145,38 @@ describe('JiraIntegrationService.listProjects', () => {
     expect(result).toEqual([{ id: '10000', key: 'ALPHA', name: 'Alpha' }]);
   });
 
+  it('falls back to legacy `host` when `instanceUrl` is present but blank', async () => {
+    // Guard against a subtle `??`-only fallback bug: `instanceUrl=""`
+    // is not nullish, so naive `instanceUrl ?? host` would latch onto
+    // the empty string and 400 even though `host` is valid. The helper
+    // treats blank `instanceUrl` as absent for fallback purposes.
+    mockListProjects.mockResolvedValueOnce([{ id: '10000', key: 'ALPHA', name: 'Alpha' }]);
+    const service = makeService();
+
+    const result = await service.listProjects({
+      instanceUrl: '',
+      host: 'https://legacy.atlassian.net',
+      email: 'user@example.com',
+      apiToken: 'token-xyz',
+    });
+
+    expect(result).toEqual([{ id: '10000', key: 'ALPHA', name: 'Alpha' }]);
+  });
+
+  it('falls back to legacy `host` when `instanceUrl` is whitespace', async () => {
+    mockListProjects.mockResolvedValueOnce([{ id: '10000', key: 'ALPHA', name: 'Alpha' }]);
+    const service = makeService();
+
+    const result = await service.listProjects({
+      instanceUrl: '   ',
+      host: 'https://legacy.atlassian.net',
+      email: 'user@example.com',
+      apiToken: 'token-xyz',
+    });
+
+    expect(result).toEqual([{ id: '10000', key: 'ALPHA', name: 'Alpha' }]);
+  });
+
   it('returns an empty array when the tenant has no projects', async () => {
     mockListProjects.mockResolvedValueOnce([]);
     const service = makeService();

--- a/packages/backend/tests/integrations/jira/service-list-projects.test.ts
+++ b/packages/backend/tests/integrations/jira/service-list-projects.test.ts
@@ -128,6 +128,23 @@ describe('JiraIntegrationService.listProjects', () => {
     ).rejects.toThrowError('Jira API error: 401');
   });
 
+  it('accepts legacy `host` field when `instanceUrl` is absent', async () => {
+    // Some stored integrations predate the `instanceUrl` rename and
+    // still carry `host` — the shared helper falls back so that
+    // `searchUsers` / `listProjects` on those rows do not 400 with
+    // "instanceUrl missing" despite the URL being populated.
+    mockListProjects.mockResolvedValueOnce([{ id: '10000', key: 'ALPHA', name: 'Alpha' }]);
+    const service = makeService();
+
+    const result = await service.listProjects({
+      host: 'https://legacy.atlassian.net',
+      email: 'user@example.com',
+      apiToken: 'token-xyz',
+    });
+
+    expect(result).toEqual([{ id: '10000', key: 'ALPHA', name: 'Alpha' }]);
+  });
+
   it('returns an empty array when the tenant has no projects', async () => {
     mockListProjects.mockResolvedValueOnce([]);
     const service = makeService();

--- a/packages/backend/tests/integrations/jira/service-list-projects.test.ts
+++ b/packages/backend/tests/integrations/jira/service-list-projects.test.ts
@@ -4,9 +4,8 @@
  * Exercises the wizard-flow path where caller-provided credentials
  * are normalized, a JiraClient is constructed, and its listProjects()
  * output is reshaped into the narrow {id, key, name} tuple the route
- * ships to the frontend. Mocks JiraClient at the module level to
- * avoid real HTTPS calls — consistent with tests/integration/
- * jira-integration-rules.test.ts.
+ * ships to the frontend. JiraClient is mocked at the module level to
+ * avoid real HTTPS calls.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';

--- a/packages/backend/tests/integrations/jira/service-list-projects.test.ts
+++ b/packages/backend/tests/integrations/jira/service-list-projects.test.ts
@@ -1,0 +1,143 @@
+/**
+ * JiraIntegrationService.listProjects unit tests.
+ *
+ * Exercises the wizard-flow path where caller-provided credentials
+ * are normalized, a JiraClient is constructed, and its listProjects()
+ * output is reshaped into the narrow {id, key, name} tuple the route
+ * ships to the frontend. Mocks JiraClient at the module level to
+ * avoid real HTTPS calls — consistent with tests/integration/
+ * jira-integration-rules.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { JiraIntegrationService } from '../../../src/integrations/jira/service.js';
+import { ValidationError } from '../../../src/api/middleware/error.js';
+
+const mockListProjects = vi.fn();
+
+vi.mock('../../../src/integrations/jira/client.js', () => ({
+  JiraClient: vi.fn().mockImplementation(() => ({
+    listProjects: mockListProjects,
+  })),
+}));
+
+function makeService(): JiraIntegrationService {
+  // listProjects() doesn't touch repos/db/storage — pass stubs.
+  return new JiraIntegrationService({} as never, {} as never, {} as never, {} as never);
+}
+
+describe('JiraIntegrationService.listProjects', () => {
+  beforeEach(() => {
+    mockListProjects.mockReset();
+  });
+
+  it('returns projects reshaped to {id, key, name}, dropping extra fields', async () => {
+    mockListProjects.mockResolvedValueOnce([
+      {
+        id: '10000',
+        key: 'ALPHA',
+        name: 'Alpha',
+        avatarUrls: { '48x48': 'https://example.atlassian.net/avatar.png' },
+      },
+      { id: '10001', key: 'BETA', name: 'Beta' },
+    ]);
+
+    const service = makeService();
+    const result = await service.listProjects({
+      instanceUrl: 'https://example.atlassian.net',
+      email: 'user@example.com',
+      apiToken: 'token-xyz',
+    });
+
+    expect(result).toEqual([
+      { id: '10000', key: 'ALPHA', name: 'Alpha' },
+      { id: '10001', key: 'BETA', name: 'Beta' },
+    ]);
+    expect(mockListProjects).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it('passes query and maxResults through to the client', async () => {
+    mockListProjects.mockResolvedValueOnce([]);
+    const service = makeService();
+
+    await service.listProjects(
+      {
+        instanceUrl: 'https://example.atlassian.net',
+        email: 'user@example.com',
+        apiToken: 'token-xyz',
+      },
+      'alp',
+      25
+    );
+
+    expect(mockListProjects).toHaveBeenCalledWith('alp', 25);
+  });
+
+  it('throws ValidationError when instanceUrl is missing', async () => {
+    const service = makeService();
+    await expect(
+      service.listProjects({
+        email: 'user@example.com',
+        apiToken: 'token-xyz',
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(mockListProjects).not.toHaveBeenCalled();
+  });
+
+  it('throws ValidationError when email is missing', async () => {
+    const service = makeService();
+    await expect(
+      service.listProjects({
+        instanceUrl: 'https://example.atlassian.net',
+        apiToken: 'token-xyz',
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('throws ValidationError when apiToken is missing', async () => {
+    const service = makeService();
+    await expect(
+      service.listProjects({
+        instanceUrl: 'https://example.atlassian.net',
+        email: 'user@example.com',
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects whitespace-only fields as invalid (not merely missing)', async () => {
+    const service = makeService();
+    await expect(
+      service.listProjects({
+        instanceUrl: '   ',
+        email: 'user@example.com',
+        apiToken: 'token-xyz',
+      })
+    ).rejects.toThrowError(/invalid:.*instanceUrl/);
+  });
+
+  it('surfaces client errors to the caller without swallowing', async () => {
+    mockListProjects.mockRejectedValueOnce(new Error('Jira API error: 401'));
+    const service = makeService();
+
+    await expect(
+      service.listProjects({
+        instanceUrl: 'https://example.atlassian.net',
+        email: 'user@example.com',
+        apiToken: 'bad-token',
+      })
+    ).rejects.toThrowError('Jira API error: 401');
+  });
+
+  it('returns an empty array when the tenant has no projects', async () => {
+    mockListProjects.mockResolvedValueOnce([]);
+    const service = makeService();
+
+    const result = await service.listProjects({
+      instanceUrl: 'https://example.atlassian.net',
+      email: 'user@example.com',
+      apiToken: 'token-xyz',
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       'tests/integrations/jira/mapper.test.ts',
       'tests/integrations/jira/mapper-enhanced.test.ts',
       'tests/integrations/jira/mapper-table-and-nested-metadata.test.ts',
+      'tests/integrations/jira/service-list-projects.test.ts',
       'tests/integrations/jira/template-renderer.test.ts',
       'tests/integrations/jira/formatters/base-formatter.test.ts',
       // Intelligence tests (pure unit, mocked dependencies)


### PR DESCRIPTION
## Summary

Slice 1 of R5a (Jira onboarding polish). Adds an endpoint so the signup wizard can populate a project picker after "Test Connection" passes but before the integration row is saved in the DB.

## Change

New route: `POST /api/v1/integrations/:platform/projects`

- Body: flat config `{ instanceUrl, email, apiToken, ... }` — same shape as `/test`.
- Querystring: `?query=<substring>&maxResults=<positive int>`, both optional.
  - `maxResults` is trimmed, then matched against `/^\d+$/` before parsing. Rejects `10.5`, `10abc`, `+10`, `-5`, `0` with a 400. Stray whitespace (`?maxResults= 10`) is tolerated.
  - Duplicate querystring entries (`?maxResults=10&maxResults=20`) are coerced to the first string — Fastify's parser returns an array, and the raw `.trim()` would have thrown `TypeError` → 500.
- Response: `{ data: { projects: [{ id, key, name }] } }`.
- Requires authentication; outbound HTTPS call to the platform.
- Sits above `POST /:platform/:projectId` so find-my-way's static-over-parametric routing resolves `/jira/projects` correctly (guarded by a dedicated test).

Jira implementation:

- [`JiraClient.listProjects()`](packages/backend/src/integrations/jira/client.ts) calls `/rest/api/3/project/search`. Clamps `maxResults` to Jira's 50-entry page cap, guards against `NaN` / non-finite values (falls back to default), floors fractional inputs.
- [`JiraIntegrationService.validateAndNormalizeCredentials()`](packages/backend/src/integrations/jira/service.ts) is a shared private helper used by both `searchUsers` (admin edit flow) and `listProjects` (wizard). Trims `instanceUrl` / `email` / `apiToken` before handing them to `JiraClient`, so whitespace-wrapped values fail fast as 400 instead of blowing up as 500 inside `new URL()`. Accepts both `instanceUrl` and legacy `host` — picks the first non-empty trimmed value, so blank `instanceUrl` doesn't block fallback.
- [`JiraIntegrationService.listProjects()`](packages/backend/src/integrations/jira/service.ts) validates via the helper, constructs a client, returns narrow `{id, key, name}` tuples.
- [`IntegrationService.listProjects?`](packages/backend/src/integrations/base-integration.service.ts) added as optional on the base interface — non-Jira platforms get a helpful 400 "not supported" message rather than a crash.

## Why narrow `{id, key, name}`?

Jira also returns `avatarUrls` per project. Avatar proxying requires an integrationId (domain validation lives in `/avatar-proxy`), which we don't have for the unsaved wizard flow. Dropping avatars keeps this slice small; a later slice can add them via a different mechanism (signed URL or base64 thumbnail).

## Tests

[tests/integrations/jira/service-list-projects.test.ts](packages/backend/tests/integrations/jira/service-list-projects.test.ts) — 11 unit tests, `JiraClient` mocked at module level:

- Reshape to `{id, key, name}`, drop extra fields.
- Query + maxResults forwarded to the client.
- `ValidationError` when `instanceUrl` / `email` / `apiToken` missing.
- Whitespace-only fields treated as invalid.
- Client errors bubble up unswallowed.
- Empty-tenant case.
- Legacy `host` field accepted when `instanceUrl` is absent, empty, or whitespace.

[tests/api/project-integration-config.test.ts](packages/backend/tests/api/project-integration-config.test.ts) — new route tests (integration, uses testcontainers Postgres):

- 200 with expected project shape.
- 401 without auth.
- 400 for unknown platform.
- 400 for platforms without `listProjects` (registered a second mock plugin).
- Explicit collision test: `/jira/projects` must not land on `/:projectId` save route.
- `?query=alp&maxResults=10` → plugin receives the args.
- `?maxResults=abc` → 400 with a message mentioning `maxResults`.
- Parametrized: `10.5`, `10abc`, `-5`, `+10`, `0` → 400.
- `?maxResults=%2010%20` (whitespace) → 200 after trim.
- `?maxResults=5&maxResults=20` (duplicate) → not 500 (array coerced).
- Generic plugin error → 500; `ValidationError` → 400 (documents both error paths).

## Test plan

- [x] `pnpm test:unit` — **2302/2302 pass** (+11 new service unit tests).
- [x] `pnpm typecheck` — no new errors in files touched by this slice (pre-existing BugReport-type drift errors in unrelated test fixtures remain).
- [ ] CI: `pnpm test:integration` exercises the new route tests against a real Postgres container.
- [ ] After merge: Slice 2 wires this into admin UI `ProjectStep` to replace the free-text project key field.

## Scope notes

- No admin UI changes in this PR — picker integration is Slice 2.
- No avatar support (see "Why narrow" above).
- No pagination — first page (≤ 50) is enough for MVP. Wizard can pass `query` to narrow.
- Covers only Jira. The interface is generic so a future GitHub/Linear integration can ship a `listProjects` without modifying the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
