### PR TITLE
fix(backend): close auth gaps on api-keys PATCH, jobs, uploads, mitigation

### DIFF
--- a/packages/backend/src/api/routes/api-keys.ts
+++ b/packages/backend/src/api/routes/api-keys.ts
@@ -439,25 +439,14 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       // or rate-limit tweaks but too weak for fields that widen what the key can
       // do. CREATE re-checks project access at issuance time; without the same
       // re-check on PATCH, a user could legitimately create a single-project key
-      // and then PATCH it to add cross-tenant projects, escalate to
-      // `permission_scope: 'full'`, or set `permissions: ['*']`.
+      // and then PATCH it to add cross-tenant projects.
+      //
+      // The gate intentionally mirrors CREATE: project-admin on every project
+      // in the post-update `allowed_projects`. Scope/permissions are bounded by
+      // that project list, so no separate scope or wildcard check is needed —
+      // matching CREATE keeps the surface symmetric and avoids the trap of
+      // PATCH being arbitrarily stricter than the path that issued the key.
       if (!isPlatformAdmin(request)) {
-        if (requestBody.permission_scope !== undefined && requestBody.permission_scope === 'full') {
-          throw new AppError(
-            'Only platform admins can grant full-scope API keys',
-            403,
-            'Forbidden'
-          );
-        }
-
-        if (requestBody.permissions?.includes('*')) {
-          throw new AppError(
-            'Only platform admins can grant wildcard permissions',
-            403,
-            'Forbidden'
-          );
-        }
-
         const grantFieldsTouched =
           requestBody.allowed_projects !== undefined ||
           requestBody.permissions !== undefined ||

--- a/packages/backend/src/api/routes/api-keys.ts
+++ b/packages/backend/src/api/routes/api-keys.ts
@@ -222,75 +222,12 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         expires_at?: string;
       };
 
-      // Authorization: Platform admins can create keys for any projects
-      // Other users need owner/admin role (explicit or inherited from org) for all specified projects
+      // Authorization: Platform admins can create keys for any projects.
+      // Other users need owner/admin role (explicit or inherited from org)
+      // for all specified projects. Same gate as PATCH — single helper so
+      // the two paths can't drift.
       if (!isPlatformAdmin(request)) {
-        if (allowed_projects.length === 0) {
-          throw new AppError('Non-admin users must specify at least one project', 403, 'Forbidden');
-        }
-
-        // Step 1: Batch-fetch explicit project roles
-        const roleMap = await db.projects.getUserRolesForProjects(
-          allowed_projects,
-          request.authUser.id
-        );
-
-        // Step 2: Identify projects needing org inheritance check
-        const needsOrgCheck = allowed_projects.filter((pid) => {
-          const role = roleMap.get(pid);
-          return role !== 'owner' && role !== 'admin';
-        });
-
-        // Step 3: Batch-fetch org memberships for projects lacking explicit admin access
-        const orgMembershipMap = new Map<string, OrgMemberRole>();
-        if (needsOrgCheck.length > 0) {
-          // Single query to fetch all projects needing org check
-          const projects = (await db.projects.findByIds(needsOrgCheck)) as Array<{
-            id: string;
-            organization_id?: string;
-          }>;
-          const projectMap = new Map(projects.map((p) => [p.id, p]));
-
-          // Reject any unknown project IDs
-          for (const pid of needsOrgCheck) {
-            if (!projectMap.has(pid)) {
-              throw new AppError(`Project not found: ${pid}`, 404, 'NotFound');
-            }
-          }
-
-          const orgIds = [
-            ...new Set(projects.map((p) => p.organization_id).filter(Boolean) as string[]),
-          ];
-
-          // Fetch user's memberships for all relevant orgs in one query
-          if (orgIds.length > 0) {
-            const memberships = await db.organizationMembers.findByUserId(request.authUser.id);
-            for (const m of memberships) {
-              if (orgIds.includes(m.organization_id)) {
-                orgMembershipMap.set(m.organization_id, m.role as OrgMemberRole);
-              }
-            }
-          }
-
-          // Step 4: Validate each project using effective role
-          for (const project of projects) {
-            const explicitRole = roleMap.get(project.id);
-            const orgRole = project.organization_id
-              ? orgMembershipMap.get(project.organization_id)
-              : undefined;
-            const effectiveRole = getEffectiveProjectRole(
-              explicitRole ? (explicitRole as 'owner' | 'admin' | 'member' | 'viewer') : undefined,
-              orgRole
-            );
-            if (!effectiveRole || !hasPermissionLevel(effectiveRole, 'admin')) {
-              throw new AppError(
-                `Access denied: You must be owner or admin of project ${project.id}`,
-                403,
-                'Forbidden'
-              );
-            }
-          }
-        }
+        await assertCanGrantProjects(db, request.authUser.id, allowed_projects);
       }
 
       // Create API key (validation handled in service)

--- a/packages/backend/src/api/routes/api-keys.ts
+++ b/packages/backend/src/api/routes/api-keys.ts
@@ -109,6 +109,79 @@ async function authorizeApiKeyReadAccess(
   throw new AppError('Access denied', 403, 'Forbidden');
 }
 
+/**
+ * Assert the caller has owner/admin (explicit or org-inherited) on every
+ * project in `projectIds`. CREATE has its own inline copy; this helper exists
+ * so PATCH can re-run the same gate when the caller is widening
+ * `allowed_projects` or otherwise touching grant-shaped fields.
+ *
+ * Without it, a user who legitimately created a single-project key could PATCH
+ * the key to add cross-tenant projects — the only check on PATCH today is
+ * "are you the creator?", which is too weak for a privilege-bearing field.
+ */
+async function assertCanGrantProjects(
+  db: DatabaseClient,
+  userId: string,
+  projectIds: string[]
+): Promise<void> {
+  if (projectIds.length === 0) {
+    throw new AppError('Non-admin users must specify at least one project', 403, 'Forbidden');
+  }
+
+  const roleMap = await db.projects.getUserRolesForProjects(projectIds, userId);
+
+  const needsOrgCheck = projectIds.filter((pid) => {
+    const role = roleMap.get(pid);
+    return role !== 'owner' && role !== 'admin';
+  });
+
+  if (needsOrgCheck.length === 0) {
+    return;
+  }
+
+  const projects = (await db.projects.findByIds(needsOrgCheck)) as Array<{
+    id: string;
+    organization_id?: string;
+  }>;
+  const projectMap = new Map(projects.map((p) => [p.id, p]));
+
+  for (const pid of needsOrgCheck) {
+    if (!projectMap.has(pid)) {
+      throw new AppError(`Project not found: ${pid}`, 404, 'NotFound');
+    }
+  }
+
+  const orgIds = [...new Set(projects.map((p) => p.organization_id).filter(Boolean) as string[])];
+
+  const orgMembershipMap = new Map<string, OrgMemberRole>();
+  if (orgIds.length > 0) {
+    const memberships = await db.organizationMembers.findByUserId(userId);
+    for (const m of memberships) {
+      if (orgIds.includes(m.organization_id)) {
+        orgMembershipMap.set(m.organization_id, m.role as OrgMemberRole);
+      }
+    }
+  }
+
+  for (const project of projects) {
+    const explicitRole = roleMap.get(project.id);
+    const orgRole = project.organization_id
+      ? orgMembershipMap.get(project.organization_id)
+      : undefined;
+    const effectiveRole = getEffectiveProjectRole(
+      explicitRole ? (explicitRole as 'owner' | 'admin' | 'member' | 'viewer') : undefined,
+      orgRole
+    );
+    if (!effectiveRole || !hasPermissionLevel(effectiveRole, 'admin')) {
+      throw new AppError(
+        `Access denied: You must be owner or admin of project ${project.id}`,
+        403,
+        'Forbidden'
+      );
+    }
+  }
+}
+
 export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
   const apiKeyService = new ApiKeyService(db);
 
@@ -354,7 +427,50 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         expires_at?: string | null;
       };
 
-      await authorizeApiKeyAccess(apiKeyService, id, request.authUser.id, isPlatformAdmin(request));
+      const existingKey = await authorizeApiKeyAccess(
+        apiKeyService,
+        id,
+        request.authUser.id,
+        isPlatformAdmin(request)
+      );
+
+      // Re-validate grant-shaped fields. The pre-existing `authorizeApiKeyAccess`
+      // check is "are you the key's creator?" — that's strong enough for `name`
+      // or rate-limit tweaks but too weak for fields that widen what the key can
+      // do. CREATE re-checks project access at issuance time; without the same
+      // re-check on PATCH, a user could legitimately create a single-project key
+      // and then PATCH it to add cross-tenant projects, escalate to
+      // `permission_scope: 'full'`, or set `permissions: ['*']`.
+      if (!isPlatformAdmin(request)) {
+        if (requestBody.permission_scope !== undefined && requestBody.permission_scope === 'full') {
+          throw new AppError(
+            'Only platform admins can grant full-scope API keys',
+            403,
+            'Forbidden'
+          );
+        }
+
+        if (requestBody.permissions?.includes('*')) {
+          throw new AppError(
+            'Only platform admins can grant wildcard permissions',
+            403,
+            'Forbidden'
+          );
+        }
+
+        const grantFieldsTouched =
+          requestBody.allowed_projects !== undefined ||
+          requestBody.permissions !== undefined ||
+          requestBody.permission_scope !== undefined;
+
+        if (grantFieldsTouched) {
+          // Validate against the post-update set of allowed projects. Falls
+          // back to the existing key's set if the caller didn't pass one.
+          const effectiveAllowedProjects =
+            requestBody.allowed_projects ?? existingKey.allowed_projects ?? [];
+          await assertCanGrantProjects(db, request.authUser.id, effectiveAllowedProjects);
+        }
+      }
 
       // Map request body to updates object
       const updates = mapUpdateFields(requestBody);

--- a/packages/backend/src/api/routes/intelligence-mitigation.ts
+++ b/packages/backend/src/api/routes/intelligence-mitigation.ts
@@ -9,7 +9,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { DatabaseClient } from '../../db/client.js';
 import type { QueueManager } from '../../queue/queue-manager.js';
-import { requireAuth } from '../middleware/auth.js';
+import { requireAuth, requireApiKeyPermission } from '../middleware/auth.js';
 import { sendSuccess } from '../utils/response.js';
 import { successResponseSchema } from '../schemas/common-schema.js';
 import { IntelligenceMitigationService } from '../../services/intelligence/mitigation-service.js';
@@ -48,7 +48,11 @@ export function intelligenceMitigationRoutes(
   fastify.get<{ Params: { projectId: string; bugId: string } }>(
     '/api/v1/intelligence/projects/:projectId/bugs/:bugId/mitigation',
     {
-      preHandler: [requireAuth],
+      // Mitigation suggestions can echo bug content (titles, repro steps,
+      // surrounding context) into the response. Same disclosure surface as
+      // GET /reports/:id, so the same `reports:read` gate applies — keeping
+      // ingest-only SDK keys out.
+      preHandler: [requireAuth, requireApiKeyPermission('reports:read')],
       schema: {
         params: mitigationParams,
         response: { 200: successResponseSchema },
@@ -91,7 +95,9 @@ export function intelligenceMitigationRoutes(
   fastify.post<{ Params: { projectId: string; bugId: string } }>(
     '/api/v1/intelligence/projects/:projectId/bugs/:bugId/mitigation',
     {
-      preHandler: [requireAuth],
+      // Triggering mitigation reads the bug + similar bugs to build the
+      // prompt; same disclosure as the GET above.
+      preHandler: [requireAuth, requireApiKeyPermission('reports:read')],
       schema: {
         params: mitigationParams,
         response: { 202: successResponseSchema },

--- a/packages/backend/src/api/routes/jobs.ts
+++ b/packages/backend/src/api/routes/jobs.ts
@@ -57,7 +57,16 @@ const REDACTED_JOB_DATA_KEYS = new Set([
 const MAX_REDACTION_DEPTH = 10;
 
 function redactValue(value: unknown, depth: number): unknown {
+  // Fail closed at the depth boundary: if we can't keep walking, we can't be
+  // sure the subtree doesn't contain a credential-shaped key, so replace the
+  // whole subtree with a placeholder rather than leaking it. Realistic job
+  // payloads don't nest this deep — hitting this branch means a buggy or
+  // malicious worker shape, and surprising the consumer with a placeholder
+  // is much better than surprising them with an unredacted credential.
   if (depth >= MAX_REDACTION_DEPTH) {
+    if (value && typeof value === 'object') {
+      return '[DEPTH_EXCEEDED]';
+    }
     return value;
   }
   if (Array.isArray(value)) {

--- a/packages/backend/src/api/routes/jobs.ts
+++ b/packages/backend/src/api/routes/jobs.ts
@@ -83,14 +83,17 @@ function redactValue(value: unknown, depth: number): unknown {
 }
 
 function redactJobStatus(jobStatus: unknown): unknown {
-  if (!jobStatus || typeof jobStatus !== 'object') {
-    return jobStatus;
-  }
-  const status = jobStatus as Record<string, unknown>;
-  if (!status.data || typeof status.data !== 'object') {
-    return status;
-  }
-  return { ...status, data: redactValue(status.data, 0) };
+  // Walk the whole job-status object, not just `data`. BullMQ also exposes
+  // `returnValue` (worker return) and may carry sensitive structures in
+  // future fields. `redactValue` only triggers on credential-shaped keys,
+  // so non-matching top-level fields (id, name, state, timestamp, etc.)
+  // pass through untouched.
+  //
+  // Known limitation: `failedReason` and `stacktrace` are string-typed; if
+  // a worker stringifies a credential into an error message, structural
+  // redaction can't catch it. Scrubbing arbitrary strings for credentials
+  // is a different problem (pattern-based, fragile) and out of scope here.
+  return redactValue(jobStatus, 0);
 }
 
 export function jobRoutes(

--- a/packages/backend/src/api/routes/jobs.ts
+++ b/packages/backend/src/api/routes/jobs.ts
@@ -32,6 +32,17 @@ interface ReportJobsParams {
  * for `process-integration` jobs include decrypted `credentials` and may grow
  * to include other secret-bearing keys; redact defensively so future job
  * shapes don't accidentally leak.
+ *
+ * Recursive: matching keys are scrubbed at any depth. A whole sub-object
+ * that matches a key (e.g. `credentials: { email, apiToken }`) is replaced
+ * outright rather than recursed into — replacing wholesale is safer than
+ * walking, because not every leaf in a credential blob is itself in the
+ * keyset (an `email` adjacent to an `apiToken` is still sensitive metadata).
+ * Non-matching objects ARE recursed so a future `data.config.apiToken` or
+ * `data.options.password` gets caught.
+ *
+ * Depth-bounded so a buggy worker can't pin the event loop with pathological
+ * nesting. 10 is well past any realistic job payload depth.
  */
 const REDACTED_JOB_DATA_KEYS = new Set([
   'credentials',
@@ -43,20 +54,34 @@ const REDACTED_JOB_DATA_KEYS = new Set([
   'secret',
 ]);
 
+const MAX_REDACTION_DEPTH = 10;
+
+function redactValue(value: unknown, depth: number): unknown {
+  if (depth >= MAX_REDACTION_DEPTH) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => redactValue(v, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = REDACTED_JOB_DATA_KEYS.has(k) ? '[REDACTED]' : redactValue(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
 function redactJobStatus(jobStatus: unknown): unknown {
   if (!jobStatus || typeof jobStatus !== 'object') {
     return jobStatus;
   }
   const status = jobStatus as Record<string, unknown>;
-  const data = status.data;
-  if (!data || typeof data !== 'object') {
+  if (!status.data || typeof status.data !== 'object') {
     return status;
   }
-  const redactedData: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
-    redactedData[key] = REDACTED_JOB_DATA_KEYS.has(key) ? '[REDACTED]' : value;
-  }
-  return { ...status, data: redactedData };
+  return { ...status, data: redactValue(status.data, 0) };
 }
 
 export function jobRoutes(

--- a/packages/backend/src/api/routes/jobs.ts
+++ b/packages/backend/src/api/routes/jobs.ts
@@ -10,6 +10,7 @@ import type { QueueName } from '../../queue/types.js';
 import { QUEUE_NAMES } from '../../queue/types.js';
 import { sendSuccess } from '../utils/response.js';
 import { checkProjectAccess, findOrThrow } from '../utils/resource.js';
+import { requireUser, requirePlatformAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
 import { getEncryptionService } from '../../utils/encryption.js';
 import { QueueNotFoundError } from '../../queue/errors.js';
@@ -26,6 +27,38 @@ interface ReportJobsParams {
   id: string;
 }
 
+/**
+ * Strip credential-shaped fields from a job status response. Worker payloads
+ * for `process-integration` jobs include decrypted `credentials` and may grow
+ * to include other secret-bearing keys; redact defensively so future job
+ * shapes don't accidentally leak.
+ */
+const REDACTED_JOB_DATA_KEYS = new Set([
+  'credentials',
+  'encrypted_credentials',
+  'apiToken',
+  'apiKey',
+  'token',
+  'password',
+  'secret',
+]);
+
+function redactJobStatus(jobStatus: unknown): unknown {
+  if (!jobStatus || typeof jobStatus !== 'object') {
+    return jobStatus;
+  }
+  const status = jobStatus as Record<string, unknown>;
+  const data = status.data;
+  if (!data || typeof data !== 'object') {
+    return status;
+  }
+  const redactedData: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    redactedData[key] = REDACTED_JOB_DATA_KEYS.has(key) ? '[REDACTED]' : value;
+  }
+  return { ...status, data: redactedData };
+}
+
 export function jobRoutes(
   fastify: FastifyInstance,
   db: DatabaseClient,
@@ -35,9 +68,20 @@ export function jobRoutes(
   /**
    * GET /api/v1/queues/:queueName/jobs/:id
    * Get status of a specific job in a queue
+   *
+   * Platform-admin only: a process-integration job's `data` carries decrypted
+   * Jira/GitHub credentials (see /admin/integrations/:platform/trigger below
+   * where the worker payload is constructed). Without this gate, any
+   * authenticated caller — including the public-facing SDK ingest key —
+   * could fetch any job by id and read another tenant's integration creds.
+   * Even with the gate, we redact credential-shaped fields below as
+   * defense-in-depth.
    */
   fastify.get<{ Params: JobParams }>(
     '/api/v1/queues/:queueName/jobs/:id',
+    {
+      preHandler: [requireUser, requirePlatformAdmin()],
+    },
     async (request, reply) => {
       if (!queueManager) {
         throw new AppError('Queue system not available', 503, 'ServiceUnavailable');
@@ -52,7 +96,7 @@ export function jobRoutes(
           throw new AppError(`Job ${id} not found in ${queueName} queue`, 404, 'NotFound');
         }
 
-        return sendSuccess(reply, jobStatus);
+        return sendSuccess(reply, redactJobStatus(jobStatus));
       } catch (error) {
         if (error instanceof AppError) {
           throw error;

--- a/packages/backend/src/api/routes/uploads.ts
+++ b/packages/backend/src/api/routes/uploads.ts
@@ -8,7 +8,7 @@ import type { DatabaseClient } from '../../db/client.js';
 import type { IStorageService } from '../../storage/types.js';
 import type { QueueManager } from '../../queue/queue-manager.js';
 import { AppError } from '../middleware/error.js';
-import { requireAuth } from '../middleware/auth.js';
+import { requireAuth, requireApiKeyPermission } from '../middleware/auth.js';
 import { sendSuccess } from '../utils/response.js';
 import { checkProjectAccess } from '../utils/resource.js';
 import { getLogger } from '../../logger.js';
@@ -190,7 +190,14 @@ export function uploadsRoutes(
   fastify.get<{ Params: { id: string } }>(
     '/api/v1/reports/:id/screenshot-url',
     {
-      preHandler: requireAuth,
+      // Why `reports:read` (not a distinct `assets:read`): the screenshot is
+      // a render of the report. Whoever can GET /reports/:id should be able
+      // to load its screenshot, and whoever cannot, should not — same audience,
+      // same gate. Adding it here closes a gap where ingest-only SDK keys
+      // (permissions: ['reports:write','sessions:write']) bypassed the
+      // permission check via requireAuth and pulled presigned URLs for any
+      // bug-report asset in their allowed project.
+      preHandler: [requireAuth, requireApiKeyPermission('reports:read')],
       schema: bugReportIdParamsSchema,
     },
     async (request, reply) => {
@@ -238,7 +245,9 @@ export function uploadsRoutes(
   fastify.get<{ Params: { id: string } }>(
     '/api/v1/reports/:id/replay-url',
     {
-      preHandler: requireAuth,
+      // See screenshot-url above for the rationale; replays carry the same
+      // PII surface (and more — full DOM, console, network).
+      preHandler: [requireAuth, requireApiKeyPermission('reports:read')],
       schema: bugReportIdParamsSchema,
     },
     async (request, reply) => {

--- a/packages/backend/tests/api/api-keys.test.ts
+++ b/packages/backend/tests/api/api-keys.test.ts
@@ -44,6 +44,7 @@ describe('API Key Routes', () => {
   let server: FastifyInstance;
   let db: DatabaseClient;
   let userToken: string;
+  let userId: string;
   let adminToken: string;
   let adminId: string;
   let projectId: string;
@@ -71,6 +72,7 @@ describe('API Key Routes', () => {
     // Create test users
     const user = await createTestUser(server, 'user', 'user');
     userToken = user.token;
+    userId = user.userId;
 
     const admin = await createTestUser(server, 'admin', 'admin', db);
     adminToken = admin.token;
@@ -821,6 +823,198 @@ describe('API Key Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+    });
+
+    // Regression: PATCH used to forward `allowed_projects` / `permissions` /
+    // `permission_scope` straight through after only an "are you the creator?"
+    // check. CREATE has always re-validated project admin; PATCH did not, so a
+    // user with admin on one project could PATCH their own key to cross
+    // tenants. The gate now mirrors CREATE.
+    describe('grant-field re-validation (regression)', () => {
+      it('rejects non-admin widening allowed_projects to a tenant they do not admin', async () => {
+        // userToken creates a key for projectId (their own project)
+        const createResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/api-keys',
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: {
+            name: 'Single-project key',
+            type: 'development',
+            permission_scope: 'custom',
+            permissions: ['reports:read'],
+            allowed_projects: [projectId],
+          },
+        });
+        expect(createResp.statusCode).toBe(201);
+        const keyId = createResp.json().data.key_details.id;
+
+        // Different user owns a different project — userToken has no role on it
+        const otherUser = await createTestUser(server, 'user', 'cross-tenant-victim');
+        const otherProjectResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/projects',
+          headers: { authorization: `Bearer ${otherUser.token}` },
+          payload: { name: 'Other Tenant Project' },
+        });
+        const otherProjectId = otherProjectResp.json().data.id;
+
+        // userToken tries to PATCH their own key to add the foreign project
+        const patchResp = await server.inject({
+          method: 'PATCH',
+          url: `/api/v1/api-keys/${keyId}`,
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: { allowed_projects: [projectId, otherProjectId] },
+        });
+
+        expect(patchResp.statusCode).toBe(403);
+        expect(patchResp.json().message).toContain('owner or admin');
+      });
+
+      it('rejects non-admin widening to a project they are only a member of', async () => {
+        // userToken creates a key for projectId
+        const createResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/api-keys',
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: {
+            name: 'Member-of-other-project key',
+            type: 'development',
+            permission_scope: 'custom',
+            permissions: ['reports:read'],
+            allowed_projects: [projectId],
+          },
+        });
+        const keyId = createResp.json().data.key_details.id;
+
+        // Other user creates a project, then adds userToken-user as member (not admin)
+        const otherUser = await createTestUser(server, 'user', 'project-owner');
+        const otherProjectResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/projects',
+          headers: { authorization: `Bearer ${otherUser.token}` },
+          payload: { name: 'Member-Only Project' },
+        });
+        const otherProjectId = otherProjectResp.json().data.id;
+
+        await db.query(
+          'INSERT INTO project_members (project_id, user_id, role) VALUES ($1, $2, $3)',
+          [otherProjectId, userId, 'member']
+        );
+
+        const patchResp = await server.inject({
+          method: 'PATCH',
+          url: `/api/v1/api-keys/${keyId}`,
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: { allowed_projects: [projectId, otherProjectId] },
+        });
+
+        expect(patchResp.statusCode).toBe(403);
+        expect(patchResp.json().message).toContain('owner or admin');
+      });
+
+      it('allows non-admin widening to a project they DO admin (positive case)', async () => {
+        // userToken creates a key for projectId
+        const createResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/api-keys',
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: {
+            name: 'About-to-be-widened key',
+            type: 'development',
+            permission_scope: 'custom',
+            permissions: ['reports:read'],
+            allowed_projects: [projectId],
+          },
+        });
+        const keyId = createResp.json().data.key_details.id;
+
+        // userToken creates a SECOND project they own
+        const project2Resp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/projects',
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: { name: 'Second Owned Project' },
+        });
+        const project2Id = project2Resp.json().data.id;
+
+        // Widening to include their own second project should pass
+        const patchResp = await server.inject({
+          method: 'PATCH',
+          url: `/api/v1/api-keys/${keyId}`,
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: { allowed_projects: [projectId, project2Id] },
+        });
+
+        expect(patchResp.statusCode).toBe(200);
+        expect(patchResp.json().data.allowed_projects).toContain(projectId);
+        expect(patchResp.json().data.allowed_projects).toContain(project2Id);
+      });
+
+      it('allows non-admin to PATCH non-grant fields (name, rate limits) without re-validation', async () => {
+        // Proves the gate isn't over-restrictive. Updating just `name` on your
+        // own key shouldn't require re-running project-admin checks.
+        const createResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/api-keys',
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: {
+            name: 'Original',
+            type: 'development',
+            permission_scope: 'custom',
+            permissions: ['reports:read'],
+            allowed_projects: [projectId],
+          },
+        });
+        const keyId = createResp.json().data.key_details.id;
+
+        const patchResp = await server.inject({
+          method: 'PATCH',
+          url: `/api/v1/api-keys/${keyId}`,
+          headers: { authorization: `Bearer ${userToken}` },
+          payload: { name: 'Renamed', rate_limit_per_minute: 50 },
+        });
+
+        expect(patchResp.statusCode).toBe(200);
+        expect(patchResp.json().data.name).toBe('Renamed');
+        expect(patchResp.json().data.rate_limit_per_minute).toBe(50);
+      });
+
+      it('platform admin can PATCH allowed_projects to any project (admin bypass)', async () => {
+        // Admin creates a full-scope key for an arbitrary project
+        const createResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/api-keys',
+          headers: { authorization: `Bearer ${adminToken}` },
+          payload: {
+            name: 'Admin-managed key',
+            type: 'development',
+            permission_scope: 'full',
+            allowed_projects: [projectId],
+          },
+        });
+        const keyId = createResp.json().data.key_details.id;
+
+        // A different user owns a project that admin has no membership in.
+        const stranger = await createTestUser(server, 'user', 'stranger');
+        const strangerProjectResp = await server.inject({
+          method: 'POST',
+          url: '/api/v1/projects',
+          headers: { authorization: `Bearer ${stranger.token}` },
+          payload: { name: 'Stranger Project' },
+        });
+        const strangerProjectId = strangerProjectResp.json().data.id;
+
+        // Platform admin should bypass the project-admin check entirely
+        const patchResp = await server.inject({
+          method: 'PATCH',
+          url: `/api/v1/api-keys/${keyId}`,
+          headers: { authorization: `Bearer ${adminToken}` },
+          payload: { allowed_projects: [projectId, strangerProjectId] },
+        });
+
+        expect(patchResp.statusCode).toBe(200);
+        expect(patchResp.json().data.allowed_projects).toContain(strangerProjectId);
+      });
     });
   });
 

--- a/packages/backend/tests/api/jobs.test.ts
+++ b/packages/backend/tests/api/jobs.test.ts
@@ -221,6 +221,42 @@ describe('Jobs API Routes', () => {
       expect(body.data.data.config).toEqual({ instanceUrl: 'https://x.atlassian.net' });
     });
 
+    it('should redact credential-shaped fields in returnValue (not just data)', async () => {
+      // BullMQ surfaces a worker's return value in `returnValue`. If a
+      // worker bug lands credentials there (or a future job shape stores
+      // results differently), structural redaction must catch it — same
+      // disclosure surface as `data`.
+      const mockJobStatus = {
+        id: 'integration-job-3',
+        name: 'process-integration',
+        state: 'completed',
+        data: { bugReportId: 'bug-3' },
+        returnValue: {
+          ticketId: 'JIRA-123',
+          credentials: { apiToken: 'leaked-via-returnValue' },
+          rotatedToken: 'plaintext-leak',
+          nested: { apiToken: 'also-leaked' },
+        },
+      };
+      (mockQueueManager.getJob as any).mockResolvedValueOnce(mockJobStatus);
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/queues/integrations/jobs/integration-job-3',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.data.returnValue.credentials).toBe('[REDACTED]');
+      expect(body.data.returnValue.nested.apiToken).toBe('[REDACTED]');
+      // Non-matching keys preserved
+      expect(body.data.returnValue.ticketId).toBe('JIRA-123');
+      // The literal credential strings must not survive anywhere in the body
+      expect(JSON.stringify(body)).not.toContain('leaked-via-returnValue');
+      expect(JSON.stringify(body)).not.toContain('also-leaked');
+    });
+
     it('should fail closed when nesting exceeds redaction depth', async () => {
       // Build a payload nested past MAX_REDACTION_DEPTH (10). The redactor
       // can't keep walking past the limit, and rather than leak the whole

--- a/packages/backend/tests/api/jobs.test.ts
+++ b/packages/backend/tests/api/jobs.test.ts
@@ -221,6 +221,40 @@ describe('Jobs API Routes', () => {
       expect(body.data.data.config).toEqual({ instanceUrl: 'https://x.atlassian.net' });
     });
 
+    it('should fail closed when nesting exceeds redaction depth', async () => {
+      // Build a payload nested past MAX_REDACTION_DEPTH (10). The redactor
+      // can't keep walking past the limit, and rather than leak the whole
+      // subtree it replaces deep objects with a placeholder. Realistic job
+      // payloads never nest this deep — hitting the limit means a buggy or
+      // malicious worker shape.
+      let deeplyNested: Record<string, unknown> = { apiToken: 'leak-me' };
+      for (let i = 0; i < 12; i++) {
+        deeplyNested = { wrapper: deeplyNested };
+      }
+      const mockJobStatus = {
+        id: 'pathological-job',
+        name: 'process-integration',
+        state: 'completed',
+        data: deeplyNested,
+      };
+      (mockQueueManager.getJob as any).mockResolvedValueOnce(mockJobStatus);
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/queues/integrations/jobs/pathological-job',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      // Walk the response. Every level must be either a wrapper object, the
+      // [DEPTH_EXCEEDED] placeholder, or [REDACTED] for matching keys —
+      // never the literal 'leak-me'.
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain('leak-me');
+      expect(serialized).toContain('[DEPTH_EXCEEDED]');
+    });
+
     it('should redact credential-shaped fields nested deep in job data', async () => {
       // Defense-in-depth against future job shapes that nest credentials
       // (e.g. config.apiToken, options.auth.password). The shallow walk

--- a/packages/backend/tests/api/jobs.test.ts
+++ b/packages/backend/tests/api/jobs.test.ts
@@ -221,6 +221,47 @@ describe('Jobs API Routes', () => {
       expect(body.data.data.config).toEqual({ instanceUrl: 'https://x.atlassian.net' });
     });
 
+    it('should redact credential-shaped fields nested deep in job data', async () => {
+      // Defense-in-depth against future job shapes that nest credentials
+      // (e.g. config.apiToken, options.auth.password). The shallow walk
+      // would have leaked these.
+      const mockJobStatus = {
+        id: 'integration-job-2',
+        name: 'process-integration',
+        state: 'completed',
+        data: {
+          bugReportId: 'bug-2',
+          projectId: 'proj-2',
+          config: {
+            instanceUrl: 'https://x.atlassian.net',
+            apiToken: 'nested-secret-1', // nested matching key
+            nested: {
+              password: 'nested-secret-2', // 2 levels deep
+              keep: 'visible',
+            },
+          },
+          options: [{ auth: { token: 'array-element-secret' }, label: 'first' }],
+        },
+      };
+      (mockQueueManager.getJob as any).mockResolvedValueOnce(mockJobStatus);
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/queues/integrations/jobs/integration-job-2',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.data.data.config.apiToken).toBe('[REDACTED]');
+      expect(body.data.data.config.nested.password).toBe('[REDACTED]');
+      expect(body.data.data.options[0].auth.token).toBe('[REDACTED]');
+      // Surrounding non-sensitive fields preserved at every depth
+      expect(body.data.data.config.instanceUrl).toBe('https://x.atlassian.net');
+      expect(body.data.data.config.nested.keep).toBe('visible');
+      expect(body.data.data.options[0].label).toBe('first');
+    });
+
     it('should handle invalid queue name', async () => {
       // Mock QueueNotFoundError being thrown
       (mockQueueManager.getJob as any).mockRejectedValueOnce(

--- a/packages/backend/tests/api/jobs.test.ts
+++ b/packages/backend/tests/api/jobs.test.ts
@@ -9,7 +9,7 @@ import { createServer } from '../../src/api/server.js';
 import type { FastifyInstance } from 'fastify';
 import type { QueueManager } from '../../src/queue/queue-manager.js';
 import type { Queue } from 'bullmq';
-import { createMockPluginRegistry, createMockStorage } from '../test-helpers.js';
+import { createMockPluginRegistry, createMockStorage, createAdminUser } from '../test-helpers.js';
 import { QueueNotFoundError } from '../../src/queue/errors.js';
 import { ApiKeyService } from '../../src/services/api-key/api-key-service.js';
 
@@ -20,6 +20,7 @@ describe('Jobs API Routes', () => {
   let testProjectId: string;
   let testApiKey: string;
   let testBugReportId: string;
+  let adminToken: string;
 
   beforeAll(async () => {
     // Initialize database
@@ -84,6 +85,10 @@ describe('Jobs API Routes', () => {
     });
     testProjectId = project.id;
 
+    // Create platform admin for routes that require it (e.g. /queues/:queueName/jobs/:id).
+    const admin = await createAdminUser(server, db, 'jobs-admin');
+    adminToken = admin.token;
+
     // Create managed API key for the project
     const apiKeyService = new ApiKeyService(db);
     const apiKeyResult = await apiKeyService.createKey({
@@ -116,7 +121,7 @@ describe('Jobs API Routes', () => {
         method: 'GET',
         url: '/api/v1/queues/screenshots/jobs/test-job',
         headers: {
-          'x-api-key': testApiKey,
+          authorization: `Bearer ${adminToken}`,
         },
       });
 
@@ -130,6 +135,25 @@ describe('Jobs API Routes', () => {
       const response = await server.inject({
         method: 'GET',
         url: '/api/v1/queues/screenshots/jobs/test-job',
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('should reject API-key auth (platform admin only)', async () => {
+      // Regression: route previously had no preHandler — any authenticated
+      // caller, including the public-facing SDK ingest key, could fetch any
+      // job by id. Process-integration jobs carry decrypted credentials in
+      // their payload, so this was a cross-tenant secret exfiltration.
+      // Note: no `mockResolvedValueOnce` here — auth fails before getJob is
+      // called, and queueing a mock would leak into the next test.
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/queues/screenshots/jobs/test-job',
+        headers: {
+          'x-api-key': testApiKey,
+        },
       });
 
       expect(response.statusCode).toBe(401);
@@ -150,7 +174,7 @@ describe('Jobs API Routes', () => {
         method: 'GET',
         url: '/api/v1/queues/screenshots/jobs/test-job-123',
         headers: {
-          'x-api-key': testApiKey,
+          authorization: `Bearer ${adminToken}`,
         },
       });
 
@@ -158,6 +182,43 @@ describe('Jobs API Routes', () => {
       const body = JSON.parse(response.body);
       expect(body.success).toBe(true);
       expect(body.data).toEqual(mockJobStatus);
+    });
+
+    it('should redact credential-shaped fields from job data', async () => {
+      // Regression: process-integration job payloads carry decrypted
+      // credentials. Defense-in-depth — even with platform-admin auth,
+      // these should never appear in the response body.
+      const mockJobStatus = {
+        id: 'integration-job-1',
+        name: 'process-integration',
+        state: 'completed',
+        data: {
+          bugReportId: 'bug-1',
+          projectId: 'proj-1',
+          platform: 'jira',
+          credentials: { email: 'svc@x.com', apiToken: 'secret-token-XXX' },
+          apiToken: 'top-secret',
+          config: { instanceUrl: 'https://x.atlassian.net' },
+        },
+      };
+      (mockQueueManager.getJob as any).mockResolvedValueOnce(mockJobStatus);
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/queues/integrations/jobs/integration-job-1',
+        headers: {
+          authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.data.data.credentials).toBe('[REDACTED]');
+      expect(body.data.data.apiToken).toBe('[REDACTED]');
+      // Non-sensitive fields preserved
+      expect(body.data.data.bugReportId).toBe('bug-1');
+      expect(body.data.data.projectId).toBe('proj-1');
+      expect(body.data.data.config).toEqual({ instanceUrl: 'https://x.atlassian.net' });
     });
 
     it('should handle invalid queue name', async () => {
@@ -170,7 +231,7 @@ describe('Jobs API Routes', () => {
         method: 'GET',
         url: '/api/v1/queues/invalid-queue/jobs/test-job',
         headers: {
-          'x-api-key': testApiKey,
+          authorization: `Bearer ${adminToken}`,
         },
       });
 

--- a/packages/backend/tests/api/routes/rbac-regression.test.ts
+++ b/packages/backend/tests/api/routes/rbac-regression.test.ts
@@ -39,6 +39,7 @@ import {
   requireAuth,
   requirePermission,
   requireProjectRole,
+  requireApiKeyPermission,
 } from '../../../src/api/middleware/auth/authorization.js';
 
 // ============================================================================
@@ -584,6 +585,109 @@ describe('requirePermission regression', () => {
       const result = await runMiddleware(middleware, { systemRole: 'viewer' });
       expect(result.allowed).toBe(viewerAllowed[action]);
     }
+  });
+});
+
+// ============================================================================
+// requireApiKeyPermission — API-key permission gate (regression: ingest-only
+// SDK keys must not bypass read permission via authProject shortcut)
+// ============================================================================
+
+describe('requireApiKeyPermission regression', () => {
+  // The signup-issued ingest-only key has permission_scope='custom' and
+  // permissions=['reports:write','sessions:write'] (see saas/services/
+  // signup.service.ts). It also has allowed_projects.length === 1, which
+  // means handlers.ts also sets request.authProject. The middleware MUST
+  // gate on request.apiKey.permissions, not fall through to authProject.
+
+  function createApiKeyRequest(opts: {
+    permissions?: string[];
+    permission_scope?: 'full' | 'read' | 'write' | 'custom';
+    hasAuthProject?: boolean;
+  }): FastifyRequest {
+    return {
+      authUser: undefined,
+      apiKey: {
+        id: 'key-1',
+        allowed_projects: ['project-1'],
+        permissions: opts.permissions ?? [],
+        permission_scope: opts.permission_scope ?? 'custom',
+      },
+      authProject: opts.hasAuthProject ? { id: 'project-1' } : undefined,
+    } as unknown as FastifyRequest;
+  }
+
+  it('JWT user bypasses (permissions checked elsewhere)', async () => {
+    const middleware = requireApiKeyPermission('reports:read');
+    const request = {
+      authUser: { id: 'u1', email: 'u@test.com', role: 'user' },
+    } as unknown as FastifyRequest;
+    const reply = createReply();
+    await middleware(request, reply);
+    expect((reply as any).code.mock.calls.length).toBe(0);
+  });
+
+  it('ingest-only key (reports:write only) is denied reports:read', async () => {
+    const middleware = requireApiKeyPermission('reports:read');
+    const request = createApiKeyRequest({
+      permissions: ['reports:write', 'sessions:write'],
+      hasAuthProject: true, // single allowed_projects → authProject is set
+    });
+    const reply = createReply();
+    await middleware(request, reply);
+    expect((reply as any)._statusCode).toBe(403);
+  });
+
+  it('ingest-only key (reports:write only) is denied sessions:read', async () => {
+    const middleware = requireApiKeyPermission('sessions:read');
+    const request = createApiKeyRequest({
+      permissions: ['reports:write', 'sessions:write'],
+      hasAuthProject: true,
+    });
+    const reply = createReply();
+    await middleware(request, reply);
+    expect((reply as any)._statusCode).toBe(403);
+  });
+
+  it('ingest-only key passes its OWN permission (reports:write)', async () => {
+    const middleware = requireApiKeyPermission('reports:write');
+    const request = createApiKeyRequest({
+      permissions: ['reports:write', 'sessions:write'],
+      hasAuthProject: true,
+    });
+    const reply = createReply();
+    await middleware(request, reply);
+    expect((reply as any).code.mock.calls.length).toBe(0);
+  });
+
+  it('full-scope key (permissions: ["*"]) passes any permission', async () => {
+    const middleware = requireApiKeyPermission('reports:read');
+    const request = createApiKeyRequest({
+      permissions: ['*'],
+      permission_scope: 'full',
+    });
+    const reply = createReply();
+    await middleware(request, reply);
+    expect((reply as any).code.mock.calls.length).toBe(0);
+  });
+
+  it('read-scope key passes reports:read', async () => {
+    const middleware = requireApiKeyPermission('reports:read');
+    const request = createApiKeyRequest({
+      permissions: ['reports:read', 'sessions:read'],
+      permission_scope: 'read',
+    });
+    const reply = createReply();
+    await middleware(request, reply);
+    expect((reply as any).code.mock.calls.length).toBe(0);
+  });
+
+  it('unauthenticated request returns 401', async () => {
+    const middleware = requireApiKeyPermission('reports:read');
+    const request = {} as FastifyRequest;
+    const reply = createReply();
+    await middleware(request, reply);
+    expect((reply as any)._statusCode).toBe(401);
   });
 });
 

--- a/packages/backend/tests/api/uploads.test.ts
+++ b/packages/backend/tests/api/uploads.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { Mock } from 'vitest';
+import bcrypt from 'bcrypt';
 import { createServer } from '../../src/api/server.js';
 import { createDatabaseClient } from '../../src/db/client.js';
 import type { FastifyInstance } from 'fastify';
@@ -631,6 +632,76 @@ describe('Uploads API', () => {
       });
 
       expect(response.statusCode).toBe(403);
+    });
+  });
+
+  // Positive path: the admin UI hits screenshot-url / replay-url with a JWT
+  // bearer token, not an API key. `requireApiKeyPermission('reports:read')`
+  // explicitly bypasses for JWT users (their permissions are gated elsewhere
+  // via project membership). These tests pin that bypass so a future tweak
+  // to the middleware can't accidentally block dashboard users.
+  describe('JWT user with project access can read assets', () => {
+    let jwtToken: string;
+
+    beforeEach(async () => {
+      const passwordHash = await bcrypt.hash('password123', 10);
+      const user = await db.users.create({
+        email: `jwt-viewer-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`,
+        password_hash: passwordHash,
+        role: 'user',
+      });
+      // Project membership at viewer level — the minimum that should still
+      // see screenshots/replays per ACCESS_CONTROL.md.
+      await db.query(
+        'INSERT INTO project_members (project_id, user_id, role) VALUES ($1, $2, $3)',
+        [testProject.id, user.id, 'viewer']
+      );
+      jwtToken = app.jwt.sign({ userId: user.id, role: 'user' }, { expiresIn: '1h' });
+
+      await db.query('UPDATE bug_reports SET screenshot_key = $1, replay_key = $2 WHERE id = $3', [
+        'screenshots/proj/bug/original.png',
+        'replays/proj/bug/replay.gz',
+        testBugReport.id,
+      ]);
+    });
+
+    it('GET screenshot-url with project-viewer JWT returns 200', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/reports/${testBugReport.id}/screenshot-url`,
+        headers: { authorization: `Bearer ${jwtToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).data.url).toBeDefined();
+    });
+
+    it('GET replay-url with project-viewer JWT returns 200', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/reports/${testBugReport.id}/replay-url`,
+        headers: { authorization: `Bearer ${jwtToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).data.url).toBeDefined();
+    });
+
+    it('GET intelligence mitigation with project-viewer JWT passes the auth gate', async () => {
+      // Mitigation is on the same `requireApiKeyPermission('reports:read')`
+      // chain. JWT users must still pass through. We don't care whether the
+      // mitigation row exists (it doesn't — would be 404), only that the
+      // response is NOT 401/403, which is what the new gate would have
+      // returned if it failed to bypass for JWT users.
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/intelligence/projects/${testProject.id}/bugs/${testBugReport.id}/mitigation`,
+        headers: { authorization: `Bearer ${jwtToken}` },
+      });
+
+      expect([200, 404]).toContain(response.statusCode);
+      expect(response.statusCode).not.toBe(401);
+      expect(response.statusCode).not.toBe(403);
     });
   });
 });

--- a/packages/backend/tests/api/uploads.test.ts
+++ b/packages/backend/tests/api/uploads.test.ts
@@ -588,4 +588,49 @@ describe('Uploads API', () => {
       expect(body.message).toContain('Access denied');
     });
   });
+
+  // Regression: ingest-only SDK keys (the kind self-service signup issues —
+  // permissions: ['reports:write','sessions:write'], no read perm) must NOT be
+  // able to fetch presigned URLs for screenshots or replays. The keys ship in
+  // public-facing front-end SDK code; granting them read access would let any
+  // page visitor pull every bug-report asset for the project.
+  describe('ingest-only API key cannot read assets (regression)', () => {
+    let ingestOnlyKey: string;
+
+    beforeEach(async () => {
+      const apiKeyService = new ApiKeyService(db);
+      const result = await apiKeyService.createKey({
+        name: 'Ingest-only SDK key',
+        permissions: ['reports:write', 'sessions:write'],
+        allowed_projects: [testProject.id],
+      });
+      ingestOnlyKey = result.plaintext;
+
+      await db.query('UPDATE bug_reports SET screenshot_key = $1, replay_key = $2 WHERE id = $3', [
+        'screenshots/proj/bug/original.png',
+        'replays/proj/bug/replay.gz',
+        testBugReport.id,
+      ]);
+    });
+
+    it('GET screenshot-url with ingest-only key returns 403', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/reports/${testBugReport.id}/screenshot-url`,
+        headers: { 'x-api-key': ingestOnlyKey },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('GET replay-url with ingest-only key returns 403', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/v1/reports/${testBugReport.id}/replay-url`,
+        headers: { 'x-api-key': ingestOnlyKey },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes four authorization gaps. All four are in routes that exist alongside correctly-gated peers — copy-paste-drift, not architectural.

- **`api-keys.ts` PATCH** — re-validates project admin on `allowed_projects` / `permissions` / `permission_scope` changes via the new `assertCanGrantProjects` helper. CREATE now calls the same helper, so the two paths can't drift. The gate intentionally **does not** block `permission_scope: 'full'` or `permissions: ['*']` outright — non-admins can already create such keys at CREATE for projects they admin, and PATCH being arbitrarily stricter than CREATE would be inconsistent. Project-admin on every project in `allowed_projects` is sufficient because scope/permissions are bounded by that list.
- **`jobs.ts` `/queues/:queueName/jobs/:id`** — gated to platform admin (was unauthenticated except for the global auth requirement). `process-integration` job payloads carry decrypted Jira/GitHub credentials, so any authenticated caller — including the public-facing SDK ingest key — could fetch any job and read another tenant's secrets. Credential-shaped fields are also redacted from the response as defense-in-depth, recursively, depth-bounded with a fail-closed `[DEPTH_EXCEEDED]` placeholder at the boundary.
- **`uploads.ts` `screenshot-url` + `replay-url`** — added `requireApiKeyPermission('reports:read')`, matching the peer `GET /reports/:id`. The signup-issued SDK ingest key has `permissions: ['reports:write','sessions:write']` and ships in customers' public-facing front-end code; without this gate, any page visitor could extract the key and pull presigned URLs for every screenshot/replay in the project.
- **`intelligence-mitigation.ts`** — same `requireApiKeyPermission('reports:read')` addition. AI mitigation echoes bug content into responses; same disclosure surface as `GET /reports/:id`.

## Test plan

- [x] `pnpm test:unit` — 2359/2359, including 7 new cases in `rbac-regression.test.ts` for the `requireApiKeyPermission` boundary
- [x] `tests/api/uploads.test.ts` — 2 ingest-only-key 403 cases + 3 project-viewer JWT 200 cases (verifies the middleware bypasses for JWT users so the admin UI flow doesn't break)
- [x] `tests/api/jobs.test.ts` — existing tests updated to auth as platform admin; 4 new cases: API-key auth rejected, top-level credential redaction, deep-nested credential redaction, fail-closed `[DEPTH_EXCEEDED]` at the depth boundary
- [x] `tests/api/api-keys.test.ts` — 5 new PATCH gate cases: cross-tenant widening rejected, member-only widening rejected, admin-of-target widening allowed, name-only PATCH unaffected, platform-admin bypass works
- [ ] Reviewer: smoke admin UI in dev — JWT auth still loads screenshots/replays
- [ ] Reviewer: confirm SDK ingest path (POST /reports) still works (writes are unaffected)

## Notes

- `intelligence-enrichment.ts` was flagged in the original audit but already uses `requireUser` (JWT-only); API keys are rejected at the door. No change needed.
- Pre-existing failing integration tests on `origin/main` (`auth.integration.test.ts`, `magic-login.integration.test.ts`, `integration-rules-permissions.test.ts`, `full-scope-api-key.test.ts`, `rule-evaluator.integration.test.ts`) confirmed to pre-date this branch — verified by checking out `origin/main` and re-running them. Tracked separately for cleanup PRs (none of them block this hotfix).
- CI bug discovered while investigating: `vitest.config.ts` excludes `tests/integration/**`, but `.github/workflows/ci.yml` still tries to run that path — vitest sees zero matches and exits 0. Integration tests have not been running in CI. Tracked as a separate cleanup PR.
- Supersedes #81 (closed for description correctness, same branch and commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)