### PR TITLE
ci: pass ANTHROPIC_API_KEY to claude-review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
         with:
+          # Pass both auth modes — the action picks whichever secret is set.
+          # ANTHROPIC_API_KEY is the simpler path (raw API billing); the OAuth
+          # token route is what `/install-github-app` populates and uses App
+          # billing. Either works; passing both means the workflow keeps
+          # running if you later switch from one to the other without
+          # re-editing the YAML.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Review PR #${{ github.event.pull_request.number }}.


### PR DESCRIPTION
## Summary

Follow-up to #84. The original workflow only wired \`claude_code_oauth_token\`, which assumed \`/install-github-app\` had populated \`CLAUDE_CODE_OAUTH_TOKEN\` in repo secrets. In practice that secret wasn't created and the action failed on auth:

\`\`\`
Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
\`\`\`

This PR passes **both** secrets — the action picks whichever is set:

- \`ANTHROPIC_API_KEY\` — simpler, raw API billing, just-added to repo secrets
- \`CLAUDE_CODE_OAUTH_TOKEN\` — App-billed, populated by \`/install-github-app\`

Supplying both keeps the workflow stable if we later switch routes without re-editing YAML.

## Test plan

- [ ] After merge, the existing \`Claude Review\` job (currently failing on auth on PR-83) re-runs and succeeds — Claude posts inline review comments
- [ ] If both secrets are unset (shouldn't happen, but), the job fails loudly with the same auth error rather than silently no-opping

## Notes

- Validated with \`actionlint\` (exit 0).
- Single 7-line addition; no behavior change other than auth path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance code review process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->