### PR TITLE
feat(integrations): seed default Jira description template on auto-create rules

### DIFF
--- a/packages/backend/src/api/routes/integration-rules.ts
+++ b/packages/backend/src/api/routes/integration-rules.ts
@@ -221,10 +221,11 @@ export async function registerIntegrationRuleRoutes(
       // Get integration (loads plugin + validates existence)
       const integration = await getIntegrationForProject(platform, projectId, registry, db);
 
-      // When auto_create is on and the caller omits a template, seed the
-      // platform's default so newly-created rules render a sensible Jira
-      // description out of the box. An explicit null/empty in the request
-      // is honoured as "the caller really wants no template".
+      // When auto_create is on and the caller omits the template key, seed
+      // the platform's default so newly-created rules render a sensible Jira
+      // description out of the box. An explicit `null` in the request is
+      // honoured as "the caller really wants no template"; an explicit empty
+      // string is preserved as-is (the column allows it).
       const callerProvidedTemplate = 'description_template' in request.body;
       const description_template = callerProvidedTemplate
         ? (request.body.description_template ?? null)

--- a/packages/backend/src/api/routes/integration-rules.ts
+++ b/packages/backend/src/api/routes/integration-rules.ts
@@ -215,12 +215,22 @@ export async function registerIntegrationRuleRoutes(
         throttle = null,
         auto_create = false,
         field_mappings = null,
-        description_template = null,
         attachment_config = null,
       } = request.body;
 
       // Get integration (loads plugin + validates existence)
       const integration = await getIntegrationForProject(platform, projectId, registry, db);
+
+      // When auto_create is on and the caller omits a template, seed the
+      // platform's default so newly-created rules render a sensible Jira
+      // description out of the box. An explicit null/empty in the request
+      // is honoured as "the caller really wants no template".
+      const callerProvidedTemplate = request.body.description_template != null;
+      const description_template = callerProvidedTemplate
+        ? (request.body.description_template ?? null)
+        : auto_create
+          ? (registry.getPluginMetadata(platform)?.defaultDescriptionTemplate ?? null)
+          : null;
 
       logger.info('Creating integration rule', {
         platform,
@@ -228,6 +238,7 @@ export async function registerIntegrationRuleRoutes(
         integrationId: integration.id,
         name,
         filtersCount: filters.length,
+        seededDefaultTemplate: !callerProvidedTemplate && description_template !== null,
         userId: getAuditUserId(request),
         apiKeyId: request.apiKey?.id ?? null,
       });

--- a/packages/backend/src/api/routes/integration-rules.ts
+++ b/packages/backend/src/api/routes/integration-rules.ts
@@ -225,7 +225,7 @@ export async function registerIntegrationRuleRoutes(
       // platform's default so newly-created rules render a sensible Jira
       // description out of the box. An explicit null/empty in the request
       // is honoured as "the caller really wants no template".
-      const callerProvidedTemplate = request.body.description_template != null;
+      const callerProvidedTemplate = 'description_template' in request.body;
       const description_template = callerProvidedTemplate
         ? (request.body.description_template ?? null)
         : auto_create

--- a/packages/backend/src/integrations/jira/default-template.ts
+++ b/packages/backend/src/integrations/jira/default-template.ts
@@ -1,0 +1,29 @@
+/**
+ * Default Jira description template applied to newly-created auto-create rules
+ * when the caller does not provide one. Uses the same {{var}} syntax as
+ * `template-renderer.ts`. Mirrors the template that ships in the demo project,
+ * with the marketing footer removed for self-hosted/customer Jiras.
+ */
+export const JIRA_DEFAULT_DESCRIPTION_TEMPLATE = `## {{title}}
+
+{{description}}
+
+---
+
+### Environment
+
+| Field    | Value          |
+| -------- | -------------- |
+| Priority | {{priority}}   |
+| Browser  | {{browser}}    |
+| OS       | {{os}}         |
+| Page URL | {{url}}        |
+
+### Session Replay
+
+[Watch session replay]({{replay_url}})
+
+### Screenshot
+
+[View screenshot]({{screenshot_url}})
+`;

--- a/packages/backend/src/integrations/jira/index.ts
+++ b/packages/backend/src/integrations/jira/index.ts
@@ -7,6 +7,7 @@ export { JiraClient } from './client.js';
 export { JiraBugReportMapper } from './mapper.js';
 export { JiraConfigManager } from './config.js';
 export { JiraIntegrationService } from './service.js';
+export { JIRA_DEFAULT_DESCRIPTION_TEMPLATE } from './default-template.js';
 
 export type {
   JiraConfig,

--- a/packages/backend/src/integrations/jira/plugin.ts
+++ b/packages/backend/src/integrations/jira/plugin.ts
@@ -5,6 +5,7 @@
 
 import type { IntegrationPlugin } from '../plugin.types.js';
 import { JiraIntegrationService } from './service.js';
+import { JIRA_DEFAULT_DESCRIPTION_TEMPLATE } from './default-template.js';
 
 /**
  * Jira integration plugin definition
@@ -18,6 +19,7 @@ export const jiraPlugin: IntegrationPlugin = {
     author: 'BugSpotter Team',
     requiredEnvVars: ['ENCRYPTION_KEY'], // For credential encryption
     isBuiltIn: true, // Built-in plugin loaded from plugin-loader.ts
+    defaultDescriptionTemplate: JIRA_DEFAULT_DESCRIPTION_TEMPLATE,
   },
 
   factory: (context) => {

--- a/packages/backend/src/integrations/plugin.types.ts
+++ b/packages/backend/src/integrations/plugin.types.ts
@@ -83,6 +83,7 @@ export interface PluginMetadata {
   author?: string; // Plugin author
   requiredEnvVars?: string[]; // Required environment variables
   isBuiltIn?: boolean; // Whether this is a built-in plugin (vs custom from database)
+  defaultDescriptionTemplate?: string; // Seeded into rule.description_template when auto_create=true and the caller omits one
 }
 
 /**

--- a/packages/backend/tests/api/integration-rules.test.ts
+++ b/packages/backend/tests/api/integration-rules.test.ts
@@ -11,6 +11,7 @@ import type { DatabaseClient } from '../../src/db/client.js';
 import { createStorage } from '../../src/storage/index.js';
 import type { IStorageService } from '../../src/storage/types.js';
 import { PluginRegistry } from '../../src/integrations/plugin-registry.js';
+import { JIRA_DEFAULT_DESCRIPTION_TEMPLATE } from '../../src/integrations/jira/default-template.js';
 import type { FilterCondition } from '../../src/types/notifications.js';
 import { createProjectIntegrationSQL, createAdminUser } from '../test-helpers.js';
 
@@ -40,6 +41,7 @@ describe('Integration Rules API Routes', () => {
         platform: 'jira',
         version: '1.0.0',
         name: 'Jira Integration (Mock)',
+        defaultDescriptionTemplate: JIRA_DEFAULT_DESCRIPTION_TEMPLATE,
       },
       factory: (_context: any) => ({
         async validateConfig() {
@@ -161,6 +163,59 @@ describe('Integration Rules API Routes', () => {
       expect(body.data.priority).toBe(0);
       // Throttle is null when not provided (JSONB null)
       expect(body.data.throttle).toBeNull();
+    });
+
+    it('seeds platform default description_template when auto_create=true and template omitted', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProjectId}/rules`,
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          name: 'Auto-create with default',
+          filters: [],
+          auto_create: true,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.data.description_template).toBe(JIRA_DEFAULT_DESCRIPTION_TEMPLATE);
+    });
+
+    it('does not seed default when auto_create is false', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProjectId}/rules`,
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          name: 'Filter-only rule',
+          filters: [],
+          auto_create: false,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.data.description_template).toBeNull();
+    });
+
+    it('preserves a caller-supplied description_template (no overwrite)', async () => {
+      const customTemplate = '# {{title}}\n\nCustom body for {{user_email}}';
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProjectId}/rules`,
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          name: 'Custom template rule',
+          filters: [],
+          auto_create: true,
+          description_template: customTemplate,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.data.description_template).toBe(customTemplate);
     });
 
     it('should reject invalid filter field', async () => {

--- a/packages/backend/tests/api/integration-rules.test.ts
+++ b/packages/backend/tests/api/integration-rules.test.ts
@@ -199,6 +199,24 @@ describe('Integration Rules API Routes', () => {
       expect(body.data.description_template).toBeNull();
     });
 
+    it('honours explicit description_template: null as caller opt-out', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProjectId}/rules`,
+        headers: { authorization: `Bearer ${authToken}` },
+        payload: {
+          name: 'Opt-out rule',
+          filters: [],
+          auto_create: true,
+          description_template: null,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.data.description_template).toBeNull();
+    });
+
     it('preserves a caller-supplied description_template (no overwrite)', async () => {
       const customTemplate = '# {{title}}\n\nCustom body for {{user_email}}';
       const response = await server.inject({

--- a/packages/backend/tests/integrations/jira/plugin.test.ts
+++ b/packages/backend/tests/integrations/jira/plugin.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../../src/integrations/jira/client.js', () => ({
   })),
 }));
 import { jiraPlugin } from '../../../src/integrations/jira/plugin.js';
+import { JIRA_DEFAULT_DESCRIPTION_TEMPLATE } from '../../../src/integrations/jira/default-template.js';
 import type { PluginContext } from '../../../src/integrations/plugin.types.js';
 
 describe('jiraPlugin', () => {
@@ -40,6 +41,7 @@ describe('jiraPlugin', () => {
         author: 'BugSpotter Team',
         requiredEnvVars: ['ENCRYPTION_KEY'],
         isBuiltIn: true,
+        defaultDescriptionTemplate: JIRA_DEFAULT_DESCRIPTION_TEMPLATE,
       });
     });
 


### PR DESCRIPTION
## Summary

When a new integration rule is created with `auto_create=true` and no `description_template`, the platform's default template is silently injected into the existing `description_template` column so freshly-created Jira integrations render a sensible ticket out of the box. Caller-supplied templates always win; `auto_create=false` rules stay `null`.

The default body is mirrored from the live demo project's existing template, with the marketing footer line stripped so self-hosted/customer Jiras don't ship branding by surprise.

Templates as a feature (column, renderer, admin UI, `JiraTemplateConfig`) already exist — this PR just supplies a non-null seed value for the column on rule creation. The default is declared per-platform via a new optional `PluginMetadata.defaultDescriptionTemplate` field, matching the existing per-platform organization (`formatters/`, `mapper.ts`, etc.) and giving future GitHub/Linear plugins the same hook.

(Replaces #108 and #109 — same intent, original architecture restored.)

## Behavior contract

| Request | Result |
|---|---|
| `auto_create: true`, no `description_template` | Default template seeded |
| `auto_create: true`, explicit `description_template: "…"` | As provided (override) |
| `auto_create: true`, explicit `description_template: null` | `null` (caller opts out) |
| `auto_create: false`, anything | Existing behavior |

A `seededDefaultTemplate` boolean is added to the create-rule log line for observability.

## What's NOT in this PR

- No admin UI changes (the existing MarkdownEditor in the field-mappings tab keeps working unchanged)
- No new DB schema, no migration, no backfill of existing rules
- No new platform defaults — only Jira (others can opt in by setting `defaultDescriptionTemplate` on their plugin metadata)

## Test plan

- [x] Unit suite green (2399 passing)
- [x] tests/api/integration-rules.test.ts 34/34 — 3 new tests pin the contract above
- [x] Typecheck clean vs. main baseline
- [ ] Reviewer: confirm the demo project's existing rule is intentionally left alone (no backfill — its older with-footer template stays as is, fine for the demo surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jira integration includes a built-in default issue description template used when auto-create is enabled and no custom template is provided.
* **Bug Fixes / Improvements**
  * Rule creation now auto-seeds the description template when appropriate and logs a seeded-default flag for observability.
* **Tests**
  * Added tests confirming auto-seeding behavior and that plugin metadata exposes the default template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->