### PR TITLE
ci: make Backend Integration Tests required (remove continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,21 +230,15 @@ jobs:
     name: Backend Integration Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Non-blocking on purpose. Integration tests stopped running in CI when
-    # `vitest.config.ts` started excluding `tests/integration/**` — the
-    # `pnpm test -- tests/integration` calls in other jobs match nothing and
-    # exit 0. Wiring `pnpm test:integration` (which uses the integration
-    # config) restores visibility, but the suite carries pre-existing
-    # baseline failures (verified pre-PR-1 by checking out origin/main).
-    # Cleanup is tracked in follow-up PRs (α–ε from the rot analysis):
-    #   - α: setup.integration-env.ts ALLOW_REGISTRATION → fixes 3
-    #   - β: rule-evaluator beforeEach cache invalidation → fixes 10
-    #   - γ: delete two stale tests (admin-register, role-required magic)
-    #   - δ: full-scope-api-key URL/enum/fixture drift → fixes 12
-    #   - ε: integration-rules-permissions role + wording → fixes 5
-    # Once those land, flip continue-on-error to false and add this job
-    # to ci-success's needs list to make it required.
-    continue-on-error: true
+    # Required. Was previously non-blocking with `continue-on-error: true`
+    # because `vitest.config.ts` had been excluding `tests/integration/**`
+    # for long enough that the suite carried significant drift from the
+    # current routes/schemas. The cleanup PRs that closed each drift
+    # cluster have all landed (integration baseline cleanup, full-scope
+    # API key + integration-rules-permissions tests, presigned-url
+    # residency-validator bypass), so the job is now stable green on
+    # main and can gate merges. Add a matching result-check below in
+    # ci-success when adjusting this — both must move together.
 
     env:
       NODE_OPTIONS: --no-node-snapshot
@@ -760,13 +754,10 @@ jobs:
   ci-success:
     name: CI
     runs-on: ubuntu-latest
-    # `test-backend-integration` is in `needs` so the required CI summary
-    # waits for it to finish — without this, CI can go green while the
-    # integration job is still running and any new regression would slip
-    # through. Intentionally NOT added to the result-check block below:
-    # the job has `continue-on-error: true` and is non-blocking until
-    # the cleanup PRs (α–ε) land. Add a result check here when those
-    # ship.
+    # `test-backend-integration` is in `needs` AND in the result-check
+    # block below. Both must move together: removing it from one without
+    # the other either lets a failure slip through (only in `needs`) or
+    # waits on a job that doesn't gate (only in checks).
     needs: [lint, test-backend-db, test-backend-api, test-backend-services, test-backend-other, test-backend-integration, playwright-admin, build, test-coverage, validate-compose]
     if: always()
     steps:
@@ -791,6 +782,10 @@ jobs:
           fi
           if [[ "${{ needs.test-backend-other.result }}" != "success" ]]; then
             echo "❌ Backend Other Tests job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.test-backend-integration.result }}" != "success" ]]; then
+            echo "❌ Backend Integration Tests job failed"
             exit 1
           fi
           if [[ "${{ needs.playwright-admin.result }}" != "success" ]]; then


### PR DESCRIPTION
## Summary

Flips the Backend Integration Tests job from non-blocking (`continue-on-error: true`) to a hard requirement. Single-file change to [`.github/workflows/ci.yml`](.github/workflows/ci.yml).

## Why now

The integration job has been non-blocking since `vitest.config.ts` started excluding `tests/integration/**` long enough ago that the suite carried significant drift from the current routes/schemas. The cleanup PRs that closed each drift cluster have all landed:

- [#87](https://github.com/apex-bridge/bugspotter/pull/87) — integration baseline cleanup (31→17 failures)
- [#95](https://github.com/apex-bridge/bugspotter/pull/95) — `full-scope-api-key.test.ts` + `integration-rules-permissions.test.ts` test cleanup (17→1)
- [#98](https://github.com/apex-bridge/bugspotter/pull/98) — `presigned-url-actual-upload.test.ts` strict-residency validator bypass (1→0)

**Verified**: integration job on the latest main commit (`16535e56`, post-#98) finishes green. Stable enough to gate merges.

## What changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` (job `test-backend-integration`) | Remove `continue-on-error: true`. Replace the stale comment block (referenced cleanup PRs that have landed and Greek-letter slice labels that no longer match anything) with a brief note about the new contract |
| `.github/workflows/ci.yml` (job `ci-success`) | Add `needs.test-backend-integration.result != 'success'` to the existing per-job result-check block. The integration job was already in the `needs` list (so the summary waited for it to finish), but wasn't in the result-check block (so its failure didn't propagate). Both must move together |

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [ ] CI on this PR runs the integration job under the new contract — if it passes, the gate works as intended
- [ ] Reviewer: a deliberate regression in any `tests/integration/**` file should fail this PR, not pass it (counterfactual test of the gate)

## Notes

The flip is one-way safe: if some genuinely flaky integration test surfaces after merge, the next step is to either fix the flake or revert this PR — both are easy. The pre-existing `Backend Integration Tests` job behaviour for testcontainers (real Postgres, Redis, MinIO via `testcontainers`) hasn't changed.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow: backend integration test failures now block the build process, ensuring stricter code quality validation. Previously, integration test failures were ignored; now they properly prevent incomplete changes from being merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->