### PR TITLE
test(admin): align auth-context navigate assertions with replace:true

### DIFF
--- a/apps/admin/src/tests/contexts/auth-context.integration.test.tsx
+++ b/apps/admin/src/tests/contexts/auth-context.integration.test.tsx
@@ -199,7 +199,7 @@ describe('Auth Context Integration Tests', () => {
 
       expect(result.current.isAuthenticated).toBe(false);
       expect(result.current.user).toBeNull();
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
       expect(sessionStorage.getItem('user')).toBeNull();
     });
 
@@ -238,7 +238,7 @@ describe('Auth Context Integration Tests', () => {
         expect(result.current.isAuthenticated).toBe(false);
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
       expect(sessionStorage.getItem('user')).toBeNull();
     });
 
@@ -324,7 +324,7 @@ describe('Auth Context Integration Tests', () => {
       expect(logoutCalled).toBe(true);
       expect(result.current.user).toBeNull();
       expect(result.current.accessToken).toBeNull();
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
     });
 
     it('should clear state even if logout API fails', async () => {
@@ -355,7 +355,7 @@ describe('Auth Context Integration Tests', () => {
 
       expect(result.current.isAuthenticated).toBe(false);
       expect(result.current.user).toBeNull();
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
     });
   });
 

--- a/apps/admin/src/tests/contexts/auth-context.test.tsx
+++ b/apps/admin/src/tests/contexts/auth-context.test.tsx
@@ -269,7 +269,7 @@ describe('AuthContext', () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
       expect(result.current.isAuthenticated).toBe(false);
       expect(result.current.user).toBeNull();
       expect(sessionStorage.getItem('user')).toBeNull();
@@ -421,7 +421,7 @@ describe('AuthContext', () => {
         expect(result.current.user).toBeNull();
         expect(result.current.accessToken).toBeNull();
         expect(sessionStorage.getItem('user')).toBeNull();
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes the red unit-test job on \`main\` after PR #60 landed: https://github.com/apex-bridge/bugspotter/actions/runs/25033921994/job/73321424044

PR #60 added \`{ replace: true }\` to \`navigate('/login', ...)\` calls in \`logout()\` and the \`initAuth\` token-refresh-failure catch path (so the back button can't return the user to a now-cleared protected page). Six existing unit-test assertions still expected the single-arg form and now fail with:

\`\`\`
AssertionError: expected "spy" to be called with arguments: [ '/login' ]
Received: [ '/login', { replace: true } ]
\`\`\`

## Changes

Updated all six assertions across two files to match the new shape:

- \`apps/admin/src/tests/contexts/auth-context.test.tsx\` (lines 272, 424)
- \`apps/admin/src/tests/contexts/auth-context.integration.test.tsx\` (lines 202, 241, 327, 358)

No production code change. Strictly a test-fixture update.

## Why this slipped through

When pushing PR #60 I only ran \`pnpm --filter @bugspotter/admin build\` — that typechecks but doesn't execute the assertions. The unit suite would have caught it. Going forward I'll run \`pnpm test\` on changes that touch behavior, not just the build.

## Test plan

- [x] \`pnpm --filter @bugspotter/admin test --run\` — 798 / 798 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)