### PR TITLE
feat(api): organization_id query filter on the 4 cross-org list endpoints

### DIFF
--- a/packages/backend/src/api/routes/api-keys.ts
+++ b/packages/backend/src/api/routes/api-keys.ts
@@ -299,11 +299,16 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         if (created_by) {
           filters.created_by = created_by;
         }
-        // Cross-org filter — only honored for platform admin. A regular
-        // user passing the param has it ignored entirely (the branch
-        // above already set `accessible_by_user_id`).
-        if (organization_id) {
-          filters.organization_id = organization_id;
+        // Cross-org filter — only honored for platform admin. Tenant
+        // subdomain context wins over the query param (matches the
+        // precedence applied in `projects.ts` and `reports.ts`): an
+        // admin already on `acme.kz.bugspotter.io` cannot widen to a
+        // different org via the query string. A regular user passing
+        // the param has it ignored entirely (the branch above already
+        // set `accessible_by_user_id`).
+        const effectiveOrgId = request.organizationId ?? organization_id;
+        if (effectiveOrgId) {
+          filters.organization_id = effectiveOrgId;
         }
       }
 

--- a/packages/backend/src/api/routes/api-keys.ts
+++ b/packages/backend/src/api/routes/api-keys.ts
@@ -268,6 +268,7 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         type,
         status,
         created_by,
+        organization_id,
         sort_by = 'created_at',
         sort_order = 'desc',
       } = request.query as {
@@ -277,6 +278,7 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         status?: 'active' | 'revoked' | 'expired';
         permission_scope?: PermissionScope;
         created_by?: string;
+        organization_id?: string;
         sort_by?: 'created_at' | 'updated_at' | 'last_used_at' | 'name';
         sort_order?: 'asc' | 'desc';
       };
@@ -293,8 +295,16 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       // Non-admin users see their own keys + keys for projects in their org
       if (!isPlatformAdmin(request)) {
         filters.accessible_by_user_id = request.authUser.id;
-      } else if (created_by) {
-        filters.created_by = created_by;
+      } else {
+        if (created_by) {
+          filters.created_by = created_by;
+        }
+        // Cross-org filter — only honored for platform admin. A regular
+        // user passing the param has it ignored entirely (the branch
+        // above already set `accessible_by_user_id`).
+        if (organization_id) {
+          filters.organization_id = organization_id;
+        }
       }
 
       const result = await apiKeyService.listKeys(

--- a/packages/backend/src/api/routes/projects.ts
+++ b/packages/backend/src/api/routes/projects.ts
@@ -8,6 +8,7 @@ import type { DatabaseClient } from '../../db/client.js';
 import {
   createProjectSchema,
   getProjectSchema,
+  listProjectsSchema,
   updateProjectSchema,
   deleteProjectSchema,
 } from '../schemas/project-schema.js';
@@ -87,24 +88,19 @@ export function projectRoutes(fastify: FastifyInstance, db: DatabaseClient) {
     '/api/v1/projects',
     {
       preHandler: [requireUser],
-      schema: {
-        querystring: {
-          type: 'object',
-          properties: {
-            organization_id: { type: 'string', format: 'uuid' },
-          },
-          additionalProperties: false,
-        },
-      },
+      schema: listProjectsSchema,
     },
     async (request, reply) => {
       // Platform admin users see all projects (scoped to org in SaaS mode).
-      // On the hub domain (no `request.organizationId`), they may pass
+      // On the hub domain (no tenant subdomain), they may pass
       // `?organization_id=` to narrow the cross-org view to a single tenant.
+      // Tenant-subdomain context wins when present — a platform admin
+      // already on `acme.kz.bugspotter.io` cannot widen to a different
+      // org via the query param, they have to navigate to that subdomain.
       // Param is consumed only inside this branch — regular users never reach it.
       if (isPlatformAdmin(request)) {
-        const adminOrgFilter = request.query.organization_id;
-        const projects = await db.projects.findAll(adminOrgFilter ?? request.organizationId);
+        const orgScope = request.organizationId ?? request.query.organization_id;
+        const projects = await db.projects.findAll(orgScope);
         return sendSuccess(reply, projects);
       }
 

--- a/packages/backend/src/api/routes/projects.ts
+++ b/packages/backend/src/api/routes/projects.ts
@@ -83,15 +83,28 @@ export function projectRoutes(fastify: FastifyInstance, db: DatabaseClient) {
    * GET /api/v1/projects
    * Get all projects for the authenticated user
    */
-  fastify.get(
+  fastify.get<{ Querystring: { organization_id?: string } }>(
     '/api/v1/projects',
     {
       preHandler: [requireUser],
+      schema: {
+        querystring: {
+          type: 'object',
+          properties: {
+            organization_id: { type: 'string', format: 'uuid' },
+          },
+          additionalProperties: false,
+        },
+      },
     },
     async (request, reply) => {
-      // Platform admin users see all projects (scoped to org in SaaS mode)
+      // Platform admin users see all projects (scoped to org in SaaS mode).
+      // On the hub domain (no `request.organizationId`), they may pass
+      // `?organization_id=` to narrow the cross-org view to a single tenant.
+      // Param is consumed only inside this branch — regular users never reach it.
       if (isPlatformAdmin(request)) {
-        const projects = await db.projects.findAll(request.organizationId);
+        const adminOrgFilter = request.query.organization_id;
+        const projects = await db.projects.findAll(adminOrgFilter ?? request.organizationId);
         return sendSuccess(reply, projects);
       }
 

--- a/packages/backend/src/api/routes/reports.ts
+++ b/packages/backend/src/api/routes/reports.ts
@@ -313,7 +313,13 @@ export function bugReportRoutes(
       const createdAfterDate = parseDateFilter(created_after, 'created_after');
       const createdBeforeDate = parseDateFilter(created_before, 'created_before');
 
-      // Build access control filters based on authentication type
+      // Tenant subdomain context wins over the query param (matches
+      // the precedence applied in `projects.ts`, `api-keys.ts`, and
+      // `users.ts`): a platform admin on `acme.kz.bugspotter.io`
+      // cannot widen to a different org via the query string. The
+      // resulting `effectiveOrgId` is consumed by `buildAccessFilters`
+      // only inside its `isPlatformAdmin` branch.
+      const effectiveOrgId = request.organizationId ?? organization_id;
       const { filters, requiresValidation } = buildAccessFilters(
         request.authUser,
         request.authProject,
@@ -324,7 +330,7 @@ export function bugReportRoutes(
           created_after: createdAfterDate,
           created_before: createdBeforeDate,
         },
-        organization_id
+        effectiveOrgId
       );
 
       // Validate project access if required (regular user + specific project_id)

--- a/packages/backend/src/api/routes/reports.ts
+++ b/packages/backend/src/api/routes/reports.ts
@@ -302,6 +302,7 @@ export function bugReportRoutes(
         status,
         priority,
         project_id,
+        organization_id,
         created_after,
         created_before,
         sort_by,
@@ -322,7 +323,8 @@ export function bugReportRoutes(
           priority,
           created_after: createdAfterDate,
           created_before: createdBeforeDate,
-        }
+        },
+        organization_id
       );
 
       // Validate project access if required (regular user + specific project_id)

--- a/packages/backend/src/api/routes/users.ts
+++ b/packages/backend/src/api/routes/users.ts
@@ -45,12 +45,16 @@ export function userRoutes(fastify: FastifyInstance, userRepo: UserRepository) {
         organization_id?: string;
       };
 
+      // Tenant subdomain context wins over the query param (matches the
+      // precedence applied in `projects.ts`, `api-keys.ts`, and
+      // `reports.ts`): a platform admin on `acme.kz.bugspotter.io`
+      // cannot widen to a different org via the query string.
       const result = await userRepo.listWithFilters({
         page,
         limit,
         role,
         email,
-        organization_id,
+        organization_id: request.organizationId ?? organization_id,
       });
 
       return reply.send({

--- a/packages/backend/src/api/routes/users.ts
+++ b/packages/backend/src/api/routes/users.ts
@@ -36,14 +36,22 @@ export function userRoutes(fastify: FastifyInstance, userRepo: UserRepository) {
         limit = 20,
         role,
         email,
+        organization_id,
       } = request.query as {
         page?: number;
         limit?: number;
         role?: 'admin' | 'user' | 'viewer';
         email?: string;
+        organization_id?: string;
       };
 
-      const result = await userRepo.listWithFilters({ page, limit, role, email });
+      const result = await userRepo.listWithFilters({
+        page,
+        limit,
+        role,
+        email,
+        organization_id,
+      });
 
       return reply.send({
         success: true,

--- a/packages/backend/src/api/schemas/api-key-schema.ts
+++ b/packages/backend/src/api/schemas/api-key-schema.ts
@@ -234,6 +234,10 @@ export const listApiKeysSchema = {
       team_id: { type: 'string', format: 'uuid' },
       created_by: { type: 'string', format: 'uuid' },
       tag: { type: 'string', minLength: 1, maxLength: 50 },
+      // Cross-org filter for platform admin. Restricts to keys whose
+      // `allowed_projects` overlaps any project in the given org.
+      // Ignored for non-platform-admin callers.
+      organization_id: { type: 'string', format: 'uuid' },
       expires_before: { type: 'string', format: 'date-time' },
       expires_after: { type: 'string', format: 'date-time' },
       search: { type: 'string', minLength: 1, maxLength: 255 },

--- a/packages/backend/src/api/schemas/bug-report-schema.ts
+++ b/packages/backend/src/api/schemas/bug-report-schema.ts
@@ -124,6 +124,9 @@ export const listBugReportsSchema = {
       status: { type: 'string', enum: bugStatusEnum },
       priority: { type: 'string', enum: bugPriorityEnum },
       project_id: { type: 'string', format: 'uuid' },
+      // Cross-org filter for platform admin on the hub domain. Ignored
+      // for non-platform-admin callers (see `buildAccessFilters`).
+      organization_id: { type: 'string', format: 'uuid' },
       created_after: { type: 'string', format: 'date' },
       created_before: { type: 'string', format: 'date' },
       sort_by: {

--- a/packages/backend/src/api/schemas/project-schema.ts
+++ b/packages/backend/src/api/schemas/project-schema.ts
@@ -16,6 +16,21 @@ export const projectSchema = {
   },
 } as const;
 
+/**
+ * `GET /api/v1/projects` — querystring schema.
+ * Currently only carries the platform-admin cross-org filter; the route
+ * itself is open to all authenticated users (handler branches by role).
+ */
+export const listProjectsSchema = {
+  querystring: {
+    type: 'object',
+    properties: {
+      organization_id: { type: 'string', format: 'uuid' },
+    },
+    additionalProperties: false,
+  },
+} as const;
+
 export const createProjectSchema = {
   body: {
     type: 'object',

--- a/packages/backend/src/api/schemas/user-schema.ts
+++ b/packages/backend/src/api/schemas/user-schema.ts
@@ -13,6 +13,8 @@ export const listUsersSchema = {
       limit: { type: 'number', minimum: 1, maximum: 100 },
       role: { type: 'string', enum: ['admin', 'user', 'viewer'] },
       email: { type: 'string', maxLength: 255 },
+      // Filter to users who are members of a specific org (SaaS only).
+      organization_id: { type: 'string', format: 'uuid' },
     },
     additionalProperties: false,
   },

--- a/packages/backend/src/api/types/bug-report-types.ts
+++ b/packages/backend/src/api/types/bug-report-types.ts
@@ -94,6 +94,8 @@ export interface ListReportsQuery {
   status?: BugStatus;
   priority?: BugPriority;
   project_id?: string;
+  /** Cross-org filter; only consumed for platform admins (see `buildAccessFilters`). */
+  organization_id?: string;
   created_after?: string;
   created_before?: string;
   sort_by?: 'created_at' | 'updated_at' | 'priority';

--- a/packages/backend/src/api/utils/bug-report-access.ts
+++ b/packages/backend/src/api/utils/bug-report-access.ts
@@ -23,7 +23,7 @@ export interface AccessControlResult {
  * Returns filters and whether additional validation is needed.
  * This function implements the access control strategy:
  * - API key → direct project filter
- * - Admin user → optional project filter (sees all if not specified)
+ * - Admin user → optional project filter / organization filter (sees all if neither specified)
  * - Regular user with project_id → requires validation, then project filter
  * - Regular user without project_id → optimized user_id JOIN filter
  *
@@ -31,6 +31,7 @@ export interface AccessControlResult {
  * @param authProject - Authenticated project (API key)
  * @param requestedProjectId - Optional project_id from query params
  * @param additionalFilters - Additional filters (status, priority, dates, etc.)
+ * @param requestedOrganizationId - Optional organization_id from query params (platform admin only)
  * @returns Object with filters to apply and validation requirement flag
  * @throws AppError(401) if not authenticated
  */
@@ -38,7 +39,8 @@ export function buildAccessFilters(
   authUser: User | undefined,
   authProject: Project | undefined,
   requestedProjectId?: string,
-  additionalFilters?: Partial<BugReportFilters>
+  additionalFilters?: Partial<BugReportFilters>,
+  requestedOrganizationId?: string
 ): AccessControlResult {
   // API key authentication - restrict to authenticated project only
   if (authProject) {
@@ -53,11 +55,16 @@ export function buildAccessFilters(
     throw new AppError('Authentication required', 401, 'Unauthorized');
   }
 
-  // Platform admin - can see all projects or filter by specific project
+  // Platform admin - can see all projects or filter by specific project /
+  // organization. The `organization_id` filter is the cross-org-investigation
+  // hatch for the hub domain; only consumed in this branch so a regular user
+  // sending the param has it ignored entirely (see the regular-user branches
+  // below — neither reads `requestedOrganizationId`).
   if (isPlatformAdmin(authUser)) {
     return {
       filters: {
         ...(requestedProjectId && { project_id: requestedProjectId }),
+        ...(requestedOrganizationId && { organization_id: requestedOrganizationId }),
         ...additionalFilters,
       },
       requiresValidation: false,

--- a/packages/backend/src/db/repositories/api-key.repository.ts
+++ b/packages/backend/src/db/repositories/api-key.repository.ts
@@ -54,6 +54,7 @@ export class ApiKeyRepository extends BaseRepository<ApiKey, ApiKeyInsert, ApiKe
       team_id,
       created_by,
       accessible_by_user_id,
+      organization_id,
       tag,
       expires_before,
       expires_after,
@@ -86,6 +87,21 @@ export class ApiKeyRepository extends BaseRepository<ApiKey, ApiKeyInsert, ApiKe
       );
     } else if (created_by) {
       filter.equals('created_by', created_by);
+    }
+
+    // Cross-org filter for platform admin: keep only keys whose
+    // `allowed_projects` overlaps any project in the given org. Composes
+    // with the access filter above (an admin filtering their own org-scoped
+    // view would still get the AND).
+    if (organization_id) {
+      const p = filter.getParamCount();
+      filter.raw(
+        `EXISTS (
+          SELECT 1 FROM ${this.schema}.projects p
+          WHERE p.organization_id = $${p} AND p.id = ANY(allowed_projects)
+        )`,
+        [organization_id]
+      );
     }
 
     const { whereClause, values, paramCount } = filter.build();

--- a/packages/backend/src/db/repositories/api-key.repository.ts
+++ b/packages/backend/src/db/repositories/api-key.repository.ts
@@ -89,16 +89,23 @@ export class ApiKeyRepository extends BaseRepository<ApiKey, ApiKeyInsert, ApiKe
       filter.equals('created_by', created_by);
     }
 
-    // Cross-org filter for platform admin: keep only keys whose
-    // `allowed_projects` overlaps any project in the given org. Composes
-    // with the access filter above (an admin filtering their own org-scoped
-    // view would still get the AND).
+    // Cross-org filter for platform admin: keep only keys that can touch
+    // projects in the given org. Wildcard keys (`allowed_projects = NULL`,
+    // documented in `001_initial_schema.sql:1211` as "NULL = all projects")
+    // grant access to every project, so by definition they can touch this
+    // org's data and must be included in the filtered view.
+    // `p.id = ANY(NULL)` evaluates to NULL → not match, so we have to check
+    // the wildcard case explicitly. The `EXISTS` still requires the org to
+    // have at least one project — a wildcard key on an empty org returns
+    // empty, which matches the use case ("what keys can touch THIS org's
+    // data?" — none, because the org has no data yet).
     if (organization_id) {
       const p = filter.getParamCount();
       filter.raw(
         `EXISTS (
           SELECT 1 FROM ${this.schema}.projects p
-          WHERE p.organization_id = $${p} AND p.id = ANY(allowed_projects)
+          WHERE p.organization_id = $${p}
+            AND (allowed_projects IS NULL OR p.id = ANY(allowed_projects))
         )`,
         [organization_id]
       );

--- a/packages/backend/src/db/repositories/user.repository.ts
+++ b/packages/backend/src/db/repositories/user.repository.ts
@@ -135,11 +135,31 @@ export class UserRepository extends BaseRepository<User, UserInsert, Partial<Use
     limit?: number;
     role?: 'admin' | 'user' | 'viewer';
     email?: string;
+    /**
+     * Restrict to users who are members of the given organization
+     * (SaaS only — falls through to no-op in self-hosted where the
+     * `saas.organization_members` table is empty).
+     */
+    organization_id?: string;
   }): Promise<PaginatedResult<Omit<User, 'password_hash'>>> {
-    const { page = 1, limit = 20, role, email } = options;
+    const { page = 1, limit = 20, role, email, organization_id } = options;
 
     // Build WHERE clause using unified FilterBuilder
     const filter = createFilter().equals('role', role).ilike('email', email);
+
+    if (organization_id) {
+      // EXISTS keeps the JOIN out of the projection and avoids row-multiplication
+      // for users with multiple memberships to the same org (shouldn't happen,
+      // but the unique constraint isn't enforced in older deployments).
+      const p = filter.getParamCount();
+      filter.raw(
+        `EXISTS (
+          SELECT 1 FROM saas.organization_members om
+          WHERE om.user_id = users.id AND om.organization_id = $${p}
+        )`,
+        [organization_id]
+      );
+    }
 
     const { whereClause, values, paramCount } = filter.build();
 

--- a/packages/backend/src/db/repositories/user.repository.ts
+++ b/packages/backend/src/db/repositories/user.repository.ts
@@ -8,6 +8,7 @@ import type { User, UserInsert, PaginatedResult } from '../types.js';
 import { createFilter } from '../filter-builder.js';
 import { createPagination } from '../pagination-builder.js';
 import { getLogger } from '../../logger.js';
+import { getDeploymentConfig, DEPLOYMENT_MODE } from '../../saas/config.js';
 
 const logger = getLogger();
 
@@ -147,7 +148,12 @@ export class UserRepository extends BaseRepository<User, UserInsert, Partial<Use
     // Build WHERE clause using unified FilterBuilder
     const filter = createFilter().equals('role', role).ilike('email', email);
 
-    if (organization_id) {
+    // SaaS-only filter: `saas.organization_members` only exists in SaaS
+    // deployments. In self-hosted, the schema may not be present at all —
+    // applying this predicate would error with "schema saas does not exist"
+    // even though the route is gated to platform admins. Skip silently in
+    // self-hosted mode (no orgs to filter by anyway).
+    if (organization_id && getDeploymentConfig().mode === DEPLOYMENT_MODE.SAAS) {
       // EXISTS keeps the JOIN out of the projection and avoids row-multiplication
       // for users with multiple memberships to the same org (shouldn't happen,
       // but the unique constraint isn't enforced in older deployments).

--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -514,6 +514,13 @@ export interface ApiKeyFilters {
   created_by?: string;
   /** Show keys created by this user OR scoped to projects in their org */
   accessible_by_user_id?: string;
+  /**
+   * Restrict to keys whose `allowed_projects` overlaps any project in the
+   * given org. Used by platform admin's cross-org filter; trusted by the
+   * caller — the route handler is responsible for only setting this when
+   * `isPlatformAdmin`.
+   */
+  organization_id?: string;
   tag?: string;
   expires_before?: Date;
   expires_after?: Date;

--- a/packages/backend/tests/api/projects-saas.test.ts
+++ b/packages/backend/tests/api/projects-saas.test.ts
@@ -331,6 +331,47 @@ describe('Project Routes — SaaS Mode', () => {
       expect(orgIds).not.toContain(otherOrg.id);
     });
 
+    it('tenant subdomain context wins over query param (admin cannot widen via ?organization_id=)', async () => {
+      // Set up a second org with its own project.
+      const ts = Date.now();
+      const otherOrg = await db.organizations.create({
+        name: `Precedence Other ${ts}`,
+        subdomain: `precedence-${ts}`,
+        subscription_status: 'trial',
+      });
+      const now = new Date();
+      await db.subscriptions.create({
+        organization_id: otherOrg.id,
+        plan_name: 'starter',
+        status: 'trial',
+        current_period_start: now,
+        current_period_end: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+        quotas: { max_projects: 10, max_bug_reports: 1000, max_storage_mb: 500 },
+      });
+
+      await db.projects.create({ name: 'In test org', organization_id: orgId });
+      await db.projects.create({ name: 'In other org', organization_id: otherOrg.id });
+
+      // Hit the test org's subdomain BUT pass `?organization_id=` pointing at
+      // the other org. The subdomain context should win, so we should see
+      // ONLY test-org's projects.
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/projects?organization_id=${otherOrg.id}`,
+        headers: {
+          authorization: `Bearer ${adminToken}`,
+          host: `${orgSubdomain}.example.com`,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const orgIds: string[] = response
+        .json()
+        .data.map((p: { organization_id: string }) => p.organization_id);
+      expect(orgIds).toContain(orgId);
+      expect(orgIds).not.toContain(otherOrg.id);
+    });
+
     it('rejects malformed organization_id query param', async () => {
       const response = await server.inject({
         method: 'GET',
@@ -368,6 +409,7 @@ describe('Project Routes — SaaS Mode', () => {
         url: '/api/v1/auth/login',
         payload: { email: memberEmail, password: 'Password123!' },
       });
+      expect(loginRes.statusCode).toBe(200);
       const token = loginRes.json().data.access_token as string;
 
       // Pass `?organization_id=` pointing at the OTHER org. A platform admin

--- a/packages/backend/tests/api/projects-saas.test.ts
+++ b/packages/backend/tests/api/projects-saas.test.ts
@@ -295,5 +295,97 @@ describe('Project Routes — SaaS Mode', () => {
       expect(json.success).toBe(true);
       expect(Array.isArray(json.data)).toBe(true);
     });
+
+    it('platform admin filters by organization_id query param on hub domain', async () => {
+      // Create a second org with one project so we can prove the filter narrows.
+      const otherOrg = await db.organizations.create({
+        name: `Other Org ${Date.now()}`,
+        subdomain: `otherorg-${Date.now()}`,
+        subscription_status: 'trial',
+      });
+      const now = new Date();
+      await db.subscriptions.create({
+        organization_id: otherOrg.id,
+        plan_name: 'starter',
+        status: 'trial',
+        current_period_start: now,
+        current_period_end: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+        quotas: { max_projects: 10, max_bug_reports: 1000, max_storage_mb: 500 },
+      });
+
+      await db.projects.create({ name: 'In Test Org', organization_id: orgId });
+      await db.projects.create({ name: 'In Other Org', organization_id: otherOrg.id });
+
+      // Hub domain, filter to first org
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/projects?organization_id=${orgId}`,
+        headers: { authorization: `Bearer ${adminToken}`, host: 'example.com' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      const orgIds: string[] = json.data.map((p: { organization_id: string }) => p.organization_id);
+      expect(orgIds.every((id) => id === orgId)).toBe(true);
+      expect(orgIds).toContain(orgId);
+      expect(orgIds).not.toContain(otherOrg.id);
+    });
+
+    it('rejects malformed organization_id query param', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/projects?organization_id=not-a-uuid',
+        headers: { authorization: `Bearer ${adminToken}`, host: 'example.com' },
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('non-admin user has organization_id query param ignored (still scoped to their access)', async () => {
+      // Create a regular (non-platform-admin) user, member of test org only
+      const timestamp = Date.now();
+      const memberEmail = `regular-${timestamp}@example.com`;
+      const passwordHash = await bcrypt.hash('Password123!', 10);
+      const memberUser = await db.users.create({
+        email: memberEmail,
+        name: 'Regular Member',
+        password_hash: passwordHash,
+        role: 'user', // app-level role, NOT platform admin
+        email_verified_at: new Date(),
+      });
+      await db.organizationMembers.createWithUser(orgId, memberUser.id, 'member');
+
+      // Project in test org (member should see it) + project in OTHER org (member must NOT)
+      const otherOrg = await db.organizations.create({
+        name: `Other Org ${timestamp}`,
+        subdomain: `otherorg2-${timestamp}`,
+        subscription_status: 'trial',
+      });
+      await db.projects.create({ name: 'Member-org project', organization_id: orgId });
+      await db.projects.create({ name: 'Other-org project', organization_id: otherOrg.id });
+
+      const loginRes = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: memberEmail, password: 'Password123!' },
+      });
+      const token = loginRes.json().data.access_token as string;
+
+      // Pass `?organization_id=` pointing at the OTHER org. A platform admin
+      // would get the other-org's projects; a regular user should still only
+      // see their own org's, because the param is consumed inside the
+      // platform-admin branch only.
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/projects?organization_id=${otherOrg.id}`,
+        headers: { authorization: `Bearer ${token}`, host: 'example.com' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const orgIds: string[] = response
+        .json()
+        .data.map((p: { organization_id: string }) => p.organization_id);
+      // Filter ignored: caller never sees the other org's data.
+      expect(orgIds).not.toContain(otherOrg.id);
+    });
   });
 });

--- a/packages/backend/tests/api/projects-saas.test.ts
+++ b/packages/backend/tests/api/projects-saas.test.ts
@@ -430,4 +430,142 @@ describe('Project Routes — SaaS Mode', () => {
       expect(orgIds).not.toContain(otherOrg.id);
     });
   });
+
+  // Tenant-subdomain precedence over the cross-org query param applies to
+  // all four list endpoints, not just projects. The original commit
+  // (8652bfb) only fixed projects.ts and only tested projects; these
+  // tests pin the same invariant on the other three so a future regression
+  // on any one of them surfaces here.
+  describe('Tenant subdomain precedence across all 4 admin list endpoints', () => {
+    it('GET /api/v1/api-keys — subdomain wins over ?organization_id=', async () => {
+      const ts = Date.now();
+      const otherOrg = await db.organizations.create({
+        name: `Precedence ApiKeys ${ts}`,
+        subdomain: `precedence-ak-${ts}`,
+        subscription_status: 'active',
+      });
+      const projectInTest = await db.projects.create({
+        name: `Test Org Project ${ts}`,
+        organization_id: orgId,
+      });
+      const projectInOther = await db.projects.create({
+        name: `Other Org Project ${ts}`,
+        organization_id: otherOrg.id,
+      });
+
+      // One API key per org, scoped via allowed_projects
+      const testOrgKey = await db.apiKeys.create({
+        key_hash: `hash-test-${ts}`,
+        key_prefix: 'bgs_test',
+        key_suffix: '0001',
+        name: `Test-org key ${ts}`,
+        allowed_projects: [projectInTest.id],
+      });
+      const otherOrgKey = await db.apiKeys.create({
+        key_hash: `hash-other-${ts}`,
+        key_prefix: 'bgs_othr',
+        key_suffix: '0002',
+        name: `Other-org key ${ts}`,
+        allowed_projects: [projectInOther.id],
+      });
+
+      // Hit test-org subdomain, query points at the other org. Subdomain wins.
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/api-keys?organization_id=${otherOrg.id}`,
+        headers: { authorization: `Bearer ${adminToken}`, host: `${orgSubdomain}.example.com` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const ids: string[] = response.json().data.map((k: { id: string }) => k.id);
+      expect(ids).toContain(testOrgKey.id);
+      expect(ids).not.toContain(otherOrgKey.id);
+    });
+
+    it('GET /api/v1/admin/users — ?organization_id= narrows the list (precedence n/a — route is tenant-exempt)', async () => {
+      // `/api/v1/admin/*` is in `TENANT_EXEMPT_PREFIXES` (see
+      // `tenant.ts:48-52`), which means tenant-resolution middleware
+      // deliberately does NOT set `request.organizationId` on this
+      // route — admin endpoints are global-admin, independently
+      // access-controlled. The `request.organizationId ?? query` guard
+      // in the handler is therefore a defensive no-op on this route
+      // (kept for consistency with the other three endpoints), and
+      // there is no "subdomain wins" semantics to assert. What we CAN
+      // pin is the positive filter behaviour: `?organization_id=` does
+      // narrow the list to that org's members.
+      const ts = Date.now();
+      const otherOrg = await db.organizations.create({
+        name: `Filter Users ${ts}`,
+        subdomain: `filter-u-${ts}`,
+        subscription_status: 'active',
+      });
+
+      const testOrgUser = await db.users.create({
+        email: `filter-test-${ts}@example.com`,
+        name: 'Test Org Member',
+        password_hash: 'hash',
+        role: 'user',
+      });
+      await db.organizationMembers.createWithUser(orgId, testOrgUser.id, 'member');
+      const otherOrgUser = await db.users.create({
+        email: `filter-other-${ts}@example.com`,
+        name: 'Other Org Member',
+        password_hash: 'hash',
+        role: 'user',
+      });
+      await db.organizationMembers.createWithUser(otherOrg.id, otherOrgUser.id, 'member');
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/admin/users?organization_id=${otherOrg.id}`,
+        headers: { authorization: `Bearer ${adminToken}`, host: 'example.com' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const userEmails: string[] = response
+        .json()
+        .data.users.map((u: { email: string }) => u.email);
+      expect(userEmails).toContain(otherOrgUser.email);
+      expect(userEmails).not.toContain(testOrgUser.email);
+    });
+
+    it('GET /api/v1/reports — subdomain wins over ?organization_id=', async () => {
+      const ts = Date.now();
+      const otherOrg = await db.organizations.create({
+        name: `Precedence Reports ${ts}`,
+        subdomain: `precedence-r-${ts}`,
+        subscription_status: 'active',
+      });
+      const projectInTest = await db.projects.create({
+        name: `Test Reports Proj ${ts}`,
+        organization_id: orgId,
+      });
+      const projectInOther = await db.projects.create({
+        name: `Other Reports Proj ${ts}`,
+        organization_id: otherOrg.id,
+      });
+
+      const testOrgReport = await db.bugReports.create({
+        project_id: projectInTest.id,
+        organization_id: orgId,
+        title: 'In test org',
+      });
+      const otherOrgReport = await db.bugReports.create({
+        project_id: projectInOther.id,
+        organization_id: otherOrg.id,
+        title: 'In other org',
+      });
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/reports?organization_id=${otherOrg.id}`,
+        headers: { authorization: `Bearer ${adminToken}`, host: `${orgSubdomain}.example.com` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const ids: string[] = response.json().data.map((r: { id: string }) => r.id);
+      expect(ids).toContain(testOrgReport.id);
+      expect(ids).not.toContain(otherOrgReport.id);
+    });
+  });
 });

--- a/packages/backend/tests/api/utils/bug-report-access.test.ts
+++ b/packages/backend/tests/api/utils/bug-report-access.test.ts
@@ -105,6 +105,31 @@ describe('buildAccessFilters', () => {
       });
     });
 
+    it('should filter by organization_id when admin requests it (cross-org filter)', () => {
+      const result = buildAccessFilters(
+        mockAdmin,
+        undefined,
+        undefined,
+        { status: 'open' },
+        'org-123'
+      );
+
+      expect(result).toEqual({
+        filters: {
+          organization_id: 'org-123',
+          status: 'open',
+        },
+        requiresValidation: false,
+      });
+    });
+
+    it('should compose project_id + organization_id when admin sets both', () => {
+      const result = buildAccessFilters(mockAdmin, undefined, 'proj-abc', undefined, 'org-123');
+
+      expect(result.filters.project_id).toBe('proj-abc');
+      expect(result.filters.organization_id).toBe('org-123');
+    });
+
     it('should work with date filters', () => {
       const createdAfter = new Date('2024-01-01');
       const createdBefore = new Date('2024-12-31');
@@ -116,6 +141,32 @@ describe('buildAccessFilters', () => {
 
       expect(result.filters.created_after).toBe(createdAfter);
       expect(result.filters.created_before).toBe(createdBefore);
+    });
+  });
+
+  describe('Regular user passing organization_id (security boundary)', () => {
+    it('ignores organization_id from a regular user with no project_id (falls through to user_id JOIN)', () => {
+      const result = buildAccessFilters(
+        mockUser,
+        undefined,
+        undefined,
+        { status: 'open' },
+        'org-evil'
+      );
+
+      // The org filter is consumed only inside the platform-admin branch.
+      // A regular user passing it must NOT have it applied — that would let
+      // them probe / enumerate other tenants' data.
+      expect(result.filters).not.toHaveProperty('organization_id');
+      expect(result.filters.user_id).toBe(mockUser.id);
+    });
+
+    it('ignores organization_id from a regular user with project_id (falls through to validated project filter)', () => {
+      const result = buildAccessFilters(mockUser, undefined, 'proj-456', undefined, 'org-evil');
+
+      expect(result.filters).not.toHaveProperty('organization_id');
+      expect(result.filters.project_id).toBe('proj-456');
+      expect(result.requiresValidation).toBe(true);
     });
   });
 

--- a/packages/backend/tests/db/api-key-repository.test.ts
+++ b/packages/backend/tests/db/api-key-repository.test.ts
@@ -16,7 +16,7 @@ describe('ApiKeyRepository', () => {
   let testUser: User;
   let testProject1: Project;
   let testProject2: Project;
-  let createdApiKeys: string[] = [];
+  const createdApiKeys: string[] = [];
 
   beforeAll(async () => {
     db = DatabaseClient.create({
@@ -52,15 +52,21 @@ describe('ApiKeyRepository', () => {
     for (const id of createdApiKeys) {
       try {
         await db.apiKeys.delete(id);
-      } catch (error) {
+      } catch {
         // Ignore errors during cleanup
       }
     }
 
     // Cleanup test data
-    if (testProject1?.id) await db.projects.delete(testProject1.id);
-    if (testProject2?.id) await db.projects.delete(testProject2.id);
-    if (testUser?.id) await db.users.delete(testUser.id);
+    if (testProject1?.id) {
+      await db.projects.delete(testProject1.id);
+    }
+    if (testProject2?.id) {
+      await db.projects.delete(testProject2.id);
+    }
+    if (testUser?.id) {
+      await db.users.delete(testUser.id);
+    }
 
     await db.close();
   });
@@ -304,6 +310,99 @@ describe('ApiKeyRepository', () => {
       if (page1.data.length > 0 && page2.data.length > 0) {
         expect(page1.data[0].id).not.toBe(page2.data[0].id);
       }
+    });
+  });
+
+  describe('organization_id filter', () => {
+    // The cross-org filter is what the platform-admin sidebar widget
+    // ultimately passes to this method. The risk surface is exactly the
+    // wildcard-key case claude flagged on PR #115: a key with
+    // `allowed_projects = NULL` grants access to every project, so it
+    // can touch the filtered org's data and must appear in the result —
+    // but `p.id = ANY(NULL)` evaluates to NULL, not match.
+
+    let orgScopedKeyId: string;
+    let otherOrgKeyId: string;
+    let wildcardKeyId: string;
+    let orgWithProject: { id: string };
+    let projectInOrg: { id: string };
+    let otherOrg: { id: string };
+    let projectInOtherOrg: { id: string };
+
+    beforeEach(async () => {
+      const ts = Date.now();
+
+      // Two orgs, each with one project. Wildcard key via NULL allowed_projects.
+      orgWithProject = await db.organizations.create({
+        name: `KeyFilter Org A ${ts}`,
+        subdomain: `keyfilter-a-${ts}`,
+        subscription_status: 'active',
+      });
+      otherOrg = await db.organizations.create({
+        name: `KeyFilter Org B ${ts}`,
+        subdomain: `keyfilter-b-${ts}`,
+        subscription_status: 'active',
+      });
+      projectInOrg = await db.projects.create({
+        name: `Proj in A ${ts}`,
+        created_by: testUser.id,
+        organization_id: orgWithProject.id,
+      });
+      projectInOtherOrg = await db.projects.create({
+        name: `Proj in B ${ts}`,
+        created_by: testUser.id,
+        organization_id: otherOrg.id,
+      });
+
+      const orgScoped = await db.apiKeys.create(
+        createTestApiKey(`Org-A-scoped ${ts}`, { allowed_projects: [projectInOrg.id] })
+      );
+      const otherScoped = await db.apiKeys.create(
+        createTestApiKey(`Org-B-scoped ${ts}`, { allowed_projects: [projectInOtherOrg.id] })
+      );
+      const wildcard = await db.apiKeys.create(
+        createTestApiKey(`Wildcard ${ts}`, { allowed_projects: null })
+      );
+
+      orgScopedKeyId = orgScoped.id;
+      otherOrgKeyId = otherScoped.id;
+      wildcardKeyId = wildcard.id;
+      createdApiKeys.push(orgScopedKeyId, otherOrgKeyId, wildcardKeyId);
+    });
+
+    it('returns keys whose allowed_projects overlaps the filtered org', async () => {
+      const result = await db.apiKeys.list({ organization_id: orgWithProject.id });
+      const ids = result.data.map((k) => k.id);
+
+      expect(ids).toContain(orgScopedKeyId);
+      expect(ids).not.toContain(otherOrgKeyId);
+    });
+
+    it('includes wildcard keys (allowed_projects = NULL) — they grant access to every project', async () => {
+      const result = await db.apiKeys.list({ organization_id: orgWithProject.id });
+      const ids = result.data.map((k) => k.id);
+
+      // Bug claude flagged: `p.id = ANY(NULL)` evaluates to NULL, so without
+      // the explicit `allowed_projects IS NULL` branch in the EXISTS clause,
+      // wildcard keys would be silently excluded from the filtered view.
+      expect(ids).toContain(wildcardKeyId);
+    });
+
+    it('returns no keys when filtering on an org with no projects', async () => {
+      const ts = Date.now();
+      const emptyOrg = await db.organizations.create({
+        name: `Empty Org ${ts}`,
+        subdomain: `empty-org-${ts}`,
+        subscription_status: 'active',
+      });
+
+      const result = await db.apiKeys.list({ organization_id: emptyOrg.id });
+      // Wildcard keys grant access to every project, but if the org has zero
+      // projects there's nothing to grant access TO. Empty result is correct.
+      const ids = result.data.map((k) => k.id);
+      expect(ids).not.toContain(orgScopedKeyId);
+      expect(ids).not.toContain(otherOrgKeyId);
+      expect(ids).not.toContain(wildcardKeyId);
     });
   });
 

--- a/packages/backend/tests/db/api-key-repository.test.ts
+++ b/packages/backend/tests/db/api-key-repository.test.ts
@@ -3,7 +3,7 @@
  * Comprehensive tests for API key management operations
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { DatabaseClient } from '../../src/db/client.js';
 import { createHash } from 'crypto';
 import type { ApiKey, User, Project } from '../../src/db/types.js';
@@ -328,6 +328,11 @@ describe('ApiKeyRepository', () => {
     let projectInOrg: { id: string };
     let otherOrg: { id: string };
     let projectInOtherOrg: { id: string };
+    // Track per-test-created fixtures so the suite can clean them up;
+    // emptyOrg is created inside one test but pushed onto the same list
+    // so the teardown sweeps it too.
+    const createdOrgIds: string[] = [];
+    const createdProjectIds: string[] = [];
 
     beforeEach(async () => {
       const ts = Date.now();
@@ -343,6 +348,7 @@ describe('ApiKeyRepository', () => {
         subdomain: `keyfilter-b-${ts}`,
         subscription_status: 'active',
       });
+      createdOrgIds.push(orgWithProject.id, otherOrg.id);
       projectInOrg = await db.projects.create({
         name: `Proj in A ${ts}`,
         created_by: testUser.id,
@@ -353,6 +359,7 @@ describe('ApiKeyRepository', () => {
         created_by: testUser.id,
         organization_id: otherOrg.id,
       });
+      createdProjectIds.push(projectInOrg.id, projectInOtherOrg.id);
 
       const orgScoped = await db.apiKeys.create(
         createTestApiKey(`Org-A-scoped ${ts}`, { allowed_projects: [projectInOrg.id] })
@@ -395,6 +402,7 @@ describe('ApiKeyRepository', () => {
         subdomain: `empty-org-${ts}`,
         subscription_status: 'active',
       });
+      createdOrgIds.push(emptyOrg.id);
 
       const result = await db.apiKeys.list({ organization_id: emptyOrg.id });
       // Wildcard keys grant access to every project, but if the org has zero
@@ -403,6 +411,20 @@ describe('ApiKeyRepository', () => {
       expect(ids).not.toContain(orgScopedKeyId);
       expect(ids).not.toContain(otherOrgKeyId);
       expect(ids).not.toContain(wildcardKeyId);
+    });
+
+    afterEach(async () => {
+      // Children first (projects FK org); both lists drained.
+      for (const id of createdProjectIds.splice(0)) {
+        await db.projects.delete(id).catch(() => {
+          /* swallow — best-effort cleanup */
+        });
+      }
+      for (const id of createdOrgIds.splice(0)) {
+        await db.organizations.delete(id).catch(() => {
+          /* swallow */
+        });
+      }
     });
   });
 

--- a/packages/backend/tests/db/user-repository-org-filter.test.ts
+++ b/packages/backend/tests/db/user-repository-org-filter.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the SaaS-mode gate on `UserRepository.listWithFilters`.
+ *
+ * The `organization_id` filter references `saas.organization_members`,
+ * which only exists in SaaS deployments. In self-hosted mode the schema
+ * may not be present at all — applying the predicate would error with
+ * "schema saas does not exist" even though the route is gated to
+ * platform admins. These tests pin that the predicate is silently
+ * skipped in self-hosted mode and present in SaaS mode.
+ *
+ * The pool's `query` is intercepted to return canned counts and inspect
+ * the SQL that the repository emits — no DB connection required.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { UserRepository } from '../../src/db/repositories/user.repository.js';
+import { resetDeploymentConfig } from '../../src/saas/config.js';
+
+function makeFakePool(captured: string[]): Pool {
+  return {
+    query: vi.fn(async (sql: string) => {
+      captured.push(sql);
+      // Count query comes first; data query comes second. Either way return
+      // an empty rowset — we only care about the SQL shape, not the data.
+      if (sql.toUpperCase().includes('COUNT')) {
+        return { rows: [{ total: '0' }] };
+      }
+      return { rows: [] };
+    }),
+  } as unknown as Pool;
+}
+
+describe('UserRepository.listWithFilters — organization_id SaaS gate', () => {
+  const originalMode = process.env.DEPLOYMENT_MODE;
+
+  afterEach(() => {
+    if (originalMode === undefined) {
+      delete process.env.DEPLOYMENT_MODE;
+    } else {
+      process.env.DEPLOYMENT_MODE = originalMode;
+    }
+    resetDeploymentConfig();
+  });
+
+  beforeEach(() => {
+    // Force a re-read of DEPLOYMENT_MODE on each test.
+    resetDeploymentConfig();
+  });
+
+  it('emits the saas.organization_members predicate in SaaS mode', async () => {
+    process.env.DEPLOYMENT_MODE = 'saas';
+    resetDeploymentConfig();
+
+    const captured: string[] = [];
+    const repo = new UserRepository(makeFakePool(captured));
+
+    await repo.listWithFilters({ organization_id: '00000000-0000-0000-0000-000000000001' });
+
+    const sql = captured.join('\n');
+    expect(sql).toMatch(/saas\.organization_members/);
+    expect(sql).toMatch(/EXISTS/);
+  });
+
+  it('omits the saas.organization_members predicate in self-hosted mode', async () => {
+    process.env.DEPLOYMENT_MODE = 'selfhosted';
+    resetDeploymentConfig();
+
+    const captured: string[] = [];
+    const repo = new UserRepository(makeFakePool(captured));
+
+    await repo.listWithFilters({ organization_id: '00000000-0000-0000-0000-000000000001' });
+
+    const sql = captured.join('\n');
+    // Self-hosted mode may not even have the `saas` schema; the predicate
+    // would error if applied.
+    expect(sql).not.toMatch(/saas\.organization_members/);
+  });
+
+  it('does not emit the predicate when organization_id is not set, regardless of mode', async () => {
+    process.env.DEPLOYMENT_MODE = 'saas';
+    resetDeploymentConfig();
+
+    const captured: string[] = [];
+    const repo = new UserRepository(makeFakePool(captured));
+
+    await repo.listWithFilters({ role: 'admin' });
+
+    const sql = captured.join('\n');
+    expect(sql).not.toMatch(/saas\.organization_members/);
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       'tests/db/base-repository-validation.test.ts',
       'tests/db/base-repository-date-filter.test.ts',
       'tests/db/retry.test.ts',
+      'tests/db/user-repository-org-filter.test.ts',
       // Jira config tests (pure unit, mocked repository)
       'tests/integrations/jira/config.test.ts',
       // Jira mapper tests (pure unit, no database)


### PR DESCRIPTION
## Summary

Platform admin on the hub domain (no tenant subdomain) currently sees a global cross-org firehose on Projects, API Keys, Users, and Bug Reports. Add an `?organization_id=X` query filter so the cross-org view can be narrowed without leaving the hub. First half of the org-filter feature; PR B (frontend sidebar widget consuming this) follows.

## Endpoints

| Endpoint | What changed |
|---|---|
| `GET /api/v1/projects` | Schema accepts `organization_id`. Handler reads it inside the existing `if (isPlatformAdmin)` branch — falls back to `request.organizationId` (subdomain) when absent. |
| `GET /api/v1/reports` | Schema accepts `organization_id`. `buildAccessFilters` gains an optional `requestedOrganizationId` param consumed only in the platform-admin branch. Repo already had `organization_id` on `BugReportFilters` (db/types.ts:561). |
| `GET /api/v1/api-keys` | Schema + `ApiKeyFilters` + repo gain `organization_id`. Repo applies `EXISTS (SELECT 1 FROM projects WHERE organization_id=$X AND id = ANY(allowed_projects))`. Set only inside the platform-admin branch in the handler. |
| `GET /api/v1/admin/users` | Schema + `listWithFilters` gain `organization_id`. Repo applies `EXISTS (SELECT 1 FROM saas.organization_members WHERE user_id = users.id AND organization_id = $X)`. Endpoint is already `requirePlatformAdmin`-gated. |

## Security boundary

In every endpoint the param is consumed only inside the `isPlatformAdmin` branch. A regular user passing `?organization_id=X` has it ignored entirely — no path reads it before the access-control filter is applied. Schemas validate `format=uuid` so malformed input returns 400 before the handler runs.

The boundary is unit-tested via `buildAccessFilters`:
- Admin filters by org → org_id in filters
- Admin composes project_id + organization_id → both present
- **Regular user with project_id + org_id** → org_id stripped, falls through to validated project filter
- **Regular user without project_id + org_id** → org_id stripped, falls through to user_id JOIN

## Test plan

- [x] Backend typecheck clean
- [x] Backend unit suite (2399 tests) — no regressions
- [x] `bug-report-access.test.ts` — 20/20 (was 16, +4 covering org filter + security boundary)
- [x] `projects-saas.test.ts` — 11/11 (was 8, +3 covering admin filter narrows, malformed UUID → 400, regular user passing param sees only their own org)
- [ ] Repo-level tests for users + api-keys org filter — **not added.** The pattern is identical to the projects + bug-reports tests above and the repo implementations are mechanical (single EXISTS clause each). Worth a follow-up if regression hits.
- [ ] Reviewer: confirm the security boundary by reading the handlers — the param is only ever read inside `isPlatformAdmin` branches.

## Follow-up

PR B (frontend) introduces the sidebar org-filter widget for platform admin and wires the 4 list pages to pass the param via `useSearchParams`. Depends on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform admins can optionally filter API key, project, report, and user listings by organization; tenant/subdomain context overrides the query param and non-admin users are unaffected. Malformed organization IDs return HTTP 400.

* **Tests**
  * Added coverage for org-filtering behavior, tenant-subdomain precedence, validation, and access-control boundaries across the relevant list endpoints and repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->