### PR TITLE
chore(admin): left-align quick-setup CTAs + tighten dismiss spacing

### DIFF
--- a/apps/admin/src/components/dashboard-layout.tsx
+++ b/apps/admin/src/components/dashboard-layout.tsx
@@ -250,11 +250,16 @@ export default function DashboardLayout() {
 
       {/* Main Content */}
       <div className="ml-64">
-        {/* Header with Quick-setup CTAs (empty-state only) and Language Switcher */}
+        {/* Header: quick-setup CTAs on the left (empty-state only),
+            language switcher right-anchored via `ml-auto` so it stays
+            on the right whether QuickSetupActions renders or returns
+            null. */}
         <div className="bg-white border-b border-gray-200 px-8 py-4">
-          <div className="flex items-center justify-end gap-4">
+          <div className="flex items-center gap-4">
             <QuickSetupActions />
-            <LanguageSwitcher />
+            <div className="ml-auto">
+              <LanguageSwitcher />
+            </div>
           </div>
         </div>
         <main className="p-8">

--- a/apps/admin/src/components/onboarding/quick-setup-actions.tsx
+++ b/apps/admin/src/components/onboarding/quick-setup-actions.tsx
@@ -135,7 +135,7 @@ export function QuickSetupActions() {
 
   return (
     <>
-      <div className="flex items-center gap-2" data-testid="quick-setup-actions">
+      <div className="flex items-center gap-3" data-testid="quick-setup-actions">
         <span className="text-xs font-medium text-gray-600 mr-1 hidden sm:inline">
           {t('quickSetup.label')}
         </span>
@@ -164,7 +164,7 @@ export function QuickSetupActions() {
                   data-testid="quick-setup-sdk-snippet-dismiss"
                   onClick={dismissSdk}
                   aria-label={t('quickSetup.dismissSdk')}
-                  className="ml-1 inline-flex items-center justify-center rounded-md p-1 text-gray-600 hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="ml-0.5 inline-flex items-center justify-center rounded-md p-1 text-gray-600 hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                   <X className="w-3.5 h-3.5" aria-hidden="true" />
                 </button>


### PR DESCRIPTION
## Summary

Two visual nits surfaced after #112 went live:

1. The quick-setup CTAs were right-aligned, sharing the right edge with the language switcher. Convention is primary/contextual actions on the left, utility (lang, account) on the right — moving them follows the dashboard pattern most users expect.
2. The dismiss `×` next to "SDK snippet" sat in no-man's-land between the two CTAs, reading as a separator rather than as "hide this CTA."

This PR:

- Move `<QuickSetupActions>` to the left of the header bar; anchor `<LanguageSwitcher>` to the right via `ml-auto` so it stays right-edge regardless of whether QuickSetupActions renders or returns null.
- `gap-2` → `gap-3` on the inner flex so the SDK+× group and the Connect Jira button read as separate actions.
- `ml-1` → `ml-0.5` between the SDK button and its dismiss `×` so they visually pair instead of looking like the × is floating.

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [x] Quick-setup + snippet-tabs unit tests still pass (11/11)
- [ ] Reviewer: visual confirm in dev server — buttons on the left, language switcher on the right, × clearly attached to SDK snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted admin dashboard header layout for improved spacing and alignment between the language switcher and quick setup actions.
  * Refined spacing and button margins in the dashboard components for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->