### PR TITLE
fix(backend): hide soft-deleted-org projects + rename default project

### DIFF
--- a/packages/backend/src/db/repositories/project.repository.ts
+++ b/packages/backend/src/db/repositories/project.repository.ts
@@ -127,13 +127,25 @@ export class ProjectRepository extends BaseRepository<Project, ProjectInsert, Pr
     // in the dashboard. LEFT JOIN (not INNER) because in self-hosted
     // mode `application.projects.organization_id` is NULL and the
     // `saas.organizations` table is empty; an INNER JOIN would filter
-    // every self-hosted project out. Admin / system queries
+    // every self-hosted project out. The org check requires either
+    // no org link at all (self-hosted) or a present-and-alive org;
+    // orphan FKs (project pointing at a non-existent org row) are
+    // hidden too, which shouldn't happen in a properly-FK'd schema
+    // but is the safer default if it ever does. Admin / system queries
     // (`findByOrganizationId`, `findAll`) intentionally don't apply
     // this filter — platform admins need visibility into soft-deleted
     // orgs for retention cleanup.
+    //
+    // The `project_members` LEFT JOIN pushes `pm.user_id = $1` into
+    // the ON clause so the join matches at most one row per project
+    // (the `(project_id, user_id)` pair is unique). Combined with
+    // `pm.user_id IS NOT NULL` in WHERE, that lets us drop SELECT
+    // DISTINCT and avoid the row-explosion that the previous form
+    // (LEFT JOIN with no ON-clause user filter) would cause for
+    // projects with many members.
     const conditions: string[] = [
-      '(p.created_by = $1 OR pm.user_id = $1)',
-      '(o.id IS NULL OR o.deleted_at IS NULL)',
+      '(p.created_by = $1 OR pm.user_id IS NOT NULL)',
+      '(p.organization_id IS NULL OR (o.id IS NOT NULL AND o.deleted_at IS NULL))',
     ];
 
     if (organizationId) {
@@ -142,9 +154,10 @@ export class ProjectRepository extends BaseRepository<Project, ProjectInsert, Pr
     }
 
     const query = `
-      SELECT DISTINCT p.* FROM ${this.schema}.${this.tableName} p
+      SELECT p.* FROM ${this.schema}.${this.tableName} p
       LEFT JOIN saas.organizations o ON o.id = p.organization_id
-      LEFT JOIN ${this.schema}.project_members pm ON p.id = pm.project_id
+      LEFT JOIN ${this.schema}.project_members pm
+        ON p.id = pm.project_id AND pm.user_id = $1
       WHERE ${conditions.join(' AND ')}
       ORDER BY p.created_at DESC
     `;

--- a/packages/backend/src/db/repositories/project.repository.ts
+++ b/packages/backend/src/db/repositories/project.repository.ts
@@ -122,7 +122,19 @@ export class ProjectRepository extends BaseRepository<Project, ProjectInsert, Pr
    */
   async getUserAccessibleProjects(userId: string, organizationId?: string): Promise<Project[]> {
     const params: unknown[] = [userId];
-    const conditions: string[] = ['(p.created_by = $1 OR pm.user_id = $1)'];
+    // Hide projects whose owning organization has been soft-deleted —
+    // otherwise a user who deleted their org keeps seeing its projects
+    // in the dashboard. LEFT JOIN (not INNER) because in self-hosted
+    // mode `application.projects.organization_id` is NULL and the
+    // `saas.organizations` table is empty; an INNER JOIN would filter
+    // every self-hosted project out. Admin / system queries
+    // (`findByOrganizationId`, `findAll`) intentionally don't apply
+    // this filter — platform admins need visibility into soft-deleted
+    // orgs for retention cleanup.
+    const conditions: string[] = [
+      '(p.created_by = $1 OR pm.user_id = $1)',
+      '(o.id IS NULL OR o.deleted_at IS NULL)',
+    ];
 
     if (organizationId) {
       conditions.push(`p.organization_id = $${params.length + 1}`);
@@ -131,6 +143,7 @@ export class ProjectRepository extends BaseRepository<Project, ProjectInsert, Pr
 
     const query = `
       SELECT DISTINCT p.* FROM ${this.schema}.${this.tableName} p
+      LEFT JOIN saas.organizations o ON o.id = p.organization_id
       LEFT JOIN ${this.schema}.project_members pm ON p.id = pm.project_id
       WHERE ${conditions.join(' AND ')}
       ORDER BY p.created_at DESC

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -68,7 +68,7 @@ export interface IVerificationEmailSender {
 const logger = getLogger();
 
 const TRIAL_DURATION_DAYS = 14;
-const DEFAULT_PROJECT_NAME = 'My First Project';
+const DEFAULT_PROJECT_NAME = 'Default';
 // 24-hour TTL on verification tokens. Long enough that a user can come
 // back the next morning, short enough that an unread message in a
 // shared inbox doesn't stay valid for weeks.

--- a/packages/backend/tests/api/routes/signup.route.test.ts
+++ b/packages/backend/tests/api/routes/signup.route.test.ts
@@ -218,7 +218,7 @@ describe('POST /api/v1/auth/signup (route smoke)', () => {
     expect(body.success).toBe(true);
     expect(body.data.user.email).toBe('founder@acme.com');
     expect(body.data.organization.subdomain).toBe('acme-corp');
-    expect(body.data.project.name).toBe('My First Project');
+    expect(body.data.project.name).toBe('Default');
     expect(body.data.api_key).toMatch(/^bgs_/);
     expect(body.data.access_token).toBeTruthy();
   });

--- a/packages/backend/tests/saas/organization-scoping.test.ts
+++ b/packages/backend/tests/saas/organization-scoping.test.ts
@@ -115,6 +115,35 @@ describe('Organization scoping', () => {
       expect(projects.some((p) => p.id === orgProject.id)).toBe(true);
       expect(projects.some((p) => p.id === standaloneProject.id)).toBe(false);
     });
+
+    it('should hide projects whose owning org is soft-deleted', async () => {
+      // Use a fresh org so the shared `orgProject` fixture stays
+      // available for the other tests in this block.
+      const freshOrg = await service.createOrganization(
+        { name: 'Soft-deleted Org', subdomain: `soft-deleted-${Date.now()}` },
+        user.id
+      );
+      createdOrgIds.push(freshOrg.id);
+      const freshProject = await db.projects.create({
+        name: 'Project of soon-deleted org',
+        created_by: user.id,
+        organization_id: freshOrg.id,
+      });
+      createdProjectIds.push(freshProject.id);
+
+      // Sanity: project is visible while the org is alive.
+      const before = await db.projects.getUserAccessibleProjects(user.id);
+      expect(before.some((p) => p.id === freshProject.id)).toBe(true);
+
+      await db.organizations.softDelete(freshOrg.id, user.id);
+
+      // After soft-delete: that org's project is hidden, but the
+      // null-org (self-hosted-shape) project stays visible — the
+      // org filter must not regress that path.
+      const after = await db.projects.getUserAccessibleProjects(user.id);
+      expect(after.some((p) => p.id === freshProject.id)).toBe(false);
+      expect(after.some((p) => p.id === standaloneProject.id)).toBe(true);
+    });
   });
 
   describe('bug reports', () => {


### PR DESCRIPTION
## Summary

Two small fixes from fresh-signup feedback:

### 1. Soft-deleted orgs leaked their projects to the dashboard

A user soft-deleted their organization and its project kept appearing in the dashboard. Cause: \`getUserAccessibleProjects\` ([project.repository.ts:123-140](https://github.com/apex-bridge/bugspotter/blob/main/packages/backend/src/db/repositories/project.repository.ts#L123-L140)) didn't filter on the parent org's \`deleted_at\`.

Added a \`LEFT JOIN\` to \`saas.organizations\` with \`(o.id IS NULL OR o.deleted_at IS NULL)\`. Important detail: **LEFT JOIN, not INNER** — self-hosted mode has projects with \`organization_id = NULL\` (the saas tables exist but stay empty per migration 001's tenancy comment), so an INNER JOIN would silently filter every self-hosted project out.

Admin / system queries (\`findByOrganizationId\`, \`findAll\`, \`countByOrganizationId\`) intentionally **don't** apply this filter — platform admins need visibility into soft-deleted orgs to do retention cleanup. The inline comment spells this out.

### 2. Default project name was \"My First Project\"

Reads like Hello-World tutorial copy. A B2B SaaS user signing up under a real company shouldn't see their first workspace called that. Renamed to \`\"Default\"\` — neutral, professional, easy to rename later. Updated the corresponding fixture assertion in \`signup.route.test.ts\`.

## What this PR doesn't fix (tracked separately)

The deeper architectural gap behind issue 1:

- Soft-deleting an org doesn't cascade to its projects.
- The retention sweep's \`hardDeleteGuarded\` rejects orgs that still have projects.
- Result: soft-deleted orgs become permanent zombies unless someone manually deletes their projects first.

Closing this needs cascade-soft-delete on org deletion + matching cleanup in the retention path. Real design discussion (concurrent project queries, restore semantics, project_members handling). Out of scope for this small unblock.

## Test plan

- [x] \`pnpm --filter @bugspotter/backend test:unit\` — 2352 / 2352 passing
- [x] \`pnpm --filter @bugspotter/backend build\` — clean
- [ ] CI integration tests will exercise the new JOIN against a real DB (\`tests/db/repositories.test.ts\` already covers \`getUserAccessibleProjects\`).
- [ ] After merge: a user soft-deletes their org → projects disappear from \`/projects\`.
- [ ] After merge: self-hosted mode dashboard still shows projects (no regression on the \`organization_id IS NULL\` path).
- [ ] After merge: a fresh signup creates a project named \"Default\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)