### PR TITLE
chore(ci): tighten Claude review prompt + add read tools to fix turn-budget exhaustion

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -88,6 +88,12 @@ jobs:
 
             Skip nits, style, theoretical issues. If nothing substantive, exit silently.
             Inline comments only — no top-level summary.
+
+            Process: read the full diff in one `gh pr diff` call. Use `Grep`
+            across the working tree only when a comment would otherwise be
+            inaccurate without the surrounding context. Don't enumerate every
+            file; pick the riskiest spots. Post inline comments on at most
+            5 issues, then stop.
           # `mcp__github_inline_comment__create_inline_comment` is the
           # MCP-bridged tool the action uses to buffer inline review
           # comments. Without it explicitly allow-listed, Claude's tool
@@ -95,14 +101,21 @@ jobs:
           # comments" — silently producing nothing visible.
           #
           # `gh pr diff` and `gh pr view` are read-only fallbacks for
-          # exploratory navigation. We deliberately do NOT allow
-          # `gh pr comment` (would enable top-level summaries we've
-          # explicitly disabled in the prompt) or `gh api:*` (supports
-          # `-X POST/PATCH/DELETE` so the wildcard would let Claude
-          # mutate any GitHub resource the workflow's GITHUB_TOKEN can
-          # touch — including posting top-level PR comments via
+          # exploratory navigation. `Read`, `Grep`, `Glob` are the
+          # built-in file-navigation tools — also read-only, but cheaper
+          # in turns than chaining multiple `gh pr view` calls when the
+          # reviewer needs context beyond the diff (the working tree is
+          # already checked out for `pull_request` events; `gh pr
+          # checkout` runs above for comment events).
+          #
+          # We deliberately do NOT allow `gh pr comment` (would enable
+          # top-level summaries we've explicitly disabled in the prompt)
+          # or `gh api:*` (supports `-X POST/PATCH/DELETE` so the
+          # wildcard would let Claude mutate any GitHub resource the
+          # workflow's GITHUB_TOKEN can touch — including posting
+          # top-level PR comments via
           # `gh api repos/.../issues/.../comments`, defeating the same
           # constraint).
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
             --max-turns 25


### PR DESCRIPTION
## Summary

The Claude Review action timed out on #112 (15 files, +961/−54) because its allowed-tools set forced exploration via repeated `gh pr view` calls — easy to burn the 25-turn budget just reading. Two narrowly-scoped fixes:

- **Tooling**: add `Read`, `Grep`, `Glob` to `--allowedTools`. Read-only, no mutation surface (the existing `gh pr comment` / `gh api:*` exclusions still hold). Lets the reviewer navigate the working tree — already checked out by the upstream step — in single turns instead of chaining `gh pr view` per file.
- **Prompt**: add an explicit process to the system prompt — "read the full diff in one `gh pr diff` call, only `Grep` when context would change a comment's accuracy, post inline comments on at most 5 issues, then stop." The 5-issue cap matches the action's intended footprint (high-signal review, not exhaustive walk-through) and keeps the conversation under budget.

`--max-turns 25` is unchanged — the prompt is the real fix; bumping the budget would just paper over the inefficiency.

## What's NOT in this PR

- No change to which events trigger the action.
- No change to the `concurrency` group or cancel-in-progress behaviour.
- No bump to `--max-turns`.

## Test plan

- [x] `actionlint .github/workflows/claude-review.yml` passes.
- [ ] Reviewer: verify the next PR's Claude Review run finishes inside the budget. If it still times out on a comparable PR, bump `--max-turns` as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code review workflow efficiency and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->