### PR TITLE
security(integration-rules): tighten copy source to require project member (closes #96)

### DIFF
--- a/packages/backend/src/api/middleware/project-access.ts
+++ b/packages/backend/src/api/middleware/project-access.ts
@@ -91,25 +91,33 @@ export function requireProjectAccess(db: DatabaseClient, options: { paramName?: 
     // "You do not have a role in this project" 403 — even though
     // `requireProjectAccess` (above) just admitted them via the inherited
     // path in `checkProjectAccess`.
+    //
+    // Both lookups run in parallel — they're independent (different
+    // tables, no shared rows). `lookupInheritedProjectRole` takes the
+    // already-fetched `project.organization_id` so it doesn't re-query
+    // the projects table for a row we just loaded above.
     if (request.authUser) {
-      const explicitRole = await db.projects.getUserRole(project.id, request.authUser.id);
-      const inheritedRole = await lookupInheritedProjectRole(project.id, request.authUser.id, db);
+      const [explicitRole, inheritedRole] = await Promise.all([
+        db.projects.getUserRole(project.id, request.authUser.id),
+        lookupInheritedProjectRole(project.id, request.authUser.id, db, project.organization_id),
+      ]);
 
       // Pick the higher of explicit and inherited. Mirrors the same
       // composition logic used inside checkProjectAccess.
-      const explicit = explicitRole && isProjectRole(explicitRole) ? explicitRole : null;
-      let effectiveRole = explicit;
-      if (explicit && inheritedRole) {
-        effectiveRole = hasPermissionLevel(explicit, inheritedRole) ? explicit : inheritedRole;
-      } else if (inheritedRole) {
-        effectiveRole = inheritedRole;
-      }
+      const explicit = isProjectRole(explicitRole) ? explicitRole : null;
+      const effectiveRole =
+        explicit && inheritedRole
+          ? hasPermissionLevel(explicit, inheritedRole)
+            ? explicit
+            : inheritedRole
+          : (explicit ?? inheritedRole);
 
       if (effectiveRole) {
         request.projectRole = effectiveRole;
       }
-      // If role is null or invalid, leave request.projectRole as undefined
-      // Downstream authorization checks will handle missing roles appropriately
+      // If both lookups returned null, leave request.projectRole undefined.
+      // Downstream authorization checks (e.g., requireProjectRole) handle
+      // missing roles appropriately.
     }
 
     // Attach project ID and project to request for downstream handlers

--- a/packages/backend/src/api/middleware/project-access.ts
+++ b/packages/backend/src/api/middleware/project-access.ts
@@ -5,8 +5,8 @@
 
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { DatabaseClient } from '../../db/client.js';
-import { findOrThrow, checkProjectAccess } from '../utils/resource.js';
-import { isProjectRole } from '../../types/project-roles.js';
+import { findOrThrow, checkProjectAccess, lookupInheritedProjectRole } from '../utils/resource.js';
+import { hasPermissionLevel, isProjectRole } from '../../types/project-roles.js';
 import { extractRouteParam, requireAuthContext } from './helpers.js';
 
 /**
@@ -81,13 +81,32 @@ export function requireProjectAccess(db: DatabaseClient, options: { paramName?: 
       apiKey: request.apiKey,
     });
 
-    // Fetch and attach user's role for downstream authorization checks (avoids N+1 queries)
+    // Fetch the user's effective project role for downstream authorization
+    // checks. Effective = max(explicit project_members row, org-inherited
+    // role). `getUserRole` only sees explicit project membership rows
+    // (and the `created_by` owner shortcut); a user whose project access
+    // is granted via org membership inheritance has `getUserRole` returning
+    // null. Without combining both, downstream `requireProjectRole`
+    // false-negatives every org-inherited member with a misleading
+    // "You do not have a role in this project" 403 — even though
+    // `requireProjectAccess` (above) just admitted them via the inherited
+    // path in `checkProjectAccess`.
     if (request.authUser) {
-      const role = await db.projects.getUserRole(project.id, request.authUser.id);
+      const explicitRole = await db.projects.getUserRole(project.id, request.authUser.id);
+      const inheritedRole = await lookupInheritedProjectRole(project.id, request.authUser.id, db);
 
-      // Validate role before attaching to request (defensive check against invalid DB data)
-      if (role && isProjectRole(role)) {
-        request.projectRole = role;
+      // Pick the higher of explicit and inherited. Mirrors the same
+      // composition logic used inside checkProjectAccess.
+      const explicit = explicitRole && isProjectRole(explicitRole) ? explicitRole : null;
+      let effectiveRole = explicit;
+      if (explicit && inheritedRole) {
+        effectiveRole = hasPermissionLevel(explicit, inheritedRole) ? explicit : inheritedRole;
+      } else if (inheritedRole) {
+        effectiveRole = inheritedRole;
+      }
+
+      if (effectiveRole) {
+        request.projectRole = effectiveRole;
       }
       // If role is null or invalid, leave request.projectRole as undefined
       // Downstream authorization checks will handle missing roles appropriately

--- a/packages/backend/src/api/middleware/project-access.ts
+++ b/packages/backend/src/api/middleware/project-access.ts
@@ -6,7 +6,7 @@
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { DatabaseClient } from '../../db/client.js';
 import { findOrThrow, checkProjectAccess, lookupInheritedProjectRole } from '../utils/resource.js';
-import { hasPermissionLevel, isProjectRole } from '../../types/project-roles.js';
+import { isProjectRole, pickHigherProjectRole } from '../../types/project-roles.js';
 import { extractRouteParam, requireAuthContext } from './helpers.js';
 
 /**
@@ -77,8 +77,12 @@ export function requireProjectAccess(db: DatabaseClient, options: { paramName?: 
     const project = await findOrThrow(() => db.projects.findById(projectId), 'Project');
 
     // Verify project access using centralized logic (handles JWT, project-scoped, and full-scope API keys)
+    // Pass organization_id so the inherited-role lookup inside
+    // checkProjectAccess can skip the redundant `db.projects.findById`
+    // (we already loaded `project` two lines above).
     await checkProjectAccess(project.id, request.authUser, request.authProject, db, 'Project', {
       apiKey: request.apiKey,
+      organizationId: project.organization_id,
     });
 
     // Fetch the user's effective project role for downstream authorization
@@ -102,15 +106,11 @@ export function requireProjectAccess(db: DatabaseClient, options: { paramName?: 
         lookupInheritedProjectRole(project.id, request.authUser.id, db, project.organization_id),
       ]);
 
-      // Pick the higher of explicit and inherited. Mirrors the same
-      // composition logic used inside checkProjectAccess.
+      // Pick the higher of explicit and inherited via the shared helper
+      // (`types/project-roles.ts:pickHigherProjectRole`) so the rule
+      // stays in one place — same call inside checkProjectAccess.
       const explicit = isProjectRole(explicitRole) ? explicitRole : null;
-      const effectiveRole =
-        explicit && inheritedRole
-          ? hasPermissionLevel(explicit, inheritedRole)
-            ? explicit
-            : inheritedRole
-          : (explicit ?? inheritedRole);
+      const effectiveRole = pickHigherProjectRole(explicit, inheritedRole);
 
       if (effectiveRole) {
         request.projectRole = effectiveRole;

--- a/packages/backend/src/api/routes/integration-rules.ts
+++ b/packages/backend/src/api/routes/integration-rules.ts
@@ -359,14 +359,25 @@ export async function registerIntegrationRuleRoutes(
         requireAuth,
         requirePermission(db, 'integration_rules', 'create'),
         requireProjectAccess(db, { paramName: 'projectId' }),
+        // Source project requires `member` role minimum (closes
+        // GH-96: cross-tenant exfiltration). Without this, a user
+        // with only `viewer` membership on the source could read
+        // the source rule's filters / field_mappings /
+        // description_template / attachment_config and persist them
+        // in a target project they admin — extracting business-
+        // sensitive logic across project boundaries. The target
+        // project still requires `admin` (inline check below).
+        // API-key auth still bypasses this gate by design (see the
+        // checkProjectAccess JSDoc on `minProjectRole`).
+        requireProjectRole('member'),
       ],
     },
     async (request, reply) => {
       const { platform, projectId, ruleId } = request.params;
       const { targetProjectId, targetIntegrationId } = request.body;
 
-      // Source project access validated by middleware (viewer+ via requireProjectAccess)
-      // Target project requires admin — inline check needed since it's a different project
+      // Source project: `member`+ enforced via preHandler above.
+      // Target project requires `admin` — inline check needed since it's a different project
       await checkProjectAccess(
         targetProjectId,
         request.authUser,

--- a/packages/backend/src/api/utils/resource.ts
+++ b/packages/backend/src/api/utils/resource.ts
@@ -22,11 +22,26 @@ import { checkProjectPermission } from '../../services/api-key/key-permissions.j
  * Returns null if no inheritance applies (project has no org, or user is
  * not an org member).
  *
- * Callers that already have the project's `organization_id` in hand
- * SHOULD pass it as the optional fourth argument — this skips a
- * `db.projects.findById` round-trip. Hot paths like `requireProjectAccess`
- * fetch the project for their own use a few lines earlier; without the
- * override this helper would re-fetch on every JWT-authenticated request.
+ * **`organizationId` parameter — TRUSTED OVERRIDE**:
+ * If supplied, this function uses it directly and SKIPS the
+ * `db.projects.findById(projectId)` round-trip that would otherwise
+ * derive `organization_id` from the project row. This is the hot-path
+ * optimisation that `requireProjectAccess` relies on (the middleware
+ * just loaded the project a few lines up; re-fetching it inside this
+ * helper would N+1 every JWT-authenticated request).
+ *
+ * **Trust contract for callers**: when you pass `organizationId`, you
+ * are asserting that it was just read from the project row identified
+ * by `projectId` (or is `null` because that project has none). The
+ * helper does NOT re-validate this — passing a mismatched/stale value
+ * would let `userId` inherit from the wrong organisation. Callers MUST:
+ *   - Have just fetched the project synchronously in the same request
+ *     (no async gap that could let the org_id change), AND
+ *   - Pass exactly `project.organization_id` (do not derive from
+ *     unrelated state like `request.authUser.organization_id`).
+ *
+ * `undefined` (or omitted) is the safe default: the helper does its
+ * own `findById` and is unconditionally correct.
  */
 export async function lookupInheritedProjectRole(
   projectId: string,

--- a/packages/backend/src/api/utils/resource.ts
+++ b/packages/backend/src/api/utils/resource.ts
@@ -12,6 +12,7 @@ import {
   hasPermissionLevel,
   isProjectRole,
   getInheritedProjectRole,
+  pickHigherProjectRole,
 } from '../../types/project-roles.js';
 import { checkProjectPermission } from '../../services/api-key/key-permissions.js';
 
@@ -156,6 +157,15 @@ export async function checkProjectAccess(
     apiKey?: ApiKey;
     /** Minimum project role required (e.g., 'admin' for config, 'member' for data). API keys bypass this. */
     minProjectRole?: ProjectRole;
+    /**
+     * Project's `organization_id`, if the caller already loaded the
+     * project. Avoids a redundant `db.projects.findById` inside
+     * `lookupInheritedProjectRole` on hot paths like
+     * `requireProjectAccess`. `undefined` (the default) keeps the
+     * original behaviour for direct callers that don't have the
+     * project in hand.
+     */
+    organizationId?: string | null;
   }
 ): Promise<void> {
   // API key authentication without JWT user — verify project permission via API key rules
@@ -198,17 +208,13 @@ export async function checkProjectAccess(
 
     // If minProjectRole specified, check effective role = max(explicit, inherited)
     if (options?.minProjectRole) {
-      const explicitRole = await db.projects.getUserRole(projectId, authUser.id);
-      const inheritedRole = await lookupInheritedProjectRole(projectId, authUser.id, db);
+      const [explicitRole, inheritedRole] = await Promise.all([
+        db.projects.getUserRole(projectId, authUser.id),
+        lookupInheritedProjectRole(projectId, authUser.id, db, options?.organizationId),
+      ]);
 
-      // Pick the higher of explicit and inherited
-      let effectiveRole: ProjectRole | null = null;
-      const explicit = explicitRole && isProjectRole(explicitRole) ? explicitRole : null;
-      if (explicit && inheritedRole) {
-        effectiveRole = hasPermissionLevel(explicit, inheritedRole) ? explicit : inheritedRole;
-      } else {
-        effectiveRole = explicit ?? inheritedRole;
-      }
+      const explicit = isProjectRole(explicitRole) ? explicitRole : null;
+      const effectiveRole = pickHigherProjectRole(explicit, inheritedRole);
 
       if (!effectiveRole) {
         throw new AppError(`Access denied to ${resourceName}`, 403, 'Forbidden');
@@ -226,8 +232,15 @@ export async function checkProjectAccess(
     // Fallback: check boolean membership (backward compatible)
     const hasAccess = await db.projects.hasAccess(projectId, authUser.id);
     if (!hasAccess) {
-      // Check org inheritance as fallback
-      const inheritedRole = await lookupInheritedProjectRole(projectId, authUser.id, db);
+      // Check org inheritance as fallback. Pass organizationId through
+      // so the helper skips the redundant `db.projects.findById` when
+      // the caller already loaded the project.
+      const inheritedRole = await lookupInheritedProjectRole(
+        projectId,
+        authUser.id,
+        db,
+        options?.organizationId
+      );
       if (!inheritedRole) {
         throw new AppError(`Access denied to ${resourceName}`, 403, 'Forbidden');
       }

--- a/packages/backend/src/api/utils/resource.ts
+++ b/packages/backend/src/api/utils/resource.ts
@@ -17,23 +17,32 @@ import { checkProjectPermission } from '../../services/api-key/key-permissions.j
 
 /**
  * Look up inherited project role from org membership.
- * Fetches project → org → membership from DB, then maps via shared getInheritedProjectRole.
- * Returns null if no inheritance applies (no org, not a member).
+ * Maps the user's org membership role via shared getInheritedProjectRole.
+ * Returns null if no inheritance applies (project has no org, or user is
+ * not an org member).
+ *
+ * Callers that already have the project's `organization_id` in hand
+ * SHOULD pass it as the optional fourth argument — this skips a
+ * `db.projects.findById` round-trip. Hot paths like `requireProjectAccess`
+ * fetch the project for their own use a few lines earlier; without the
+ * override this helper would re-fetch on every JWT-authenticated request.
  */
 export async function lookupInheritedProjectRole(
   projectId: string,
   userId: string,
-  db: DatabaseClient
+  db: DatabaseClient,
+  organizationId?: string | null
 ): Promise<ProjectRole | null> {
-  const project = await db.projects.findById(projectId);
-  if (!project?.organization_id) {
+  let orgId: string | null | undefined = organizationId;
+  if (orgId === undefined) {
+    const project = await db.projects.findById(projectId);
+    orgId = project?.organization_id ?? null;
+  }
+  if (!orgId) {
     return null;
   }
 
-  const { membership } = await db.organizationMembers.checkOrganizationAccess(
-    project.organization_id,
-    userId
-  );
+  const { membership } = await db.organizationMembers.checkOrganizationAccess(orgId, userId);
   if (!membership) {
     return null;
   }

--- a/packages/backend/src/api/utils/resource.ts
+++ b/packages/backend/src/api/utils/resource.ts
@@ -20,7 +20,7 @@ import { checkProjectPermission } from '../../services/api-key/key-permissions.j
  * Fetches project → org → membership from DB, then maps via shared getInheritedProjectRole.
  * Returns null if no inheritance applies (no org, not a member).
  */
-async function lookupInheritedProjectRole(
+export async function lookupInheritedProjectRole(
   projectId: string,
   userId: string,
   db: DatabaseClient

--- a/packages/backend/src/types/project-roles.ts
+++ b/packages/backend/src/types/project-roles.ts
@@ -143,13 +143,7 @@ export function getEffectiveProjectRole(
   orgRole: OrgMemberRole | undefined
 ): ProjectRole | undefined {
   const inherited = orgRole ? getInheritedProjectRole(orgRole) : undefined;
-  if (!explicitRole) {
-    return inherited;
-  }
-  if (!inherited) {
-    return explicitRole;
-  }
-  return hasPermissionLevel(explicitRole, inherited) ? explicitRole : inherited;
+  return pickHigherProjectRole(explicitRole, inherited) ?? undefined;
 }
 
 /**

--- a/packages/backend/src/types/project-roles.ts
+++ b/packages/backend/src/types/project-roles.ts
@@ -151,3 +151,29 @@ export function getEffectiveProjectRole(
   }
   return hasPermissionLevel(explicitRole, inherited) ? explicitRole : inherited;
 }
+
+/**
+ * Pick the higher of two already-resolved project roles.
+ *
+ * Both `getEffectiveProjectRole` (above) and the `requireProjectAccess`
+ * middleware need the same composition: given an explicit project role
+ * and an inherited project role (either side may be null/undefined),
+ * return the one with the higher permission level. The previous form was
+ * inlined in both locations; centralising here keeps the rule in one
+ * place so a future change to `ROLE_HIERARCHY` or to the picking policy
+ * doesn't drift across callers.
+ *
+ * Pure function, no DB access. Accepts `null` for "role not set" so
+ * callers don't need to defensively coerce undefined.
+ */
+export function pickHigherProjectRole(
+  a: ProjectRole | null | undefined,
+  b: ProjectRole | null | undefined
+): ProjectRole | null {
+  const left = a ?? null;
+  const right = b ?? null;
+  if (left && right) {
+    return hasPermissionLevel(left, right) ? left : right;
+  }
+  return left ?? right ?? null;
+}

--- a/packages/backend/tests/integration/integration-rules-permissions.test.ts
+++ b/packages/backend/tests/integration/integration-rules-permissions.test.ts
@@ -826,13 +826,16 @@ describe('Integration Rules Permissions - E2E', () => {
     // inherits `viewer` (< member) and would correctly be denied by
     // `requireProjectRole('member')` even after the fix.
     it('should allow org-inherited admin on source project to copy rules', async () => {
-      // Set up: user has org-level admin (inherits project `admin`),
-      // NO explicit project_members row on the source project. They
-      // have explicit admin on a fresh target.
+      // Use DEDICATED projects rather than mutating the shared `testProject`.
+      // If an assertion below fails, `cleanup.cleanup()` deletes the
+      // organization via `trackOrganization`, and a previously-mutated
+      // `testProject.organization_id` would FK-cascade through every
+      // remaining test in the file. Dedicated projects keep this test
+      // isolated from the rest of the suite even on assertion failure.
       const orgUserData = await createTestUser(db, { role: 'user' });
       cleanup.trackUser(orgUserData.user.id);
 
-      // Create org and add user as `admin` so they inherit project `admin`.
+      // Org with this user as admin (inherits project `admin`).
       const sourceOrg = await db.organizations.create({
         name: `Inherited Admin Test Org ${Date.now()}`,
         subdomain: `inh-adm-${Date.now()}`,
@@ -844,16 +847,47 @@ describe('Integration Rules Permissions - E2E', () => {
         role: 'admin',
       });
 
-      // Move testProject under this org so the user inherits access.
-      // (testProject was created with no organization_id in beforeAll;
-      // updating it in-place is fine for this isolated test.)
+      // Source project: scoped to the org. User has NO explicit
+      // project_members row — access is purely via inheritance, which is
+      // the regression scenario.
+      const sourceProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(sourceProject.id);
       await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
         sourceOrg.id,
-        testProject.id,
+        sourceProject.id,
       ]);
+      const sourceJiraIntegration = await db.projectIntegrations.create({
+        project_id: sourceProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'INHSRC',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
 
-      // Target project: same org, fresh, with the user as explicit admin
-      // and an integration configured.
+      // Source rule, owned by adminJwt (not the user under test).
+      const sourceRuleResponse = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules`,
+        headers: { authorization: `Bearer ${adminJwt}` },
+        payload: {
+          name: 'Inherited-admin source rule',
+          enabled: true,
+          filters: [{ field: 'priority', operator: 'equals', value: 'low' }],
+          auto_create: false,
+        },
+      });
+      const sourceRuleId = JSON.parse(sourceRuleResponse.body).data.id;
+
+      // Target project: same org, user has explicit admin.
       const targetProject = await createTestProject(db, { created_by: adminUser.id });
       cleanup.trackProject(targetProject.id);
       await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
@@ -866,7 +900,7 @@ describe('Integration Rules Permissions - E2E', () => {
         integration_id: jiraIntegrationGlobalId,
         config: {
           instanceUrl: 'https://example.atlassian.net',
-          projectKey: 'INH',
+          projectKey: 'INHTGT',
           issueType: 'Bug',
           autoCreate: false,
           syncStatus: false,
@@ -886,25 +920,18 @@ describe('Integration Rules Permissions - E2E', () => {
       expect(orgUserLogin.statusCode).toBe(200);
       const orgUserJwt = JSON.parse(orgUserLogin.body).data.access_token;
 
-      // Reset rule name so the assertion below isn't order-dependent.
-      await db.integrationRules.update(ruleId, { name: 'High Severity Auto-Create' });
-
       const response = await server.inject({
         method: 'POST',
-        url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}/copy`,
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules/${sourceRuleId}/copy`,
         headers: { authorization: `Bearer ${orgUserJwt}` },
         payload: { targetProjectId: targetProject.id },
       });
 
       expect(response.statusCode).toBe(201);
-      const copied = JSON.parse(response.body).data.rule;
-
-      // Clean up
-      await db.query('DELETE FROM integration_rules WHERE id = $1', [copied.id]);
-      // Reset testProject's organization_id so other tests aren't affected.
-      await db.query('UPDATE application.projects SET organization_id = NULL WHERE id = $1', [
-        testProject.id,
-      ]);
+      // No tail cleanup needed: the dedicated source/target projects (and
+      // their integrations / rules) cascade-delete via cleanup.cleanup()
+      // in afterAll. testProject is never touched.
+      void sourceJiraIntegration;
     });
   });
 

--- a/packages/backend/tests/integration/integration-rules-permissions.test.ts
+++ b/packages/backend/tests/integration/integration-rules-permissions.test.ts
@@ -805,6 +805,107 @@ describe('Integration Rules Permissions - E2E', () => {
       // 'Insufficient project role for Integration Rules').
       expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
     });
+
+    // Regression guard: a user whose source-project access is granted
+    // ONLY via org membership inheritance (no explicit project_members
+    // row) was previously locked out by `requireProjectRole('member')`
+    // because the middleware only populated `request.projectRole` from
+    // `db.projects.getUserRole()` — a query that ignores org-level
+    // inheritance. The underlying middleware fix (project-access.ts
+    // now combines explicit + inherited via `lookupInheritedProjectRole`)
+    // benefits every callsite of `requireProjectRole`, but this is the
+    // route where the regression was introduced and is the natural test
+    // home for it.
+    //
+    // Org-to-project role inheritance (project-roles.ts:122-126) maps:
+    //   owner  → admin
+    //   admin  → admin
+    //   member → viewer
+    // To exercise the regression, the org role must inherit a project
+    // role >= 'member' — that means org admin or owner. Org `member`
+    // inherits `viewer` (< member) and would correctly be denied by
+    // `requireProjectRole('member')` even after the fix.
+    it('should allow org-inherited admin on source project to copy rules', async () => {
+      // Set up: user has org-level admin (inherits project `admin`),
+      // NO explicit project_members row on the source project. They
+      // have explicit admin on a fresh target.
+      const orgUserData = await createTestUser(db, { role: 'user' });
+      cleanup.trackUser(orgUserData.user.id);
+
+      // Create org and add user as `admin` so they inherit project `admin`.
+      const sourceOrg = await db.organizations.create({
+        name: `Inherited Admin Test Org ${Date.now()}`,
+        subdomain: `inh-adm-${Date.now()}`,
+      });
+      cleanup.trackOrganization(sourceOrg.id);
+      await db.organizationMembers.create({
+        organization_id: sourceOrg.id,
+        user_id: orgUserData.user.id,
+        role: 'admin',
+      });
+
+      // Move testProject under this org so the user inherits access.
+      // (testProject was created with no organization_id in beforeAll;
+      // updating it in-place is fine for this isolated test.)
+      await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
+        sourceOrg.id,
+        testProject.id,
+      ]);
+
+      // Target project: same org, fresh, with the user as explicit admin
+      // and an integration configured.
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
+        sourceOrg.id,
+        targetProject.id,
+      ]);
+      await db.projectMembers.addMember(targetProject.id, orgUserData.user.id, 'admin');
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'INH',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      const orgUserLogin = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: orgUserData.user.email, password: orgUserData.password },
+      });
+      expect(orgUserLogin.statusCode).toBe(200);
+      const orgUserJwt = JSON.parse(orgUserLogin.body).data.access_token;
+
+      // Reset rule name so the assertion below isn't order-dependent.
+      await db.integrationRules.update(ruleId, { name: 'High Severity Auto-Create' });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}/copy`,
+        headers: { authorization: `Bearer ${orgUserJwt}` },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const copied = JSON.parse(response.body).data.rule;
+
+      // Clean up
+      await db.query('DELETE FROM integration_rules WHERE id = $1', [copied.id]);
+      // Reset testProject's organization_id so other tests aren't affected.
+      await db.query('UPDATE application.projects SET organization_id = NULL WHERE id = $1', [
+        testProject.id,
+      ]);
+    });
   });
 
   describe('Admin Bypass', () => {

--- a/packages/backend/tests/integration/integration-rules-permissions.test.ts
+++ b/packages/backend/tests/integration/integration-rules-permissions.test.ts
@@ -15,6 +15,7 @@ import { createTestUser, createTestProject, TestCleanupTracker } from '../utils/
 import type { DatabaseClient } from '../../src/db/client.js';
 import type { User, Project } from '../../src/db/types.js';
 import { getEncryptionService } from '../../src/utils/encryption.js';
+import { ApiKeyService } from '../../src/services/api-key/index.js';
 
 describe('Integration Rules Permissions - E2E', () => {
   let server: FastifyInstance;
@@ -743,21 +744,67 @@ describe('Integration Rules Permissions - E2E', () => {
       expect(JSON.parse(response.body).message).toContain('Insufficient project role');
     });
 
-    // FOLLOW-UP / DEFERRED: cross-tenant data exfiltration via copy.
-    // Tracked in: https://github.com/apex-bridge/bugspotter/issues/96
-    //
-    // The copy preHandler is `requireProjectAccess` with no minProjectRole
-    // (integration-rules.ts:361), so a user with only `viewer` membership
-    // on the source project can extract that project's rule configurations
-    // (filters / field_mappings / description_template / attachment_config)
-    // by copying them into a project they admin. Fix is a one-line route
-    // change (add `requireProjectRole('member')` to the copy source
-    // preHandler) — see issue #96 for full repro and the acceptance test
-    // shape. Belongs to the queued RBAC tightening PR rather than this
-    // test cleanup. Intentionally NOT pinning a passing 201 lock-in test
-    // here, because doing so would tell CI to permanently accept the
-    // bypass and a future tightening would be blocked rather than
-    // welcomed.
+    // Closes GH-96: cross-tenant exfiltration via copy. The route fix
+    // (`requireProjectRole('member')` on the copy source preHandler at
+    // integration-rules.ts:361) makes viewer-source-copy a 403 instead
+    // of a 201. Without this guard a user with only `viewer` membership
+    // on the source project could extract that project's rule
+    // configurations (filters / field_mappings / description_template /
+    // attachment_config) by copying them into a project they admin.
+    it('should deny viewer on source project from copying rules', async () => {
+      // Source: user has `viewer` membership only on testProject.
+      // Target: user has `admin` on a fresh project (passes the inline
+      // target-admin gate). Without the route fix the request would 201;
+      // with the fix the source `requireProjectRole('member')` returns
+      // 403 BEFORE the handler body runs.
+      const sourceViewerData = await createTestUser(db, { role: 'user' });
+      cleanup.trackUser(sourceViewerData.user.id);
+      await db.projectMembers.addMember(testProject.id, sourceViewerData.user.id, 'viewer');
+
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.projectMembers.addMember(targetProject.id, sourceViewerData.user.id, 'admin');
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'VTGT',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      const sourceViewerLogin = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: {
+          email: sourceViewerData.user.email,
+          password: sourceViewerData.password,
+        },
+      });
+      expect(sourceViewerLogin.statusCode).toBe(200);
+      const sourceViewerJwt = JSON.parse(sourceViewerLogin.body).data.access_token;
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}/copy`,
+        headers: { authorization: `Bearer ${sourceViewerJwt}` },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(403);
+      // Denial comes from `requireProjectRole('member')` on the source —
+      // distinct from the target inline check (which would say
+      // 'Insufficient project role for Integration Rules').
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
+    });
   });
 
   describe('Admin Bypass', () => {
@@ -813,6 +860,106 @@ describe('Integration Rules Permissions - E2E', () => {
       // Clean up admin-created rule
       const adminRuleId = JSON.parse(createResponse.body).data.id;
       await db.query('DELETE FROM integration_rules WHERE id = $1', [adminRuleId]);
+    });
+  });
+
+  // Pins the existing intentional behaviour for full-scope API keys:
+  // they reach handler bodies regardless of project membership or role,
+  // because `requirePermission`, `requireProjectRole`, and the
+  // `apiKey && !authUser` branch of `checkProjectAccess` ALL skip
+  // their gates for API-key auth. This is the security model — full-
+  // scope keys (`allowed_projects: []`) are intentionally project-
+  // unbounded — but it was previously undocumented and untested.
+  // If product later adds explicit API-key admin enforcement, these
+  // assertions flip from 201 to 403 and the bypass-comments in
+  // `src/api/utils/resource.ts` should be updated to match.
+  describe('Full-scope API key bypass (lock-in)', () => {
+    let fullScopeKey: string;
+
+    beforeAll(async () => {
+      const apiKeyService = new ApiKeyService(db);
+      const result = await apiKeyService.createKey({
+        name: 'Full-scope test key (rule bypass lock-in)',
+        type: 'development',
+        permission_scope: 'full',
+        // requirePermission is skipped for API-key auth, so the
+        // permissions array is irrelevant on these routes — included
+        // for completeness with the production CRUD shape.
+        permissions: ['integration_rules:create', 'integration_rules:update'],
+        created_by: adminUser.id,
+        allowed_projects: [], // full-scope
+      });
+      fullScopeKey = result.plaintext;
+    });
+
+    it('should allow full-scope API key to create rules in any project (no membership / no admin role required)', async () => {
+      // testProject was created by adminUser; the API key has zero
+      // project membership of its own. The route still accepts the
+      // request because `requireProjectRole`/`requirePermission` both
+      // return early for API-key auth, and `checkProjectAccess` takes
+      // the `apiKey && !authUser` branch which only validates against
+      // `allowed_projects` (empty = all).
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules`,
+        headers: { 'x-api-key': fullScopeKey },
+        payload: {
+          name: 'Created via full-scope key',
+          enabled: true,
+          filters: [{ field: 'priority', operator: 'equals', value: 'low' }],
+          auto_create: false,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const created = JSON.parse(response.body).data;
+      expect(created.name).toBe('Created via full-scope key');
+
+      // Clean up
+      await db.query('DELETE FROM integration_rules WHERE id = $1', [created.id]);
+    });
+
+    it('should allow full-scope API key to copy rules to any target (no admin role on target required)', async () => {
+      // Inline `checkProjectAccess(targetProjectId, …, { minProjectRole: 'admin' })`
+      // in the COPY handler is skipped for API-key auth (branch (1) of
+      // checkProjectAccess returns before reaching the role check).
+      // Combined with the source-side bypass on `requireProjectRole`,
+      // a full-scope key copies anything to anywhere.
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'APIK',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      // Reset rule name so the assertion below isn't order-dependent.
+      await db.integrationRules.update(ruleId, { name: 'High Severity Auto-Create' });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}/copy`,
+        headers: { 'x-api-key': fullScopeKey },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const copied = JSON.parse(response.body).data.rule;
+      expect(copied.project_id).toBe(targetProject.id);
+
+      // Clean up
+      await db.query('DELETE FROM integration_rules WHERE id = $1', [copied.id]);
     });
   });
 });

--- a/packages/backend/tests/integration/integration-rules-permissions.test.ts
+++ b/packages/backend/tests/integration/integration-rules-permissions.test.ts
@@ -933,6 +933,110 @@ describe('Integration Rules Permissions - E2E', () => {
       // in afterAll. testProject is never touched.
       void sourceJiraIntegration;
     });
+
+    // Counterpart to the inherited-admin allow test: pins the
+    // `ORG_TO_PROJECT_ROLE` mapping in `types/project-roles.ts:122-126`
+    // (member → viewer). If anyone changes that map to `member: 'member'`,
+    // org members would silently gain copy access — this test catches that.
+    // The viewer-deny test above exercises the same `requireProjectRole`
+    // gate but via an EXPLICIT project_members row, not via inheritance,
+    // so it doesn't cover the mapping branch.
+    it('should deny org-member (inherits viewer) on source project from copying rules', async () => {
+      const orgMemberData = await createTestUser(db, { role: 'user' });
+      cleanup.trackUser(orgMemberData.user.id);
+
+      // Org with this user as `member` — inherits project `viewer`,
+      // which is below the `member` floor enforced by
+      // `requireProjectRole('member')` on the copy source.
+      const sourceOrg = await db.organizations.create({
+        name: `Inherited Member Deny Test Org ${Date.now()}`,
+        subdomain: `inh-mem-deny-${Date.now()}`,
+      });
+      cleanup.trackOrganization(sourceOrg.id);
+      await db.organizationMembers.create({
+        organization_id: sourceOrg.id,
+        user_id: orgMemberData.user.id,
+        role: 'member',
+      });
+
+      // Source project: scoped to the org, no explicit project_members row
+      // for this user (access comes purely from org-member inheritance).
+      const sourceProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(sourceProject.id);
+      await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
+        sourceOrg.id,
+        sourceProject.id,
+      ]);
+      await db.projectIntegrations.create({
+        project_id: sourceProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'IMDS',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+      const sourceRuleResponse = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules`,
+        headers: { authorization: `Bearer ${adminJwt}` },
+        payload: {
+          name: 'Inherited-member deny source rule',
+          enabled: true,
+          filters: [{ field: 'priority', operator: 'equals', value: 'low' }],
+          auto_create: false,
+        },
+      });
+      const sourceRuleId = JSON.parse(sourceRuleResponse.body).data.id;
+
+      // Target: user has explicit admin so the source gate is the only
+      // thing that can deny — isolates the test to the inheritance mapping.
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.projectMembers.addMember(targetProject.id, orgMemberData.user.id, 'admin');
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'IMDT',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      const orgUserLogin = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: orgMemberData.user.email, password: orgMemberData.password },
+      });
+      expect(orgUserLogin.statusCode).toBe(200);
+      const orgUserJwt = JSON.parse(orgUserLogin.body).data.access_token;
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules/${sourceRuleId}/copy`,
+        headers: { authorization: `Bearer ${orgUserJwt}` },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(403);
+      // Same gate as the explicit-viewer test, just reached via inheritance.
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
+    });
   });
 
   describe('Admin Bypass', () => {


### PR DESCRIPTION
Closes [#96](https://github.com/apex-bridge/bugspotter/issues/96) — **intra-organisation viewer-source exfiltration** on integration-rules COPY.

## Scope: intra-org only

This PR closes the specific exfiltration case named in #96: a project `viewer` (within the same organisation) extracting rule configurations to a project they admin. The fix raises the source-project floor from "any membership" to "member or higher".

**Cross-organisation copy is a separate concern, tracked in [#101](https://github.com/apex-bridge/bugspotter/issues/101)** — a user who is `member` on org A's project and `admin` on org B's project can still copy across org boundaries. That's a related-but-distinct authorisation policy decision (cross-org collaboration: allow for sufficiently-privileged users, or never?) and warrants its own PR with the deliberate decision documented.

## Summary

Adds `requireProjectRole('member')` to the source-project preHandler chain on `POST /api/v1/integrations/:platform/:projectId/rules/:ruleId/copy`. Previously the route enforced `admin` on the target only; the source accepted any membership level including `viewer`.

| Layer | Before | After |
|---|---|---|
| Source preHandler | `requireProjectAccess` (any membership) | `requireProjectAccess` + `requireProjectRole('member')` |
| Target inline check | `checkProjectAccess(targetProjectId, ..., { minProjectRole: 'admin' })` | unchanged |

## Middleware fix bundled in (necessary)

`requireProjectRole('member')` exposed a pre-existing bug: `requireProjectAccess` populated `request.projectRole` from `db.projects.getUserRole()` only — that query ignores org-level inheritance, so org admins/owners with no explicit `project_members` row had `request.projectRole` undefined and were 403'd by `requireProjectRole` with a misleading "You do not have a role in this project" message.

The bug affects all 9 callsites of `requireProjectRole` (integration-rules, integrations, data-residency, retention) — patching only my route would leave the others broken. Fix: middleware now combines explicit + inherited role via the new `pickHigherProjectRole(a, b)` helper in `types/project-roles.ts`, mirroring the same composition logic that already existed inside `checkProjectAccess`.

## Performance

The middleware change adds inheritance lookup per JWT-authenticated request. Mitigations applied:

- `lookupInheritedProjectRole` accepts an optional `organizationId` parameter; the middleware passes `project.organization_id` (already loaded) to skip the redundant `findById`. Both internal callsites in `resource.ts` now also use this passthrough
- `db.projects.getUserRole` and `lookupInheritedProjectRole` run in parallel via `Promise.all` (independent tables, no shared rows)
- For org-inherited users specifically, there's still a residual double `checkOrganizationAccess` (one in `checkProjectAccess`'s fallback, one in the middleware role-population block). Eliminating it requires changing `checkProjectAccess` to return the resolved effective role — a `Promise<void>` → `Promise<ProjectRole | null>` change across 26 callsites. Out of scope here; good candidate for a follow-up RBAC perf PR

## Tests

5 new tests in `tests/integration/integration-rules-permissions.test.ts` (21 → 26):

1. `should deny viewer on source project from copying rules` — acceptance test for #96, explicit project_members row
2. `should allow org-inherited admin on source project to copy rules` — regression guard for the middleware fix; user has org admin role, no explicit project_members row
3. `should deny org-member (inherits viewer) on source project from copying rules` — pins `ORG_TO_PROJECT_ROLE.member → 'viewer'`; catches any future change to the inheritance map
4. `should allow full-scope API key to create rules in any project` — lock-in for the existing API-key bypass on `requireProjectRole`/`requirePermission` (full-scope keys intentionally project-unbounded)
5. `should allow full-scope API key to copy rules to any target` — lock-in for API-key bypass on the inline target-admin check

`pnpm test:integration tests/integration/integration-rules-permissions.test.ts` locally: 26/26 passing.

## Test plan

- [x] Typecheck clean
- [x] Local integration tests green (26/26)
- [x] CI: integration job exercises the new guard
- [ ] Reviewer: confirm `member` is the right source floor (alternative `admin` is stricter; member is the lowest role with explicit collaboration intent)
- [ ] Reviewer: confirm the middleware change is acceptable scope expansion. The bug it fixes affects 9 routes; patching only this one would leave the others broken

## Notes

- **Backward-compat impact**: any existing caller who is only `viewer` on a source project and was relying on COPY will start receiving 403. Intentional. Viewer can still GET the rule body and craft an equivalent POST manually if cross-project rule duplication is a real workflow, but the silent automated path is closed
- Audit-identity gap [#97](https://github.com/apex-bridge/bugspotter/issues/97) (JWT + API key obscures user attribution) is a separate concern, not addressed here
- Cross-org gap [#101](https://github.com/apex-bridge/bugspotter/issues/101) tracked separately

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project role validation for integration rules copying to properly enforce source project membership requirements and correctly apply organization-level role inheritance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->