### PR TITLE
fix(cache): invalidateIntegrationRules now clears auto-create entries

### DIFF
--- a/packages/backend/src/cache/cache-keys.ts
+++ b/packages/backend/src/cache/cache-keys.ts
@@ -78,9 +78,24 @@ export const CacheKeys = {
   /**
    * Pattern to invalidate all rules for a project
    * @param projectId - Project ID
+   *
+   * Note: this matches `<prefix>:<projectId>:*` only — it does NOT match
+   * the auto-create variant `<prefix>:auto:<projectId>:<integrationId>`
+   * because `auto` precedes `<projectId>` in that key. Use
+   * `autoCreateRulesPattern(projectId)` for that side, or call both when
+   * invalidating after a rule mutation.
    */
   integrationRulesPattern(projectId: string): string {
     return buildCachePattern(buildCacheKey(CachePrefix.INTEGRATION_RULES, projectId));
+  },
+
+  /**
+   * Pattern to invalidate all auto-create rules for a project. Sibling of
+   * `integrationRulesPattern` — see that note for why we need both.
+   * @param projectId - Project ID
+   */
+  autoCreateRulesPattern(projectId: string): string {
+    return buildCachePattern(buildCacheKey(CachePrefix.INTEGRATION_RULES, 'auto', projectId));
   },
 
   /**

--- a/packages/backend/src/cache/cache-keys.ts
+++ b/packages/backend/src/cache/cache-keys.ts
@@ -79,11 +79,17 @@ export const CacheKeys = {
    * Pattern to invalidate all rules for a project
    * @param projectId - Project ID
    *
-   * Note: this matches `<prefix>:<projectId>:*` only — it does NOT match
-   * the auto-create variant `<prefix>:auto:<projectId>:<integrationId>`
-   * because `auto` precedes `<projectId>` in that key. Use
-   * `autoCreateRulesPattern(projectId)` for that side, or call both when
-   * invalidating after a rule mutation.
+   * Note: this matches `<prefix>:<projectId>:*` only. It does NOT match:
+   *   - The bare project key `<prefix>:<projectId>` written by
+   *     `integrationRules(projectId)` (no trailing segment for `:*`
+   *     to land on) — delete that key explicitly.
+   *   - The auto-create variant `<prefix>:auto:<projectId>:<integrationId>`
+   *     because `auto` precedes `<projectId>` — use
+   *     `autoCreateRulesPattern(projectId)` for that side.
+   *
+   * `cacheService.invalidateIntegrationRules` handles all three shapes;
+   * direct callers of this pattern should be aware they're only catching
+   * one of them.
    */
   integrationRulesPattern(projectId: string): string {
     return buildCachePattern(buildCacheKey(CachePrefix.INTEGRATION_RULES, projectId));

--- a/packages/backend/src/cache/cache-service.ts
+++ b/packages/backend/src/cache/cache-service.ts
@@ -298,12 +298,28 @@ export class CacheService {
   }
 
   /**
-   * Invalidate all integration rules for a project
+   * Invalidate all integration rules for a project, including auto-create
+   * rule cache entries. Two separate pattern deletes are required because
+   * auto-create keys are shaped `<prefix>:auto:<projectId>:<integrationId>`
+   * — the `auto` segment precedes `<projectId>`, so a wildcard rooted at
+   * `<projectId>` doesn't reach them.
+   *
+   * Production route handlers call this after every rule create/update/
+   * delete; without the auto-create pattern, the auto-create cache would
+   * stay stale for up to `CacheTTL.SHORT` (60s) after a rule change.
    */
   async invalidateIntegrationRules(projectId: string): Promise<void> {
-    const pattern = CacheKeys.integrationRulesPattern(projectId);
-    const deleted = await this.deletePattern(pattern);
-    logger.debug('Invalidated integration rules cache', { projectId, deleted });
+    const generalPattern = CacheKeys.integrationRulesPattern(projectId);
+    const autoCreatePattern = CacheKeys.autoCreateRulesPattern(projectId);
+    const [deletedGeneral, deletedAutoCreate] = await Promise.all([
+      this.deletePattern(generalPattern),
+      this.deletePattern(autoCreatePattern),
+    ]);
+    logger.debug('Invalidated integration rules cache', {
+      projectId,
+      deletedGeneral,
+      deletedAutoCreate,
+    });
   }
 
   /**

--- a/packages/backend/src/cache/cache-service.ts
+++ b/packages/backend/src/cache/cache-service.ts
@@ -320,6 +320,17 @@ export class CacheService {
    * cache for up to `CacheTTL.SHORT` (60s) after a rule change.
    */
   async invalidateIntegrationRules(projectId: string): Promise<void> {
+    // Guard against empty/whitespace projectId. `buildCacheKey` filters
+    // out empty-string parts, so an empty `projectId` would collapse the
+    // patterns to `rules:*` and `rules:auto:*` — wiping every project's
+    // rules cache, not just one. Treat as a no-op rather than a global
+    // nuke; a real caller should never reach this branch.
+    if (!projectId || !projectId.trim()) {
+      logger.warn('invalidateIntegrationRules called with empty projectId — ignoring', {
+        projectId,
+      });
+      return;
+    }
     const baseKey = CacheKeys.integrationRules(projectId);
     const generalPattern = CacheKeys.integrationRulesPattern(projectId);
     const autoCreatePattern = CacheKeys.autoCreateRulesPattern(projectId);

--- a/packages/backend/src/cache/cache-service.ts
+++ b/packages/backend/src/cache/cache-service.ts
@@ -298,20 +298,33 @@ export class CacheService {
   }
 
   /**
-   * Invalidate all integration rules for a project, including auto-create
-   * rule cache entries. Two separate pattern deletes are required because
-   * auto-create keys are shaped `<prefix>:auto:<projectId>:<integrationId>`
-   * — the `auto` segment precedes `<projectId>`, so a wildcard rooted at
-   * `<projectId>` doesn't reach them.
+   * Invalidate all integration rules for a project. Three deletes are
+   * required because the rules cache has three key shapes:
+   *
+   *   1. `<prefix>:<projectId>`                       — bare project key
+   *      written by `CacheKeys.integrationRules(projectId)` when the
+   *      caller wants the full rule list for a project, no integration
+   *      filter. This is an EXACT key, not a pattern — wildcards can't
+   *      match it (no trailing colon segment for `:*` to land on).
+   *
+   *   2. `<prefix>:<projectId>:<integrationId>`        — per-integration
+   *      key written by `CacheKeys.integrationRules(projectId, integ)`.
+   *      Caught by the general pattern `<prefix>:<projectId>:*`.
+   *
+   *   3. `<prefix>:auto:<projectId>:<integrationId>`   — auto-create
+   *      variant. `auto` precedes `<projectId>`, so a wildcard rooted
+   *      at `<projectId>` can't reach it — needs its own pattern.
    *
    * Production route handlers call this after every rule create/update/
-   * delete; without the auto-create pattern, the auto-create cache would
-   * stay stale for up to `CacheTTL.SHORT` (60s) after a rule change.
+   * delete; missing any of the three shapes leaves stale rules in the
+   * cache for up to `CacheTTL.SHORT` (60s) after a rule change.
    */
   async invalidateIntegrationRules(projectId: string): Promise<void> {
+    const baseKey = CacheKeys.integrationRules(projectId);
     const generalPattern = CacheKeys.integrationRulesPattern(projectId);
     const autoCreatePattern = CacheKeys.autoCreateRulesPattern(projectId);
-    const [deletedGeneral, deletedAutoCreate] = await Promise.all([
+    const [, deletedGeneral, deletedAutoCreate] = await Promise.all([
+      this.delete(baseKey),
       this.deletePattern(generalPattern),
       this.deletePattern(autoCreatePattern),
     ]);

--- a/packages/backend/tests/cache/cache-keys.test.ts
+++ b/packages/backend/tests/cache/cache-keys.test.ts
@@ -118,6 +118,16 @@ describe('Cache Keys', () => {
         expect(CacheKeys.integrationRulesPattern('project-1')).toBe('rules:project-1:*');
       });
 
+      // Pin the exact output so a typo in argument order to `buildCacheKey`
+      // (e.g. swapping `projectId` and `'auto'`) can't silently produce a
+      // pattern that doesn't match real auto-create cache keys at runtime.
+      // The shape-invariant test in cache-service.test.ts is necessary but
+      // not sufficient: `startsWith(prefix)` would pass for several wrong
+      // shapes that have the right components in the wrong order.
+      it('should generate auto-create rules pattern for project', () => {
+        expect(CacheKeys.autoCreateRulesPattern('project-1')).toBe('rules:auto:project-1:*');
+      });
+
       it('should generate all integration rules pattern', () => {
         expect(CacheKeys.allIntegrationRulesPattern()).toBe('rules:*');
       });

--- a/packages/backend/tests/cache/cache-service.test.ts
+++ b/packages/backend/tests/cache/cache-service.test.ts
@@ -479,36 +479,54 @@ describe('CacheService', () => {
       // `<projectId>`). Production route handlers thought they were
       // invalidating after rule mutations but the auto-create cache
       // stayed stale until TTL expired.
-      it('should delete BOTH the general rules pattern and the auto-create rules pattern', async () => {
+      it('should delete the bare project key, the general pattern, AND the auto-create pattern', async () => {
         vi.mocked(mockMemoryCache.deletePattern).mockResolvedValue(2);
         vi.mocked(mockRedisCache.deletePattern).mockResolvedValue(1);
+        vi.mocked(mockMemoryCache.delete).mockResolvedValue(true);
+        vi.mocked(mockRedisCache.delete).mockResolvedValue(true);
 
         await cacheService.invalidateIntegrationRules('proj-1');
 
+        const baseKey = CacheKeys.integrationRules('proj-1');
         const generalPattern = CacheKeys.integrationRulesPattern('proj-1');
         const autoCreatePattern = CacheKeys.autoCreateRulesPattern('proj-1');
 
+        // Bare project key (`<prefix>:<projectId>`) — exact key, not a pattern.
+        // Wildcard `<prefix>:<projectId>:*` doesn't match because there's no
+        // trailing colon segment to match the `*`.
+        expect(mockMemoryCache.delete).toHaveBeenCalledWith(baseKey);
+        expect(mockRedisCache.delete).toHaveBeenCalledWith(baseKey);
+
+        // Per-integration keys (`<prefix>:<projectId>:<integrationId>`).
         expect(mockMemoryCache.deletePattern).toHaveBeenCalledWith(generalPattern);
-        expect(mockMemoryCache.deletePattern).toHaveBeenCalledWith(autoCreatePattern);
         expect(mockRedisCache.deletePattern).toHaveBeenCalledWith(generalPattern);
+
+        // Auto-create variant (`<prefix>:auto:<projectId>:<integrationId>`).
+        expect(mockMemoryCache.deletePattern).toHaveBeenCalledWith(autoCreatePattern);
         expect(mockRedisCache.deletePattern).toHaveBeenCalledWith(autoCreatePattern);
       });
 
-      it('should clear the auto-create cache key written by getAutoCreateRules', async () => {
-        // End-to-end shape check: an entry written by getAutoCreateRules
-        // must be removed by invalidateIntegrationRules. This is the
-        // invariant that route handlers depend on.
+      it('should clear ALL three integration-rules cache key shapes', async () => {
+        // End-to-end shape check: every entry written by the rules cache
+        // methods must be reachable by some part of invalidateIntegrationRules.
+        const baseKey = CacheKeys.integrationRules('proj-1');
+        const perIntegrationKey = CacheKeys.integrationRules('proj-1', 'integ-1');
         const autoCreateKey = CacheKeys.autoCreateRules('proj-1', 'integ-1');
-        const autoCreatePattern = CacheKeys.autoCreateRulesPattern('proj-1');
 
-        // The pattern's wildcard suffix must match the actual key.
-        // (Strip the trailing `*` and confirm the key starts with the prefix.)
-        const prefix = autoCreatePattern.replace(/\*$/, '');
-        expect(autoCreateKey.startsWith(prefix)).toBe(true);
-
-        // And the OLD general pattern (the buggy one) must NOT match.
         const generalPattern = CacheKeys.integrationRulesPattern('proj-1');
+        const autoCreatePattern = CacheKeys.autoCreateRulesPattern('proj-1');
         const generalPrefix = generalPattern.replace(/\*$/, '');
+        const autoCreatePrefix = autoCreatePattern.replace(/\*$/, '');
+
+        // baseKey is matched by exact delete (bare key, no wildcard match).
+        expect(baseKey).toBe('rules:proj-1');
+
+        // perIntegrationKey is matched by the general pattern.
+        expect(perIntegrationKey.startsWith(generalPrefix)).toBe(true);
+
+        // autoCreateKey is matched by the auto-create pattern.
+        expect(autoCreateKey.startsWith(autoCreatePrefix)).toBe(true);
+        // And NOT by the general pattern (the original PR-88 bug).
         expect(autoCreateKey.startsWith(generalPrefix)).toBe(false);
       });
     });

--- a/packages/backend/tests/cache/cache-service.test.ts
+++ b/packages/backend/tests/cache/cache-service.test.ts
@@ -506,6 +506,26 @@ describe('CacheService', () => {
         expect(mockRedisCache.deletePattern).toHaveBeenCalledWith(autoCreatePattern);
       });
 
+      it.each([
+        ['empty string', ''],
+        ['whitespace only', '   '],
+      ])(
+        'should NOT make any cache calls when projectId is %s (guard against global wipe)',
+        async (_label, badProjectId) => {
+          // `buildCacheKey` filters out empty-string parts. Without the
+          // guard, an empty projectId would collapse the patterns to
+          // `rules:*` and `rules:auto:*`, wiping every project's rules
+          // cache — far worse than a no-op. Assert that NEITHER `delete`
+          // NOR `deletePattern` is called for invalid input.
+          await cacheService.invalidateIntegrationRules(badProjectId);
+
+          expect(mockMemoryCache.delete).not.toHaveBeenCalled();
+          expect(mockRedisCache.delete).not.toHaveBeenCalled();
+          expect(mockMemoryCache.deletePattern).not.toHaveBeenCalled();
+          expect(mockRedisCache.deletePattern).not.toHaveBeenCalled();
+        }
+      );
+
       it('should clear ALL three integration-rules cache key shapes', async () => {
         // End-to-end shape check: every entry written by the rules cache
         // methods must be reachable by some part of invalidateIntegrationRules.

--- a/packages/backend/tests/cache/cache-service.test.ts
+++ b/packages/backend/tests/cache/cache-service.test.ts
@@ -471,6 +471,48 @@ describe('CacheService', () => {
       });
     });
 
+    describe('invalidateIntegrationRules', () => {
+      // Regression: prior implementation called only the general
+      // `integrationRulesPattern` (`<prefix>:<projectId>:*`) which does
+      // NOT match the auto-create cache key shape
+      // (`<prefix>:auto:<projectId>:<integrationId>` — `auto` precedes
+      // `<projectId>`). Production route handlers thought they were
+      // invalidating after rule mutations but the auto-create cache
+      // stayed stale until TTL expired.
+      it('should delete BOTH the general rules pattern and the auto-create rules pattern', async () => {
+        vi.mocked(mockMemoryCache.deletePattern).mockResolvedValue(2);
+        vi.mocked(mockRedisCache.deletePattern).mockResolvedValue(1);
+
+        await cacheService.invalidateIntegrationRules('proj-1');
+
+        const generalPattern = CacheKeys.integrationRulesPattern('proj-1');
+        const autoCreatePattern = CacheKeys.autoCreateRulesPattern('proj-1');
+
+        expect(mockMemoryCache.deletePattern).toHaveBeenCalledWith(generalPattern);
+        expect(mockMemoryCache.deletePattern).toHaveBeenCalledWith(autoCreatePattern);
+        expect(mockRedisCache.deletePattern).toHaveBeenCalledWith(generalPattern);
+        expect(mockRedisCache.deletePattern).toHaveBeenCalledWith(autoCreatePattern);
+      });
+
+      it('should clear the auto-create cache key written by getAutoCreateRules', async () => {
+        // End-to-end shape check: an entry written by getAutoCreateRules
+        // must be removed by invalidateIntegrationRules. This is the
+        // invariant that route handlers depend on.
+        const autoCreateKey = CacheKeys.autoCreateRules('proj-1', 'integ-1');
+        const autoCreatePattern = CacheKeys.autoCreateRulesPattern('proj-1');
+
+        // The pattern's wildcard suffix must match the actual key.
+        // (Strip the trailing `*` and confirm the key starts with the prefix.)
+        const prefix = autoCreatePattern.replace(/\*$/, '');
+        expect(autoCreateKey.startsWith(prefix)).toBe(true);
+
+        // And the OLD general pattern (the buggy one) must NOT match.
+        const generalPattern = CacheKeys.integrationRulesPattern('proj-1');
+        const generalPrefix = generalPattern.replace(/\*$/, '');
+        expect(autoCreateKey.startsWith(generalPrefix)).toBe(false);
+      });
+    });
+
     describe('getSystemConfig', () => {
       it('should return cached system config', async () => {
         const config = { maxUploadSize: 1024000 };


### PR DESCRIPTION
## The bug

\`cache.invalidateIntegrationRules(projectId)\` doesn't actually invalidate the auto-create rules cache. Found while debugging the rule-evaluator integration test in #87.

**Why:**
\`\`\`
autoCreateRules key:        <prefix>:auto:<projectId>:<integrationId>
integrationRulesPattern():  <prefix>:<projectId>:*    ← never matches!
\`\`\`

The wildcard sits at \`<projectId>:*\` but the auto-create key has \`auto\` BEFORE \`<projectId>\`. The pattern's wildcard can't reach across.

## Production impact

Route handlers in \`integration-rules.ts\` call \`cache.invalidateIntegrationRules(projectId)\` after every rule create / update / delete / copy. Those calls cleared the regular \`integrationRules\` cache but left \`autoCreateRules\` entries intact.

Worst case: a customer changes a Jira routing rule via the dashboard, but bug reports created within the next ~60s (\`CacheTTL.SHORT\`) still match against the **old** rule. Bounded blast radius — TTL is short and auto-create matching mostly determines *which* integration receives a ticket (not *whether* one is created) — but the invariant the route layer was designed around ("cache is fresh after a rule mutation") was silently broken.

## Fix

- Add sibling \`autoCreateRulesPattern(projectId)\` in \`CacheKeys\`
- Have \`invalidateIntegrationRules\` delete BOTH patterns (in parallel via \`Promise.all\`)
- Comments updated on both methods to call out the shape mismatch and prevent regression

**Did not** restructure the cache key shape (e.g. moving \`auto\` after \`<projectId>\` to make a single pattern work). That would be a refactor with deployment-transition risk; this fix is strictly additive.

## Tests

Two new unit tests in \`tests/cache/cache-service.test.ts\`:

1. **Behavior**: verifies \`invalidateIntegrationRules\` calls \`deletePattern\` with BOTH the general pattern and the auto-create pattern, on both memory (L1) and Redis (L2) tiers.
2. **Shape invariant**: shape-checks that the actual key written by \`getAutoCreateRules\` starts with the auto-create pattern's prefix, and does NOT start with the buggy general pattern's prefix. Pins the relationship so a future key-shape change can't silently re-introduce the gap.

All 2361 unit tests pass.

## Note for #87

PR #87's β test fix uses \`cache.clear()\` as a sledgehammer because this bug existed when the test was written. After this lands, a small follow-up could simplify the test back to \`cache.invalidateIntegrationRules(testProjectId)\` — but it's not required, \`clear()\` keeps working.

## Test plan

- [x] \`pnpm --filter @bugspotter/backend test:unit\` — 2361/2361 passing
- [ ] Reviewer: confirm route handlers in \`integration-rules.ts\` haven't been touched (this PR only changes the cache layer; the contract for callers is unchanged)
- [ ] Reviewer (optional): smoke test in dev — change a rule via the dashboard, immediately create a bug report, confirm the new rule is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache invalidation for integration rules now clears both standard and auto-created rule entries concurrently and reports separate deletion counts, preventing stale rule data.
  * Guard added to skip invalidation when the project identifier is empty/whitespace (no deletions performed; a warning is logged).

* **Tests**
  * Added tests verifying both rule-pattern types are recognized and removed, and that empty/whitespace identifiers do not trigger deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->