### PR TITLE
feat(backend): email verification for self-service signup

### DIFF
--- a/packages/backend/src/api/routes/signup.ts
+++ b/packages/backend/src/api/routes/signup.ts
@@ -28,10 +28,15 @@ import type { DatabaseClient } from '../../db/client.js';
 import { config } from '../../config.js';
 import { AppError } from '../middleware/error.js';
 import { omitFields } from '../utils/resource.js';
-import { sendCreated } from '../utils/response.js';
+import { sendCreated, sendSuccess } from '../utils/response.js';
 import { buildRefreshCookieOptions } from '../utils/auth-cookies.js';
 import { generateAuthTokens } from '../utils/auth-tokens.js';
-import { signupSchema } from '../schemas/auth-schema.js';
+import {
+  signupSchema,
+  verifyEmailSchema,
+  resendVerificationSchema,
+} from '../schemas/auth-schema.js';
+import { requireUser } from '../middleware/auth.js';
 import {
   SignupService,
   parseDataResidencyRegion,
@@ -116,6 +121,70 @@ export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void
         access_token: tokens.access_token,
         expires_in: tokens.expires_in,
         token_type: tokens.token_type,
+      });
+    }
+  );
+
+  /**
+   * POST /api/v1/auth/verify-email
+   *
+   * Public — the user clicks a link in their email after signup. The
+   * token IS the auth, so we don't require a session here. Validates
+   * + consumes the token, sets users.email_verified_at = NOW().
+   *
+   * Rate-limited the same way as signup: a malicious client trying to
+   * brute-force valid tokens would have to do so behind the per-IP
+   * cap. Token entropy (32 bytes) makes guessing infeasible anyway,
+   * but a low cap is cheap defense in depth.
+   */
+  fastify.post<{ Body: { token: string } }>(
+    '/api/v1/auth/verify-email',
+    {
+      schema: verifyEmailSchema,
+      config: {
+        public: true,
+        rateLimit: { max: 5, timeWindow: '1 minute' },
+      },
+    },
+    async (request, reply) => {
+      if (!config.auth.selfServiceSignupEnabled) {
+        throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
+      }
+      await service.verifyEmail(request.body.token);
+      return sendSuccess(reply, { email_verified: true });
+    }
+  );
+
+  /**
+   * POST /api/v1/auth/resend-verification
+   *
+   * Authenticated — only the signed-in user can ask to resend their
+   * own verification email. Tighter rate limit than signup: an authed
+   * user pressing the button repeatedly should hit a low cap fast,
+   * which both protects SMTP capacity and discourages email-bombing.
+   */
+  fastify.post(
+    '/api/v1/auth/resend-verification',
+    {
+      schema: resendVerificationSchema,
+      preHandler: [requireUser],
+      config: {
+        rateLimit: { max: 3, timeWindow: '1 minute' },
+      },
+    },
+    async (request, reply) => {
+      if (!config.auth.selfServiceSignupEnabled) {
+        throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
+      }
+      // requireUser guarantees authUser is present; non-null assertion
+      // mirrors the pattern used elsewhere in this file.
+      const user = request.authUser!;
+      await service.resendVerification(user.id);
+      // Same 200 whether the user was already verified or we just sent
+      // a fresh token — keeping the response shape stable avoids
+      // leaking verification state in a probe-able way.
+      return sendSuccess(reply, {
+        message: 'If your email is unverified, a new link has been sent.',
       });
     }
   );

--- a/packages/backend/src/api/routes/signup.ts
+++ b/packages/backend/src/api/routes/signup.ts
@@ -23,7 +23,7 @@
  * pre-prod blocker.
  */
 
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { DatabaseClient } from '../../db/client.js';
 import { config } from '../../config.js';
 import { AppError } from '../middleware/error.js';
@@ -62,10 +62,26 @@ export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void
   const region = parseDataResidencyRegion(config.dataResidency.region);
   const service = new SignupService(db, region);
 
+  /**
+   * Shared 403-gate for all three self-service-signup routes. Replaces
+   * the inline `if (!config.auth.selfServiceSignupEnabled)` that used to
+   * sit at the top of each handler — single source of truth that flips
+   * with the env var, no chance of a new sibling route forgetting it.
+   */
+  const requireSelfServiceSignupEnabled = async (
+    _request: FastifyRequest,
+    _reply: FastifyReply
+  ) => {
+    if (!config.auth.selfServiceSignupEnabled) {
+      throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
+    }
+  };
+
   fastify.post<{ Body: SignupBody }>(
     '/api/v1/auth/signup',
     {
       schema: signupSchema,
+      preHandler: [requireSelfServiceSignupEnabled],
       config: {
         public: true,
         // Per-IP burst cap — tighter than the global default because this
@@ -76,10 +92,6 @@ export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void
       },
     },
     async (request, reply) => {
-      if (!config.auth.selfServiceSignupEnabled) {
-        throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
-      }
-
       const input: SignupInput = {
         email: request.body.email,
         password: request.body.password,
@@ -141,15 +153,13 @@ export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void
     '/api/v1/auth/verify-email',
     {
       schema: verifyEmailSchema,
+      preHandler: [requireSelfServiceSignupEnabled],
       config: {
         public: true,
         rateLimit: { max: 5, timeWindow: '1 minute' },
       },
     },
     async (request, reply) => {
-      if (!config.auth.selfServiceSignupEnabled) {
-        throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
-      }
       await service.verifyEmail(request.body.token);
       return sendSuccess(reply, { email_verified: true });
     }
@@ -167,15 +177,16 @@ export function signupRoutes(fastify: FastifyInstance, db: DatabaseClient): void
     '/api/v1/auth/resend-verification',
     {
       schema: resendVerificationSchema,
-      preHandler: [requireUser],
+      // requireSelfServiceSignupEnabled runs FIRST so a 403 is
+      // returned before we touch auth state — keeps the disabled-
+      // mode response uniform with the other two routes regardless
+      // of session.
+      preHandler: [requireSelfServiceSignupEnabled, requireUser],
       config: {
         rateLimit: { max: 3, timeWindow: '1 minute' },
       },
     },
     async (request, reply) => {
-      if (!config.auth.selfServiceSignupEnabled) {
-        throw new AppError('Self-service signup is disabled', 403, 'Forbidden');
-      }
       // requireUser guarantees authUser is present; non-null assertion
       // mirrors the pattern used elsewhere in this file.
       const user = request.authUser!;

--- a/packages/backend/src/api/schemas/auth-schema.ts
+++ b/packages/backend/src/api/schemas/auth-schema.ts
@@ -237,3 +237,55 @@ export const registrationStatusSchema = {
     },
   },
 } as const;
+
+// Bounds: tokens come from `generateShareToken()` which produces 43
+// base64url chars (32 bytes encoded). Allow a small range so a future
+// length tweak doesn't immediately break the schema.
+export const verifyEmailSchema = {
+  body: {
+    type: 'object',
+    required: ['token'],
+    properties: {
+      token: { type: 'string', minLength: 32, maxLength: 128 },
+    },
+    additionalProperties: false,
+  },
+  response: {
+    200: {
+      type: 'object',
+      required: ['success', 'data', 'timestamp'],
+      properties: {
+        success: { type: 'boolean', enum: [true] },
+        data: {
+          type: 'object',
+          required: ['email_verified'],
+          properties: {
+            email_verified: { type: 'boolean', enum: [true] },
+          },
+        },
+        timestamp: { type: 'string', format: 'date-time' },
+      },
+    },
+  },
+} as const;
+
+export const resendVerificationSchema = {
+  // No body — resend acts on the authenticated user.
+  response: {
+    200: {
+      type: 'object',
+      required: ['success', 'data', 'timestamp'],
+      properties: {
+        success: { type: 'boolean', enum: [true] },
+        data: {
+          type: 'object',
+          required: ['message'],
+          properties: {
+            message: { type: 'string' },
+          },
+        },
+        timestamp: { type: 'string', format: 'date-time' },
+      },
+    },
+  },
+} as const;

--- a/packages/backend/src/db/client.ts
+++ b/packages/backend/src/db/client.ts
@@ -19,6 +19,7 @@ import type {
   ShareTokenRepository,
   SystemConfigRepository,
 } from './repositories.js';
+import type { EmailVerificationTokenRepository } from './repositories/email-verification-token.repository.js';
 import type { AuditLogRepository } from './repositories/audit-log.repository.js';
 import type { ProjectIntegrationRepository } from './project-integration.repository.js';
 import type { IntegrationRuleRepository } from './integration-rule.repository.js';
@@ -81,6 +82,7 @@ export interface CoreRepositories {
   users: UserRepository;
   tickets: TicketRepository;
   shareTokens: ShareTokenRepository;
+  emailVerificationTokens: EmailVerificationTokenRepository;
   systemConfig: SystemConfigRepository;
   auditLogs: AuditLogRepository;
   retention: BugReportRepository;
@@ -152,6 +154,7 @@ export class DatabaseClient implements RepositoryRegistry {
   public readonly users!: UserRepository;
   public readonly tickets!: TicketRepository;
   public readonly shareTokens!: ShareTokenRepository;
+  public readonly emailVerificationTokens!: EmailVerificationTokenRepository;
   public readonly projectIntegrations!: ProjectIntegrationRepository;
   public readonly systemConfig!: SystemConfigRepository;
   public readonly auditLogs!: AuditLogRepository;
@@ -204,6 +207,7 @@ export class DatabaseClient implements RepositoryRegistry {
     this.users = this.wrapWithRetry(repositories.users);
     this.tickets = this.wrapWithRetry(repositories.tickets);
     this.shareTokens = this.wrapWithRetry(repositories.shareTokens);
+    this.emailVerificationTokens = this.wrapWithRetry(repositories.emailVerificationTokens);
     this.projectIntegrations = this.wrapWithRetry(repositories.projectIntegrations);
     this.analytics = new AnalyticsService(pool);
     // Data residency repository

--- a/packages/backend/src/db/migrations/019_email_verification.sql
+++ b/packages/backend/src/db/migrations/019_email_verification.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- EMAIL VERIFICATION
+-- ============================================================================
+-- Self-service-signup email verification. Sentry-style non-blocking flow:
+-- the API key + session are issued immediately on signup; verification just
+-- toggles `users.email_verified_at` and dismisses the onboarding banner.
+--
+-- Separate from `organization_requests.email_verified_at` (the enterprise
+-- admin-approval flow) which has its own state machine and email subject
+-- copy. Self-service signup creates a user directly; this table tracks
+-- the post-signup verification token for that user.
+-- ============================================================================
+
+SET search_path TO application;
+
+-- ---------------------------------------------------------------------------
+-- 1. users.email_verified_at — null until the user clicks the email link.
+-- ---------------------------------------------------------------------------
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN users.email_verified_at IS
+  'When the user verified their email via /auth/verify-email. Null until verified. Self-service signup is non-blocking — features stay available before this is set.';
+
+-- ---------------------------------------------------------------------------
+-- 2. email_verification_tokens — one row per outstanding verification email.
+--    Resending invalidates prior unused tokens (handled in service layer).
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token VARCHAR(255) UNIQUE NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    -- One-time-use marker; set when /auth/verify-email consumes the token.
+    -- Distinct from users.email_verified_at: this tracks token consumption
+    -- (per-row), the users column tracks the user-level verified state.
+    consumed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Foreign key + token uniqueness already covered by table definition.
+-- Active-token lookup by user (resend path needs to find latest unconsumed).
+CREATE INDEX IF NOT EXISTS idx_email_verification_user_active
+    ON email_verification_tokens(user_id, created_at DESC)
+    WHERE consumed_at IS NULL;
+
+-- Cleanup: opportunistic delete of expired-and-consumed rows by a future
+-- janitor job. Indexed so the cleanup query stays cheap.
+CREATE INDEX IF NOT EXISTS idx_email_verification_expires
+    ON email_verification_tokens(expires_at);
+
+COMMENT ON TABLE email_verification_tokens IS
+  'One-time tokens for self-service signup email verification. Distinct from organization_requests.';
+COMMENT ON COLUMN email_verification_tokens.token IS
+  'Cryptographically secure random token (43 base64url chars from generateShareToken).';
+COMMENT ON COLUMN email_verification_tokens.consumed_at IS
+  'Set when the token is consumed via /auth/verify-email. Tokens are single-use; resend issues a new row.';
+
+-- Reset search_path
+SET search_path TO application, saas, public;

--- a/packages/backend/src/db/repositories/email-verification-token.repository.ts
+++ b/packages/backend/src/db/repositories/email-verification-token.repository.ts
@@ -50,9 +50,13 @@ export class EmailVerificationTokenRepository extends BaseRepository<
   }
 
   /**
-   * Mark a token consumed. Returns true on success. Idempotent — a second
-   * call with the same id returns false because consumed_at is already set.
-   * The route layer treats false as "already used" and produces 400.
+   * Mark a token consumed. Returns true on success. Returns false when:
+   *  - the token was already consumed, OR
+   *  - the token has expired (defends the race window between
+   *    `findActiveByToken` and this call — without the `expires_at`
+   *    check here, a token that crossed its TTL between the two calls
+   *    would still be marked verified).
+   * The route layer treats false as "invalid or expired" and produces 400.
    */
   async consume(id: string): Promise<boolean> {
     const query = `
@@ -60,6 +64,7 @@ export class EmailVerificationTokenRepository extends BaseRepository<
       SET consumed_at = NOW()
       WHERE id = $1
         AND consumed_at IS NULL
+        AND expires_at > NOW()
     `;
     const result = await this.getClient().query(query, [id]);
     return (result.rowCount ?? 0) > 0;

--- a/packages/backend/src/db/repositories/email-verification-token.repository.ts
+++ b/packages/backend/src/db/repositories/email-verification-token.repository.ts
@@ -1,0 +1,84 @@
+/**
+ * Email Verification Token Repository
+ *
+ * Manages one-time verification tokens for self-service signup. Tokens are
+ * single-use: `consumed_at` flips to NOW() when /auth/verify-email succeeds.
+ * Resend invalidates prior unconsumed tokens for the same user before
+ * issuing a new row, which is enforced in the service layer (the table
+ * has no unique-active constraint to keep the resend path simple).
+ *
+ * Distinct from `share_tokens` (no soft delete here — verification is
+ * single-use and users.email_verified_at is the durable state).
+ */
+
+import type { Pool, PoolClient } from 'pg';
+import { BaseRepository } from './base-repository.js';
+import type {
+  EmailVerificationToken,
+  EmailVerificationTokenInsert,
+  EmailVerificationTokenUpdate,
+} from '../types.js';
+
+export class EmailVerificationTokenRepository extends BaseRepository<
+  EmailVerificationToken,
+  EmailVerificationTokenInsert,
+  EmailVerificationTokenUpdate
+> {
+  constructor(pool: Pool | PoolClient) {
+    super(pool, 'application', 'email_verification_tokens', []);
+  }
+
+  /**
+   * Find a verification token row by token string. Returns null when:
+   *  - the token doesn't exist,
+   *  - the token has already been consumed (single-use), OR
+   *  - the token has expired.
+   *
+   * The combined check lets the route caller produce a single
+   * "invalid or expired" 400 without having to disambiguate.
+   */
+  async findActiveByToken(token: string): Promise<EmailVerificationToken | null> {
+    const query = `
+      SELECT *
+      FROM application.email_verification_tokens
+      WHERE token = $1
+        AND consumed_at IS NULL
+        AND expires_at > NOW()
+    `;
+    const result = await this.getClient().query<EmailVerificationToken>(query, [token]);
+    return result.rows[0] || null;
+  }
+
+  /**
+   * Mark a token consumed. Returns true on success. Idempotent — a second
+   * call with the same id returns false because consumed_at is already set.
+   * The route layer treats false as "already used" and produces 400.
+   */
+  async consume(id: string): Promise<boolean> {
+    const query = `
+      UPDATE application.email_verification_tokens
+      SET consumed_at = NOW()
+      WHERE id = $1
+        AND consumed_at IS NULL
+    `;
+    const result = await this.getClient().query(query, [id]);
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Invalidate all unconsumed tokens for a user by stamping consumed_at.
+   * Called from the resend flow before issuing a new token so a user
+   * who lost the email can always trust the latest link to be the only
+   * one that works. Returns the number of invalidated rows.
+   */
+  async invalidateUnconsumedForUser(userId: string): Promise<number> {
+    const query = `
+      UPDATE application.email_verification_tokens
+      SET consumed_at = NOW()
+      WHERE user_id = $1
+        AND consumed_at IS NULL
+    `;
+    const result = await this.getClient().query(query, [userId]);
+    return result.rowCount ?? 0;
+  }
+}

--- a/packages/backend/src/db/repositories/factory.ts
+++ b/packages/backend/src/db/repositories/factory.ts
@@ -10,6 +10,7 @@ import { BugReportRepository } from './bug-report.repository.js';
 import { UserRepository } from './user.repository.js';
 import { TicketRepository } from './ticket.repository.js';
 import { ShareTokenRepository } from './share-token.repository.js';
+import { EmailVerificationTokenRepository } from './email-verification-token.repository.js';
 import { SystemConfigRepository } from './system-config.repository.js';
 import { AuditLogRepository } from './audit-log.repository.js';
 import { ProjectIntegrationRepository } from '../project-integration.repository.js';
@@ -45,6 +46,7 @@ export interface RepositoryRegistry {
   users: UserRepository;
   tickets: TicketRepository;
   shareTokens: ShareTokenRepository;
+  emailVerificationTokens: EmailVerificationTokenRepository;
   projectIntegrations: ProjectIntegrationRepository;
   systemConfig: SystemConfigRepository;
   auditLogs: AuditLogRepository;
@@ -91,6 +93,7 @@ export function createRepositories(pool: Pool | PoolClient): RepositoryRegistry 
     users: new UserRepository(pool),
     tickets: new TicketRepository(pool),
     shareTokens: new ShareTokenRepository(pool),
+    emailVerificationTokens: new EmailVerificationTokenRepository(pool),
     projectIntegrations: new ProjectIntegrationRepository(pool),
     systemConfig: new SystemConfigRepository(pool),
     auditLogs: new AuditLogRepository(pool),

--- a/packages/backend/src/db/repositories/user.repository.ts
+++ b/packages/backend/src/db/repositories/user.repository.ts
@@ -17,6 +17,23 @@ export class UserRepository extends BaseRepository<User, UserInsert, Partial<Use
   }
 
   /**
+   * Take a row-level lock on the user record, scoped to the current
+   * transaction. Used by flows that need to serialize per-user
+   * mutations (e.g. `resendVerification` — without serialization, two
+   * concurrent resend requests can both invalidate prior tokens and
+   * each insert a new one, leaving multiple "active" tokens for the
+   * same user and breaking the "latest link is the only one that
+   * works" guarantee).
+   *
+   * Must be called inside a `db.transaction(...)` callback — otherwise
+   * the lock is released immediately on statement completion and the
+   * call has no serializing effect.
+   */
+  async lockForUpdate(id: string): Promise<void> {
+    await this.getClient().query('SELECT id FROM application.users WHERE id = $1 FOR UPDATE', [id]);
+  }
+
+  /**
    * Override serialization to handle defaults
    */
   protected serializeForInsert(data: UserInsert): Record<string, unknown> {

--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -68,8 +68,33 @@ export interface User {
   oauth_provider: string | null;
   oauth_id: string | null;
   preferences: UserPreferences;
+  // Set when the user clicks the link in the verification email sent by
+  // self-service signup. Null until verified. Sentry-style non-blocking
+  // — features stay available while this is null; the onboarding banner
+  // dismisses once it's set. See migration 019.
+  email_verified_at: Date | null;
   created_at: Date;
 }
+
+export interface EmailVerificationToken {
+  id: string;
+  user_id: string;
+  token: string;
+  expires_at: Date;
+  consumed_at: Date | null;
+  created_at: Date;
+}
+
+export type EmailVerificationTokenInsert = Omit<
+  EmailVerificationToken,
+  'id' | 'created_at' | 'consumed_at'
+> & {
+  id?: string;
+  created_at?: Date;
+  consumed_at?: Date | null;
+};
+
+export type EmailVerificationTokenUpdate = Partial<Pick<EmailVerificationToken, 'consumed_at'>>;
 
 export interface BugReport {
   id: string;

--- a/packages/backend/src/saas/services/signup-email.service.ts
+++ b/packages/backend/src/saas/services/signup-email.service.ts
@@ -1,0 +1,214 @@
+/**
+ * Signup Email Service
+ *
+ * Sends the post-signup verification email for the self-service flow.
+ * Mirrors `OrgRequestEmailService` (SMTP via nodemailer, locale-aware,
+ * never throws — returns boolean success).
+ *
+ * Distinct service rather than methods on `OrgRequestEmailService`
+ * because the copy and verification URL differ (`/verify-email` vs
+ * `/verify-request`) and the surface is owned by a different flow.
+ * Sharing the SMTP transporter is fine — both services read the same
+ * SMTP_* env vars.
+ */
+
+import nodemailer from 'nodemailer';
+import type { Transporter } from 'nodemailer';
+import { config } from '../../config.js';
+import { getLogger } from '../../logger.js';
+import { ConfigurationError } from '../../api/middleware/error.js';
+
+export type EmailLocale = 'en' | 'ru' | 'kk';
+
+const logger = getLogger();
+
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+// ============================================================================
+// LOCALE STRINGS
+// ============================================================================
+
+interface VerificationStrings {
+  subject: string;
+  heading: string;
+  body: (name: string) => string;
+  button: string;
+  expiryNotice: string;
+  ignoreNotice: string;
+}
+
+const VERIFICATION_STRINGS: Record<EmailLocale, VerificationStrings> = {
+  en: {
+    subject: 'Verify your email — BugSpotter',
+    heading: 'Welcome to BugSpotter',
+    body: (name) =>
+      `Hi ${name}, please confirm your email address so we can finish setting up your account. You can keep using BugSpotter while this is pending — verifying just dismisses the banner.`,
+    button: 'Verify Email',
+    expiryNotice: 'This link expires in 24 hours.',
+    ignoreNotice: "If you didn't sign up for BugSpotter, you can safely ignore this email.",
+  },
+  ru: {
+    subject: 'Подтвердите email — BugSpotter',
+    heading: 'Добро пожаловать в BugSpotter',
+    body: (name) =>
+      `Здравствуйте, ${name}! Подтвердите, пожалуйста, ваш email, чтобы мы завершили настройку аккаунта. Вы можете продолжать пользоваться BugSpotter — подтверждение просто убирает баннер.`,
+    button: 'Подтвердить email',
+    expiryNotice: 'Ссылка действительна 24 часа.',
+    ignoreNotice: 'Если вы не регистрировались в BugSpotter, просто проигнорируйте это письмо.',
+  },
+  kk: {
+    subject: 'Email-ді растаңыз — BugSpotter',
+    heading: 'BugSpotter-ге қош келдіңіз',
+    body: (name) =>
+      `Сәлеметсіз бе, ${name}! Аккаунтыңызды баптауды аяқтау үшін email-ді растаңыз. Сіз BugSpotter-ді пайдалануды жалғастыра аласыз — растау тек баннерді жояды.`,
+    button: 'Email-ді растау',
+    expiryNotice: 'Сілтеме 24 сағат бойы жарамды.',
+    ignoreNotice: 'Егер сіз BugSpotter-ге тіркелмеген болсаңыз, бұл хатты елемей қойсаңыз болады.',
+  },
+};
+
+// ============================================================================
+// SERVICE
+// ============================================================================
+
+export interface SendVerificationEmailParams {
+  recipientEmail: string;
+  contactName: string;
+  token: string;
+  locale?: EmailLocale;
+}
+
+export class SignupEmailService {
+  private transporter: Transporter | null = null;
+
+  private getTransporter(): Transporter {
+    if (this.transporter) {
+      return this.transporter;
+    }
+
+    const host = process.env.SMTP_HOST;
+    const port = parseInt(process.env.SMTP_PORT ?? '587', 10);
+    const user = process.env.SMTP_USER;
+    const pass = process.env.SMTP_PASS;
+
+    if (!host || !user || !pass) {
+      throw new ConfigurationError(
+        'SMTP not configured. Set SMTP_HOST, SMTP_USER, SMTP_PASS env vars.',
+        'SignupEmailService'
+      );
+    }
+
+    const useSecure = port === 465;
+
+    this.transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure: useSecure,
+      requireTLS: port === 587,
+      auth: { user, pass },
+      tls: {
+        rejectUnauthorized: process.env.SMTP_TLS_REJECT_UNAUTHORIZED !== 'false',
+      },
+    });
+
+    return this.transporter;
+  }
+
+  private getFromAddress(): string {
+    return process.env.EMAIL_FROM_ADDRESS ?? 'noreply@bugspotter.io';
+  }
+
+  /**
+   * Send the post-signup email-verification email to the user.
+   *
+   * Returns false (and logs) instead of throwing on any failure — the
+   * signup flow is non-blocking, so a transient SMTP issue must not
+   * roll back the user's API key. They can hit /auth/resend-verification
+   * later if the email never arrives.
+   */
+  async sendVerificationEmail(params: SendVerificationEmailParams): Promise<boolean> {
+    const locale = params.locale ?? 'en';
+    const strings = VERIFICATION_STRINGS[locale];
+    const frontendUrl = config.frontend.url;
+
+    if (!frontendUrl) {
+      logger.warn('FRONTEND_URL not configured — signup verification email not sent', {
+        email: params.recipientEmail,
+      });
+      return false;
+    }
+
+    const verifyUrl = `${frontendUrl}/verify-email?token=${encodeURIComponent(params.token)}`;
+    const safeName = escapeHtml(params.contactName);
+    const safeUrl = escapeHtml(verifyUrl);
+
+    const html = `
+<!DOCTYPE html>
+<html lang="${locale}">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
+  <div style="background: #f8f9fa; border-radius: 8px; padding: 32px; text-align: center;">
+    <h1 style="color: #1a1a2e; margin: 0 0 8px 0; font-size: 24px;">${strings.heading}</h1>
+    <p style="color: #666; margin: 0; font-size: 16px;">${strings.body(safeName)}</p>
+  </div>
+  <div style="text-align: center; margin: 32px 0;">
+    <a href="${safeUrl}" style="background: #4f46e5; color: #fff; padding: 14px 32px; border-radius: 8px; text-decoration: none; font-size: 16px; font-weight: 600; display: inline-block;">
+      ${strings.button}
+    </a>
+  </div>
+  <p style="color: #888; font-size: 13px; text-align: center;">
+    ${strings.expiryNotice}<br>${strings.ignoreNotice}
+  </p>
+</body>
+</html>`.trim();
+
+    const text = [
+      strings.heading,
+      '',
+      strings.body(params.contactName),
+      '',
+      `${strings.button}: ${verifyUrl}`,
+      '',
+      strings.expiryNotice,
+    ].join('\n');
+
+    return this.send(params.recipientEmail, strings.subject, html, text);
+  }
+
+  private async send(to: string, subject: string, html: string, text: string): Promise<boolean> {
+    try {
+      const transporter = this.getTransporter();
+      const result = await transporter.sendMail({
+        from: `BugSpotter <${this.getFromAddress()}>`,
+        to,
+        subject,
+        html,
+        text,
+      });
+
+      logger.info('Signup verification email sent', {
+        to,
+        subject,
+        messageId: result.messageId,
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof ConfigurationError) {
+        logger.warn('SMTP not configured — signup verification email not sent', { to });
+      } else {
+        logger.error('Failed to send signup verification email', {
+          to,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return false;
+    }
+  }
+}

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -42,12 +42,18 @@ import {
   hashKey,
   extractKeyMetadata,
 } from '../../services/api-key/key-crypto.js';
+import { generateShareToken } from '../../utils/token-generator.js';
 import { getLogger } from '../../logger.js';
+import { SignupEmailService, type EmailLocale } from './signup-email.service.js';
 
 const logger = getLogger();
 
 const TRIAL_DURATION_DAYS = 14;
 const DEFAULT_PROJECT_NAME = 'My First Project';
+// 24-hour TTL on verification tokens. Long enough that a user can come
+// back the next morning, short enough that an unread message in a
+// shared inbox doesn't stay valid for weeks.
+const VERIFICATION_TOKEN_TTL_HOURS = 24;
 
 export interface SignupInput {
   email: string;
@@ -78,13 +84,20 @@ export interface SignupResult {
 export class SignupService {
   private readonly subdomainService: SubdomainService;
   private readonly spamFilter: SpamFilterService;
+  private readonly emailService: SignupEmailService;
 
   constructor(
     private readonly db: DatabaseClient,
-    private readonly region: DataResidencyRegion
+    private readonly region: DataResidencyRegion,
+    /**
+     * Override hook for tests — mocks the email service so unit tests
+     * don't need SMTP env vars. Production wiring uses the default.
+     */
+    emailService?: SignupEmailService
   ) {
     this.subdomainService = new SubdomainService(db);
     this.spamFilter = new SpamFilterService(db);
+    this.emailService = emailService ?? new SignupEmailService();
   }
 
   /**
@@ -115,6 +128,11 @@ export class SignupService {
     const now = new Date();
     const trialEnd = addDays(now, TRIAL_DURATION_DAYS);
 
+    // Generated outside the transaction so the same value is shared
+    // between the in-txn DB row and the post-commit email.
+    const verificationToken = generateShareToken();
+    const verificationExpiresAt = addHours(now, VERIFICATION_TOKEN_TTL_HOURS);
+
     let result: SignupResult;
     try {
       result = await this.db.transaction(async (tx) => {
@@ -123,6 +141,16 @@ export class SignupService {
           name: input.name?.trim() || null,
           password_hash: passwordHash,
           role: 'user',
+        });
+
+        // Insert the verification token in the same transaction as the
+        // user create, so we can never end up with a user that has no
+        // way to verify (and never with a token row referencing a
+        // user that doesn't exist if the txn rolls back).
+        await tx.emailVerificationTokens.create({
+          user_id: user.id,
+          token: verificationToken,
+          expires_at: verificationExpiresAt,
         });
 
         const organization = await tx.organizations.create({
@@ -228,7 +256,117 @@ export class SignupService {
       projectId: result.project.id,
     });
 
+    // Fire-and-forget verification email. Non-blocking by design:
+    // signup is "Sentry-style" — a transient SMTP outage must never
+    // roll back the user's API key. The user can hit
+    // /auth/resend-verification later if the email never arrives.
+    void this.emailService
+      .sendVerificationEmail({
+        recipientEmail: result.user.email,
+        contactName: result.user.name || result.user.email.split('@')[0] || 'there',
+        token: verificationToken,
+      })
+      .catch((err) => {
+        logger.error('Failed to send signup verification email (non-blocking)', {
+          userId: result.user.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+
     return result;
+  }
+
+  /**
+   * Consume a verification token: mark it used, set
+   * `users.email_verified_at = NOW()`, return the user id.
+   *
+   * Idempotent only in the "already verified" sense — calling twice
+   * with the same valid token, the second call returns 400 because
+   * the token is single-use. Calling /verify-email after the user is
+   * already verified via a different token also returns 400. Both
+   * cases produce the same generic message to avoid leaking which
+   * tokens previously existed.
+   */
+  async verifyEmail(rawToken: string): Promise<{ user_id: string }> {
+    const token = rawToken.trim();
+    if (token.length === 0) {
+      throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+    }
+
+    return this.db.transaction(async (tx) => {
+      const tokenRow = await tx.emailVerificationTokens.findActiveByToken(token);
+      if (!tokenRow) {
+        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+      }
+
+      const consumed = await tx.emailVerificationTokens.consume(tokenRow.id);
+      if (!consumed) {
+        // Race with another verify-email request for the same token.
+        // The other side wins; we behave as though the token was already
+        // consumed, which it was.
+        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+      }
+
+      await tx.users.update(tokenRow.user_id, {
+        email_verified_at: new Date(),
+      });
+
+      return { user_id: tokenRow.user_id };
+    });
+  }
+
+  /**
+   * Issue a fresh verification token + email for a user. Called from
+   * /auth/resend-verification after the user clicks "Didn't receive
+   * the email?" in onboarding.
+   *
+   * Invalidates prior unconsumed tokens so the most recent email is
+   * the only one that works — prevents an attacker who intercepted
+   * an old token from using it after the user re-requests.
+   *
+   * Returns silently when the user is already verified; the caller
+   * (route handler) treats both verified and not-yet-verified as the
+   * same 200 response so we don't leak verification state.
+   */
+  async resendVerification(userId: string, locale?: EmailLocale): Promise<void> {
+    const user = await this.db.users.findById(userId);
+    if (!user) {
+      // Tighten down — if the JWT carries a user id that no longer
+      // resolves, something is wrong with the session. Don't reveal.
+      throw new AppError('User not found', 404, 'NotFound');
+    }
+    if (user.email_verified_at) {
+      // Already verified — silently no-op. The route returns 200 in
+      // both cases so the client UI doesn't have to branch.
+      return;
+    }
+
+    const newToken = generateShareToken();
+    const expiresAt = addHours(new Date(), VERIFICATION_TOKEN_TTL_HOURS);
+
+    await this.db.transaction(async (tx) => {
+      await tx.emailVerificationTokens.invalidateUnconsumedForUser(user.id);
+      await tx.emailVerificationTokens.create({
+        user_id: user.id,
+        token: newToken,
+        expires_at: expiresAt,
+      });
+    });
+
+    // Fire-and-forget — same non-blocking rationale as signup.
+    void this.emailService
+      .sendVerificationEmail({
+        recipientEmail: user.email,
+        contactName: user.name || user.email.split('@')[0] || 'there',
+        token: newToken,
+        locale,
+      })
+      .catch((err) => {
+        logger.error('Failed to send resend verification email (non-blocking)', {
+          userId: user.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
   }
 
   /**
@@ -310,6 +448,12 @@ export class SignupService {
 function addDays(base: Date, days: number): Date {
   const end = new Date(base);
   end.setDate(end.getDate() + days);
+  return end;
+}
+
+function addHours(base: Date, hours: number): Date {
+  const end = new Date(base);
+  end.setHours(end.getHours() + hours);
   return end;
 }
 

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -44,7 +44,21 @@ import {
 } from '../../services/api-key/key-crypto.js';
 import { generateShareToken } from '../../utils/token-generator.js';
 import { getLogger } from '../../logger.js';
-import { SignupEmailService, type EmailLocale } from './signup-email.service.js';
+import {
+  SignupEmailService,
+  type EmailLocale,
+  type SendVerificationEmailParams,
+} from './signup-email.service.js';
+
+/**
+ * Minimal interface so tests can pass a stub without casting through
+ * `as never`. The concrete `SignupEmailService` has private fields that
+ * structural mocks can't satisfy; depending on the interface keeps the
+ * test API clean.
+ */
+export interface IVerificationEmailSender {
+  sendVerificationEmail(params: SendVerificationEmailParams): Promise<boolean>;
+}
 
 const logger = getLogger();
 
@@ -84,7 +98,7 @@ export interface SignupResult {
 export class SignupService {
   private readonly subdomainService: SubdomainService;
   private readonly spamFilter: SpamFilterService;
-  private readonly emailService: SignupEmailService;
+  private readonly emailService: IVerificationEmailSender;
 
   constructor(
     private readonly db: DatabaseClient,
@@ -92,12 +106,22 @@ export class SignupService {
     /**
      * Override hook for tests — mocks the email service so unit tests
      * don't need SMTP env vars. Production wiring uses the default.
+     * Typed as the narrow interface so test stubs don't need casts.
      */
-    emailService?: SignupEmailService
+    emailService?: IVerificationEmailSender
   ) {
     this.subdomainService = new SubdomainService(db);
     this.spamFilter = new SpamFilterService(db);
     this.emailService = emailService ?? new SignupEmailService();
+  }
+
+  /**
+   * Build a friendly display name for verification emails. Falls back
+   * to the local-part of the email, then to "there" so a missing name
+   * never produces a creepy "Hi ," greeting.
+   */
+  private getContactNameForEmail(user: { name: string | null; email: string }): string {
+    return user.name || user.email.split('@')[0] || 'there';
   }
 
   /**
@@ -263,7 +287,7 @@ export class SignupService {
     void this.emailService
       .sendVerificationEmail({
         recipientEmail: result.user.email,
-        contactName: result.user.name || result.user.email.split('@')[0] || 'there',
+        contactName: this.getContactNameForEmail(result.user),
         token: verificationToken,
       })
       .catch((err) => {
@@ -280,12 +304,15 @@ export class SignupService {
    * Consume a verification token: mark it used, set
    * `users.email_verified_at = NOW()`, return the user id.
    *
-   * Idempotent only in the "already verified" sense — calling twice
-   * with the same valid token, the second call returns 400 because
-   * the token is single-use. Calling /verify-email after the user is
-   * already verified via a different token also returns 400. Both
-   * cases produce the same generic message to avoid leaking which
-   * tokens previously existed.
+   * Returns 400 with the same generic "invalid or expired" message in
+   * every failure case (unknown token, expired, already consumed,
+   * consume race) so we don't leak which tokens previously existed.
+   *
+   * If the user was already verified via some other path (admin
+   * backfill, or a stale unconsumed token surviving an unclean state),
+   * we refuse to consume the token and return the same generic 400.
+   * Otherwise an active token would still flip `email_verified_at`,
+   * overwriting the prior verification timestamp for no reason.
    */
   async verifyEmail(rawToken: string): Promise<{ user_id: string }> {
     const token = rawToken.trim();
@@ -299,11 +326,22 @@ export class SignupService {
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
+      // Already-verified guard. Match the docstring: refuse rather
+      // than re-stamp `email_verified_at`. We don't consume the
+      // token in this branch — leaving it active is harmless (it'll
+      // expire) and consuming silently would be a side effect with
+      // no observable benefit.
+      const user = await tx.users.findById(tokenRow.user_id);
+      if (user?.email_verified_at) {
+        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+      }
+
       const consumed = await tx.emailVerificationTokens.consume(tokenRow.id);
       if (!consumed) {
-        // Race with another verify-email request for the same token.
-        // The other side wins; we behave as though the token was already
-        // consumed, which it was.
+        // Race with another verify-email request for the same token,
+        // OR the token expired in the gap between findActive and
+        // consume (which now also rechecks expires_at). Same generic
+        // 400 either way.
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
@@ -329,41 +367,66 @@ export class SignupService {
    * same 200 response so we don't leak verification state.
    */
   async resendVerification(userId: string, locale?: EmailLocale): Promise<void> {
-    const user = await this.db.users.findById(userId);
-    if (!user) {
-      // Tighten down — if the JWT carries a user id that no longer
-      // resolves, something is wrong with the session. Don't reveal.
-      throw new AppError('User not found', 404, 'NotFound');
-    }
-    if (user.email_verified_at) {
-      // Already verified — silently no-op. The route returns 200 in
-      // both cases so the client UI doesn't have to branch.
-      return;
-    }
-
     const newToken = generateShareToken();
     const expiresAt = addHours(new Date(), VERIFICATION_TOKEN_TTL_HOURS);
 
+    // Capture data we need for the post-commit email send. Set inside
+    // the txn only when we actually issued a new token; otherwise the
+    // post-commit branch below skips the send.
+    let recipientEmail: string | null = null;
+    let contactName = 'there';
+
     await this.db.transaction(async (tx) => {
+      // Lock the user row for the duration of this transaction. Two
+      // concurrent resend requests for the same user without this
+      // lock can both invalidate prior tokens (each seeing 0 active
+      // tokens) and each insert a new one — leaving the user with
+      // multiple "active" tokens and breaking the "latest link is
+      // the only one that works" guarantee. Adding a partial UNIQUE
+      // index would make the second insert fail visibly with 500;
+      // serializing here keeps both succeed-paths and last-writer
+      // semantics.
+      await tx.users.lockForUpdate(userId);
+
+      const user = await tx.users.findById(userId);
+      if (!user) {
+        // JWT carries a user id that no longer resolves — session is
+        // stale. Throw inside the txn so it rolls back cleanly.
+        throw new AppError('User not found', 404, 'NotFound');
+      }
+      if (user.email_verified_at) {
+        // Already verified — silently no-op. The route returns 200
+        // in both cases so the client UI doesn't have to branch.
+        return;
+      }
+
       await tx.emailVerificationTokens.invalidateUnconsumedForUser(user.id);
       await tx.emailVerificationTokens.create({
         user_id: user.id,
         token: newToken,
         expires_at: expiresAt,
       });
+
+      recipientEmail = user.email;
+      contactName = this.getContactNameForEmail(user);
     });
+
+    if (!recipientEmail) {
+      // Already-verified branch — nothing to send.
+      return;
+    }
 
     // Fire-and-forget — same non-blocking rationale as signup.
     void this.emailService
       .sendVerificationEmail({
-        recipientEmail: user.email,
-        contactName: user.name || user.email.split('@')[0] || 'there',
+        recipientEmail,
+        contactName,
         token: newToken,
         locale,
       })
       .catch((err) => {
         logger.error('Failed to send resend verification email (non-blocking)', {
-          userId: user.id,
+          userId,
           error: err instanceof Error ? err.message : String(err),
         });
       });

--- a/packages/backend/tests/api/routes/signup.route.test.ts
+++ b/packages/backend/tests/api/routes/signup.route.test.ts
@@ -109,10 +109,29 @@ function createHappyMockDb(): DatabaseClient {
       })),
       logAudit: vi.fn(async () => undefined),
     },
+    emailVerificationTokens: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({
+        id: 'evt-uuid',
+        consumed_at: null,
+        created_at: new Date(),
+        ...d,
+      })),
+      findActiveByToken: vi.fn(async () => null),
+      consume: vi.fn(async () => true),
+      invalidateUnconsumedForUser: vi.fn(async () => 0),
+    },
   };
 
+  // tx.users.update is used by verifyEmail to stamp users.email_verified_at.
+  (tx as unknown as { users: Record<string, unknown> }).users.update = vi.fn(
+    async (id: string, d: Record<string, unknown>) => ({ id, ...d })
+  );
+
   return {
-    users: { findByEmail: vi.fn(async () => null) },
+    users: {
+      findByEmail: vi.fn(async () => null),
+      findById: vi.fn(async () => null),
+    },
     organizations: { isSubdomainAvailable: vi.fn(async () => true) },
     organizationRequests: {
       countRecentByIp: vi.fn(async () => 0),
@@ -136,6 +155,12 @@ async function buildServer(db: DatabaseClient): Promise<FastifyInstance> {
     timeWindow: '1 minute',
   });
   await server.register(jwt, { secret: mockConfig.jwt.secret });
+  // Mirror production: an onRequest hook reads the Bearer token (if
+  // present) and populates request.authUser. Public routes still work
+  // without one — `authUser` is just undefined. We need this for the
+  // resend-verification tests, which gate on requireUser.
+  const { createAuthMiddleware } = await import('../../../src/api/middleware/auth.js');
+  server.addHook('onRequest', createAuthMiddleware(db));
   server.setErrorHandler(errorHandler);
   signupRoutes(server, db);
   await server.ready();
@@ -263,5 +288,189 @@ describe('POST /api/v1/auth/signup (route smoke)', () => {
     });
 
     expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/v1/auth/verify-email (route smoke)', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    mockConfig.auth.selfServiceSignupEnabled = true;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+    }
+  });
+
+  it('returns 200 with email_verified=true when the token is valid', async () => {
+    const db = createHappyMockDb();
+    // Wire findActiveByToken on the in-memory tx object the mock uses.
+    // The mock's `transaction` callback is the only path that sees `tx`,
+    // so we reach into the same closure's tx by replacing the
+    // transaction implementation with one that exposes the same shape.
+    const tx = {
+      users: {
+        update: vi.fn(async (id: string, d: Record<string, unknown>) => ({ id, ...d })),
+      },
+      emailVerificationTokens: {
+        findActiveByToken: vi.fn(async () => ({
+          id: 'evt-1',
+          user_id: 'user-uuid',
+          token: 'a'.repeat(43),
+          expires_at: new Date(Date.now() + 60_000),
+          consumed_at: null,
+          created_at: new Date(),
+        })),
+        consume: vi.fn(async () => true),
+        create: vi.fn(),
+        invalidateUnconsumedForUser: vi.fn(),
+      },
+    };
+    (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      async (cb: (t: unknown) => Promise<unknown>) => cb(tx)
+    );
+
+    server = await buildServer(db);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/verify-email',
+      payload: { token: 'a'.repeat(43) },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data.email_verified).toBe(true);
+  });
+
+  it('returns 400 for an unknown token', async () => {
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/verify-email',
+      payload: { token: 'a'.repeat(43) },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 when SELF_SERVICE_SIGNUP_ENABLED is false', async () => {
+    mockConfig.auth.selfServiceSignupEnabled = false;
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/verify-email',
+      payload: { token: 'a'.repeat(43) },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 when token is shorter than the minLength', async () => {
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/verify-email',
+      payload: { token: 'too-short' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/v1/auth/resend-verification (route smoke)', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    mockConfig.auth.selfServiceSignupEnabled = true;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+    }
+  });
+
+  function makeAuthHeader(s: FastifyInstance) {
+    // handleJwtAuth (api/middleware/auth/handlers.ts) reads
+    // `decoded.userId`. Match that, not `id`.
+    return `Bearer ${s.jwt.sign({ userId: 'user-uuid' })}`;
+  }
+
+  it('returns 401 without an Authorization header', async () => {
+    server = await buildServer(createHappyMockDb());
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/resend-verification',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 200 + generic message when user is unverified', async () => {
+    const db = createHappyMockDb();
+    (db.users.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'user-uuid',
+      email: 'founder@acme.com',
+      name: 'Jane',
+      email_verified_at: null,
+    });
+    server = await buildServer(db);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/resend-verification',
+      headers: { authorization: makeAuthHeader(server) },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(typeof res.json().data.message).toBe('string');
+  });
+
+  it('returns 200 + generic message when user is already verified (no leak)', async () => {
+    const db = createHappyMockDb();
+    (db.users.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'user-uuid',
+      email: 'founder@acme.com',
+      name: 'Jane',
+      email_verified_at: new Date(),
+    });
+    server = await buildServer(db);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/resend-verification',
+      headers: { authorization: makeAuthHeader(server) },
+    });
+
+    // SAME response shape and status whether verified or not — prevents
+    // a probe that distinguishes unverified accounts from verified ones.
+    expect(res.statusCode).toBe(200);
+    expect(typeof res.json().data.message).toBe('string');
+  });
+
+  it('returns 403 when SELF_SERVICE_SIGNUP_ENABLED is false', async () => {
+    mockConfig.auth.selfServiceSignupEnabled = false;
+    const db = createHappyMockDb();
+    (db.users.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'user-uuid',
+      email: 'founder@acme.com',
+      name: 'Jane',
+      email_verified_at: null,
+    });
+    server = await buildServer(db);
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/auth/resend-verification',
+      headers: { authorization: makeAuthHeader(server) },
+    });
+
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/packages/backend/tests/api/routes/signup.route.test.ts
+++ b/packages/backend/tests/api/routes/signup.route.test.ts
@@ -122,10 +122,12 @@ function createHappyMockDb(): DatabaseClient {
     },
   };
 
-  // tx.users.update is used by verifyEmail to stamp users.email_verified_at.
-  (tx as unknown as { users: Record<string, unknown> }).users.update = vi.fn(
-    async (id: string, d: Record<string, unknown>) => ({ id, ...d })
-  );
+  // Extend tx.users with the methods used outside signup() — verifyEmail
+  // reads + writes; resendVerification locks first, then reads.
+  const txUsers = (tx as unknown as { users: Record<string, unknown> }).users;
+  txUsers.update = vi.fn(async (id: string, d: Record<string, unknown>) => ({ id, ...d }));
+  txUsers.findById = vi.fn(async () => null);
+  txUsers.lockForUpdate = vi.fn(async () => undefined);
 
   return {
     users: {
@@ -313,6 +315,15 @@ describe('POST /api/v1/auth/verify-email (route smoke)', () => {
     const tx = {
       users: {
         update: vi.fn(async (id: string, d: Record<string, unknown>) => ({ id, ...d })),
+        // verifyEmail's already-verified guard reads the user. Return
+        // an unverified user so we proceed past the guard.
+        findById: vi.fn(async () => ({
+          id: 'user-uuid',
+          email: 'founder@acme.com',
+          name: 'Jane',
+          email_verified_at: null,
+        })),
+        lockForUpdate: vi.fn(async () => undefined),
       },
       emailVerificationTokens: {
         findActiveByToken: vi.fn(async () => ({
@@ -401,6 +412,49 @@ describe('POST /api/v1/auth/resend-verification (route smoke)', () => {
     return `Bearer ${s.jwt.sign({ userId: 'user-uuid' })}`;
   }
 
+  /**
+   * Replace `db.transaction` with one that runs the callback against
+   * a tx object whose `users.findById` returns the supplied user
+   * shape. The service's `resendVerification` reads via tx (so it
+   * sees consistent state under the row lock), so a top-level
+   * `db.users.findById` mock wouldn't be exercised.
+   */
+  function buildResendDb(verified: boolean): DatabaseClient {
+    const db = createHappyMockDb();
+    const txUser = {
+      id: 'user-uuid',
+      email: 'founder@acme.com',
+      name: 'Jane',
+      email_verified_at: verified ? new Date() : null,
+    };
+    // The auth middleware (handleJwtAuth) reads via db.users.findById,
+    // NOT through a transaction — has to succeed before the route
+    // body runs at all, otherwise we'd get 401 instead of 200/403.
+    (db.users.findById as ReturnType<typeof vi.fn>).mockResolvedValue(txUser);
+    const tx = {
+      users: {
+        lockForUpdate: vi.fn(async () => undefined),
+        findById: vi.fn(async () => txUser),
+        update: vi.fn(async (id: string, d: Record<string, unknown>) => ({ id, ...d })),
+      },
+      emailVerificationTokens: {
+        invalidateUnconsumedForUser: vi.fn(async () => 0),
+        create: vi.fn(async (d: Record<string, unknown>) => ({
+          id: 'evt-uuid',
+          consumed_at: null,
+          created_at: new Date(),
+          ...d,
+        })),
+        findActiveByToken: vi.fn(),
+        consume: vi.fn(),
+      },
+    };
+    (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      async (cb: (t: unknown) => Promise<unknown>) => cb(tx)
+    );
+    return db;
+  }
+
   it('returns 401 without an Authorization header', async () => {
     server = await buildServer(createHappyMockDb());
 
@@ -413,14 +467,7 @@ describe('POST /api/v1/auth/resend-verification (route smoke)', () => {
   });
 
   it('returns 200 + generic message when user is unverified', async () => {
-    const db = createHappyMockDb();
-    (db.users.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
-      id: 'user-uuid',
-      email: 'founder@acme.com',
-      name: 'Jane',
-      email_verified_at: null,
-    });
-    server = await buildServer(db);
+    server = await buildServer(buildResendDb(false));
 
     const res = await server.inject({
       method: 'POST',
@@ -433,14 +480,7 @@ describe('POST /api/v1/auth/resend-verification (route smoke)', () => {
   });
 
   it('returns 200 + generic message when user is already verified (no leak)', async () => {
-    const db = createHappyMockDb();
-    (db.users.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
-      id: 'user-uuid',
-      email: 'founder@acme.com',
-      name: 'Jane',
-      email_verified_at: new Date(),
-    });
-    server = await buildServer(db);
+    server = await buildServer(buildResendDb(true));
 
     const res = await server.inject({
       method: 'POST',
@@ -456,14 +496,7 @@ describe('POST /api/v1/auth/resend-verification (route smoke)', () => {
 
   it('returns 403 when SELF_SERVICE_SIGNUP_ENABLED is false', async () => {
     mockConfig.auth.selfServiceSignupEnabled = false;
-    const db = createHappyMockDb();
-    (db.users.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
-      id: 'user-uuid',
-      email: 'founder@acme.com',
-      name: 'Jane',
-      email_verified_at: null,
-    });
-    server = await buildServer(db);
+    server = await buildServer(buildResendDb(false));
 
     const res = await server.inject({
       method: 'POST',

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -11,7 +11,10 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { SignupService } from '../../src/saas/services/signup.service.js';
+import {
+  SignupService,
+  type IVerificationEmailSender,
+} from '../../src/saas/services/signup.service.js';
 import type { DatabaseClient } from '../../src/db/client.js';
 import { DATA_RESIDENCY_REGION } from '../../src/db/types.js';
 import { hashKey } from '../../src/services/api-key/key-crypto.js';
@@ -165,10 +168,13 @@ function createMockDb(overrides: DbOverrides = {}): {
     },
   };
 
-  // Make `tx.users.update` available for verifyEmail's email_verified_at write.
-  (tx as unknown as { users: Record<string, unknown> }).users.update = vi.fn(
-    async (id: string, data: unknown) => ({ id, ...(data as object) })
-  );
+  // Extend tx.users with the methods used outside signup() — verifyEmail
+  // reads + writes, resendVerification locks first then reads. Each
+  // delegates to the same override-aware function as the db-level repo.
+  const txUsers = (tx as unknown as { users: Record<string, unknown> }).users;
+  txUsers.update = vi.fn(async (id: string, data: unknown) => ({ id, ...(data as object) }));
+  txUsers.findById = vi.fn(overrides.findById ?? (async () => null));
+  txUsers.lockForUpdate = vi.fn(async () => undefined);
 
   const db = {
     users: {
@@ -208,13 +214,14 @@ function createMockDb(overrides: DbOverrides = {}): {
 // Tests
 // ---------------------------------------------------------------------------
 
-// Stub email service — real one tries to construct an SMTP transporter
-// from env vars and would throw `ConfigurationError` in unit tests
-// (the .catch in signup.service swallows it, but using a stub keeps
-// the test output clean and lets us assert on call counts).
+// Stub email service — using the real service would try to construct
+// an SMTP transporter from env vars (the real `send()` catches
+// ConfigurationError internally and returns false, so it wouldn't
+// throw). The stub avoids the SMTP/log noise and lets us assert
+// deterministically on call counts.
 function createMockEmailService(): {
   send: ReturnType<typeof vi.fn>;
-  service: { sendVerificationEmail: (params: unknown) => Promise<boolean> };
+  service: IVerificationEmailSender;
 } {
   const send = vi.fn(async () => true);
   return {
@@ -231,7 +238,7 @@ describe('SignupService', () => {
   beforeEach(() => {
     mock = createMockDb();
     email = createMockEmailService();
-    service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+    service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
   });
 
   describe('happy path', () => {
@@ -560,7 +567,7 @@ describe('SignupService', () => {
           }),
           consumeToken: async () => true,
         });
-        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         const result = await service.verifyEmail('good');
         expect(result).toEqual({ user_id: fakeUserId });
@@ -568,7 +575,7 @@ describe('SignupService', () => {
 
       it('rejects an unknown token with 400', async () => {
         mock = createMockDb({ findActiveByToken: async () => null });
-        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('nope')).rejects.toMatchObject({
           statusCode: 400,
@@ -578,7 +585,7 @@ describe('SignupService', () => {
       it('rejects an empty/whitespace token with 400 without hitting the DB', async () => {
         const findSpy = vi.fn();
         mock = createMockDb({ findActiveByToken: findSpy });
-        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('   ')).rejects.toMatchObject({ statusCode: 400 });
         expect(findSpy).not.toHaveBeenCalled();
@@ -600,7 +607,7 @@ describe('SignupService', () => {
           }),
           consumeToken: async () => false,
         });
-        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
       });
@@ -618,7 +625,7 @@ describe('SignupService', () => {
           }),
           invalidateUnconsumed: invalidate,
         });
-        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await service.resendVerification('user-uuid');
 
@@ -640,7 +647,7 @@ describe('SignupService', () => {
             email_verified_at: new Date(),
           }),
         });
-        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.resendVerification('user-uuid')).resolves.toBeUndefined();
         expect(mock.log.emailVerificationTokens).toHaveLength(0);
@@ -649,7 +656,7 @@ describe('SignupService', () => {
 
       it('throws 404 when the user no longer exists (stale JWT)', async () => {
         mock = createMockDb({ findById: async () => null });
-        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.resendVerification('ghost-uuid')).rejects.toMatchObject({
           statusCode: 404,

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -37,6 +37,7 @@ interface InsertLog {
   projects: unknown[];
   apiKeys: unknown[];
   apiKeyAudits: unknown[];
+  emailVerificationTokens: unknown[];
 }
 
 function validInput() {
@@ -52,6 +53,10 @@ function validInput() {
 
 interface DbOverrides {
   findByEmail?: () => Promise<unknown>;
+  findById?: () => Promise<unknown>;
+  findActiveByToken?: () => Promise<unknown>;
+  consumeToken?: () => Promise<boolean>;
+  invalidateUnconsumed?: () => Promise<number>;
   countRecentByIp?: () => Promise<number>;
   findPendingByEmail?: () => Promise<unknown>;
   isSubdomainTaken?: () => Promise<boolean>;
@@ -74,6 +79,7 @@ function createMockDb(overrides: DbOverrides = {}): {
     projects: [],
     apiKeys: [],
     apiKeyAudits: [],
+    emailVerificationTokens: [],
   };
   const transactionCalled = { value: 0 };
 
@@ -142,11 +148,32 @@ function createMockDb(overrides: DbOverrides = {}): {
         log.apiKeyAudits.push(data);
       }),
     },
+    emailVerificationTokens: {
+      create: vi.fn(async (data: unknown) => {
+        const row = {
+          id: 'evt-uuid',
+          consumed_at: null,
+          created_at: new Date(),
+          ...(data as object),
+        };
+        log.emailVerificationTokens.push(row);
+        return row;
+      }),
+      findActiveByToken: vi.fn(overrides.findActiveByToken ?? (async () => null)),
+      consume: vi.fn(overrides.consumeToken ?? (async () => true)),
+      invalidateUnconsumedForUser: vi.fn(overrides.invalidateUnconsumed ?? (async () => 0)),
+    },
   };
+
+  // Make `tx.users.update` available for verifyEmail's email_verified_at write.
+  (tx as unknown as { users: Record<string, unknown> }).users.update = vi.fn(
+    async (id: string, data: unknown) => ({ id, ...(data as object) })
+  );
 
   const db = {
     users: {
       findByEmail: vi.fn(overrides.findByEmail ?? (async () => null)),
+      findById: vi.fn(overrides.findById ?? (async () => null)),
     },
     organizations: {
       isSubdomainAvailable: vi.fn(overrides.orgIsSubdomainAvailable ?? (async () => true)),
@@ -181,13 +208,30 @@ function createMockDb(overrides: DbOverrides = {}): {
 // Tests
 // ---------------------------------------------------------------------------
 
+// Stub email service — real one tries to construct an SMTP transporter
+// from env vars and would throw `ConfigurationError` in unit tests
+// (the .catch in signup.service swallows it, but using a stub keeps
+// the test output clean and lets us assert on call counts).
+function createMockEmailService(): {
+  send: ReturnType<typeof vi.fn>;
+  service: { sendVerificationEmail: (params: unknown) => Promise<boolean> };
+} {
+  const send = vi.fn(async () => true);
+  return {
+    send,
+    service: { sendVerificationEmail: send },
+  };
+}
+
 describe('SignupService', () => {
   let mock: ReturnType<typeof createMockDb>;
   let service: SignupService;
+  let email: ReturnType<typeof createMockEmailService>;
 
   beforeEach(() => {
     mock = createMockDb();
-    service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
+    email = createMockEmailService();
+    service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
   });
 
   describe('happy path', () => {
@@ -467,6 +511,150 @@ describe('SignupService', () => {
       service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ);
 
       await expect(service.signup(validInput())).rejects.toThrow(/simulated commit failure/);
+    });
+  });
+
+  describe('email verification', () => {
+    describe('signup → verification token row', () => {
+      it('creates exactly one verification token row inside the signup transaction', async () => {
+        await service.signup(validInput());
+
+        expect(mock.log.emailVerificationTokens).toHaveLength(1);
+        const row = mock.log.emailVerificationTokens[0] as Record<string, unknown>;
+        // user_id binds to the user just created in the same transaction
+        expect(row.user_id).toBe('user-uuid');
+        expect(typeof row.token).toBe('string');
+        // 24h TTL — defensively assert it's in the future, not exactly 24h
+        // (so a small clock-drift in tests doesn't flake the assertion).
+        expect((row.expires_at as Date).getTime()).toBeGreaterThan(Date.now());
+      });
+
+      it('fires the verification email exactly once on success', async () => {
+        await service.signup(validInput());
+        expect(email.send).toHaveBeenCalledTimes(1);
+        const arg = email.send.mock.calls[0][0] as Record<string, unknown>;
+        expect(arg.recipientEmail).toBe('founder@acme.com');
+        expect(typeof arg.token).toBe('string');
+      });
+
+      it('does not fail signup when email send rejects (non-blocking)', async () => {
+        email.send.mockRejectedValueOnce(new Error('smtp down'));
+        // signup must still resolve with the API key — Sentry-style.
+        await expect(service.signup(validInput())).resolves.toMatchObject({
+          api_key: expect.any(String),
+        });
+      });
+    });
+
+    describe('verifyEmail', () => {
+      it('marks the token consumed and stamps users.email_verified_at on success', async () => {
+        const fakeUserId = 'user-uuid';
+        mock = createMockDb({
+          findActiveByToken: async () => ({
+            id: 'evt-1',
+            user_id: fakeUserId,
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          consumeToken: async () => true,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+
+        const result = await service.verifyEmail('good');
+        expect(result).toEqual({ user_id: fakeUserId });
+      });
+
+      it('rejects an unknown token with 400', async () => {
+        mock = createMockDb({ findActiveByToken: async () => null });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+
+        await expect(service.verifyEmail('nope')).rejects.toMatchObject({
+          statusCode: 400,
+        });
+      });
+
+      it('rejects an empty/whitespace token with 400 without hitting the DB', async () => {
+        const findSpy = vi.fn();
+        mock = createMockDb({ findActiveByToken: findSpy });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+
+        await expect(service.verifyEmail('   ')).rejects.toMatchObject({ statusCode: 400 });
+        expect(findSpy).not.toHaveBeenCalled();
+      });
+
+      it('treats a race-lost consume as already-used and returns 400', async () => {
+        // findActiveByToken returns a row, but consume() returns false —
+        // simulates two parallel verify-email requests for the same token
+        // where the other side already won. Caller must not proceed to
+        // marking the user verified.
+        mock = createMockDb({
+          findActiveByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          consumeToken: async () => false,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+
+        await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
+      });
+    });
+
+    describe('resendVerification', () => {
+      it('invalidates prior tokens, issues a fresh one, and sends the email', async () => {
+        const invalidate = vi.fn(async () => 1);
+        mock = createMockDb({
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: null,
+          }),
+          invalidateUnconsumed: invalidate,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+
+        await service.resendVerification('user-uuid');
+
+        expect(invalidate).toHaveBeenCalledWith('user-uuid');
+        expect(mock.log.emailVerificationTokens).toHaveLength(1);
+        // Fire-and-forget — the .catch inside resendVerification means
+        // the await on resendVerification resolves before the send promise
+        // settles. Wait a microtask tick for the dispatch.
+        await new Promise((r) => setImmediate(r));
+        expect(email.send).toHaveBeenCalledTimes(1);
+      });
+
+      it('no-ops silently when the user is already verified (no leak of state)', async () => {
+        mock = createMockDb({
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: new Date(),
+          }),
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+
+        await expect(service.resendVerification('user-uuid')).resolves.toBeUndefined();
+        expect(mock.log.emailVerificationTokens).toHaveLength(0);
+        expect(email.send).not.toHaveBeenCalled();
+      });
+
+      it('throws 404 when the user no longer exists (stale JWT)', async () => {
+        mock = createMockDb({ findById: async () => null });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service as never);
+
+        await expect(service.resendVerification('ghost-uuid')).rejects.toMatchObject({
+          statusCode: 404,
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Phase-1 follow-up from R1 self-service signup. Adds the email-verification backend that the onboarding banner ([PR #45](https://github.com/apex-bridge/bugspotter/pull/45)) is waiting for. Two new public-API endpoints close the loop:

- `POST /api/v1/auth/verify-email` — public, body `{ token }`, click-from-email handler
- `POST /api/v1/auth/resend-verification` — auth-required, "didn't receive the email?" button

Non-blocking by design — the API key + session are issued unconditionally on signup; verification just dismisses the banner. A transient SMTP outage logs but does not roll back the user's account.

## Why this slice now

Per the corrected R1 ordering, this is purely-additive backend work that unblocks the admin `/verify-email` route slice and lets the onboarding banner go from display-only to dynamic. It does not depend on the deploy-config items still pending (`COOKIE_DOMAIN`, `CORS_ORIGINS`).

## Change

### Migration 019 — [019_email_verification.sql](packages/backend/src/db/migrations/019_email_verification.sql)

- `application.users.email_verified_at TIMESTAMPTZ NULL` — null until verified.
- `application.email_verification_tokens` table: `id`, `user_id` FK, `token` UNIQUE, `expires_at`, `consumed_at` (single-use marker), `created_at`.
- Active-token-by-user partial index for the resend lookup.
- Comments distinguishing this from the existing `organization_requests.email_verified_at` (the enterprise admin-approval flow has its own state machine and email copy).

### Service — [signup.service.ts](packages/backend/src/saas/services/signup.service.ts)

- **Inside the existing signup transaction**, after user creation, insert a token row with the same `expires_at` shared across the flow. A COMMIT failure rolls back BOTH user and token — never an orphan.
- **After COMMIT and the existing log line**, fire-and-forget the verification email. SMTP failure is logged but does not surface to the caller. User can resend.
- **`verifyEmail(token)`** — looks up active token, consumes it inside a transaction, stamps `users.email_verified_at = NOW()`. Returns 400 for unknown / expired / already-consumed tokens with the same generic message — no leak of which tokens previously existed.
- **`resendVerification(userId, locale?)`** — invalidates prior unconsumed tokens, issues a fresh one, fires email. Silent no-op when the user is already verified so the route returns the same 200 in both cases (no probe-able state).

### Email — [signup-email.service.ts](packages/backend/src/saas/services/signup-email.service.ts)

New service mirroring [`OrgRequestEmailService`](packages/backend/src/saas/services/org-request-email.service.ts) — SMTP via nodemailer, en/ru/kk locales, never throws. Distinct from the org-request service because the verification URL (`/verify-email` vs `/verify-request`) and copy differ.

### Routes — [signup.ts](packages/backend/src/api/routes/signup.ts)

- `POST /api/v1/auth/verify-email` — public, rate-limited 5/min/IP. Token entropy (32 bytes) makes guessing infeasible; the cap is defense-in-depth.
- `POST /api/v1/auth/resend-verification` — `requireUser` preHandler, tighter 3/min cap so an authed user pressing the button repeatedly hits it fast (protects SMTP capacity + discourages email-bombing).
- Both gate on `config.auth.selfServiceSignupEnabled` and 403 when off, mirroring the signup route.

### Repository / DB wiring

- New [`EmailVerificationTokenRepository`](packages/backend/src/db/repositories/email-verification-token.repository.ts) with three domain methods: `findActiveByToken`, `consume` (idempotent), `invalidateUnconsumedForUser`.
- Wired into `RepositoryRegistry`, `DatabaseClient`, `factory.ts`.

### Schemas

- `verifyEmailSchema` — body `{ token: string (32-128 chars) }`, response `{ email_verified: true }`.
- `resendVerificationSchema` — no body, response `{ message }`.

## Tests

[tests/saas/signup.service.test.ts](packages/backend/tests/saas/signup.service.test.ts) — **+10** new cases (24 → 34):
- Signup creates exactly one token row inside the transaction.
- Signup fires the verification email after commit; non-blocking on SMTP failure.
- `verifyEmail` happy path; rejects unknown/empty/whitespace/race-lost token with 400.
- `resendVerification` invalidates priors + issues new + sends; silent no-op on already-verified; 404 on stale JWT.

Mock DB extended with `findById`, `findActiveByToken`, `consume`, `invalidateUnconsumedForUser`, `tx.users.update`, plus a stub email service.

[tests/api/routes/signup.route.test.ts](packages/backend/tests/api/routes/signup.route.test.ts) — **+8** new cases (6 → 14):
- `verify-email`: 200 on valid token, 400 on unknown / too-short, 403 when feature flag off.
- `resend-verification`: 401 without auth, 200 generic message both verified-and-not (no leak), 403 when flag off.
- Test harness now registers `createAuthMiddleware` so `requireUser` populates `request.authUser` from the test JWT (matches production wiring).

## Test plan

- [x] `pnpm --filter @bugspotter/backend test:unit` — **2321/2321 pass** (+18 new).
- [ ] `pnpm --filter @bugspotter/backend test:integration` — runs migration 019 against testcontainers Postgres in CI.
- [ ] After merge + deploy: hit `POST /api/v1/auth/signup` with valid creds, confirm verification email arrives. Click link, confirm `users.email_verified_at` is set.

## Scope guardrails (deferred)

- **Admin UI banner stays display-only** — making it conditional on `email_verified` is a separate slice once the response shape is finalized.
- **No queue worker for emails** — direct SMTP, same as existing org-request flow. Migrating all transactional emails to BullMQ is a separate reliability concern.
- **No "you must verify before billing"** — Sentry-style non-blocking. Future R6 hardening can flip this for billing actions if needed.

## What's next

Once this lands, the admin `/verify-email` route can wire up to call `POST /auth/verify-email` from the click-from-email link, and the banner can be made conditional. Both are admin-side slices in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
