### PR TITLE
ci: claude review — only cancel in-flight runs on new pushes

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,11 +15,24 @@ on:
   pull_request_review_comment:
     types: [created]
 
-# Cancel in-flight reviews when new commits are pushed — no point
-# reviewing a stale revision and burning credits doing it.
+# Cancel in-flight reviews when new COMMITS are pushed (so we don't
+# review a stale revision) — but NOT when comment events fire.
+#
+# Comment-triggered runs (`issue_comment`, `pull_request_review_comment`)
+# share the same concurrency group as `pull_request` runs. Without the
+# event-aware `cancel-in-progress`, every comment on a PR — even bot
+# threads or replies the workflow's `if:` guard would skip — would
+# cancel an in-flight pull_request review on the same ref. That's how
+# four laconic replies on review threads accidentally killed PR-90's
+# real review run.
+#
+# With this expression, only `pull_request` events (= new pushes) cancel
+# in-flight runs. Comment events queue behind / run alongside, and any
+# without `@claude` get filtered out by the job-level `if:` guard
+# anyway.
 concurrency:
   group: claude-review-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   claude-review:


### PR DESCRIPTION
## The bug (observed on PR #90)

A real Claude review on the latest commit got cancelled by laconic replies on bot review threads:

1. Push commit X → \`pull_request\` event → Claude review starts
2. Reply on a bot thread → \`pull_request_review_comment\` event → workflow re-triggers
3. \`concurrency.group\` is the same → \`cancel-in-progress: true\` → **in-flight \`pull_request\` run gets killed**
4. Re-triggered run hits the job-level \`if:\` guard (no \`@claude\` in reply), gets skipped → **no review for commit X**

The \`if:\` guard correctly rejects non-\`@claude\` comments at the **job** level. But concurrency runs at the **workflow** level — so the cancel happens BEFORE the if-guard evaluates. Every drive-by comment-triggered re-run kills the real review even though the re-run itself does nothing.

## Fix

Make \`cancel-in-progress\` event-aware:

\`\`\`yaml
concurrency:
  group: claude-review-\${{ github.ref }}
  cancel-in-progress: \${{ github.event_name == 'pull_request' }}
\`\`\`

Now:
- \`pull_request\` event (new push) → cancel any in-flight run (preserves the original intent — don't burn credits reviewing a stale revision)
- \`issue_comment\` / \`pull_request_review_comment\` → don't cancel; just queue or get filtered by the if-guard

Inline comment block in the workflow explains the failure mode so the next person who looks at this code understands why we're not just \`cancel-in-progress: true\`.

## Test plan

- [x] \`actionlint\` clean (exit 0)
- [ ] After merge: on any open PR, post several comments quickly during a review run and confirm Claude completes its review on the original commit
- [ ] Push a new commit during a review run and confirm the in-flight run still gets cancelled (preserving the original intent)

## Notes

- Single line change to a workflow expression. Self-contained; no related code touched.
- The PR-90 anti-exfiltration constraint applies here too: until this lands on main, modifying \`claude-review.yml\` on a feature branch will fail the action's workflow-validation check. After merge, future PRs benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated review workflow to prevent comment-triggered reviews from interrupting in-progress reviews from new commits. Comment-based invocations now queue separately without canceling the latest commit-based review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->