### PR TITLE
feat(backend): make verifyEmail idempotent for already-verified users

### DIFF
--- a/packages/backend/src/db/repositories/email-verification-token.repository.ts
+++ b/packages/backend/src/db/repositories/email-verification-token.repository.ts
@@ -53,7 +53,11 @@ export class EmailVerificationTokenRepository extends BaseRepository<
    *    `findByToken` and this call — without the `expires_at`
    *    check here, a token that crossed its TTL between the two calls
    *    would still be marked verified).
-   * The route layer treats false as "invalid or expired" and produces 400.
+   *
+   * `verifyEmail` interprets `false` together with the user's
+   * verification state — an already-verified user receives an
+   * idempotent 200 (the winning tx of a race already stamped them),
+   * an unverified user receives a 400.
    */
   async consume(id: string): Promise<boolean> {
     const query = `

--- a/packages/backend/src/db/repositories/email-verification-token.repository.ts
+++ b/packages/backend/src/db/repositories/email-verification-token.repository.ts
@@ -29,21 +29,18 @@ export class EmailVerificationTokenRepository extends BaseRepository<
   }
 
   /**
-   * Find a verification token row by token string. Returns null when:
-   *  - the token doesn't exist,
-   *  - the token has already been consumed (single-use), OR
-   *  - the token has expired.
-   *
-   * The combined check lets the route caller produce a single
-   * "invalid or expired" 400 without having to disambiguate.
+   * Find a verification token row by token string. Returns null only
+   * when the token doesn't exist; consumed and expired rows are still
+   * returned so the caller can distinguish "never existed" from
+   * "exists but unusable" — the verifyEmail service uses that
+   * distinction to respond idempotently when the underlying user is
+   * already verified.
    */
-  async findActiveByToken(token: string): Promise<EmailVerificationToken | null> {
+  async findByToken(token: string): Promise<EmailVerificationToken | null> {
     const query = `
       SELECT *
       FROM application.email_verification_tokens
       WHERE token = $1
-        AND consumed_at IS NULL
-        AND expires_at > NOW()
     `;
     const result = await this.getClient().query<EmailVerificationToken>(query, [token]);
     return result.rows[0] || null;
@@ -53,7 +50,7 @@ export class EmailVerificationTokenRepository extends BaseRepository<
    * Mark a token consumed. Returns true on success. Returns false when:
    *  - the token was already consumed, OR
    *  - the token has expired (defends the race window between
-   *    `findActiveByToken` and this call — without the `expires_at`
+   *    `findByToken` and this call — without the `expires_at`
    *    check here, a token that crossed its TTL between the two calls
    *    would still be marked verified).
    * The route layer treats false as "invalid or expired" and produces 400.

--- a/packages/backend/src/db/repositories/email-verification-token.repository.ts
+++ b/packages/backend/src/db/repositories/email-verification-token.repository.ts
@@ -39,7 +39,7 @@ export class EmailVerificationTokenRepository extends BaseRepository<
   async findByToken(token: string): Promise<EmailVerificationToken | null> {
     const query = `
       SELECT *
-      FROM application.email_verification_tokens
+      FROM ${this.schema}.${this.tableName}
       WHERE token = $1
     `;
     const result = await this.getClient().query<EmailVerificationToken>(query, [token]);
@@ -61,7 +61,7 @@ export class EmailVerificationTokenRepository extends BaseRepository<
    */
   async consume(id: string): Promise<boolean> {
     const query = `
-      UPDATE application.email_verification_tokens
+      UPDATE ${this.schema}.${this.tableName}
       SET consumed_at = NOW()
       WHERE id = $1
         AND consumed_at IS NULL
@@ -79,7 +79,7 @@ export class EmailVerificationTokenRepository extends BaseRepository<
    */
   async invalidateUnconsumedForUser(userId: string): Promise<number> {
     const query = `
-      UPDATE application.email_verification_tokens
+      UPDATE ${this.schema}.${this.tableName}
       SET consumed_at = NOW()
       WHERE user_id = $1
         AND consumed_at IS NULL

--- a/packages/backend/src/db/repositories/user.repository.ts
+++ b/packages/backend/src/db/repositories/user.repository.ts
@@ -40,8 +40,8 @@ export class UserRepository extends BaseRepository<User, UserInsert, Partial<Use
    *
    * Returns true on first verification, false when the user was
    * already verified by a concurrent transaction. Combined with the
-   * `findActiveByToken` + `consume` flow, this closes a race where
-   * two verify-email requests for the same user could both pass the
+   * `findByToken` + `consume` flow, this closes a race where two
+   * verify-email requests for the same user could both pass the
    * upfront guard and re-stamp `email_verified_at`.
    */
   async markEmailVerified(id: string): Promise<boolean> {

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -313,15 +313,20 @@ export class SignupService {
    * Consume a verification token: mark it used, set
    * `users.email_verified_at = NOW()`, return the user id.
    *
-   * Returns 400 with the same generic "invalid or expired" message in
-   * every failure case (unknown token, expired, already consumed,
-   * consume race) so we don't leak which tokens previously existed.
+   * Idempotent on already-verified users — clicking the link a second
+   * time (refresh-mid-flight, two browser tabs, an email-link
+   * pre-fetcher that already consumed it) returns success rather
+   * than a confusing "invalid" error. This trades a tiny information-
+   * leak window (an attacker who captured the token can confirm the
+   * user is verified by observing 200 vs 400) for a meaningful UX
+   * improvement; possession of the token already implies access to
+   * the user's email or in-flight URL, so the leak isn't materially
+   * actionable.
    *
-   * If the user was already verified via some other path (admin
-   * backfill, or a stale unconsumed token surviving an unclean state),
-   * we refuse to consume the token and return the same generic 400.
-   * Otherwise an active token would still flip `email_verified_at`,
-   * overwriting the prior verification timestamp for no reason.
+   * Returns 400 with a generic "invalid or expired" message for the
+   * remaining failure modes (unknown token, expired, partial-failure
+   * consumed-but-not-verified state, consume race) so we don't leak
+   * which tokens previously existed.
    */
   async verifyEmail(token: string): Promise<{ user_id: string }> {
     // Input validation lives at the route schema (`verifyEmailSchema`
@@ -331,45 +336,52 @@ export class SignupService {
     // normalization would mask client bugs by turning them into
     // successful "not found" lookups.
     return this.db.transaction(async (tx) => {
-      const tokenRow = await tx.emailVerificationTokens.findActiveByToken(token);
+      // Look up the row WITHOUT the active filter so we can recognize
+      // a re-submission of an already-consumed token and respond
+      // idempotently when the underlying user is verified.
+      const tokenRow = await tx.emailVerificationTokens.findByToken(token);
       if (!tokenRow) {
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
-      // Already-verified guard (read-side fast-path). Refuse rather
-      // than re-stamp `email_verified_at`. We don't consume the
-      // token here — leaving it active is harmless (it'll expire),
-      // and consuming silently would be a side effect with no
-      // observable benefit. The atomic UPDATE below is the
-      // authoritative race-safe check; this just avoids consuming a
-      // valid token unnecessarily in the non-racy case.
+      // Idempotent fast-path: user is already verified. Return the
+      // same shape as a fresh successful verify regardless of
+      // whether THIS token was the one that did it. Don't consume
+      // the row here — if it's still active it'll expire on its own,
+      // and consuming it silently would be a side effect with no
+      // observable benefit.
       const user = await tx.users.findById(tokenRow.user_id);
       if (user?.email_verified_at) {
+        return { user_id: tokenRow.user_id };
+      }
+
+      // From here the user is NOT yet verified — we need a real
+      // consume + stamp to make progress. Reject already-consumed
+      // tokens explicitly: this only happens after a partial-failure
+      // state (consume succeeded, stamp didn't) which a fresh
+      // /resend-verification will recover from.
+      if (tokenRow.consumed_at !== null) {
+        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+      }
+      if (tokenRow.expires_at <= new Date()) {
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
       const consumed = await tx.emailVerificationTokens.consume(tokenRow.id);
       if (!consumed) {
         // Race with another verify-email request for the same token,
-        // OR the token expired in the gap between findActive and
-        // consume (which now also rechecks expires_at). Same generic
-        // 400 either way.
+        // OR the token expired in the gap between findByToken and
+        // consume (which rechecks expires_at).
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
-      // Atomic stamp via DB `NOW()` (consistent clock with token
-      // tables) and a `WHERE email_verified_at IS NULL` guard
-      // (closes the read-vs-update race — two concurrent verifies
-      // can't both re-stamp the column). If markEmailVerified
-      // returns false, another transaction won the race; the
-      // current user is still verified, but THIS request didn't
-      // contribute the stamp, so we surface the same generic 400
-      // for symmetry with the upfront guard.
-      const stamped = await tx.users.markEmailVerified(tokenRow.user_id);
-      if (!stamped) {
-        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
-      }
-
+      // Atomic stamp via DB `NOW()` and a `WHERE email_verified_at IS
+      // NULL` guard. If markEmailVerified returns false another
+      // transaction won the race and the user IS verified now —
+      // treat that as success too (consistent with the idempotent
+      // fast-path above; this request still observed a verified
+      // outcome for the user, just didn't contribute the stamp).
+      await tx.users.markEmailVerified(tokenRow.user_id);
       return { user_id: tokenRow.user_id };
     });
   }

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -320,9 +320,19 @@ export class SignupService {
    * email-link pre-fetchers) and post-consume races resolve to a
    * consistent 200 instead of a confusing "invalid" error.
    *
+   * The "verified user wins over token state" contract is enforced
+   * at every potential race point. Postgres runs at READ COMMITTED
+   * by default, so between any two reads in this transaction a
+   * concurrent verify-email request could commit a stamp our cached
+   * `user` snapshot doesn't reflect. Each failure path therefore
+   * re-reads user state and returns success if a concurrent
+   * transaction verified the user in the meantime.
+   *
    * Returns 400 (with a generic "invalid or expired" message that
    * doesn't disambiguate which sub-case fired) when:
    *   - the token doesn't exist, OR
+   *   - the token row references a non-existent user (defense-in-
+   *     depth — the FK CASCADE should prevent this), OR
    *   - the user is unverified AND the token has been consumed
    *     (partial-failure state — caller must re-request via
    *     /auth/resend-verification), OR
@@ -351,15 +361,26 @@ export class SignupService {
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
+      // Helper for the "the path I tried failed; succeed only if a
+      // concurrent transaction verified the user in the meantime"
+      // pattern. Each potential race point below routes failures
+      // through this so the "verified user wins" contract holds at
+      // every step under READ COMMITTED.
+      const succeedIfNowVerified = async (): Promise<{ user_id: string }> => {
+        const refreshed = await tx.users.findById(tokenRow.user_id);
+        if (refreshed?.email_verified_at) {
+          return { user_id: tokenRow.user_id };
+        }
+        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+      };
+
       // Defense-in-depth: the FK has `ON DELETE CASCADE` so a token
       // for a non-existent user shouldn't reach this point under
       // normal DB operation. If it does (replication oddity, manual
-      // FK mutation, future schema change that loosens cascade),
-      // falling through to consume + markEmailVerified would silently
-      // return success for a user_id that resolves to nothing —
-      // markEmailVerified's WHERE clause matches no rows but we
-      // don't check its return value. Throw the same generic 400 as
-      // the other failure modes so we don't leak orphan-token state.
+      // FK mutation, future schema change), throw rather than fall
+      // through — the rest of the function assumes a real user
+      // exists. Same generic 400 as other failure modes so we don't
+      // leak orphan-token state.
       const user = await tx.users.findById(tokenRow.user_id);
       if (!user) {
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
@@ -375,13 +396,14 @@ export class SignupService {
         return { user_id: tokenRow.user_id };
       }
 
-      // From here the user is NOT yet verified — we need a real
-      // consume + stamp to make progress. Reject already-consumed
-      // tokens explicitly: this only happens after a partial-failure
-      // state (consume succeeded, stamp didn't) which a fresh
-      // /resend-verification will recover from.
+      // From here the user is NOT yet verified at our snapshot — we
+      // need a real consume + stamp to make progress. Reject
+      // already-consumed tokens — but route through
+      // succeedIfNowVerified so a concurrent verify of the SAME user
+      // via a DIFFERENT token (committed between our findById and
+      // here) still wins over the token-state rejection.
       if (tokenRow.consumed_at !== null) {
-        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+        return succeedIfNowVerified();
       }
 
       // Don't perform a JS-side expiry check here — `consume()`'s
@@ -394,27 +416,27 @@ export class SignupService {
       if (!consumed) {
         // !consumed means either:
         //  - Expiry: the SQL guard rejected because expires_at <=
-        //    NOW(). The user was unverified above and remains so;
-        //    400 is correct.
+        //    NOW(). The user was unverified above and remains so —
+        //    succeedIfNowVerified will throw 400.
         //  - Race-loss: a concurrent verify-email request for the
         //    same token won consume() and may already have stamped
-        //    the user. Re-read user state — if verified, return
-        //    success too (consistent with the idempotent fast-path
-        //    above; the observable outcome is the same).
-        const refreshed = await tx.users.findById(tokenRow.user_id);
-        if (refreshed?.email_verified_at) {
-          return { user_id: tokenRow.user_id };
-        }
-        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+        //    the user. The re-read returns success in that case.
+        return succeedIfNowVerified();
       }
 
-      // Atomic stamp via DB `NOW()` and a `WHERE email_verified_at IS
-      // NULL` guard. If markEmailVerified returns false another
-      // transaction won the race and the user IS verified now —
-      // treat that as success too (consistent with the idempotent
-      // fast-path above).
-      await tx.users.markEmailVerified(tokenRow.user_id);
-      return { user_id: tokenRow.user_id };
+      // Atomic stamp via DB `NOW()` and a `WHERE email_verified_at
+      // IS NULL` guard. False return means the UPDATE matched no
+      // rows: either another transaction won the race and stamped
+      // the user (return success via the re-read), or the user was
+      // deleted between our findById and the stamp (re-read returns
+      // null, throw 400). Capturing the boolean instead of dropping
+      // it on the floor avoids the silent-success-for-deleted-user
+      // failure mode.
+      const verified = await tx.users.markEmailVerified(tokenRow.user_id);
+      if (verified) {
+        return { user_id: tokenRow.user_id };
+      }
+      return succeedIfNowVerified();
     });
   }
 

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -313,20 +313,27 @@ export class SignupService {
    * Consume a verification token: mark it used, set
    * `users.email_verified_at = NOW()`, return the user id.
    *
-   * Idempotent on already-verified users — clicking the link a second
-   * time (refresh-mid-flight, two browser tabs, an email-link
-   * pre-fetcher that already consumed it) returns success rather
-   * than a confusing "invalid" error. This trades a tiny information-
-   * leak window (an attacker who captured the token can confirm the
-   * user is verified by observing 200 vs 400) for a meaningful UX
-   * improvement; possession of the token already implies access to
-   * the user's email or in-flight URL, so the leak isn't materially
-   * actionable.
+   * Idempotent for already-verified users. Once a user is verified,
+   * the observable outcome is the same regardless of the token's own
+   * state — active, consumed, or expired all return success. This
+   * makes link re-clicks (refresh-mid-flight, two browser tabs,
+   * email-link pre-fetchers) and post-consume races resolve to a
+   * consistent 200 instead of a confusing "invalid" error.
    *
-   * Returns 400 with a generic "invalid or expired" message for the
-   * remaining failure modes (unknown token, expired, partial-failure
-   * consumed-but-not-verified state, consume race) so we don't leak
-   * which tokens previously existed.
+   * Returns 400 (with a generic "invalid or expired" message that
+   * doesn't disambiguate which sub-case fired) when:
+   *   - the token doesn't exist, OR
+   *   - the user is unverified AND the token has been consumed
+   *     (partial-failure state — caller must re-request via
+   *     /auth/resend-verification), OR
+   *   - the user is unverified AND the token expired before any
+   *     verify call could consume it.
+   *
+   * Trades a tiny information-leak window (an attacker who captured
+   * the token can confirm the user is verified by observing 200 vs
+   * 400) for a meaningful UX improvement; possession of the token
+   * already implies access to the user's email or in-flight URL, so
+   * the leak isn't materially actionable.
    */
   async verifyEmail(token: string): Promise<{ user_id: string }> {
     // Input validation lives at the route schema (`verifyEmailSchema`
@@ -346,10 +353,10 @@ export class SignupService {
 
       // Idempotent fast-path: user is already verified. Return the
       // same shape as a fresh successful verify regardless of
-      // whether THIS token was the one that did it. Don't consume
-      // the row here — if it's still active it'll expire on its own,
-      // and consuming it silently would be a side effect with no
-      // observable benefit.
+      // whether THIS token was the one that did it, or whether it's
+      // still active. Don't consume the row — if it's active it'll
+      // expire on its own, and consuming silently would be a side
+      // effect with no observable benefit.
       const user = await tx.users.findById(tokenRow.user_id);
       if (user?.email_verified_at) {
         return { user_id: tokenRow.user_id };
@@ -363,15 +370,28 @@ export class SignupService {
       if (tokenRow.consumed_at !== null) {
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
-      if (tokenRow.expires_at <= new Date()) {
-        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
-      }
 
+      // Don't perform a JS-side expiry check here — `consume()`'s
+      // SQL guard (`expires_at > NOW()`) is authoritative and uses
+      // the same Postgres clock that wrote `expires_at` in the
+      // first place. A JS-side check against the app server clock
+      // could prematurely reject still-valid tokens under NTP/
+      // container clock skew between the app and the database.
       const consumed = await tx.emailVerificationTokens.consume(tokenRow.id);
       if (!consumed) {
-        // Race with another verify-email request for the same token,
-        // OR the token expired in the gap between findByToken and
-        // consume (which rechecks expires_at).
+        // !consumed means either:
+        //  - Expiry: the SQL guard rejected because expires_at <=
+        //    NOW(). The user was unverified above and remains so;
+        //    400 is correct.
+        //  - Race-loss: a concurrent verify-email request for the
+        //    same token won consume() and may already have stamped
+        //    the user. Re-read user state — if verified, return
+        //    success too (consistent with the idempotent fast-path
+        //    above; the observable outcome is the same).
+        const refreshed = await tx.users.findById(tokenRow.user_id);
+        if (refreshed?.email_verified_at) {
+          return { user_id: tokenRow.user_id };
+        }
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
@@ -379,8 +399,7 @@ export class SignupService {
       // NULL` guard. If markEmailVerified returns false another
       // transaction won the race and the user IS verified now —
       // treat that as success too (consistent with the idempotent
-      // fast-path above; this request still observed a verified
-      // outcome for the user, just didn't contribute the stamp).
+      // fast-path above).
       await tx.users.markEmailVerified(tokenRow.user_id);
       return { user_id: tokenRow.user_id };
     });

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -351,14 +351,27 @@ export class SignupService {
         throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
       }
 
+      // Defense-in-depth: the FK has `ON DELETE CASCADE` so a token
+      // for a non-existent user shouldn't reach this point under
+      // normal DB operation. If it does (replication oddity, manual
+      // FK mutation, future schema change that loosens cascade),
+      // falling through to consume + markEmailVerified would silently
+      // return success for a user_id that resolves to nothing —
+      // markEmailVerified's WHERE clause matches no rows but we
+      // don't check its return value. Throw the same generic 400 as
+      // the other failure modes so we don't leak orphan-token state.
+      const user = await tx.users.findById(tokenRow.user_id);
+      if (!user) {
+        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+      }
+
       // Idempotent fast-path: user is already verified. Return the
       // same shape as a fresh successful verify regardless of
       // whether THIS token was the one that did it, or whether it's
       // still active. Don't consume the row — if it's active it'll
       // expire on its own, and consuming silently would be a side
       // effect with no observable benefit.
-      const user = await tx.users.findById(tokenRow.user_id);
-      if (user?.email_verified_at) {
+      if (user.email_verified_at) {
         return { user_id: tokenRow.user_id };
       }
 

--- a/packages/backend/tests/api/routes/signup.route.test.ts
+++ b/packages/backend/tests/api/routes/signup.route.test.ts
@@ -116,7 +116,7 @@ function createHappyMockDb(): DatabaseClient {
         created_at: new Date(),
         ...d,
       })),
-      findActiveByToken: vi.fn(async () => null),
+      findByToken: vi.fn(async () => null),
       consume: vi.fn(async () => true),
       invalidateUnconsumedForUser: vi.fn(async () => 0),
     },
@@ -309,7 +309,7 @@ describe('POST /api/v1/auth/verify-email (route smoke)', () => {
 
   it('returns 200 with email_verified=true when the token is valid', async () => {
     const db = createHappyMockDb();
-    // Wire findActiveByToken on the in-memory tx object the mock uses.
+    // Wire findByToken on the in-memory tx object the mock uses.
     // The mock's `transaction` callback is the only path that sees `tx`,
     // so we reach into the same closure's tx by replacing the
     // transaction implementation with one that exposes the same shape.
@@ -329,7 +329,7 @@ describe('POST /api/v1/auth/verify-email (route smoke)', () => {
         markEmailVerified: vi.fn(async () => true),
       },
       emailVerificationTokens: {
-        findActiveByToken: vi.fn(async () => ({
+        findByToken: vi.fn(async () => ({
           id: 'evt-1',
           user_id: 'user-uuid',
           token: 'a'.repeat(43),
@@ -448,7 +448,7 @@ describe('POST /api/v1/auth/resend-verification (route smoke)', () => {
           created_at: new Date(),
           ...d,
         })),
-        findActiveByToken: vi.fn(),
+        findByToken: vi.fn(),
         consume: vi.fn(),
       },
     };

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -57,7 +57,7 @@ function validInput() {
 interface DbOverrides {
   findByEmail?: () => Promise<unknown>;
   findById?: () => Promise<unknown>;
-  findActiveByToken?: () => Promise<unknown>;
+  findByToken?: () => Promise<unknown>;
   consumeToken?: () => Promise<boolean>;
   invalidateUnconsumed?: () => Promise<number>;
   markVerified?: () => Promise<boolean>;
@@ -163,7 +163,7 @@ function createMockDb(overrides: DbOverrides = {}): {
         log.emailVerificationTokens.push(row);
         return row;
       }),
-      findActiveByToken: vi.fn(overrides.findActiveByToken ?? (async () => null)),
+      findByToken: vi.fn(overrides.findByToken ?? (async () => null)),
       consume: vi.fn(overrides.consumeToken ?? (async () => true)),
       invalidateUnconsumedForUser: vi.fn(overrides.invalidateUnconsumed ?? (async () => 0)),
     },
@@ -560,7 +560,7 @@ describe('SignupService', () => {
       it('marks the token consumed and stamps users.email_verified_at on success', async () => {
         const fakeUserId = 'user-uuid';
         mock = createMockDb({
-          findActiveByToken: async () => ({
+          findByToken: async () => ({
             id: 'evt-1',
             user_id: fakeUserId,
             token: 'good',
@@ -577,7 +577,7 @@ describe('SignupService', () => {
       });
 
       it('rejects an unknown token with 400', async () => {
-        mock = createMockDb({ findActiveByToken: async () => null });
+        mock = createMockDb({ findByToken: async () => null });
         service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('nope')).rejects.toMatchObject({
@@ -593,20 +593,24 @@ describe('SignupService', () => {
         // direct caller, in which case the lookup-and-fail path
         // produces the correct generic 400.
         const findSpy = vi.fn(async () => null);
-        mock = createMockDb({ findActiveByToken: findSpy });
+        mock = createMockDb({ findByToken: findSpy });
         service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('   ')).rejects.toMatchObject({ statusCode: 400 });
         expect(findSpy).toHaveBeenCalledWith('   ');
       });
 
-      it('refuses with 400 when the user is already verified (no token consume)', async () => {
-        // The guard fires BEFORE the consume — leaving an active token
-        // alone (it'll expire) is preferable to silently consuming it
-        // and re-stamping email_verified_at.
+      it('idempotent: returns success without consuming when the user is already verified', async () => {
+        // Re-clicking a verification link (refresh-mid-flight, two
+        // tabs, an email-link pre-fetcher) shouldn't surface "invalid"
+        // when the underlying user is already verified. We don't
+        // consume the row — if it's still active it'll expire on its
+        // own; consuming it silently is a side effect with no
+        // observable benefit.
         const consumeSpy = vi.fn(async () => true);
+        const markSpy = vi.fn(async () => true);
         mock = createMockDb({
-          findActiveByToken: async () => ({
+          findByToken: async () => ({
             id: 'evt-1',
             user_id: 'user-uuid',
             token: 'good',
@@ -621,20 +625,101 @@ describe('SignupService', () => {
             email_verified_at: new Date('2026-04-01T00:00:00Z'),
           }),
           consumeToken: consumeSpy,
+          markVerified: markSpy,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        const result = await service.verifyEmail('good');
+        expect(result).toEqual({ user_id: 'user-uuid' });
+        expect(consumeSpy).not.toHaveBeenCalled();
+        expect(markSpy).not.toHaveBeenCalled();
+      });
+
+      it('idempotent: a previously-consumed token still returns success when the user is verified', async () => {
+        // The realistic path that motivates idempotency: an email-
+        // link pre-fetcher (or a duplicate browser tab) consumed the
+        // token. The legitimate user clicks → row is consumed_at-set
+        // and the user is verified → return 200 instead of 400.
+        const consumeSpy = vi.fn(async () => false);
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: new Date('2026-04-01T00:00:00Z'),
+            created_at: new Date(),
+          }),
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: new Date('2026-04-01T00:00:00Z'),
+          }),
+          consumeToken: consumeSpy,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        const result = await service.verifyEmail('good');
+        expect(result).toEqual({ user_id: 'user-uuid' });
+        expect(consumeSpy).not.toHaveBeenCalled();
+      });
+
+      it('rejects a consumed token with 400 when the user is NOT verified (partial-failure state)', async () => {
+        // Consumed-but-not-verified means the previous verifyEmail
+        // crashed between consume and stamp. There's nothing to do
+        // here — the user must request a fresh /resend-verification.
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: new Date('2026-04-01T00:00:00Z'),
+            created_at: new Date(),
+          }),
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: null,
+          }),
         });
         service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
-        expect(consumeSpy).not.toHaveBeenCalled();
       });
 
-      it('refuses with 400 when the atomic UPDATE finds no row (race-lost stamp)', async () => {
-        // markEmailVerified returns false when another tx beat us to
-        // setting email_verified_at. We've already consumed our token,
-        // but THIS request didn't contribute the verification — so we
-        // surface the same generic 400 for symmetry with the guard.
+      it('rejects an expired token with 400', async () => {
         mock = createMockDb({
-          findActiveByToken: async () => ({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() - 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: null,
+          }),
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
+      });
+
+      it('treats a race-lost markEmailVerified as success (someone else stamped first)', async () => {
+        // markEmailVerified returns false when another tx beat us
+        // setting email_verified_at. The user IS verified now — that's
+        // the same observable outcome as a fresh success, so under
+        // idempotency we return success. (Pre-idempotency this was a
+        // 400 for symmetry with the upfront guard.)
+        mock = createMockDb({
+          findByToken: async () => ({
             id: 'evt-1',
             user_id: 'user-uuid',
             token: 'good',
@@ -653,22 +738,29 @@ describe('SignupService', () => {
         });
         service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
-        await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
+        const result = await service.verifyEmail('good');
+        expect(result).toEqual({ user_id: 'user-uuid' });
       });
 
       it('treats a race-lost consume as already-used and returns 400', async () => {
-        // findActiveByToken returns a row, but consume() returns false —
-        // simulates two parallel verify-email requests for the same token
-        // where the other side already won. Caller must not proceed to
-        // marking the user verified.
+        // findByToken returns an active row, but consume() returns false
+        // — simulates two parallel verify-email requests for the same
+        // token where the other side already won. Caller must not
+        // proceed to marking the user verified.
         mock = createMockDb({
-          findActiveByToken: async () => ({
+          findByToken: async () => ({
             id: 'evt-1',
             user_id: 'user-uuid',
             token: 'good',
             expires_at: new Date(Date.now() + 60_000),
             consumed_at: null,
             created_at: new Date(),
+          }),
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: null,
           }),
           consumeToken: async () => false,
         });

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -568,6 +568,12 @@ describe('SignupService', () => {
             consumed_at: null,
             created_at: new Date(),
           }),
+          findById: async () => ({
+            id: fakeUserId,
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: null,
+          }),
           consumeToken: async () => true,
         });
         service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
@@ -583,6 +589,32 @@ describe('SignupService', () => {
         await expect(service.verifyEmail('nope')).rejects.toMatchObject({
           statusCode: 400,
         });
+      });
+
+      it('rejects with 400 when the token row exists but the user does not (defense-in-depth)', async () => {
+        // The schema's ON DELETE CASCADE FK should prevent this from
+        // happening in practice — but the service must not silently
+        // return success for an orphan token if the invariant is
+        // ever violated. Same generic 400 as other failure modes so
+        // we don't expose orphan-token state via the response code.
+        const consumeSpy = vi.fn(async () => true);
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          findById: async () => null,
+          consumeToken: consumeSpy,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
+        // Throw before consume — no DB write side-effects on this path.
+        expect(consumeSpy).not.toHaveBeenCalled();
       });
 
       it('treats whitespace as a normal not-found lookup — does not silently trim', async () => {

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -57,8 +57,8 @@ function validInput() {
 interface DbOverrides {
   findByEmail?: () => Promise<unknown>;
   findById?: () => Promise<unknown>;
-  findByToken?: () => Promise<unknown>;
-  consumeToken?: () => Promise<boolean>;
+  findByToken?: (token: string) => Promise<unknown>;
+  consumeToken?: (id: string) => Promise<boolean>;
   invalidateUnconsumed?: () => Promise<number>;
   markVerified?: () => Promise<boolean>;
   countRecentByIp?: () => Promise<number>;
@@ -779,12 +779,13 @@ describe('SignupService', () => {
         expect(result).toEqual({ user_id: 'user-uuid' });
       });
 
-      it('treats a race-lost markEmailVerified as success (someone else stamped first)', async () => {
+      it('treats a race-lost markEmailVerified as success when the post-stamp re-read shows verified', async () => {
         // markEmailVerified returns false when another tx beat us
-        // setting email_verified_at. The user IS verified now — that's
-        // the same observable outcome as a fresh success, so under
-        // idempotency we return success. (Pre-idempotency this was a
-        // 400 for symmetry with the upfront guard.)
+        // setting email_verified_at. The user IS verified now (by the
+        // winning tx). The post-stamp re-read catches up under READ
+        // COMMITTED and returns success — same observable outcome as
+        // the idempotent fast-path.
+        let findByIdCalls = 0;
         mock = createMockDb({
           findByToken: async () => ({
             id: 'evt-1',
@@ -794,12 +795,25 @@ describe('SignupService', () => {
             consumed_at: null,
             created_at: new Date(),
           }),
-          findById: async () => ({
-            id: 'user-uuid',
-            email: 'founder@acme.com',
-            name: 'Jane',
-            email_verified_at: null,
-          }),
+          findById: async () => {
+            findByIdCalls++;
+            // First call (pre-consume guard): user unverified.
+            // Second call (succeedIfNowVerified re-read after the
+            // failed stamp): the winning concurrent tx has committed.
+            return findByIdCalls === 1
+              ? {
+                  id: 'user-uuid',
+                  email: 'founder@acme.com',
+                  name: 'Jane',
+                  email_verified_at: null,
+                }
+              : {
+                  id: 'user-uuid',
+                  email: 'founder@acme.com',
+                  name: 'Jane',
+                  email_verified_at: new Date('2026-04-01T00:00:00Z'),
+                };
+          },
           consumeToken: async () => true,
           markVerified: async () => false,
         });
@@ -807,6 +821,91 @@ describe('SignupService', () => {
 
         const result = await service.verifyEmail('good');
         expect(result).toEqual({ user_id: 'user-uuid' });
+        expect(findByIdCalls).toBe(2);
+      });
+
+      it('rejects with 400 when markEmailVerified fails and the re-read still shows unverified', async () => {
+        // Defense against silent-success-for-deleted-user. The
+        // earlier !user guard catches the common case, but a user
+        // could be deleted between findById and markEmailVerified
+        // (CASCADE deletes the token row, the next stamp matches 0
+        // rows). The post-stamp re-read returns null → throw.
+        let findByIdCalls = 0;
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          findById: async () => {
+            findByIdCalls++;
+            // First call: user exists, unverified.
+            // Second call (re-read): user deleted between the stamp
+            // attempt and now — null.
+            return findByIdCalls === 1
+              ? {
+                  id: 'user-uuid',
+                  email: 'founder@acme.com',
+                  name: 'Jane',
+                  email_verified_at: null,
+                }
+              : null;
+          },
+          consumeToken: async () => true,
+          markVerified: async () => false,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
+        expect(findByIdCalls).toBe(2);
+      });
+
+      it('treats a consumed-but-our-snapshot-stale token as success when a concurrent tx verified the user via a different token', async () => {
+        // Race scenario: at our findById (call #1) the user looks
+        // unverified, but a concurrent verify-email request for the
+        // SAME user via a DIFFERENT token has since committed a
+        // stamp. Without the consumed_at-path re-read, we'd throw
+        // 400 for a user who is actually verified — contradicting
+        // the "verified-user-wins" contract under READ COMMITTED.
+        let findByIdCalls = 0;
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: new Date('2026-04-01T00:00:00Z'),
+            created_at: new Date(),
+          }),
+          findById: async () => {
+            findByIdCalls++;
+            // First call (pre-consumed_at guard): user unverified
+            // (the concurrent tx via a different token hasn't
+            // committed at our snapshot yet).
+            // Second call (succeedIfNowVerified): committed by now.
+            return findByIdCalls === 1
+              ? {
+                  id: 'user-uuid',
+                  email: 'founder@acme.com',
+                  name: 'Jane',
+                  email_verified_at: null,
+                }
+              : {
+                  id: 'user-uuid',
+                  email: 'founder@acme.com',
+                  name: 'Jane',
+                  email_verified_at: new Date('2026-04-01T00:00:00Z'),
+                };
+          },
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        const result = await service.verifyEmail('good');
+        expect(result).toEqual({ user_id: 'user-uuid' });
+        expect(findByIdCalls).toBe(2);
       });
 
       it('rejects a race-lost consume with 400 when the user is still unverified', async () => {

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -690,7 +690,12 @@ describe('SignupService', () => {
         await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
       });
 
-      it('rejects an expired token with 400', async () => {
+      it('rejects an expired token with 400 when the user is NOT verified', async () => {
+        // Service no longer does a JS-side expiry check; rejection
+        // comes from consume()'s SQL guard (`expires_at > NOW()`),
+        // which the mock simulates by returning false. The
+        // post-consume re-read of user state confirms the user is
+        // still unverified — 400 is the correct outcome.
         mock = createMockDb({
           findByToken: async () => ({
             id: 'evt-1',
@@ -706,10 +711,40 @@ describe('SignupService', () => {
             name: 'Jane',
             email_verified_at: null,
           }),
+          consumeToken: async () => false,
         });
         service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
+      });
+
+      it('idempotent: an expired token still returns success when the user is already verified', async () => {
+        // Locks in the contract that the verified-user fast-path
+        // wins over token state — once the user is verified, the
+        // observable outcome is the same regardless of whether the
+        // token is active, consumed, or expired. Without this test,
+        // reordering the fast-path vs expiry/consumed checks could
+        // silently flip behavior.
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() - 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: new Date('2026-04-01T00:00:00Z'),
+          }),
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        const result = await service.verifyEmail('good');
+        expect(result).toEqual({ user_id: 'user-uuid' });
       });
 
       it('treats a race-lost markEmailVerified as success (someone else stamped first)', async () => {
@@ -742,11 +777,12 @@ describe('SignupService', () => {
         expect(result).toEqual({ user_id: 'user-uuid' });
       });
 
-      it('treats a race-lost consume as already-used and returns 400', async () => {
-        // findByToken returns an active row, but consume() returns false
-        // — simulates two parallel verify-email requests for the same
-        // token where the other side already won. Caller must not
-        // proceed to marking the user verified.
+      it('rejects a race-lost consume with 400 when the user is still unverified', async () => {
+        // findByToken returns an active row, consume() returns false
+        // (the other side won), and a re-read of user state still
+        // shows them unverified — meaning the winning tx hasn't
+        // committed the stamp yet, OR the false was caused by token
+        // expiry rather than a race. Either way, 400 is correct.
         mock = createMockDb({
           findByToken: async () => ({
             id: 'evt-1',
@@ -767,6 +803,51 @@ describe('SignupService', () => {
         service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
 
         await expect(service.verifyEmail('good')).rejects.toMatchObject({ statusCode: 400 });
+      });
+
+      it('treats a race-lost consume as success when the user is now verified by the winning tx', async () => {
+        // The fast-path didn't fire on first read (the winning tx
+        // hadn't stamped yet from this snapshot's perspective), but
+        // by the time consume() returns false the winning tx has
+        // committed and the user IS verified. The post-consume
+        // re-read catches up and returns success — same observable
+        // outcome as the idempotent fast-path.
+        let findByIdCalls = 0;
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          findById: async () => {
+            findByIdCalls++;
+            // First read (pre-consume fast-path): user is unverified.
+            // Second read (post-consume re-check): user has been
+            // verified by the winning concurrent transaction.
+            return findByIdCalls === 1
+              ? {
+                  id: 'user-uuid',
+                  email: 'founder@acme.com',
+                  name: 'Jane',
+                  email_verified_at: null,
+                }
+              : {
+                  id: 'user-uuid',
+                  email: 'founder@acme.com',
+                  name: 'Jane',
+                  email_verified_at: new Date('2026-04-01T00:00:00Z'),
+                };
+          },
+          consumeToken: async () => false,
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        const result = await service.verifyEmail('good');
+        expect(result).toEqual({ user_id: 'user-uuid' });
+        expect(findByIdCalls).toBe(2);
       });
     });
 


### PR DESCRIPTION
## Summary

A user clicking the verification link more than once should land on the same observable outcome as the first click. Today the second click hits a 400 \"invalid or expired\" — confusing for the user, who sees a failure right after a successful verification.

Real-world triggers for repeat clicks:
- **Email-link safety scanners** (Outlook, Gmail safe-links, corporate proxies, Slack unfurl) that pre-fetch and execute the page's verify call before the user clicks
- **Two browser tabs** opening the same link (happens with some clients)
- **Refresh-mid-flight** — paired with the admin-side change in #51, the page now keeps `?token=` in the URL on transient errors so a refresh can retry; without idempotency the retry hits 400 if the original call already consumed the token

## Implementation

- **Repository:** rename `findActiveByToken` → `findByToken`. Returns rows regardless of consumed/expired state; the active filter pushes down into `consume()` (which already had `WHERE consumed_at IS NULL AND expires_at > NOW()` for race-safety).
- **Service:** after looking up the row, check `users.email_verified_at` first. If the user is already verified, return success without consuming — leaving the row alone is harmless (it'll expire) and consuming it silently is a side effect with no observable benefit.
- **Service:** a race-lost `markEmailVerified` (another tx beat us to the stamp) now also returns success. The user IS verified now, which matches the observable outcome of the idempotent fast-path.
- **Still 400** on consumed-but-not-verified (partial-failure state — consume succeeded but stamp failed; user must re-request via `/resend-verification`) and on expired tokens.

## Threat model

Returning 200 vs 400 on a consumed token leaks \"this user is verified\" to a holder of the token. But holding the token already implies access to the user's email or in-flight URL, so the leak isn't materially actionable. Trading a marginal info-leak for a real UX improvement on a flow users hit during the most fragile moment of onboarding.

## Tests

9 `verifyEmail` specs (was 6):
- Existing: success path, unknown token, whitespace-no-trim, race-lost consume → 400
- **Updated:** race-lost markEmailVerified → 200 (was 400; the user is verified, which is the same observable outcome)
- **New:** idempotent on already-verified user (no consume call), idempotent on previously-consumed token + verified user, rejects consumed-but-not-verified with 400 (partial-failure state), rejects expired with 400

## Test plan

- [x] `pnpm vitest run --config vitest.unit.config.ts tests/saas/signup.service.test.ts tests/api/routes/signup.route.test.ts` — 55 pass
- [ ] Manual: verify a fresh token → 200 success
- [ ] Manual: re-POST the same token → 200 (was 400 before)
- [ ] Manual: POST a token belonging to a user already verified by admin backfill → 200 (was 400)
- [ ] Manual: POST an expired token → 400
- [ ] Manual: POST an unknown token → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)