### PR TITLE
test(integration): set DISABLE_STRICT_RESIDENCY_VALIDATION in test setup

### DIFF
--- a/packages/backend/tests/setup.integration.ts
+++ b/packages/backend/tests/setup.integration.ts
@@ -53,6 +53,13 @@ export async function setup() {
   process.env.RATE_LIMIT_MAX_REQUESTS = '10000'; // Very high limit for tests
   process.env.RATE_LIMIT_WINDOW_MS = '60000'; // 1 minute window
   process.env.ALLOW_REGISTRATION = 'true'; // Enable registration for tests
+  // Skip the strict-residency storage validator at server boot. Strict
+  // regions (kz, rf) are hardcoded in src/data-residency/types.ts and
+  // require per-region S3 endpoints — integration tests use a local
+  // testcontainer (postgres/redis/minio) and don't model regional
+  // routing, so the validator would always fail. The escape hatch is
+  // documented at src/data-residency/config.ts:354-366.
+  process.env.DISABLE_STRICT_RESIDENCY_VALIDATION = 'true';
 
   console.log('✅ PostgreSQL container started');
   console.log('📍 Database:', connectionUri.replace(/:[^:@]+@/, ':***@'));


### PR DESCRIPTION
## Summary

Sets `DISABLE_STRICT_RESIDENCY_VALIDATION=true` in [`tests/setup.integration.ts`](packages/backend/tests/setup.integration.ts) so the global integration setup uses the documented escape hatch from [`data-residency/config.ts:354-366`](packages/backend/src/data-residency/config.ts#L354-L366).

**Test-only change. No production source touched.**

## Why

`tests/integration/presigned-url-actual-upload.test.ts` calls `createServer` with a MinIO-backed S3 `StorageService`. `createServer` runs `validateStrictResidencyStorage()` whenever storage is an `instanceof StorageService` ([server.ts:183](packages/backend/src/api/server.ts#L183)), and the validator unconditionally requires per-region storage configuration for the strict-residency regions hardcoded in [`data-residency/types.ts:49-52`](packages/backend/src/data-residency/types.ts#L49) (`kz`, `rf`).

Integration tests run against ephemeral testcontainers (Postgres, Redis, MinIO on dynamic ports) and have no regional storage to configure. The validator therefore throws at `createServer`, the test fails before any assertion runs, and the integration job stays red.

Same failure has been on `main` for multiple runs (verified — appears on commit `311e4e34` and current HEAD); `continue-on-error: true` on the integration job masks it from the merge gate. Surfaced during PR-95's CI runs.

## Verified

- `pnpm --filter @bugspotter/backend test:integration tests/integration/presigned-url-actual-upload.test.ts` locally: **6/6 passing** after the change
- Other integration tests unaffected — the env var only short-circuits `validateStrictResidencyStorage()`, no other code paths gate on it

## Unblocks

The one-line follow-up to remove `continue-on-error: true` from the Backend Integration Tests job. After this lands, the integration suite is fully green and the CI gate can be tightened.

## Notes

The fact that strict-residency regions (`kz`, `rf`) are hardcoded in `types.ts` rather than env-driven is its own design question — a self-hosted deployment without those compliance requirements would still hit the validator. Out of scope for this PR; the escape hatch exists for the same reason.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configuration to adjust validation settings for test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->