### PR TITLE
security(integration-rules) + docs: close intra-org copy exfil + add RBAC reference

### DIFF
--- a/packages/backend/CLAUDE.md
+++ b/packages/backend/CLAUDE.md
@@ -15,6 +15,8 @@ Every request can carry up to four auth artifacts:
 
 **`authProject` is NOT a legacy flag.** It's set inside `handleNewApiKeyAuth` (`src/api/middleware/auth/handlers.ts`), only after `request.apiKey` is set, and only for single-project keys — which includes the self-service-signup-issued ingest-only key. Bypassing on `authProject` would let that key read reports, so don't.
 
+For the full RBAC reference — header precedence rules, the 3-layer authorization model, effective project role (explicit ∪ inherited), API-key bypass rules, and open policy questions — see [docs/auth.md](docs/auth.md).
+
 ## API key permission enforcement
 
 - Read routes enforce the key's `permissions` via `requireApiKeyPermission('resource:action')` as a preHandler.

--- a/packages/backend/docs/auth.md
+++ b/packages/backend/docs/auth.md
@@ -28,13 +28,28 @@ read reports across projects — don't.
 
 ## 2. Header precedence (and the audit-identity caveat)
 
-The auth middleware ([auth/middleware.ts:54-76](../src/api/middleware/auth/middleware.ts#L54-L76)) tries
-the `x-api-key` header **first** and short-circuits as soon as the key
-validates. JWT is only consulted when no API-key header is present. So
-when both headers arrive together:
+The auth middleware ([auth/middleware.ts:42-86](../src/api/middleware/auth/middleware.ts#L42-L86))
+tries auth methods in a fixed order, short-circuiting on the first one
+that's _applicable_ (not first-success — see the gotcha below):
+
+1. **`shareToken`** (query param on GET, body on POST) — if present and
+   valid, returns immediately.
+2. **`x-api-key`** header — if the header exists, runs API-key auth.
+3. **`Authorization: Bearer …`** JWT — only consulted when no
+   `x-api-key` header was present.
+
+**Critical gotcha**: if `x-api-key` is present but invalid/revoked/expired,
+the request is **rejected** — JWT is **not** tried as a fallback. The
+middleware returns at the end of the api-key block regardless of
+success or failure ([line 71](../src/api/middleware/auth/middleware.ts#L71)).
+Operators sometimes assume a valid JWT will rescue a bad API key; it
+won't. Either drop the api-key header or refresh the key.
+
+When `x-api-key` AND `Authorization: Bearer` are both present and the
+API key validates:
 
 - `request.apiKey` is populated
-- `request.authUser` stays **undefined**
+- `request.authUser` stays **undefined** (JWT was never consulted)
 
 This is _not_ a privilege-escalation surface (a leaked full-scope key
 already grants full access; presenting JWT alongside adds nothing). But

--- a/packages/backend/docs/auth.md
+++ b/packages/backend/docs/auth.md
@@ -1,0 +1,151 @@
+# Authentication and Authorization
+
+Reference for how requests are authenticated and authorized in
+`@bugspotter/backend`. Source-of-truth pointers in every section — if
+this doc drifts from the code, the file:line links break visibly.
+
+---
+
+## 1. Authentication artifacts
+
+Every request can carry up to four auth artifacts. Each is set by
+exactly one auth handler and is read-only after middleware runs.
+
+| Field                    | Set by                                                                                         | Carries                                                    | Used by                                                                           |
+| ------------------------ | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `request.authUser`       | JWT bearer token (`handleJwtAuth`, [auth/handlers.ts](../src/api/middleware/auth/handlers.ts)) | Dashboard user (id, role, organization_id)                 | Project-role and platform-permission checks                                       |
+| `request.apiKey`         | `X-API-Key: bgs_…` header (`handleNewApiKeyAuth`)                                              | The full ApiKey row (allowed_projects, permissions, scope) | API-key path of `checkProjectAccess`                                              |
+| `request.authProject`    | Set alongside `apiKey` when `allowed_projects.length === 1`                                    | The single Project the key is scoped to                    | Convenience flag for project-scoped keys; do NOT bypass on this alone (see below) |
+| `request.authShareToken` | `?shareToken=` query param or POST body (`handleShareTokenAuth`)                               | The decoded share token + bug-report scope                 | Public replay-access routes only                                                  |
+
+**`authProject` is not a legacy flag.** It's set inside
+`handleNewApiKeyAuth` _only_ after `request.apiKey` is set, _only_ for
+single-project keys (which includes the self-service-signup-issued
+ingest-only key). Bypassing on `authProject` alone would let that key
+read reports across projects — don't.
+
+---
+
+## 2. Header precedence (and the audit-identity caveat)
+
+The auth middleware ([auth/middleware.ts:54-76](../src/api/middleware/auth/middleware.ts#L54-L76)) tries
+the `x-api-key` header **first** and short-circuits as soon as the key
+validates. JWT is only consulted when no API-key header is present. So
+when both headers arrive together:
+
+- `request.apiKey` is populated
+- `request.authUser` stays **undefined**
+
+This is _not_ a privilege-escalation surface (a leaked full-scope key
+already grants full access; presenting JWT alongside adds nothing). But
+it does have an audit-trail consequence: downstream loggers that read
+`userId: request.authUser?.id || 'api-key'` record `'api-key'` even
+when the JWT user is the actual actor. A user can deliberately combine
+their JWT with an org's full-scope key to mask attribution. Tracked in
+[#97](https://github.com/apex-bridge/bugspotter/issues/97).
+
+---
+
+## 3. The 3-layer authorization model
+
+Most write routes compose three checks in their preHandler chain:
+
+```ts
+preHandler: [
+  requireAuth,                                            // 1. Some auth ran
+  requirePermission(db, 'integration_rules', 'create'),   // 2. Platform permission
+  requireProjectAccess(db, { paramName: 'projectId' }),   // 3. Project membership
+  requireProjectRole('admin'),                            // 4. Project role floor
+],
+```
+
+| Layer                   | Source                                                                                                                               | What it checks                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| **Platform permission** | [auth/authorization.ts:243](../src/api/middleware/auth/authorization.ts#L243)                                                        | The user's platform role has `(resource, action)` in the seeded `permissions` table |
+| **Project access**      | [middleware/project-access.ts](../src/api/middleware/project-access.ts) → [utils/resource.ts:144](../src/api/utils/resource.ts#L144) | The user/key has _some_ membership on the target project                            |
+| **Project role floor**  | [auth/authorization.ts:272](../src/api/middleware/auth/authorization.ts#L272)                                                        | Effective project role meets the minimum (`viewer < member < admin < owner`)        |
+
+**Cross-resource gates** (like the COPY route's target-project admin
+check) live inline in the handler body via
+`checkProjectAccess(targetProjectId, …, { minProjectRole: 'admin' })`
+— preHandlers can only enforce on the route's path-param project.
+
+---
+
+## 4. Effective project role: explicit ∪ inherited
+
+A user's project role is the **max** of two sources:
+
+- **Explicit**: a row in `application.project_members` (or the
+  `created_by` shortcut for owner). Read via
+  [`db.projects.getUserRole`](../src/db/repositories/project.repository.ts).
+- **Inherited**: the user's org membership, mapped through
+  [`ORG_TO_PROJECT_ROLE`](../src/types/project-roles.ts):
+
+  ```
+  org owner   → project admin
+  org admin   → project admin
+  org member  → project viewer
+  ```
+
+The composition is centralised in
+[`pickHigherProjectRole`](../src/types/project-roles.ts) — both
+`requireProjectAccess` middleware and the JWT branch of
+`checkProjectAccess` use it. **Do not inline the comparison
+elsewhere** — a future change to the precedence rule should be a
+one-line edit.
+
+`request.projectRole` is populated by `requireProjectAccess` from the
+combined effective role, then read by `requireProjectRole` and any
+handler that needs to make a finer-grained decision.
+
+### Performance note
+
+`requireProjectAccess` runs _both_ lookups in parallel
+(`Promise.all([getUserRole, lookupInheritedProjectRole])`). For
+hot-path callers, `lookupInheritedProjectRole` accepts an optional
+`organizationId` to skip a redundant `findById`; the caller asserts
+the org_id was just read from the same project. Trust contract is
+documented at the function's JSDoc.
+
+---
+
+## 5. API-key bypass rules
+
+API keys authenticate as a machine, not a project member. Three middleware
+layers explicitly skip their gates for API-key auth:
+
+| Middleware                                                                                        | API-key behaviour                                                                                                       | Reason                                                       |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `requirePermission` ([authorization.ts:247](../src/api/middleware/auth/authorization.ts#L247))    | Returns early if `apiKey` set without `authUser`                                                                        | Platform-permission table is keyed by user role, not machine |
+| `requireProjectRole` ([authorization.ts:277](../src/api/middleware/auth/authorization.ts#L277))   | Returns early if `apiKey` set without `authUser`                                                                        | Same — no "project role" concept for machines                |
+| `checkProjectAccess` minProjectRole branch ([resource.ts:144](../src/api/utils/resource.ts#L144)) | The `apiKey && !authUser` branch validates against `checkProjectPermission` only — `minProjectRole` is **NOT enforced** | Same — projects are scoped via `allowed_projects`, not roles |
+
+**Net effect**: a full-scope API key (`allowed_projects: []`) can do
+anything against any project on routes guarded only by these middlewares.
+This is the design — full-scope keys are intentionally project-unbounded.
+Limited-scope keys (`allowed_projects: [A]`) are still bounded by
+`checkProjectPermission`'s allowed-list check.
+
+If a route needs admin-level enforcement against API keys (e.g., to
+reject machine-issued mutations), it must either reject API-key auth at
+the preHandler or add an explicit check — `minProjectRole` doesn't do it.
+
+The [`tests/integration/full-scope-api-key.test.ts`](../tests/integration/full-scope-api-key.test.ts)
+suite has lock-in tests for this behaviour. Any future tightening of
+the API-key path will fail those tests, surfacing the change rather
+than shipping it silently.
+
+---
+
+## 6. Open questions
+
+These behaviours are documented, tested, and consistent with the current
+design — but they're known design choices that may change. New work
+adjacent to these should consult the linked issues before assuming
+permanence.
+
+- **[#97](https://github.com/apex-bridge/bugspotter/issues/97) — Audit-identity masking**: JWT + full-scope API key obscures user attribution in logs because `request.authUser` is never set when an API key is present. Three fix options proposed (populate `authUser` anyway, log both identities, or reject dual-header). Decision needed.
+- **[#101](https://github.com/apex-bridge/bugspotter/issues/101) — Cross-organisation rule copy**: a user who is `member` on org A's project + `admin` on org B's project can copy rules across orgs. The intra-org viewer-source case was closed in [#100](https://github.com/apex-bridge/bugspotter/pull/100); cross-org is a separate policy decision (allow for sufficiently-privileged users vs. never).
+- **API-key admin enforcement**: the bypass rules in §5 are intentional today, but the lock-in tests document them so a future product decision to add machine-level admin gates would surface as test diffs. No active ticket.
+- **`checkProjectAccess` return type**: currently `Promise<void>` (throws on failure). Changing to `Promise<ProjectRole | null>` would let `requireProjectAccess` reuse the role resolved during access verification, eliminating the second `checkOrganizationAccess` round-trip for org-inherited users. 26 callsites; significant blast radius. Good candidate for a follow-up RBAC perf PR.

--- a/packages/backend/docs/auth.md
+++ b/packages/backend/docs/auth.md
@@ -82,7 +82,7 @@ A user's project role is the **max** of two sources:
 - **Inherited**: the user's org membership, mapped through
   [`ORG_TO_PROJECT_ROLE`](../src/types/project-roles.ts):
 
-  ```
+  ```text
   org owner   → project admin
   org admin   → project admin
   org member  → project viewer
@@ -146,6 +146,6 @@ adjacent to these should consult the linked issues before assuming
 permanence.
 
 - **[#97](https://github.com/apex-bridge/bugspotter/issues/97) — Audit-identity masking**: JWT + full-scope API key obscures user attribution in logs because `request.authUser` is never set when an API key is present. Three fix options proposed (populate `authUser` anyway, log both identities, or reject dual-header). Decision needed.
-- **[#101](https://github.com/apex-bridge/bugspotter/issues/101) — Cross-organisation rule copy**: a user who is `member` on org A's project + `admin` on org B's project can copy rules across orgs. The intra-org viewer-source case was closed in [#100](https://github.com/apex-bridge/bugspotter/pull/100); cross-org is a separate policy decision (allow for sufficiently-privileged users vs. never).
+- **[#101](https://github.com/apex-bridge/bugspotter/issues/101) — Cross-organisation rule copy**: a user who is `member` on org A's project + `admin` on org B's project can copy rules across orgs. The intra-org viewer-source case was closed in [#102](https://github.com/apex-bridge/bugspotter/pull/102); cross-org is a separate policy decision (allow for sufficiently-privileged users vs. never).
 - **API-key admin enforcement**: the bypass rules in §5 are intentional today, but the lock-in tests document them so a future product decision to add machine-level admin gates would surface as test diffs. No active ticket.
 - **`checkProjectAccess` return type**: currently `Promise<void>` (throws on failure). Changing to `Promise<ProjectRole | null>` would let `requireProjectAccess` reuse the role resolved during access verification, eliminating the second `checkOrganizationAccess` round-trip for org-inherited users. 26 callsites; significant blast radius. Good candidate for a follow-up RBAC perf PR.

--- a/packages/backend/src/api/middleware/project-access.ts
+++ b/packages/backend/src/api/middleware/project-access.ts
@@ -5,8 +5,8 @@
 
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { DatabaseClient } from '../../db/client.js';
-import { findOrThrow, checkProjectAccess } from '../utils/resource.js';
-import { isProjectRole } from '../../types/project-roles.js';
+import { findOrThrow, checkProjectAccess, lookupInheritedProjectRole } from '../utils/resource.js';
+import { isProjectRole, pickHigherProjectRole } from '../../types/project-roles.js';
 import { extractRouteParam, requireAuthContext } from './helpers.js';
 
 /**
@@ -77,20 +77,47 @@ export function requireProjectAccess(db: DatabaseClient, options: { paramName?: 
     const project = await findOrThrow(() => db.projects.findById(projectId), 'Project');
 
     // Verify project access using centralized logic (handles JWT, project-scoped, and full-scope API keys)
+    // Pass organization_id so the inherited-role lookup inside
+    // checkProjectAccess can skip the redundant `db.projects.findById`
+    // (we already loaded `project` two lines above).
     await checkProjectAccess(project.id, request.authUser, request.authProject, db, 'Project', {
       apiKey: request.apiKey,
+      organizationId: project.organization_id,
     });
 
-    // Fetch and attach user's role for downstream authorization checks (avoids N+1 queries)
+    // Fetch the user's effective project role for downstream authorization
+    // checks. Effective = max(explicit project_members row, org-inherited
+    // role). `getUserRole` only sees explicit project membership rows
+    // (and the `created_by` owner shortcut); a user whose project access
+    // is granted via org membership inheritance has `getUserRole` returning
+    // null. Without combining both, downstream `requireProjectRole`
+    // false-negatives every org-inherited member with a misleading
+    // "You do not have a role in this project" 403 — even though
+    // `requireProjectAccess` (above) just admitted them via the inherited
+    // path in `checkProjectAccess`.
+    //
+    // Both lookups run in parallel — they're independent (different
+    // tables, no shared rows). `lookupInheritedProjectRole` takes the
+    // already-fetched `project.organization_id` so it doesn't re-query
+    // the projects table for a row we just loaded above.
     if (request.authUser) {
-      const role = await db.projects.getUserRole(project.id, request.authUser.id);
+      const [explicitRole, inheritedRole] = await Promise.all([
+        db.projects.getUserRole(project.id, request.authUser.id),
+        lookupInheritedProjectRole(project.id, request.authUser.id, db, project.organization_id),
+      ]);
 
-      // Validate role before attaching to request (defensive check against invalid DB data)
-      if (role && isProjectRole(role)) {
-        request.projectRole = role;
+      // Pick the higher of explicit and inherited via the shared helper
+      // (`types/project-roles.ts:pickHigherProjectRole`) so the rule
+      // stays in one place — same call inside checkProjectAccess.
+      const explicit = isProjectRole(explicitRole) ? explicitRole : null;
+      const effectiveRole = pickHigherProjectRole(explicit, inheritedRole);
+
+      if (effectiveRole) {
+        request.projectRole = effectiveRole;
       }
-      // If role is null or invalid, leave request.projectRole as undefined
-      // Downstream authorization checks will handle missing roles appropriately
+      // If both lookups returned null, leave request.projectRole undefined.
+      // Downstream authorization checks (e.g., requireProjectRole) handle
+      // missing roles appropriately.
     }
 
     // Attach project ID and project to request for downstream handlers

--- a/packages/backend/src/api/routes/integration-rules.ts
+++ b/packages/backend/src/api/routes/integration-rules.ts
@@ -359,14 +359,25 @@ export async function registerIntegrationRuleRoutes(
         requireAuth,
         requirePermission(db, 'integration_rules', 'create'),
         requireProjectAccess(db, { paramName: 'projectId' }),
+        // Source project requires `member` role minimum (closes
+        // GH-96: cross-tenant exfiltration). Without this, a user
+        // with only `viewer` membership on the source could read
+        // the source rule's filters / field_mappings /
+        // description_template / attachment_config and persist them
+        // in a target project they admin — extracting business-
+        // sensitive logic across project boundaries. The target
+        // project still requires `admin` (inline check below).
+        // API-key auth still bypasses this gate by design (see the
+        // checkProjectAccess JSDoc on `minProjectRole`).
+        requireProjectRole('member'),
       ],
     },
     async (request, reply) => {
       const { platform, projectId, ruleId } = request.params;
       const { targetProjectId, targetIntegrationId } = request.body;
 
-      // Source project access validated by middleware (viewer+ via requireProjectAccess)
-      // Target project requires admin — inline check needed since it's a different project
+      // Source project: `member`+ enforced via preHandler above.
+      // Target project requires `admin` — inline check needed since it's a different project
       await checkProjectAccess(
         targetProjectId,
         request.authUser,

--- a/packages/backend/src/api/utils/resource.ts
+++ b/packages/backend/src/api/utils/resource.ts
@@ -12,28 +12,53 @@ import {
   hasPermissionLevel,
   isProjectRole,
   getInheritedProjectRole,
+  pickHigherProjectRole,
 } from '../../types/project-roles.js';
 import { checkProjectPermission } from '../../services/api-key/key-permissions.js';
 
 /**
  * Look up inherited project role from org membership.
- * Fetches project → org → membership from DB, then maps via shared getInheritedProjectRole.
- * Returns null if no inheritance applies (no org, not a member).
+ * Maps the user's org membership role via shared getInheritedProjectRole.
+ * Returns null if no inheritance applies (project has no org, or user is
+ * not an org member).
+ *
+ * **`organizationId` parameter — TRUSTED OVERRIDE**:
+ * If supplied, this function uses it directly and SKIPS the
+ * `db.projects.findById(projectId)` round-trip that would otherwise
+ * derive `organization_id` from the project row. This is the hot-path
+ * optimisation that `requireProjectAccess` relies on (the middleware
+ * just loaded the project a few lines up; re-fetching it inside this
+ * helper would N+1 every JWT-authenticated request).
+ *
+ * **Trust contract for callers**: when you pass `organizationId`, you
+ * are asserting that it was just read from the project row identified
+ * by `projectId` (or is `null` because that project has none). The
+ * helper does NOT re-validate this — passing a mismatched/stale value
+ * would let `userId` inherit from the wrong organisation. Callers MUST:
+ *   - Have just fetched the project synchronously in the same request
+ *     (no async gap that could let the org_id change), AND
+ *   - Pass exactly `project.organization_id` (do not derive from
+ *     unrelated state like `request.authUser.organization_id`).
+ *
+ * `undefined` (or omitted) is the safe default: the helper does its
+ * own `findById` and is unconditionally correct.
  */
-async function lookupInheritedProjectRole(
+export async function lookupInheritedProjectRole(
   projectId: string,
   userId: string,
-  db: DatabaseClient
+  db: DatabaseClient,
+  organizationId?: string | null
 ): Promise<ProjectRole | null> {
-  const project = await db.projects.findById(projectId);
-  if (!project?.organization_id) {
+  let orgId: string | null | undefined = organizationId;
+  if (orgId === undefined) {
+    const project = await db.projects.findById(projectId);
+    orgId = project?.organization_id ?? null;
+  }
+  if (!orgId) {
     return null;
   }
 
-  const { membership } = await db.organizationMembers.checkOrganizationAccess(
-    project.organization_id,
-    userId
-  );
+  const { membership } = await db.organizationMembers.checkOrganizationAccess(orgId, userId);
   if (!membership) {
     return null;
   }
@@ -147,6 +172,15 @@ export async function checkProjectAccess(
     apiKey?: ApiKey;
     /** Minimum project role required (e.g., 'admin' for config, 'member' for data). API keys bypass this. */
     minProjectRole?: ProjectRole;
+    /**
+     * Project's `organization_id`, if the caller already loaded the
+     * project. Avoids a redundant `db.projects.findById` inside
+     * `lookupInheritedProjectRole` on hot paths like
+     * `requireProjectAccess`. `undefined` (the default) keeps the
+     * original behaviour for direct callers that don't have the
+     * project in hand.
+     */
+    organizationId?: string | null;
   }
 ): Promise<void> {
   // API key authentication without JWT user — verify project permission via API key rules
@@ -189,17 +223,13 @@ export async function checkProjectAccess(
 
     // If minProjectRole specified, check effective role = max(explicit, inherited)
     if (options?.minProjectRole) {
-      const explicitRole = await db.projects.getUserRole(projectId, authUser.id);
-      const inheritedRole = await lookupInheritedProjectRole(projectId, authUser.id, db);
+      const [explicitRole, inheritedRole] = await Promise.all([
+        db.projects.getUserRole(projectId, authUser.id),
+        lookupInheritedProjectRole(projectId, authUser.id, db, options?.organizationId),
+      ]);
 
-      // Pick the higher of explicit and inherited
-      let effectiveRole: ProjectRole | null = null;
-      const explicit = explicitRole && isProjectRole(explicitRole) ? explicitRole : null;
-      if (explicit && inheritedRole) {
-        effectiveRole = hasPermissionLevel(explicit, inheritedRole) ? explicit : inheritedRole;
-      } else {
-        effectiveRole = explicit ?? inheritedRole;
-      }
+      const explicit = isProjectRole(explicitRole) ? explicitRole : null;
+      const effectiveRole = pickHigherProjectRole(explicit, inheritedRole);
 
       if (!effectiveRole) {
         throw new AppError(`Access denied to ${resourceName}`, 403, 'Forbidden');
@@ -217,8 +247,15 @@ export async function checkProjectAccess(
     // Fallback: check boolean membership (backward compatible)
     const hasAccess = await db.projects.hasAccess(projectId, authUser.id);
     if (!hasAccess) {
-      // Check org inheritance as fallback
-      const inheritedRole = await lookupInheritedProjectRole(projectId, authUser.id, db);
+      // Check org inheritance as fallback. Pass organizationId through
+      // so the helper skips the redundant `db.projects.findById` when
+      // the caller already loaded the project.
+      const inheritedRole = await lookupInheritedProjectRole(
+        projectId,
+        authUser.id,
+        db,
+        options?.organizationId
+      );
       if (!inheritedRole) {
         throw new AppError(`Access denied to ${resourceName}`, 403, 'Forbidden');
       }

--- a/packages/backend/src/types/project-roles.ts
+++ b/packages/backend/src/types/project-roles.ts
@@ -143,11 +143,31 @@ export function getEffectiveProjectRole(
   orgRole: OrgMemberRole | undefined
 ): ProjectRole | undefined {
   const inherited = orgRole ? getInheritedProjectRole(orgRole) : undefined;
-  if (!explicitRole) {
-    return inherited;
+  return pickHigherProjectRole(explicitRole, inherited) ?? undefined;
+}
+
+/**
+ * Pick the higher of two already-resolved project roles.
+ *
+ * Both `getEffectiveProjectRole` (above) and the `requireProjectAccess`
+ * middleware need the same composition: given an explicit project role
+ * and an inherited project role (either side may be null/undefined),
+ * return the one with the higher permission level. The previous form was
+ * inlined in both locations; centralising here keeps the rule in one
+ * place so a future change to `ROLE_HIERARCHY` or to the picking policy
+ * doesn't drift across callers.
+ *
+ * Pure function, no DB access. Accepts `null` for "role not set" so
+ * callers don't need to defensively coerce undefined.
+ */
+export function pickHigherProjectRole(
+  a: ProjectRole | null | undefined,
+  b: ProjectRole | null | undefined
+): ProjectRole | null {
+  const left = a ?? null;
+  const right = b ?? null;
+  if (left && right) {
+    return hasPermissionLevel(left, right) ? left : right;
   }
-  if (!inherited) {
-    return explicitRole;
-  }
-  return hasPermissionLevel(explicitRole, inherited) ? explicitRole : inherited;
+  return left ?? right ?? null;
 }

--- a/packages/backend/tests/integration/integration-rules-permissions.test.ts
+++ b/packages/backend/tests/integration/integration-rules-permissions.test.ts
@@ -15,6 +15,7 @@ import { createTestUser, createTestProject, TestCleanupTracker } from '../utils/
 import type { DatabaseClient } from '../../src/db/client.js';
 import type { User, Project } from '../../src/db/types.js';
 import { getEncryptionService } from '../../src/utils/encryption.js';
+import { ApiKeyService } from '../../src/services/api-key/index.js';
 
 describe('Integration Rules Permissions - E2E', () => {
   let server: FastifyInstance;
@@ -743,21 +744,299 @@ describe('Integration Rules Permissions - E2E', () => {
       expect(JSON.parse(response.body).message).toContain('Insufficient project role');
     });
 
-    // FOLLOW-UP / DEFERRED: cross-tenant data exfiltration via copy.
-    // Tracked in: https://github.com/apex-bridge/bugspotter/issues/96
+    // Closes GH-96: cross-tenant exfiltration via copy. The route fix
+    // (`requireProjectRole('member')` on the copy source preHandler at
+    // integration-rules.ts:361) makes viewer-source-copy a 403 instead
+    // of a 201. Without this guard a user with only `viewer` membership
+    // on the source project could extract that project's rule
+    // configurations (filters / field_mappings / description_template /
+    // attachment_config) by copying them into a project they admin.
+    it('should deny viewer on source project from copying rules', async () => {
+      // Source: user has `viewer` membership only on testProject.
+      // Target: user has `admin` on a fresh project (passes the inline
+      // target-admin gate). Without the route fix the request would 201;
+      // with the fix the source `requireProjectRole('member')` returns
+      // 403 BEFORE the handler body runs.
+      const sourceViewerData = await createTestUser(db, { role: 'user' });
+      cleanup.trackUser(sourceViewerData.user.id);
+      await db.projectMembers.addMember(testProject.id, sourceViewerData.user.id, 'viewer');
+
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.projectMembers.addMember(targetProject.id, sourceViewerData.user.id, 'admin');
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'VTGT',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      const sourceViewerLogin = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: {
+          email: sourceViewerData.user.email,
+          password: sourceViewerData.password,
+        },
+      });
+      expect(sourceViewerLogin.statusCode).toBe(200);
+      const sourceViewerJwt = JSON.parse(sourceViewerLogin.body).data.access_token;
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}/copy`,
+        headers: { authorization: `Bearer ${sourceViewerJwt}` },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(403);
+      // Denial comes from `requireProjectRole('member')` on the source —
+      // distinct from the target inline check (which would say
+      // 'Insufficient project role for Integration Rules').
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
+    });
+
+    // Regression guard: a user whose source-project access is granted
+    // ONLY via org membership inheritance (no explicit project_members
+    // row) was previously locked out by `requireProjectRole('member')`
+    // because the middleware only populated `request.projectRole` from
+    // `db.projects.getUserRole()` — a query that ignores org-level
+    // inheritance. The underlying middleware fix (project-access.ts
+    // now combines explicit + inherited via `lookupInheritedProjectRole`)
+    // benefits every callsite of `requireProjectRole`, but this is the
+    // route where the regression was introduced and is the natural test
+    // home for it.
     //
-    // The copy preHandler is `requireProjectAccess` with no minProjectRole
-    // (integration-rules.ts:361), so a user with only `viewer` membership
-    // on the source project can extract that project's rule configurations
-    // (filters / field_mappings / description_template / attachment_config)
-    // by copying them into a project they admin. Fix is a one-line route
-    // change (add `requireProjectRole('member')` to the copy source
-    // preHandler) — see issue #96 for full repro and the acceptance test
-    // shape. Belongs to the queued RBAC tightening PR rather than this
-    // test cleanup. Intentionally NOT pinning a passing 201 lock-in test
-    // here, because doing so would tell CI to permanently accept the
-    // bypass and a future tightening would be blocked rather than
-    // welcomed.
+    // Org-to-project role inheritance (project-roles.ts:122-126) maps:
+    //   owner  → admin
+    //   admin  → admin
+    //   member → viewer
+    // To exercise the regression, the org role must inherit a project
+    // role >= 'member' — that means org admin or owner. Org `member`
+    // inherits `viewer` (< member) and would correctly be denied by
+    // `requireProjectRole('member')` even after the fix.
+    it('should allow org-inherited admin on source project to copy rules', async () => {
+      // Use DEDICATED projects rather than mutating the shared `testProject`.
+      // If an assertion below fails, `cleanup.cleanup()` deletes the
+      // organization via `trackOrganization`, and a previously-mutated
+      // `testProject.organization_id` would FK-cascade through every
+      // remaining test in the file. Dedicated projects keep this test
+      // isolated from the rest of the suite even on assertion failure.
+      const orgUserData = await createTestUser(db, { role: 'user' });
+      cleanup.trackUser(orgUserData.user.id);
+
+      // Org with this user as admin (inherits project `admin`).
+      const sourceOrg = await db.organizations.create({
+        name: `Inherited Admin Test Org ${Date.now()}`,
+        subdomain: `inh-adm-${Date.now()}`,
+      });
+      cleanup.trackOrganization(sourceOrg.id);
+      await db.organizationMembers.create({
+        organization_id: sourceOrg.id,
+        user_id: orgUserData.user.id,
+        role: 'admin',
+      });
+
+      // Source project: scoped to the org. User has NO explicit
+      // project_members row — access is purely via inheritance, which is
+      // the regression scenario.
+      const sourceProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(sourceProject.id);
+      await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
+        sourceOrg.id,
+        sourceProject.id,
+      ]);
+      const sourceJiraIntegration = await db.projectIntegrations.create({
+        project_id: sourceProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'INHSRC',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      // Source rule, owned by adminJwt (not the user under test).
+      const sourceRuleResponse = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules`,
+        headers: { authorization: `Bearer ${adminJwt}` },
+        payload: {
+          name: 'Inherited-admin source rule',
+          enabled: true,
+          filters: [{ field: 'priority', operator: 'equals', value: 'low' }],
+          auto_create: false,
+        },
+      });
+      const sourceRuleId = JSON.parse(sourceRuleResponse.body).data.id;
+
+      // Target project: same org, user has explicit admin.
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
+        sourceOrg.id,
+        targetProject.id,
+      ]);
+      await db.projectMembers.addMember(targetProject.id, orgUserData.user.id, 'admin');
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'INHTGT',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      const orgUserLogin = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: orgUserData.user.email, password: orgUserData.password },
+      });
+      expect(orgUserLogin.statusCode).toBe(200);
+      const orgUserJwt = JSON.parse(orgUserLogin.body).data.access_token;
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules/${sourceRuleId}/copy`,
+        headers: { authorization: `Bearer ${orgUserJwt}` },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(201);
+      // No tail cleanup needed: the dedicated source/target projects (and
+      // their integrations / rules) cascade-delete via cleanup.cleanup()
+      // in afterAll. testProject is never touched.
+      void sourceJiraIntegration;
+    });
+
+    // Counterpart to the inherited-admin allow test: pins the
+    // `ORG_TO_PROJECT_ROLE` mapping in `types/project-roles.ts:122-126`
+    // (member → viewer). If anyone changes that map to `member: 'member'`,
+    // org members would silently gain copy access — this test catches that.
+    // The viewer-deny test above exercises the same `requireProjectRole`
+    // gate but via an EXPLICIT project_members row, not via inheritance,
+    // so it doesn't cover the mapping branch.
+    it('should deny org-member (inherits viewer) on source project from copying rules', async () => {
+      const orgMemberData = await createTestUser(db, { role: 'user' });
+      cleanup.trackUser(orgMemberData.user.id);
+
+      // Org with this user as `member` — inherits project `viewer`,
+      // which is below the `member` floor enforced by
+      // `requireProjectRole('member')` on the copy source.
+      const sourceOrg = await db.organizations.create({
+        name: `Inherited Member Deny Test Org ${Date.now()}`,
+        subdomain: `inh-mem-deny-${Date.now()}`,
+      });
+      cleanup.trackOrganization(sourceOrg.id);
+      await db.organizationMembers.create({
+        organization_id: sourceOrg.id,
+        user_id: orgMemberData.user.id,
+        role: 'member',
+      });
+
+      // Source project: scoped to the org, no explicit project_members row
+      // for this user (access comes purely from org-member inheritance).
+      const sourceProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(sourceProject.id);
+      await db.query('UPDATE application.projects SET organization_id = $1 WHERE id = $2', [
+        sourceOrg.id,
+        sourceProject.id,
+      ]);
+      await db.projectIntegrations.create({
+        project_id: sourceProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'IMDS',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+      const sourceRuleResponse = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules`,
+        headers: { authorization: `Bearer ${adminJwt}` },
+        payload: {
+          name: 'Inherited-member deny source rule',
+          enabled: true,
+          filters: [{ field: 'priority', operator: 'equals', value: 'low' }],
+          auto_create: false,
+        },
+      });
+      const sourceRuleId = JSON.parse(sourceRuleResponse.body).data.id;
+
+      // Target: user has explicit admin so the source gate is the only
+      // thing that can deny — isolates the test to the inheritance mapping.
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.projectMembers.addMember(targetProject.id, orgMemberData.user.id, 'admin');
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'IMDT',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      const orgUserLogin = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: orgMemberData.user.email, password: orgMemberData.password },
+      });
+      expect(orgUserLogin.statusCode).toBe(200);
+      const orgUserJwt = JSON.parse(orgUserLogin.body).data.access_token;
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${sourceProject.id}/rules/${sourceRuleId}/copy`,
+        headers: { authorization: `Bearer ${orgUserJwt}` },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(403);
+      // Same gate as the explicit-viewer test, just reached via inheritance.
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
+    });
   });
 
   describe('Admin Bypass', () => {
@@ -813,6 +1092,106 @@ describe('Integration Rules Permissions - E2E', () => {
       // Clean up admin-created rule
       const adminRuleId = JSON.parse(createResponse.body).data.id;
       await db.query('DELETE FROM integration_rules WHERE id = $1', [adminRuleId]);
+    });
+  });
+
+  // Pins the existing intentional behaviour for full-scope API keys:
+  // they reach handler bodies regardless of project membership or role,
+  // because `requirePermission`, `requireProjectRole`, and the
+  // `apiKey && !authUser` branch of `checkProjectAccess` ALL skip
+  // their gates for API-key auth. This is the security model — full-
+  // scope keys (`allowed_projects: []`) are intentionally project-
+  // unbounded — but it was previously undocumented and untested.
+  // If product later adds explicit API-key admin enforcement, these
+  // assertions flip from 201 to 403 and the bypass-comments in
+  // `src/api/utils/resource.ts` should be updated to match.
+  describe('Full-scope API key bypass (lock-in)', () => {
+    let fullScopeKey: string;
+
+    beforeAll(async () => {
+      const apiKeyService = new ApiKeyService(db);
+      const result = await apiKeyService.createKey({
+        name: 'Full-scope test key (rule bypass lock-in)',
+        type: 'development',
+        permission_scope: 'full',
+        // requirePermission is skipped for API-key auth, so the
+        // permissions array is irrelevant on these routes — included
+        // for completeness with the production CRUD shape.
+        permissions: ['integration_rules:create', 'integration_rules:update'],
+        created_by: adminUser.id,
+        allowed_projects: [], // full-scope
+      });
+      fullScopeKey = result.plaintext;
+    });
+
+    it('should allow full-scope API key to create rules in any project (no membership / no admin role required)', async () => {
+      // testProject was created by adminUser; the API key has zero
+      // project membership of its own. The route still accepts the
+      // request because `requireProjectRole`/`requirePermission` both
+      // return early for API-key auth, and `checkProjectAccess` takes
+      // the `apiKey && !authUser` branch which only validates against
+      // `allowed_projects` (empty = all).
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules`,
+        headers: { 'x-api-key': fullScopeKey },
+        payload: {
+          name: 'Created via full-scope key',
+          enabled: true,
+          filters: [{ field: 'priority', operator: 'equals', value: 'low' }],
+          auto_create: false,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const created = JSON.parse(response.body).data;
+      expect(created.name).toBe('Created via full-scope key');
+
+      // Clean up
+      await db.query('DELETE FROM integration_rules WHERE id = $1', [created.id]);
+    });
+
+    it('should allow full-scope API key to copy rules to any target (no admin role on target required)', async () => {
+      // Inline `checkProjectAccess(targetProjectId, …, { minProjectRole: 'admin' })`
+      // in the COPY handler is skipped for API-key auth (branch (1) of
+      // checkProjectAccess returns before reaching the role check).
+      // Combined with the source-side bypass on `requireProjectRole`,
+      // a full-scope key copies anything to anywhere.
+      const targetProject = await createTestProject(db, { created_by: adminUser.id });
+      cleanup.trackProject(targetProject.id);
+      await db.projectIntegrations.create({
+        project_id: targetProject.id,
+        integration_id: jiraIntegrationGlobalId,
+        config: {
+          instanceUrl: 'https://example.atlassian.net',
+          projectKey: 'APIK',
+          issueType: 'Bug',
+          autoCreate: false,
+          syncStatus: false,
+          syncComments: false,
+        },
+        encrypted_credentials: encryptionService.encrypt(
+          JSON.stringify({ email: 'test@example.com', apiToken: 'test-token' })
+        ),
+        enabled: true,
+      });
+
+      // Reset rule name so the assertion below isn't order-dependent.
+      await db.integrationRules.update(ruleId, { name: 'High Severity Auto-Create' });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}/copy`,
+        headers: { 'x-api-key': fullScopeKey },
+        payload: { targetProjectId: targetProject.id },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const copied = JSON.parse(response.body).data.rule;
+      expect(copied.project_id).toBe(targetProject.id);
+
+      // Clean up
+      await db.query('DELETE FROM integration_rules WHERE id = $1', [copied.id]);
     });
   });
 });


### PR DESCRIPTION
**Replaces #100** — same final state (route fix + middleware fix + tests + JSDoc improvements), squashed into one coherent commit, **plus a new RBAC reference doc**. Closes [#96](https://github.com/apex-bridge/bugspotter/issues/96).

## Scope: intra-org only

This PR closes the specific exfiltration case named in #96: a project `viewer` (within the same organisation) extracting rule configurations to a project they admin. The fix raises the source-project floor from "any membership" to "member or higher".

**Cross-organisation copy is a separate concern, tracked in [#101](https://github.com/apex-bridge/bugspotter/issues/101)** — a user who is `member` on org A's project and `admin` on org B's project can still copy across org boundaries. That's a related-but-distinct authorisation policy decision and warrants its own PR.

## Route fix

Adds `requireProjectRole('member')` to the source-project preHandler chain on `POST /api/v1/integrations/:platform/:projectId/rules/:ruleId/copy`. Target inline check unchanged.

| Layer | Before | After |
|---|---|---|
| Source preHandler | `requireProjectAccess` (any membership) | `requireProjectAccess` + `requireProjectRole('member')` |
| Target inline check | `checkProjectAccess(targetProjectId, ..., { minProjectRole: 'admin' })` | unchanged |

## Middleware fix bundled in (necessary)

`requireProjectRole('member')` exposed a pre-existing bug: `requireProjectAccess` populated `request.projectRole` from `db.projects.getUserRole()` only — that query ignores org-level inheritance, so org admins/owners with no explicit `project_members` row had `request.projectRole` undefined and were 403'd by `requireProjectRole` with a misleading "You do not have a role in this project" message — even though `checkProjectAccess` (called moments earlier) had just admitted them via the inherited path.

The bug affects all 9 callsites of `requireProjectRole` (integration-rules, integrations, data-residency, retention) — patching only my route would leave the others broken.

**Fix**: middleware now combines explicit + inherited role via the new `pickHigherProjectRole(a, b)` helper in `types/project-roles.ts`. Both lookups run in parallel via `Promise.all`. The inherited helper accepts an optional `organizationId` to skip a redundant `findById` (caller asserts the org_id was just read from the same project; trust contract documented at the function's JSDoc).

## RBAC reference doc

New `packages/backend/docs/auth.md` (linked from `packages/backend/CLAUDE.md`):

- Authentication artifacts (the four request fields)
- Header precedence (api-key wins; audit-identity caveat → #97)
- The 3-layer authorization model (platform / project access / project role)
- Effective project role: explicit ∪ inherited via `pickHigherProjectRole`, with the `ORG_TO_PROJECT_ROLE` mapping
- API-key bypass rules (intentional design; lock-in tested)
- Open questions section linking #97, #101, and the deeper `checkProjectAccess` refactor

Source-file pointers in every section so doc rot fails visibly rather than silently.

## Tests

5 new tests in `tests/integration/integration-rules-permissions.test.ts` (21 → 26):

1. `should deny viewer on source project from copying rules` — acceptance test for #96, explicit project_members row
2. `should allow org-inherited admin on source project to copy rules` — regression guard for the middleware fix
3. `should deny org-member (inherits viewer) on source project from copying rules` — pins `ORG_TO_PROJECT_ROLE.member → 'viewer'`
4. `should allow full-scope API key to create rules in any project` — lock-in for the existing API-key bypass on `requireProjectRole`/`requirePermission`
5. `should allow full-scope API key to copy rules to any target` — lock-in for API-key bypass on the inline target-admin check

`pnpm test:integration tests/integration/integration-rules-permissions.test.ts` locally: 26/26 passing.

## Test plan

- [x] Typecheck clean
- [x] Local integration tests green (26/26)
- [ ] CI: integration job exercises the new guard
- [ ] Reviewer: skim `docs/auth.md` for accuracy / missing surfaces — feedback into the open-questions section is welcome
- [ ] Reviewer: confirm the middleware change is acceptable scope expansion. The bug it fixes affects 9 routes; patching only this one would leave the others broken

## Out of scope (tracked)

- [#97](https://github.com/apex-bridge/bugspotter/issues/97) — audit-identity masking when JWT + full-scope API key both present
- [#101](https://github.com/apex-bridge/bugspotter/issues/101) — cross-organisation rule copy (member-on-A + admin-on-B across orgs)
- `checkProjectAccess` return-type refactor to eliminate the residual double `checkOrganizationAccess` for org-inherited users (26-callsite blast radius; follow-up RBAC perf PR)

## Notes

- **Backward-compat impact**: any existing caller who is only `viewer` on a source project and was relying on COPY will start receiving 403. Intentional. Viewer can still GET the rule body and craft an equivalent POST manually if cross-project rule duplication is a real workflow, but the silent automated path is closed.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive auth reference clarifying request auth artifacts, header precedence, API-key bypass rules, audit-identity caveats, and open questions.

* **New Features**
  * Project-role resolution now considers inherited organization roles when determining effective project access.

* **Bug Fixes**
  * Enforced stricter source-project role checks for copying integration rules and improved role-resolution.

* **Tests**
  * Added end-to-end coverage for copy permission rules and full-scope API key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->