### PR TITLE
feat(backend): signup telemetry — counters + audit logs + structured events

### DIFF
--- a/packages/backend/src/metrics/registry.ts
+++ b/packages/backend/src/metrics/registry.ts
@@ -65,5 +65,86 @@ export const orgHardDeleteTotal = new client.Counter({
   registers: [register],
 });
 
+// === Self-service signup ===
+// Funnel + abuse-mitigation telemetry. Lets ops dashboards answer
+// questions like "did adding hCaptcha drop bot rejections?" or "what
+// fraction of signups complete email verification?". Per-event audit
+// log rows live in `application.audit_logs`; counters here are the
+// rate-of-change view that pairs with them.
+//
+// Outcomes for `signup_attempts_total`:
+//   'success'         — user, org, project, API key, verification token all committed
+//   'spam_rejected'   — runSpamChecks rejected with 403 Forbidden (real
+//                        spam signal); per-check breakdown lives on
+//                        `signup_spam_check_total`
+//   'duplicate_email' — findByEmail found an existing user, OR a unique-
+//                        violation race-loss on users_email_key, OR a 409
+//                        PendingEnterpriseRequest from runSpamChecks
+//                        (existing org_requests row blocks self-service)
+//   'invalid_input'   — empty company_name, invalid/taken subdomain
+//                        (4xx AppError from resolveSubdomain or the
+//                        organizations_subdomain_key race-loss path)
+//   'error'           — operational failure not caused by the user:
+//                        503 from spam-filter infra, DB outage, txn abort,
+//                        any non-AppError or 5xx exception. Distinguishes
+//                        "system broke" from "user did something we
+//                        rejected" so dashboards / alerts can fire on the
+//                        right one.
+// Keep dashboards/alerts in sync when adding new outcomes.
+export const signupAttemptsTotal = new client.Counter({
+  name: 'bugspotter_signup_attempts_total',
+  help: 'Self-service signup attempts by terminal outcome',
+  labelNames: ['outcome'] as const,
+  registers: [register],
+});
+
+// Per-check rejection breakdown for the spam filter. Counts only
+// fire when the request is actually rejected — sub-threshold
+// heuristic hits (e.g. a request whose suspicious_pattern alone
+// scored 20, below the 50 threshold) do NOT increment, so the
+// metric is interpretable as "what fraction of rejections involved
+// each check?" rather than "how often does each heuristic fire?".
+//
+// A single rejected attempt can trip multiple checks (e.g.
+// disposable_email + suspicious_pattern summing past the score
+// threshold), so totals here can exceed the `spam_rejected` count
+// on `signup_attempts_total`. That's intentional — it lets the
+// disposable-email blocklist Tier-B PR be evaluated independently
+// of other checks also firing on the same request.
+//
+// Checks: 'honeypot' | 'rate_limit' | 'duplicate_pending' |
+//         'disposable_email' | 'suspicious_pattern'
+export const signupSpamCheckTotal = new client.Counter({
+  name: 'bugspotter_signup_spam_check_total',
+  help: 'Self-service signup spam-check fires (per check, not per request)',
+  labelNames: ['check'] as const,
+  registers: [register],
+});
+
+// Outcomes for email verification:
+//   'success' — token consumed (or idempotent 200 for already-verified user)
+//   'invalid' — terminal 4xx AppError (unknown / consumed-but-not-verified / expired)
+//   'error'   — anything else (DB outage, txn abort, unexpected throw)
+export const signupEmailVerificationTotal = new client.Counter({
+  name: 'bugspotter_signup_email_verification_total',
+  help: 'Email verification attempts by outcome',
+  labelNames: ['outcome'] as const,
+  registers: [register],
+});
+
+// Outcomes for verification email resend:
+//   'success'           — new token issued + email dispatched (or silent
+//                          no-op when user is already verified — same
+//                          response shape, no probe-able state leak)
+//   'user_not_found'    — JWT carries a stale user id (rare; normally
+//                          requireUser would have rejected upstream)
+//   'error'             — anything else (DB outage, unexpected throw)
+export const signupVerificationResendTotal = new client.Counter({
+  name: 'bugspotter_signup_verification_resend_total',
+  help: 'Verification email resend requests by outcome',
+  labelNames: ['outcome'] as const,
+  registers: [register],
+});
+
 // Note: queueDepth and dbPoolSize gauges are created in collectors.ts
 // with async collect callbacks (populated on each /metrics scrape).

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -45,6 +45,11 @@ import {
 import { generateShareToken } from '../../utils/token-generator.js';
 import { getLogger } from '../../logger.js';
 import {
+  signupAttemptsTotal,
+  signupEmailVerificationTotal,
+  signupVerificationResendTotal,
+} from '../../metrics/registry.js';
+import {
   SignupEmailService,
   type EmailLocale,
   type SendVerificationEmailParams,
@@ -142,17 +147,67 @@ export class SignupService {
     const companyName = input.company_name.trim();
 
     if (companyName.length === 0) {
+      signupAttemptsTotal.inc({ outcome: 'invalid_input' });
       throw new AppError('Company name is required', 400, 'ValidationError');
     }
 
-    await this.runSpamChecks(email, companyName, input);
+    // runSpamChecks can throw three distinct AppError shapes plus
+    // arbitrary operational errors. Classify so the funnel doesn't
+    // silently absorb infra failures into the spam bucket:
+    //   - 403 Forbidden          — real spam rejection
+    //   - 409 PendingEnterpriseRequest — existing org_requests row
+    //                              blocks self-service; not bot
+    //                              traffic, closer to "duplicate"
+    //                              for funnel semantics
+    //   - 503 ServiceUnavailable — spam-check infra failed (DB, etc.)
+    //   - anything else          — unexpected, count as error too
+    try {
+      await this.runSpamChecks(email, companyName, input);
+    } catch (err) {
+      let outcome: 'spam_rejected' | 'duplicate_email' | 'error';
+      if (err instanceof AppError && err.statusCode === 403) {
+        outcome = 'spam_rejected';
+      } else if (err instanceof AppError && err.statusCode === 409) {
+        outcome = 'duplicate_email';
+      } else {
+        outcome = 'error';
+      }
+      signupAttemptsTotal.inc({ outcome });
+      throw err;
+    }
 
-    const existingUser = await this.db.users.findByEmail(email);
+    let existingUser: Awaited<ReturnType<typeof this.db.users.findByEmail>>;
+    try {
+      existingUser = await this.db.users.findByEmail(email);
+    } catch (err) {
+      // DB outage / pool exhaustion on the duplicate-check read.
+      // Without this catch the request rethrows uncounted, so the
+      // funnel total dips below total attempts during incidents —
+      // exactly the case the 'error' bucket exists to make visible.
+      signupAttemptsTotal.inc({ outcome: 'error' });
+      throw err;
+    }
     if (existingUser) {
+      signupAttemptsTotal.inc({ outcome: 'duplicate_email' });
       throw new AppError('User with this email already exists', 409, 'Conflict');
     }
 
-    const subdomain = await this.resolveSubdomain(companyName, input.subdomain);
+    let subdomain: string;
+    try {
+      subdomain = await this.resolveSubdomain(companyName, input.subdomain);
+    } catch (err) {
+      // 4xx AppErrors — the user supplied something we can't accept
+      // (invalid format, taken slug). 5xx and unexpected throws
+      // (availability check hits a DB outage, etc.) belong in the
+      // 'error' bucket; classifying them as user input would make the
+      // funnel show false-positive user drop-off during outages.
+      const outcome =
+        err instanceof AppError && err.statusCode >= 400 && err.statusCode < 500
+          ? 'invalid_input'
+          : 'error';
+      signupAttemptsTotal.inc({ outcome });
+      throw err;
+    }
 
     const passwordHash = await bcrypt.hash(input.password, PASSWORD.SALT_ROUNDS);
 
@@ -258,6 +313,28 @@ export class SignupService {
           },
         });
 
+        // Audit row for the user-facing signup event itself. Inside
+        // the tx so a COMMIT failure rolls back the audit alongside
+        // the user/org/project/key inserts — same pattern as the
+        // api_key audit above. Spam-rejected attempts deliberately
+        // do NOT get audit rows: those are bot traffic and would
+        // bloat the table; the metric counters provide the
+        // aggregate view there.
+        await tx.auditLogs.create({
+          action: 'signup_completed',
+          resource: 'auth/signup',
+          resource_id: user.id,
+          user_id: user.id,
+          organization_id: organization.id,
+          ip_address: input.ip_address,
+          details: {
+            subdomain,
+            project_id: project.id,
+            data_residency_region: this.region,
+          },
+          success: true,
+        });
+
         return {
           user,
           organization,
@@ -275,14 +352,37 @@ export class SignupService {
       // the proper 409 Conflict they'd get from the read-side checks.
       const remapped = remapUniqueViolation(err);
       if (remapped) {
-        throw remapped;
+        // Bucket by the underlying constraint name. The remapped
+        // AppError flattens both known violations into code='Conflict',
+        // so we'd lose the distinction without the constraint:
+        //  - users_email_key             → duplicate_email (matches
+        //                                   the read-side findByEmail
+        //                                   bucket above).
+        //  - organizations_subdomain_key → invalid_input  (same
+        //                                   bucket as resolveSubdomain
+        //                                   validation failures).
+        //  - any other unique constraint → 'error'  (defensive default
+        //                                   so a future migration that
+        //                                   adds a new unique key
+        //                                   doesn't silently mis-bucket
+        //                                   into duplicate_email).
+        signupAttemptsTotal.inc({
+          outcome: UNIQUE_CONSTRAINT_OUTCOME_BUCKETS[remapped.constraint] ?? 'error',
+        });
+        throw remapped.error;
       }
+      // Anything else from inside the tx (DB outage, txn abort,
+      // unexpected Postgres error) is operational — count it as
+      // 'error' so the funnel doesn't silently drop these requests.
+      signupAttemptsTotal.inc({ outcome: 'error' });
       throw err;
     }
 
-    // Log AFTER commit — logging inside the tx callback would record
-    // success even if the COMMIT itself fails.
+    // Log + count AFTER commit — incrementing inside the tx callback
+    // would record success even if the COMMIT itself fails.
+    signupAttemptsTotal.inc({ outcome: 'success' });
     logger.info('Self-service signup completed', {
+      event: 'signup_completed',
       userId: result.user.id,
       organizationId: result.organization.id,
       subdomain,
@@ -352,92 +452,134 @@ export class SignupService {
     // base64url tokens never contain whitespace, and silent
     // normalization would mask client bugs by turning them into
     // successful "not found" lookups.
-    return this.db.transaction(async (tx) => {
-      // Look up the row WITHOUT the active filter so we can recognize
-      // a re-submission of an already-consumed token and respond
-      // idempotently when the underlying user is verified.
-      const tokenRow = await tx.emailVerificationTokens.findByToken(token);
-      if (!tokenRow) {
-        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
-      }
+    let result: { user_id: string };
+    try {
+      result = await this.db.transaction(async (tx) => {
+        // Look up the row WITHOUT the active filter so we can recognize
+        // a re-submission of an already-consumed token and respond
+        // idempotently when the underlying user is verified.
+        const tokenRow = await tx.emailVerificationTokens.findByToken(token);
+        if (!tokenRow) {
+          throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+        }
 
-      // Helper for the "the path I tried failed; succeed only if a
-      // concurrent transaction verified the user in the meantime"
-      // pattern. Each potential race point below routes failures
-      // through this so the "verified user wins" contract holds at
-      // every step under READ COMMITTED.
-      const succeedIfNowVerified = async (): Promise<{ user_id: string }> => {
-        const refreshed = await tx.users.findById(tokenRow.user_id);
-        if (refreshed?.email_verified_at) {
+        // Helper for the "the path I tried failed; succeed only if a
+        // concurrent transaction verified the user in the meantime"
+        // pattern. Each potential race point below routes failures
+        // through this so the "verified user wins" contract holds at
+        // every step under READ COMMITTED.
+        const succeedIfNowVerified = async (): Promise<{ user_id: string }> => {
+          const refreshed = await tx.users.findById(tokenRow.user_id);
+          if (refreshed?.email_verified_at) {
+            return { user_id: tokenRow.user_id };
+          }
+          throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+        };
+
+        // Defense-in-depth: the FK has `ON DELETE CASCADE` so a token
+        // for a non-existent user shouldn't reach this point under
+        // normal DB operation. If it does (replication oddity, manual
+        // FK mutation, future schema change), throw rather than fall
+        // through — the rest of the function assumes a real user
+        // exists. Same generic 400 as other failure modes so we don't
+        // leak orphan-token state.
+        const user = await tx.users.findById(tokenRow.user_id);
+        if (!user) {
+          throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
+        }
+
+        // Idempotent fast-path: user is already verified. Return the
+        // same shape as a fresh successful verify regardless of
+        // whether THIS token was the one that did it, or whether it's
+        // still active. Don't consume the row — if it's active it'll
+        // expire on its own, and consuming silently would be a side
+        // effect with no observable benefit.
+        if (user.email_verified_at) {
           return { user_id: tokenRow.user_id };
         }
-        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
-      };
 
-      // Defense-in-depth: the FK has `ON DELETE CASCADE` so a token
-      // for a non-existent user shouldn't reach this point under
-      // normal DB operation. If it does (replication oddity, manual
-      // FK mutation, future schema change), throw rather than fall
-      // through — the rest of the function assumes a real user
-      // exists. Same generic 400 as other failure modes so we don't
-      // leak orphan-token state.
-      const user = await tx.users.findById(tokenRow.user_id);
-      if (!user) {
-        throw new AppError('Invalid or expired verification token', 400, 'BadRequest');
-      }
+        // From here the user is NOT yet verified at our snapshot — we
+        // need a real consume + stamp to make progress. Reject
+        // already-consumed tokens — but route through
+        // succeedIfNowVerified so a concurrent verify of the SAME user
+        // via a DIFFERENT token (committed between our findById and
+        // here) still wins over the token-state rejection.
+        if (tokenRow.consumed_at !== null) {
+          return succeedIfNowVerified();
+        }
 
-      // Idempotent fast-path: user is already verified. Return the
-      // same shape as a fresh successful verify regardless of
-      // whether THIS token was the one that did it, or whether it's
-      // still active. Don't consume the row — if it's active it'll
-      // expire on its own, and consuming silently would be a side
-      // effect with no observable benefit.
-      if (user.email_verified_at) {
+        // Don't perform a JS-side expiry check here — `consume()`'s
+        // SQL guard (`expires_at > NOW()`) is authoritative and uses
+        // the same Postgres clock that wrote `expires_at` in the
+        // first place. A JS-side check against the app server clock
+        // could prematurely reject still-valid tokens under NTP/
+        // container clock skew between the app and the database.
+        const consumed = await tx.emailVerificationTokens.consume(tokenRow.id);
+        if (!consumed) {
+          // !consumed means either:
+          //  - Expiry: the SQL guard rejected because expires_at <=
+          //    NOW(). The user was unverified above and remains so —
+          //    succeedIfNowVerified will throw 400.
+          //  - Race-loss: a concurrent verify-email request for the
+          //    same token won consume() and may already have stamped
+          //    the user. The re-read returns success in that case.
+          return succeedIfNowVerified();
+        }
+
+        // Atomic stamp via DB `NOW()` and a `WHERE email_verified_at
+        // IS NULL` guard. False return means the UPDATE matched no
+        // rows: either another transaction won the race and stamped
+        // the user (return success via the re-read), or the user was
+        // deleted between our findById and the stamp (re-read returns
+        // null, throw 400). Capturing the boolean instead of dropping
+        // it on the floor avoids the silent-success-for-deleted-user
+        // failure mode.
+        const verified = await tx.users.markEmailVerified(tokenRow.user_id);
+        if (!verified) {
+          return succeedIfNowVerified();
+        }
+
+        // Audit row for the user-facing terminal action. Inside the
+        // tx so a COMMIT failure rolls it back together with the stamp.
+        // Idempotent fast-path returns (already-verified user) skip
+        // the audit row — the original verification already produced
+        // one and a duplicate would just be noise. ip_address /
+        // user_agent are not threaded through to this service today;
+        // omitting rather than wiring them up keeps this slice
+        // focused. Tracked as a follow-up.
+        await tx.auditLogs.create({
+          action: 'email_verified',
+          resource: 'auth/verify-email',
+          resource_id: tokenRow.user_id,
+          user_id: tokenRow.user_id,
+          details: { token_id: tokenRow.id },
+          success: true,
+        });
+
         return { user_id: tokenRow.user_id };
-      }
+      });
+    } catch (err) {
+      // 4xx AppErrors are user-facing terminal failures (unknown /
+      // consumed-but-not-verified / expired). Anything else (5xx
+      // AppError, DB outage, unexpected throw) is operational —
+      // count under 'error' so dashboards don't conflate "your link
+      // is dead" with "the database died."
+      const outcome =
+        err instanceof AppError && err.statusCode >= 400 && err.statusCode < 500
+          ? 'invalid'
+          : 'error';
+      signupEmailVerificationTotal.inc({ outcome });
+      throw err;
+    }
 
-      // From here the user is NOT yet verified at our snapshot — we
-      // need a real consume + stamp to make progress. Reject
-      // already-consumed tokens — but route through
-      // succeedIfNowVerified so a concurrent verify of the SAME user
-      // via a DIFFERENT token (committed between our findById and
-      // here) still wins over the token-state rejection.
-      if (tokenRow.consumed_at !== null) {
-        return succeedIfNowVerified();
-      }
-
-      // Don't perform a JS-side expiry check here — `consume()`'s
-      // SQL guard (`expires_at > NOW()`) is authoritative and uses
-      // the same Postgres clock that wrote `expires_at` in the
-      // first place. A JS-side check against the app server clock
-      // could prematurely reject still-valid tokens under NTP/
-      // container clock skew between the app and the database.
-      const consumed = await tx.emailVerificationTokens.consume(tokenRow.id);
-      if (!consumed) {
-        // !consumed means either:
-        //  - Expiry: the SQL guard rejected because expires_at <=
-        //    NOW(). The user was unverified above and remains so —
-        //    succeedIfNowVerified will throw 400.
-        //  - Race-loss: a concurrent verify-email request for the
-        //    same token won consume() and may already have stamped
-        //    the user. The re-read returns success in that case.
-        return succeedIfNowVerified();
-      }
-
-      // Atomic stamp via DB `NOW()` and a `WHERE email_verified_at
-      // IS NULL` guard. False return means the UPDATE matched no
-      // rows: either another transaction won the race and stamped
-      // the user (return success via the re-read), or the user was
-      // deleted between our findById and the stamp (re-read returns
-      // null, throw 400). Capturing the boolean instead of dropping
-      // it on the floor avoids the silent-success-for-deleted-user
-      // failure mode.
-      const verified = await tx.users.markEmailVerified(tokenRow.user_id);
-      if (verified) {
-        return { user_id: tokenRow.user_id };
-      }
-      return succeedIfNowVerified();
+    // Successful or idempotent fast-path — both observable as
+    // "user is verified now."
+    signupEmailVerificationTotal.inc({ outcome: 'success' });
+    logger.info('Email verification succeeded', {
+      event: 'email_verified',
+      userId: result.user_id,
     });
+    return result;
   }
 
   /**
@@ -467,47 +609,80 @@ export class SignupService {
     // signup-email service's default).
     let resolvedLocale: EmailLocale | undefined = locale;
 
-    await this.db.transaction(async (tx) => {
-      // Lock the user row for the duration of this transaction. Two
-      // concurrent resend requests for the same user without this
-      // lock can both invalidate prior tokens (each seeing 0 active
-      // tokens) and each insert a new one — leaving the user with
-      // multiple "active" tokens and breaking the "latest link is
-      // the only one that works" guarantee. Adding a partial UNIQUE
-      // index would make the second insert fail visibly with 500;
-      // serializing here keeps both succeed-paths and last-writer
-      // semantics.
-      await tx.users.lockForUpdate(userId);
+    try {
+      await this.db.transaction(async (tx) => {
+        // Lock the user row for the duration of this transaction. Two
+        // concurrent resend requests for the same user without this
+        // lock can both invalidate prior tokens (each seeing 0 active
+        // tokens) and each insert a new one — leaving the user with
+        // multiple "active" tokens and breaking the "latest link is
+        // the only one that works" guarantee. Adding a partial UNIQUE
+        // index would make the second insert fail visibly with 500;
+        // serializing here keeps both succeed-paths and last-writer
+        // semantics.
+        await tx.users.lockForUpdate(userId);
 
-      const user = await tx.users.findById(userId);
-      if (!user) {
-        // JWT carries a user id that no longer resolves — session is
-        // stale. Throw inside the txn so it rolls back cleanly.
-        throw new AppError('User not found', 404, 'NotFound');
-      }
-      if (user.email_verified_at) {
-        // Already verified — silently no-op. The route returns 200
-        // in both cases so the client UI doesn't have to branch.
-        return;
-      }
-
-      await tx.emailVerificationTokens.invalidateUnconsumedForUser(user.id);
-      await tx.emailVerificationTokens.create({
-        user_id: user.id,
-        token: newToken,
-        expires_at: expiresAt,
-      });
-
-      recipientEmail = user.email;
-      contactName = this.getContactNameForEmail(user);
-      // `user.preferences` is required on the type but defaults to {}
-      // in the DB — `language` is optional inside it.
-      if (!resolvedLocale) {
-        const stored = user.preferences?.language;
-        if (stored === 'en' || stored === 'ru' || stored === 'kk') {
-          resolvedLocale = stored;
+        const user = await tx.users.findById(userId);
+        if (!user) {
+          // JWT carries a user id that no longer resolves — session is
+          // stale. Throw inside the txn so it rolls back cleanly.
+          throw new AppError('User not found', 404, 'NotFound');
         }
+        if (user.email_verified_at) {
+          // Already verified — silently no-op. The route returns 200
+          // in both cases so the client UI doesn't have to branch.
+          return;
+        }
+
+        await tx.emailVerificationTokens.invalidateUnconsumedForUser(user.id);
+        await tx.emailVerificationTokens.create({
+          user_id: user.id,
+          token: newToken,
+          expires_at: expiresAt,
+        });
+
+        // Audit row for the resend action. Inside the tx so a COMMIT
+        // failure rolls it back together with the new token. Skipped
+        // for the already-verified silent no-op above (no work to
+        // record; would just be noise).
+        await tx.auditLogs.create({
+          action: 'verification_resent',
+          resource: 'auth/resend-verification',
+          resource_id: user.id,
+          user_id: user.id,
+          details: {},
+          success: true,
+        });
+
+        recipientEmail = user.email;
+        contactName = this.getContactNameForEmail(user);
+        // `user.preferences` is required on the type but defaults to {}
+        // in the DB — `language` is optional inside it.
+        if (!resolvedLocale) {
+          const stored = user.preferences?.language;
+          if (stored === 'en' || stored === 'ru' || stored === 'kk') {
+            resolvedLocale = stored;
+          }
+        }
+      });
+    } catch (err) {
+      if (err instanceof AppError && err.statusCode === 404) {
+        signupVerificationResendTotal.inc({ outcome: 'user_not_found' });
+      } else {
+        signupVerificationResendTotal.inc({ outcome: 'error' });
       }
+      throw err;
+    }
+
+    // Either a new token was issued OR the user was already verified
+    // (silent no-op). Both surface as 200 to the client; we count
+    // them under 'success' since the user-observable outcome is
+    // "your request was processed."
+    signupVerificationResendTotal.inc({ outcome: 'success' });
+    logger.info('Verification email resend processed', {
+      event: 'verification_resent',
+      userId,
+      sentEmail: recipientEmail !== null,
     });
 
     if (!recipientEmail) {
@@ -642,11 +817,28 @@ const UNIQUE_CONSTRAINT_MESSAGES: Readonly<Record<string, string>> = Object.free
 });
 
 /**
- * If `err` is a Postgres unique_violation, return a user-facing 409 AppError
- * identifying the specific field that collided; otherwise return null so the
- * caller can rethrow the original error.
+ * Funnel-bucket mapping for the unique-violation race-loss path. Lives next
+ * to `UNIQUE_CONSTRAINT_MESSAGES` so the constraint-name knowledge stays in
+ * one place — adding a new unique constraint to the signup tables means
+ * extending both maps together. Unknown constraints intentionally fall
+ * through to the `error` outcome at the call site so a future migration
+ * doesn't silently mis-bucket a new race-loss into `duplicate_email`.
  */
-function remapUniqueViolation(err: unknown): AppError | null {
+const UNIQUE_CONSTRAINT_OUTCOME_BUCKETS: Readonly<
+  Record<string, 'duplicate_email' | 'invalid_input'>
+> = Object.freeze({
+  users_email_key: 'duplicate_email',
+  organizations_subdomain_key: 'invalid_input',
+});
+
+/**
+ * If `err` is a Postgres unique_violation, return the remapped 409 AppError
+ * AND the underlying constraint name so the caller can both (a) surface the
+ * user-facing message and (b) bucket the failure into the funnel without
+ * having to re-parse the original error. Returns null when `err` is not a
+ * unique_violation; the caller rethrows in that case.
+ */
+function remapUniqueViolation(err: unknown): { error: AppError; constraint: string } | null {
   if (!err || typeof err !== 'object') {
     return null;
   }
@@ -657,7 +849,7 @@ function remapUniqueViolation(err: unknown): AppError | null {
 
   const constraint = typeof candidate.constraint === 'string' ? candidate.constraint : '';
   const message = UNIQUE_CONSTRAINT_MESSAGES[constraint] ?? 'A conflicting record already exists';
-  return new AppError(message, 409, 'Conflict');
+  return { error: new AppError(message, 409, 'Conflict'), constraint };
 }
 
 /** Resolve a region string from config into the DataResidencyRegion enum, or throw. */

--- a/packages/backend/src/saas/services/spam-filter.service.ts
+++ b/packages/backend/src/saas/services/spam-filter.service.ts
@@ -7,6 +7,7 @@
 
 import type { DatabaseClient } from '../../db/client.js';
 import { getLogger } from '../../logger.js';
+import { signupSpamCheckTotal } from '../../metrics/registry.js';
 import { DISPOSABLE_EMAIL_DOMAINS } from '../data/disposable-email-domains.js';
 
 const logger = getLogger();
@@ -45,6 +46,7 @@ export class SpamFilterService {
 
     // 1. Honeypot — instant reject
     if (input.honeypot && input.honeypot.trim().length > 0) {
+      signupSpamCheckTotal.inc({ check: 'honeypot' });
       logger.info('Spam check: honeypot triggered', { ip: input.ip_address });
       return { rejected: true, spam_score: 100, reasons: ['honeypot'] };
     }
@@ -55,6 +57,7 @@ export class SpamFilterService {
       RATE_LIMIT_WINDOW_MINUTES
     );
     if (recentCount >= RATE_LIMIT_MAX) {
+      signupSpamCheckTotal.inc({ check: 'rate_limit' });
       logger.info('Spam check: rate limit exceeded', {
         ip: input.ip_address,
         count: recentCount,
@@ -65,6 +68,7 @@ export class SpamFilterService {
     // 3. Duplicate pending request — instant reject
     const existing = await this.db.organizationRequests.findPendingByEmail(input.contact_email);
     if (existing) {
+      signupSpamCheckTotal.inc({ check: 'duplicate_pending' });
       logger.info('Spam check: duplicate pending request', {
         email: input.contact_email,
         existingId: existing.id,
@@ -89,6 +93,19 @@ export class SpamFilterService {
 
     const rejected = score >= SPAM_THRESHOLD;
     if (rejected) {
+      // Per-check breakdown for the score-based contributors only
+      // counts when the request is actually rejected. Hard-reject
+      // checks above (honeypot, rate_limit, duplicate_pending)
+      // increment inline because they always coincide with their
+      // early-return rejection; score-based reasons need this
+      // post-decision check so the counter doesn't fire for
+      // sub-threshold heuristic hits the request ultimately
+      // survives. Keeps `signup_spam_check_total` interpretable as
+      // a "rejection reason breakdown" rather than a "heuristic hit
+      // rate".
+      for (const reason of reasons) {
+        signupSpamCheckTotal.inc({ check: reason });
+      }
       logger.info('Spam check: request rejected', {
         score,
         reasons,

--- a/packages/backend/tests/api/routes/signup.route.test.ts
+++ b/packages/backend/tests/api/routes/signup.route.test.ts
@@ -120,6 +120,13 @@ function createHappyMockDb(): DatabaseClient {
       consume: vi.fn(async () => true),
       invalidateUnconsumedForUser: vi.fn(async () => 0),
     },
+    auditLogs: {
+      create: vi.fn(async (d: Record<string, unknown>) => ({
+        id: 'audit-uuid',
+        timestamp: new Date(),
+        ...d,
+      })),
+    },
   };
 
   // Extend tx.users with the methods used outside signup() — verifyEmail
@@ -341,6 +348,9 @@ describe('POST /api/v1/auth/verify-email (route smoke)', () => {
         create: vi.fn(),
         invalidateUnconsumedForUser: vi.fn(),
       },
+      auditLogs: {
+        create: vi.fn(async () => undefined),
+      },
     };
     (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(
       async (cb: (t: unknown) => Promise<unknown>) => cb(tx)
@@ -450,6 +460,9 @@ describe('POST /api/v1/auth/resend-verification (route smoke)', () => {
         })),
         findByToken: vi.fn(),
         consume: vi.fn(),
+      },
+      auditLogs: {
+        create: vi.fn(async () => undefined),
       },
     };
     (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(

--- a/packages/backend/tests/saas/signup.service.test.ts
+++ b/packages/backend/tests/saas/signup.service.test.ts
@@ -10,7 +10,7 @@
  * - API key returned in plaintext; stored as SHA-256 hash
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   SignupService,
   type IVerificationEmailSender,
@@ -18,6 +18,7 @@ import {
 import type { DatabaseClient } from '../../src/db/client.js';
 import { DATA_RESIDENCY_REGION } from '../../src/db/types.js';
 import { hashKey } from '../../src/services/api-key/key-crypto.js';
+import { signupAttemptsTotal, signupEmailVerificationTotal } from '../../src/metrics/registry.js';
 
 vi.mock('../../src/logger.js', () => ({
   getLogger: () => ({
@@ -41,6 +42,7 @@ interface InsertLog {
   apiKeys: unknown[];
   apiKeyAudits: unknown[];
   emailVerificationTokens: unknown[];
+  auditLogs: unknown[];
 }
 
 function validInput() {
@@ -84,6 +86,7 @@ function createMockDb(overrides: DbOverrides = {}): {
     apiKeys: [],
     apiKeyAudits: [],
     emailVerificationTokens: [],
+    auditLogs: [],
   };
   const transactionCalled = { value: 0 };
 
@@ -167,6 +170,17 @@ function createMockDb(overrides: DbOverrides = {}): {
       consume: vi.fn(overrides.consumeToken ?? (async () => true)),
       invalidateUnconsumedForUser: vi.fn(overrides.invalidateUnconsumed ?? (async () => 0)),
     },
+    auditLogs: {
+      create: vi.fn(async (data: unknown) => {
+        const row = {
+          id: 'audit-uuid',
+          timestamp: new Date(),
+          ...(data as object),
+        };
+        log.auditLogs.push(row);
+        return row;
+      }),
+    },
   };
 
   // Extend tx.users with the methods used outside signup() — verifyEmail
@@ -237,11 +251,32 @@ describe('SignupService', () => {
   let mock: ReturnType<typeof createMockDb>;
   let service: SignupService;
   let email: ReturnType<typeof createMockEmailService>;
+  // Spy on the Prometheus counters so tests can assert which outcome
+  // bucket each path lands in. The spies use `vi.spyOn` so the real
+  // counters still increment in-process — harmless across tests, and
+  // we don't need to mock the registry module wholesale.
+  let attemptsIncSpy: ReturnType<typeof vi.spyOn>;
+  let verifyIncSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     mock = createMockDb();
     email = createMockEmailService();
     service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+    attemptsIncSpy = vi.spyOn(signupAttemptsTotal, 'inc');
+    verifyIncSpy = vi.spyOn(signupEmailVerificationTotal, 'inc');
+  });
+
+  afterEach(() => {
+    // Restore the prom-client `inc` spies so they don't accumulate
+    // across tests in this file. Each call to `vi.spyOn` wraps the
+    // underlying method, and without restoration the wrapping piles
+    // up — harmless functionally, but leaks the indirection across
+    // tests and confuses any future test that checks the method
+    // identity directly. `restoreAllMocks` also clears the call
+    // history captured by these spies; per-test `mockClear()` calls
+    // remain in place so an individual test's assertions don't see
+    // counts from `beforeEach` setup.
+    vi.restoreAllMocks();
   });
 
   describe('happy path', () => {
@@ -262,6 +297,25 @@ describe('SignupService', () => {
       expect(result.project.id).toBe('project-uuid');
       expect(result.api_key).toMatch(/^bgs_/);
       expect(result.api_key_id).toBe('apikey-uuid');
+    });
+
+    it('writes a signup_completed audit row inside the transaction', async () => {
+      // The audit row lives in the same tx as the user/org/project
+      // inserts. Locking it in here ensures a future refactor that
+      // accidentally moves it post-commit (or drops it entirely)
+      // surfaces as a test failure rather than silent data loss.
+      const result = await service.signup(validInput());
+
+      expect(mock.log.auditLogs).toHaveLength(1);
+      expect(mock.log.auditLogs[0]).toMatchObject({
+        action: 'signup_completed',
+        resource: 'auth/signup',
+        resource_id: result.user.id,
+        user_id: result.user.id,
+        organization_id: result.organization.id,
+        ip_address: '203.0.113.7',
+        success: true,
+      });
     });
 
     it('stores the API key as a SHA-256 hex hash (not plaintext, not bcrypt)', async () => {
@@ -580,6 +634,45 @@ describe('SignupService', () => {
 
         const result = await service.verifyEmail('good');
         expect(result).toEqual({ user_id: fakeUserId });
+        // Audit row written inside the tx, only on the path that
+        // actually contributed the stamp. Idempotent fast-paths
+        // (already-verified user, race-lost stamp) skip it — those
+        // are exercised by other tests in this describe block.
+        expect(mock.log.auditLogs).toHaveLength(1);
+        expect(mock.log.auditLogs[0]).toMatchObject({
+          action: 'email_verified',
+          resource: 'auth/verify-email',
+          resource_id: fakeUserId,
+          user_id: fakeUserId,
+          success: true,
+        });
+      });
+
+      it('skips the audit row on the idempotent fast-path (user already verified)', async () => {
+        // The fast-path is: token row exists, user.email_verified_at
+        // already set → return success. No new stamp, no audit row.
+        // The original verification already produced one; a second
+        // would just be noise.
+        mock = createMockDb({
+          findByToken: async () => ({
+            id: 'evt-1',
+            user_id: 'user-uuid',
+            token: 'good',
+            expires_at: new Date(Date.now() + 60_000),
+            consumed_at: null,
+            created_at: new Date(),
+          }),
+          findById: async () => ({
+            id: 'user-uuid',
+            email: 'founder@acme.com',
+            name: 'Jane',
+            email_verified_at: new Date(),
+          }),
+        });
+        service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+
+        await service.verifyEmail('good');
+        expect(mock.log.auditLogs).toHaveLength(0);
       });
 
       it('rejects an unknown token with 400', async () => {
@@ -1000,6 +1093,15 @@ describe('SignupService', () => {
 
         expect(invalidate).toHaveBeenCalledWith('user-uuid');
         expect(mock.log.emailVerificationTokens).toHaveLength(1);
+        // Audit row written inside the tx, alongside the new token.
+        expect(mock.log.auditLogs).toHaveLength(1);
+        expect(mock.log.auditLogs[0]).toMatchObject({
+          action: 'verification_resent',
+          resource: 'auth/resend-verification',
+          resource_id: 'user-uuid',
+          user_id: 'user-uuid',
+          success: true,
+        });
         // Fire-and-forget — the .catch inside resendVerification means
         // the await on resendVerification resolves before the send promise
         // settles. Wait a microtask tick for the dispatch.
@@ -1020,6 +1122,9 @@ describe('SignupService', () => {
 
         await expect(service.resendVerification('user-uuid')).resolves.toBeUndefined();
         expect(mock.log.emailVerificationTokens).toHaveLength(0);
+        // Already-verified branch skips the audit row — same response
+        // shape to the client, no work done, nothing to record.
+        expect(mock.log.auditLogs).toHaveLength(0);
         expect(email.send).not.toHaveBeenCalled();
       });
 
@@ -1070,6 +1175,188 @@ describe('SignupService', () => {
         const arg = email.send.mock.calls[0][0] as { locale?: string };
         expect(arg.locale).toBe('kk');
       });
+    });
+  });
+
+  describe('telemetry: outcome classification', () => {
+    // The funnel counter (`signup_attempts_total`) and the email-
+    // verification counter MUST distinguish "user did something we
+    // rejected" (4xx AppErrors → invalid_input / duplicate_email /
+    // spam_rejected / invalid) from "system broke" (503 from spam
+    // infra, DB outage, txn abort, anything else → 'error'). These
+    // tests lock that classification in so a future refactor can't
+    // silently re-bucket operational failures into user-facing
+    // funnel buckets — exactly the regression that would skew the
+    // dashboards we'd build hCaptcha / disposable-email comparisons
+    // on top of.
+
+    it("classifies a 503 from spam-filter infra as 'error', not 'spam_rejected'", async () => {
+      mock = createMockDb({ spamFilterThrows: true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      attemptsIncSpy.mockClear();
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({ statusCode: 503 });
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'error' });
+      expect(attemptsIncSpy).not.toHaveBeenCalledWith({ outcome: 'spam_rejected' });
+    });
+
+    it("classifies a 409 PendingEnterpriseRequest as 'duplicate_email', not 'spam_rejected'", async () => {
+      mock = createMockDb({
+        findPendingByEmail: async () => ({
+          id: 'existing-request',
+          status: 'pending_verification',
+        }),
+      });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      attemptsIncSpy.mockClear();
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({ statusCode: 409 });
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'duplicate_email' });
+      expect(attemptsIncSpy).not.toHaveBeenCalledWith({ outcome: 'spam_rejected' });
+    });
+
+    it("classifies a 403 honeypot rejection as 'spam_rejected'", async () => {
+      attemptsIncSpy.mockClear();
+
+      await expect(
+        service.signup({ ...validInput(), honeypot: 'spam-bot-filled-this' })
+      ).rejects.toMatchObject({ statusCode: 403 });
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'spam_rejected' });
+    });
+
+    it("classifies a successful signup as 'success'", async () => {
+      attemptsIncSpy.mockClear();
+
+      await service.signup(validInput());
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'success' });
+    });
+
+    it("classifies a duplicate findByEmail as 'duplicate_email'", async () => {
+      mock = createMockDb({ findByEmail: async () => ({ id: 'existing' }) });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      attemptsIncSpy.mockClear();
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({ statusCode: 409 });
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'duplicate_email' });
+    });
+
+    it("classifies an empty company name as 'invalid_input'", async () => {
+      attemptsIncSpy.mockClear();
+
+      await expect(service.signup({ ...validInput(), company_name: '' })).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'invalid_input' });
+    });
+
+    it("classifies a non-unique-violation throw inside the tx as 'error'", async () => {
+      // Simulates an unexpected DB-side failure mid-tx (timeout,
+      // connection drop, anything that isn't 23505). Without the
+      // catch-all 'error' bucket this case used to rethrow without
+      // counting, leaving the funnel total < total attempts.
+      mock = createMockDb({ transactionThrows: true });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      attemptsIncSpy.mockClear();
+
+      await expect(service.signup(validInput())).rejects.toThrow('simulated commit failure');
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'error' });
+    });
+
+    it("classifies a findByEmail DB outage as 'error'", async () => {
+      // findByEmail runs OUTSIDE the tx — its own dedicated read on
+      // the duplicate-check path. Without the catch this case used
+      // to rethrow uncounted, leaving the funnel total < total
+      // attempts during incidents (which is exactly the case the
+      // 'error' bucket exists to make visible).
+      mock = createMockDb({
+        findByEmail: async () => {
+          throw new Error('simulated DB pool exhaustion');
+        },
+      });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      attemptsIncSpy.mockClear();
+
+      await expect(service.signup(validInput())).rejects.toThrow(/DB pool exhaustion/);
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'error' });
+      expect(attemptsIncSpy).not.toHaveBeenCalledWith({ outcome: 'duplicate_email' });
+    });
+
+    it("classifies a unique-violation on an unknown constraint as 'error'", async () => {
+      // Defense-in-depth for a future migration that adds a unique
+      // constraint to a signup-touched table without updating
+      // UNIQUE_CONSTRAINT_OUTCOME_BUCKETS. The remapped 409 still
+      // surfaces to the caller (with a generic message), but the
+      // funnel correctly buckets it as operational rather than
+      // silently calling it duplicate_email.
+      const { db, transactionCalled } = createMockDb();
+      (db.transaction as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        transactionCalled.value++;
+        const err = new Error('duplicate key value violates unique constraint') as Error & {
+          code: string;
+          constraint: string;
+        };
+        err.code = '23505';
+        err.constraint = 'some_future_unique_key';
+        throw err;
+      });
+      service = new SignupService(db, DATA_RESIDENCY_REGION.KZ, email.service);
+      attemptsIncSpy.mockClear();
+
+      await expect(service.signup(validInput())).rejects.toMatchObject({ statusCode: 409 });
+      expect(attemptsIncSpy).toHaveBeenCalledWith({ outcome: 'error' });
+      expect(attemptsIncSpy).not.toHaveBeenCalledWith({ outcome: 'duplicate_email' });
+    });
+
+    it("classifies a 4xx verifyEmail failure as 'invalid'", async () => {
+      mock = createMockDb({ findByToken: async () => null });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      verifyIncSpy.mockClear();
+
+      await expect(service.verifyEmail('nope')).rejects.toMatchObject({ statusCode: 400 });
+      expect(verifyIncSpy).toHaveBeenCalledWith({ outcome: 'invalid' });
+    });
+
+    it("classifies an unexpected verifyEmail failure as 'error'", async () => {
+      // Throw a non-AppError from the tx so the catch sees a raw
+      // Error. With the old logic this got bucketed into 'invalid';
+      // now it lands in 'error' so dashboards can distinguish dead
+      // tokens from a misbehaving DB.
+      mock = createMockDb({
+        findByToken: async () => {
+          throw new Error('simulated DB outage');
+        },
+      });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      verifyIncSpy.mockClear();
+
+      await expect(service.verifyEmail('whatever')).rejects.toThrow('simulated DB outage');
+      expect(verifyIncSpy).toHaveBeenCalledWith({ outcome: 'error' });
+      expect(verifyIncSpy).not.toHaveBeenCalledWith({ outcome: 'invalid' });
+    });
+
+    it("classifies a successful verifyEmail as 'success'", async () => {
+      mock = createMockDb({
+        findByToken: async () => ({
+          id: 'evt-1',
+          user_id: 'user-uuid',
+          token: 'good',
+          expires_at: new Date(Date.now() + 60_000),
+          consumed_at: null,
+          created_at: new Date(),
+        }),
+        findById: async () => ({
+          id: 'user-uuid',
+          email: 'founder@acme.com',
+          name: 'Jane',
+          email_verified_at: null,
+        }),
+        consumeToken: async () => true,
+      });
+      service = new SignupService(mock.db, DATA_RESIDENCY_REGION.KZ, email.service);
+      verifyIncSpy.mockClear();
+
+      await service.verifyEmail('good');
+      expect(verifyIncSpy).toHaveBeenCalledWith({ outcome: 'success' });
     });
   });
 });

--- a/packages/backend/tests/saas/spam-filter.service.test.ts
+++ b/packages/backend/tests/saas/spam-filter.service.test.ts
@@ -4,9 +4,10 @@
  * and suspicious pattern checks.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SpamFilterService } from '../../src/saas/services/spam-filter.service.js';
 import type { DatabaseClient } from '../../src/db/client.js';
+import { signupSpamCheckTotal } from '../../src/metrics/registry.js';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -223,6 +224,83 @@ describe('SpamFilterService', () => {
 
       expect(result.rejected).toBe(true);
       expect(result.spam_score).toBeGreaterThanOrEqual(50);
+    });
+  });
+
+  // ─── Per-check counter semantics ───
+  // The `signup_spam_check_total{check}` counter is documented as
+  // a rejection-reason BREAKDOWN, not a heuristic-hit rate. A
+  // request whose score-based reason fired but whose total stayed
+  // below the threshold (so the request was NOT rejected) must NOT
+  // increment the counter — otherwise dashboards interpreting the
+  // counter as "share of rejections involving each check" would be
+  // misleading.
+
+  describe('per-check counter semantics', () => {
+    let incSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      incSpy = vi.spyOn(signupSpamCheckTotal, 'inc');
+    });
+
+    afterEach(() => {
+      incSpy.mockRestore();
+    });
+
+    it('does NOT increment for a sub-threshold suspicious_pattern hit', async () => {
+      // 'ACME' is all-caps and >3 chars → suspicious_pattern fires
+      // for +20. With no other contributors, total stays at 20 <
+      // SPAM_THRESHOLD (50), so the request is NOT rejected.
+      const result = await service.check({
+        ...validInput(),
+        company_name: 'ACME',
+      });
+
+      expect(result.rejected).toBe(false);
+      expect(result.reasons).toContain('suspicious_pattern');
+      expect(incSpy).not.toHaveBeenCalledWith({ check: 'suspicious_pattern' });
+    });
+
+    it('does NOT increment when no checks fire on a clean submission', async () => {
+      const result = await service.check(validInput());
+
+      expect(result.rejected).toBe(false);
+      expect(incSpy).not.toHaveBeenCalled();
+    });
+
+    it('increments per reason when the score-based path actually rejects', async () => {
+      // Disposable email alone: +50 score = SPAM_THRESHOLD → rejected.
+      const result = await service.check({
+        ...validInput(),
+        contact_email: 'x@yopmail.com',
+      });
+
+      expect(result.rejected).toBe(true);
+      expect(incSpy).toHaveBeenCalledWith({ check: 'disposable_email' });
+    });
+
+    it('increments multiple reasons when several score-based checks contribute to a rejection', async () => {
+      // Disposable (+50) + suspicious all-caps name (+20) → 70 ≥ 50 → rejected.
+      const result = await service.check({
+        ...validInput(),
+        company_name: 'SPAM CORP',
+        contact_email: 'x@yopmail.com',
+      });
+
+      expect(result.rejected).toBe(true);
+      expect(incSpy).toHaveBeenCalledWith({ check: 'disposable_email' });
+      expect(incSpy).toHaveBeenCalledWith({ check: 'suspicious_pattern' });
+    });
+
+    it('increments inline for hard-reject checks (early-return paths)', async () => {
+      // Honeypot: instant rejection. Counter increments inside the
+      // honeypot branch, not via the post-decision loop.
+      await service.check({
+        ...validInput(),
+        honeypot: 'spam-bot-filled-this',
+      });
+
+      expect(incSpy).toHaveBeenCalledWith({ check: 'honeypot' });
     });
   });
 


### PR DESCRIPTION
## Summary

Three layers of signup-flow telemetry, ahead of the Tier-B launch blockers (hCaptcha, disposable-email blocklist). Without baseline numbers we can't tell whether those protections actually catch bots vs. burn legitimate signups.

| Layer | Purpose | Mechanism |
|---|---|---|
| **Counters** | Dashboards / rate-of-change | \`prom-client\` registry, exported via existing \`/metrics\` |
| **Audit logs** | Compliance / per-user history | Rows in \`application.audit_logs\` |
| **Structured logs** | Debugging individual incidents | New \`event:\` field on existing \`logger.info\` calls |

## Counters

- \`bugspotter_signup_attempts_total{outcome}\` — funnel view. Outcomes: \`success\` / \`spam_rejected\` / \`duplicate_email\` / \`invalid_input\` / \`error\`. The \`error\` bucket separates operational failures from user-facing 4xx outcomes.
- \`bugspotter_signup_spam_check_total{check}\` — **rejection breakdown** (not heuristic-hit rate). Counts only fire when the request is actually rejected; sub-threshold heuristic hits do NOT increment.
- \`bugspotter_signup_email_verification_total{outcome}\` — \`success\` / \`invalid\` / \`error\`.
- \`bugspotter_signup_verification_resend_total{outcome}\` — \`success\` / \`user_not_found\` / \`error\`.

## Catch-site classification

Every potential failure point counts into a documented bucket — no silent rethrows.

| Throw site | Bucket |
|---|---|
| Empty company_name | \`invalid_input\` |
| \`runSpamChecks\` 403 (real spam) | \`spam_rejected\` |
| \`runSpamChecks\` 409 PendingEnterpriseRequest | \`duplicate_email\` (existing user state, not bot) |
| \`runSpamChecks\` 503 (infra failure) | \`error\` |
| \`findByEmail\` throws (DB outage) | \`error\` |
| \`findByEmail\` returns existing user | \`duplicate_email\` |
| \`resolveSubdomain\` 4xx | \`invalid_input\` |
| \`resolveSubdomain\` operational throw | \`error\` |
| Tx remap \`users_email_key\` | \`duplicate_email\` |
| Tx remap \`organizations_subdomain_key\` | \`invalid_input\` |
| Tx remap unknown constraint | \`error\` (defensive default for schema evolution) |
| Tx other throw (txn abort, non-23505) | \`error\` |
| \`verifyEmail\` 4xx | \`invalid\` |
| \`verifyEmail\` non-4xx throw | \`error\` |

\`remapUniqueViolation\` was refactored to return \`{ error, constraint }\` so the caller buckets without re-parsing the original error. \`UNIQUE_CONSTRAINT_OUTCOME_BUCKETS\` lives next to \`UNIQUE_CONSTRAINT_MESSAGES\` to keep constraint-name knowledge in one place.

## Audit logs

Only for user-initiated successful actions: \`signup_completed\`, \`email_verified\`, \`verification_resent\`. Spam-rejected attempts deliberately don't get audit rows — they're bot traffic and would bloat the table; the metric counters provide the aggregate view there.

All inserts inside their respective transactions, matching the existing \`api_key\` audit pattern in this same service. A COMMIT failure rolls the audit row back alongside the work it audits. \`email_verified\` audit is skipped on the idempotent fast-path (already-verified user, race-lost stamp/consume) — the original verification already wrote one.

## Structured logs

Existing \`logger.info\` calls now carry an \`event:\` field (\`signup_completed\`, \`email_verified\`, \`verification_resent\`) for grep-friendly machine parsing. Existing metadata + messages preserved.

## Code touched

- \`packages/backend/src/metrics/registry.ts\` — pure add: 4 new counters with documented outcome enums.
- \`packages/backend/src/saas/services/signup.service.ts\` — counter increments + audit-log inserts + classification at each existing outcome point. **No control flow changes**; each instrumentation is a 1–3 line insertion next to an existing throw or return.
- \`packages/backend/src/saas/services/spam-filter.service.ts\` — counter increments at the existing rejection points. Score-based contributors moved to a post-decision loop gated on \`rejected === true\`.
- Tests: extended the tx mock factory with \`auditLogs.create\`; added 21 specs across three describe blocks.

## Review rounds addressed

This PR was opened, reviewed by Copilot and Gemini across three rounds (8 + 4 + 2 comments), then closed and re-opened with the squashed branch.

**Round 1** — operational vs user-facing classification
- 8 comments converging: operational failures (DB outage, 503, unexpected throws) were misclassified into user-facing funnel outcomes. Added explicit \`error\` outcome to \`signupAttemptsTotal\` and \`signupEmailVerificationTotal\`; reclassified each catch site to separate user 4xx from infra failures.
- Closed the silent-rethrow gap in the tx catch (non-unique-violation rethrow now counts as \`error\`).
- 409 PendingEnterpriseRequest moved from \`spam_rejected\` → \`duplicate_email\` (existing user state, not bot signal).

**Round 2** — schema-evolution + test isolation
- (Copilot) Added \`afterEach(vi.restoreAllMocks())\` to pair with the new prom-client \`inc\` spies.
- (Copilot) Fixed \`users.email_key\` → \`users_email_key\` typo in registry doc.
- (Gemini ×2) Refactored \`remapUniqueViolation\` to return \`{ error, constraint }\`, removing duplicated constraint extraction. Added \`UNIQUE_CONSTRAINT_OUTCOME_BUCKETS\` map; unknown constraints default to \`error\` so a future migration that adds a unique key can't silently mis-bucket race-losses.

**Round 3** — uncounted findByEmail + spam-check semantics
- (Copilot) \`findByEmail\` was outside all catches — DB outage rethrew uncounted. Wrapped with \`error\` increment.
- (Gemini) \`signupSpamCheckTotal\` was billed as a rejection breakdown but score-based contributors fired the counter regardless of rejection. Switched to rejection-only semantics: hard-reject checks keep their inline increments (always coincide with rejection); score-based contributors moved to a post-decision loop.

## Out of scope (deferred)

- Threading \`ip_address\` / \`user_agent\` through to \`verifyEmail\` and \`resendVerification\` — the service signatures don't currently take request context. Audit rows for those events get \`user_id\` only.
- OpenTelemetry tracing — separate slice. We have prom-client; OTel is a different abstraction.

## Test plan

- [x] \`pnpm vitest run --config vitest.unit.config.ts\` — 2352 unit tests pass; +21 new specs (audit + classification + spam-check semantics)
- [x] \`pnpm typecheck\` — pre-existing failures only (rule-evaluator/ticket-template-renderer fixtures, setup-file-polyfill); none from this PR
- [ ] Manual: hit \`/metrics\` after a successful signup → see \`bugspotter_signup_attempts_total{outcome=\"success\"}\` increment
- [ ] Manual: bot submission with honeypot → \`signup_attempts_total{outcome=\"spam_rejected\"}\` and \`signup_spam_check_total{check=\"honeypot\"}\` both increment
- [ ] Manual: signup with all-caps company name (suspicious_pattern alone, sub-threshold) → counter does NOT increment
- [ ] Manual: kill the DB mid-spam-check → \`signup_attempts_total{outcome=\"error\"}\` increments (NOT \`spam_rejected\`)
- [ ] Manual: kill the DB on findByEmail path → \`signup_attempts_total{outcome=\"error\"}\` increments
- [ ] Manual: verify the audit_logs table has rows for signup_completed / email_verified / verification_resent after each respective happy path
- [ ] Manual: spam-rejected attempt does NOT produce an audit_logs row

🤖 Generated with [Claude Code](https://claude.com/claude-code)