### PR TITLE
ci: claude review — fix @claude trigger from PR comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,6 +41,23 @@ jobs:
           # Shallow clone — review only needs the diff, not full history.
           fetch-depth: 1
 
+      # `issue_comment` and `pull_request_review_comment` events run
+      # against the default branch (main), not the PR's HEAD — that's
+      # how GitHub dispatches comment-triggered workflows. Without this
+      # step, Claude is staring at `main` and has to discover the PR's
+      # contents via repeated `gh pr diff` / `gh api` calls, burning
+      # max-turns before it can post anything. Switch to the PR branch
+      # so Claude sees the actual diff in the working tree.
+      - name: Checkout PR branch when triggered by comment
+        if: |
+          github.event_name == 'issue_comment' ||
+          github.event_name == 'pull_request_review_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          gh pr checkout "$PR_NUMBER"
+
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
         with:
@@ -77,4 +94,4 @@ jobs:
           # no-top-level-summary preference.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
-            --max-turns 8
+            --max-turns 15


### PR DESCRIPTION
## The bug

\`@claude review this PR\` comments on PRs were silently failing. Run \`25243082772\` (triggered by exactly that comment on #87):

\`\`\`
Action failed with error: SDK execution error:
Error: Claude Code returned an error result:
Reached maximum number of turns (8)
\`\`\`

## Root cause — two compounding issues

**(1) Wrong branch checked out.** \`issue_comment\` and \`pull_request_review_comment\` events dispatch the workflow against the **default branch (main)**, not the PR's HEAD. That's GitHub's design — it prevents PRs from modifying their own review workflow. The default \`actions/checkout@v4\` lands on main, so Claude was staring at main's working tree and had to discover what's in PR #87 via \`gh pr diff\`/\`gh api\` calls. Each call costs a turn.

**(2) \`--max-turns 8\` too tight for discovery.** Plenty for \`pull_request\` events (Claude already has the diff), too tight when Claude has to navigate to the PR contents first.

## Fix

**(a) Conditional \`gh pr checkout\`** — runs only when triggered by comment events. After the default checkout lands on main, switches to the PR's HEAD ref. Claude now sees the actual diff in the working tree from the start.

**(b) Bump \`--max-turns\` from 8 to 15** — gives headroom for real reviews even when discovery is needed.

## Test plan

- [x] \`actionlint\` clean (exit 0)
- [ ] After merge, on any open PR, comment \`@claude review this PR\` and confirm Claude actually reviews it (not "Reached maximum number of turns")
- [ ] On a fresh PR, the existing \`pull_request\` trigger still works (the new conditional step is no-op for those events)

## Notes

- Doesn't affect the security model: the \`@claude\` mention guard in the \`if:\` block still requires the trigger comment to literally contain \`@claude\`, so a malicious PR can't fork-attack via comments.
- The conditional \`gh pr checkout\` uses \`github.token\` (default GITHUB_TOKEN) which has \`pull-requests: write\` per the existing permissions block — sufficient for fetching the PR ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow to enhance handling of pull request review comments with increased conversation capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->