### PR TITLE
test(admin/e2e): bootstrap users with an org before login (SaaS gate)

### DIFF
--- a/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
+++ b/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
@@ -89,16 +89,6 @@ test.describe('Bug Reports - Access Control & Filters', () => {
       regularUserId = userData.data.id;
     }
 
-    // Login as regular user to get token
-    const regularLoginResponse = await request.post(`${API_URL}/api/v1/auth/login`, {
-      data: {
-        email: TEST_USER.email,
-        password: TEST_USER.password,
-      },
-    });
-    const regularData = await regularLoginResponse.json();
-    regularUserToken = regularData.data.access_token;
-
     // Create a dedicated org for this spec's projects. We can't reuse
     // the admin's default E2E org because the trial plan caps at 2
     // projects and earlier specs in the suite (api-keys, audit-logs,
@@ -114,6 +104,11 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     // otherwise this spec leaves the admin with an extra membership
     // and later specs that pick `myOrgs[0]` could select the wrong
     // one.
+    //
+    // Creation order matters: org + member-add MUST happen before
+    // the regular user logs in. SaaS-mode `/auth/login` rejects with
+    // 403 OrgAccessRevoked when the user has zero non-deleted org
+    // memberships — see auth.ts `assertUserHasActiveOrgAccess`.
     const orgTimestamp = Date.now();
     const bugReportOrgResponse = await request.post(`${API_URL}/api/v1/organizations`, {
       headers: { Authorization: `Bearer ${adminToken}` },
@@ -130,6 +125,35 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     }
     bugReportOrgId = (await bugReportOrgResponse.json()).data.id as string;
     const organizationId = bugReportOrgId;
+
+    // Add the regular user as a member of the org so they have at
+    // least one active membership and pass the SaaS-mode login gate.
+    // Admin is the org owner (creator above), so they have the
+    // permission to add members on this endpoint.
+    if (regularUserId) {
+      const addMemberResponse = await request.post(
+        `${API_URL}/api/v1/organizations/${organizationId}/members`,
+        {
+          headers: { Authorization: `Bearer ${adminToken}` },
+          data: { user_id: regularUserId, role: 'member' },
+        }
+      );
+      if (!addMemberResponse.ok()) {
+        throw new Error(
+          `Failed to add regular user to test org: ${addMemberResponse.status()} ${await addMemberResponse.text()}`
+        );
+      }
+    }
+
+    // Login as regular user to get token (they now have an org membership)
+    const regularLoginResponse = await request.post(`${API_URL}/api/v1/auth/login`, {
+      data: {
+        email: TEST_USER.email,
+        password: TEST_USER.password,
+      },
+    });
+    const regularData = await regularLoginResponse.json();
+    regularUserToken = regularData.data.access_token;
 
     // Create two projects
     const project1Response = await request.post(`${API_URL}/api/v1/projects`, {

--- a/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
+++ b/apps/admin/src/tests/e2e/bug-reports-access-control.spec.ts
@@ -130,28 +130,35 @@ test.describe('Bug Reports - Access Control & Filters', () => {
     // least one active membership and pass the SaaS-mode login gate.
     // Admin is the org owner (creator above), so they have the
     // permission to add members on this endpoint.
-    if (regularUserId) {
-      const addMemberResponse = await request.post(
-        `${API_URL}/api/v1/organizations/${organizationId}/members`,
-        {
-          headers: { Authorization: `Bearer ${adminToken}` },
-          data: { user_id: regularUserId, role: 'member' },
-        }
-      );
-      if (!addMemberResponse.ok()) {
-        throw new Error(
-          `Failed to add regular user to test org: ${addMemberResponse.status()} ${await addMemberResponse.text()}`
-        );
+    // Fail loudly if regularUserId is somehow missing — a silent
+    // skip would produce a less informative 403 at the login step
+    // below. The user-creation block above already handles "user
+    // already exists" gracefully, but if we got past that without
+    // an id we want to know.
+    const addMemberResponse = await request.post(
+      `${API_URL}/api/v1/organizations/${organizationId}/members`,
+      {
+        headers: { Authorization: `Bearer ${adminToken}` },
+        data: { user_id: regularUserId, role: 'member' },
       }
+    );
+    if (!addMemberResponse.ok()) {
+      throw new Error(
+        `Failed to add regular user to test org: ${addMemberResponse.status()} ${await addMemberResponse.text()}`
+      );
     }
 
-    // Login as regular user to get token (they now have an org membership)
+    // Login as regular user to get token (they now have an org membership).
+    // Assert ok() so a regression in the SaaS login gate (or a
+    // failure in the member-add above) surfaces with a clear
+    // message instead of a TypeError when reading .data.access_token.
     const regularLoginResponse = await request.post(`${API_URL}/api/v1/auth/login`, {
       data: {
         email: TEST_USER.email,
         password: TEST_USER.password,
       },
     });
+    expect(regularLoginResponse.ok()).toBeTruthy();
     const regularData = await regularLoginResponse.json();
     regularUserToken = regularData.data.access_token;
 

--- a/apps/admin/src/tests/e2e/role-based-access.spec.ts
+++ b/apps/admin/src/tests/e2e/role-based-access.spec.ts
@@ -130,11 +130,12 @@ test.describe('Role-based page access', () => {
     //    `/api/v1/admin/organizations` accepts `owner_user_id`, so
     //    admin can establish orgUser as the owner without orgUser
     //    needing a session.
+    const orgTimestamp = Date.now();
     const createOrg = await request.post(`${E2E_API_URL}/api/v1/admin/organizations`, {
       headers: { Authorization: `Bearer ${adminToken}` },
       data: {
-        name: `RBAC Test Org ${Date.now()}`,
-        subdomain: `rbac-org-${Date.now()}`,
+        name: `RBAC Test Org ${orgTimestamp}`,
+        subdomain: `rbac-org-${orgTimestamp}`,
         owner_user_id: orgUserId,
       },
     });

--- a/apps/admin/src/tests/e2e/role-based-access.spec.ts
+++ b/apps/admin/src/tests/e2e/role-based-access.spec.ts
@@ -82,7 +82,6 @@ test.describe('Role-based page access', () => {
   let adminToken: string;
   let adminOrgId: string;
   let orgUserId: string;
-  let orgUserToken: string;
   let orgId: string;
   let noOrgUserId: string;
 
@@ -123,20 +122,33 @@ test.describe('Role-based page access', () => {
     expect(createNoOrgUser.ok()).toBeTruthy();
     noOrgUserId = (await createNoOrgUser.json()).data.id;
 
-    // 5. Login as orgUser to get their token
+    // 5. Admin creates orgUser's org (with orgUser as owner) BEFORE
+    //    orgUser logs in. Login was previously the first step, but
+    //    SaaS-mode now rejects login for users with zero non-deleted
+    //    org memberships (auth.ts `assertUserHasActiveOrgAccess`).
+    //    Bootstrapping has to seed the membership first.
+    //    `/api/v1/admin/organizations` accepts `owner_user_id`, so
+    //    admin can establish orgUser as the owner without orgUser
+    //    needing a session.
+    const createOrg = await request.post(`${E2E_API_URL}/api/v1/admin/organizations`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      data: {
+        name: `RBAC Test Org ${Date.now()}`,
+        subdomain: `rbac-org-${Date.now()}`,
+        owner_user_id: orgUserId,
+      },
+    });
+    expect(createOrg.ok()).toBeTruthy();
+    orgId = (await createOrg.json()).data.id;
+
+    // 6. Verify orgUser can now log in — they have an org membership.
+    //    The token isn't needed downstream (admin already created the
+    //    org); this is a regression-check for the SaaS-mode login
+    //    gate that came in alongside this PR.
     const orgUserLogin = await request.post(`${E2E_API_URL}/api/v1/auth/login`, {
       data: { email: ORG_USER.email, password: ORG_USER.password },
     });
     expect(orgUserLogin.ok()).toBeTruthy();
-    orgUserToken = (await orgUserLogin.json()).data.access_token;
-
-    // 6. orgUser creates an org (becomes owner)
-    const createOrg = await request.post(`${E2E_API_URL}/api/v1/organizations`, {
-      headers: { Authorization: `Bearer ${orgUserToken}` },
-      data: { name: `RBAC Test Org ${Date.now()}`, subdomain: `rbac-org-${Date.now()}` },
-    });
-    expect(createOrg.ok()).toBeTruthy();
-    orgId = (await createOrg.json()).data.id;
 
     // 7. Admin creates an org too (so admin has org section visible)
     const createAdminOrg = await request.post(`${E2E_API_URL}/api/v1/organizations`, {
@@ -278,8 +290,22 @@ test.describe('Role-based page access', () => {
   });
 
   // ── Regular User without Org ────────────────────────────────────────
+  //
+  // These tests verified the dashboard-emptiness UX for a logged-in
+  // user with zero org memberships. That state is now unreachable in
+  // SaaS mode — `/api/v1/auth/login` rejects with 403 OrgAccessRevoked
+  // before issuing a token (see auth.ts `assertUserHasActiveOrgAccess`).
+  // The user-visible behavior is now an inline "access revoked" alert
+  // on the login form, not an empty dashboard, so the assertions below
+  // can never fire.
+  //
+  // Coverage of the new behavior lives in the backend integration
+  // tests (auth.test.ts SaaS describe block). If a frontend E2E for
+  // the access-revoked alert is wanted, that's a separate spec —
+  // these tests are deleted in spirit, just .skipped here for the
+  // git history trail.
 
-  test.describe('Regular user without org', () => {
+  test.describe.skip('Regular user without org', () => {
     test.beforeEach(async ({ page }) => {
       await loginAs(page, NO_ORG_USER.email, NO_ORG_USER.password, /\/projects/);
     });


### PR DESCRIPTION
## Summary

CI on \`main\` has been red since PR #67 merged: https://github.com/apex-bridge/bugspotter/actions/runs/25096888420

> \`role-based-access.spec.ts:130\` — \`expect(orgUserLogin.ok()).toBeTruthy()\` returned false
> \`bug-reports-access-control.spec.ts:355\` — same setup pattern

PR #67 added the SaaS-mode \`assertUserHasActiveOrgAccess\` gate at \`/api/v1/auth/login\`. Two E2E specs were creating a regular user via \`/admin/users\` and immediately logging them in — at that moment the user has zero org memberships, so login now rejects with \`403 OrgAccessRevoked\`. The bootstrap pattern was incompatible with the new invariant.

## What changed

### \`role-based-access.spec.ts\`

- Swap the order in \`beforeAll\`: admin uses \`/api/v1/admin/organizations\` with \`owner_user_id\` to create the test org with \`orgUser\` as owner **before** \`orgUser\` tries to log in. \`orgUser\`'s login is now a regression-check for the SaaS gate, not a setup blocker.
- Drop the unused \`orgUserToken\` capture (the token isn't needed downstream — admin already created the org with elevated permissions).
- Mark the \`Regular user without org\` describe block as \`.skip\`. The scenario it covered (logged-in user with zero org memberships) is unreachable in SaaS mode by design — that's exactly what PR #67's gate enforces. Backend coverage of the new behavior lives in \`auth.test.ts\` SaaS describe block. A separate frontend E2E for the access-revoked alert can be added if wanted; these tests are kept \`.skip\` rather than deleted for git-history trail.

### \`bug-reports-access-control.spec.ts\`

- Move \`bugReportOrg\` creation **before** the regular user's login.
- After the org is created (admin owner), admin uses \`/api/v1/organizations/:id/members\` to add \`TEST_USER\` as a member so they pass the SaaS login gate. Admin holds the \`orgRole=owner\` required by that endpoint.
- The regular user's login then succeeds with a real membership.

## Honest disclosure

I had pushed this fix earlier, but to the now-orphaned \`feat/login-revoked-org-check\` branch (PR #67's source) instead of branching fresh off \`main\`. PR #67 was squash-merged so the source branch lingers on the remote but no longer triggers anything — the fix sat there doing nothing while \`main\` stayed red. This PR re-applies the same commit on a fresh branch off the current \`main\`.

## Test plan

- [x] \`pnpm --filter @bugspotter/admin build\` — clean
- [ ] CI E2E suite runs the previously-failed specs (role-based-access, bug-reports-access-control) end-to-end against the SaaS-mode test backend; expecting them to pass with the bootstrap rearranged

🤖 Generated with [Claude Code](https://claude.com/claude-code)