### PR TITLE
chore(ci): @claude-triggered reviews always post a top-level acknowledgement

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -123,6 +123,14 @@ jobs:
           # `-X POST/PATCH/DELETE` so the wildcard would let Claude
           # mutate any GitHub resource the workflow's GITHUB_TOKEN can
           # touch).
+          # Note on the `${{ ... && ... || '' }}` expression below: GitHub
+          # Actions treats empty strings as falsy, so the common
+          # `cond && truthyA || B` ternary trick only works when `A` is
+          # truthy. Writing `cond == 'pull_request' && '' || ',Bash(...)'`
+          # would return the fallback even when the condition is true
+          # (`'' || ',Bash(...)'` evaluates to the fallback). Keep the
+          # expression in this form: condition true → non-empty branch
+          # appended; condition false → `''` as the fallback.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob${{ github.event_name == 'pull_request' && '' || ',Bash(gh pr comment:*)' }}"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob${{ github.event_name != 'pull_request' && ',Bash(gh pr comment:*)' || '' }}"
             --max-turns 25

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -86,8 +86,9 @@ jobs:
             - Missing tests for new behavior
             - Concrete bugs at file:line — name the failure mode
 
-            Skip nits, style, theoretical issues. If nothing substantive, exit silently.
-            Inline comments only — no top-level summary.
+            Skip nits, style, theoretical issues.
+
+            ${{ github.event_name == 'pull_request' && 'Output rules: inline comments only — no top-level summary. If nothing substantive, exit silently (this is an automatic per-push review; silence is the right default).' || 'Output rules: this review was triggered explicitly by a human via @claude — they need to know the action ran and what you concluded. Post inline comments for any real-impact issues you find, then ALWAYS post exactly ONE short top-level comment via `gh pr comment` summarising the outcome (e.g. "Reviewed N files; no real-impact issues found." or "Posted N inline comments — see threads above."). Never exit silently on a human-triggered review.' }}
 
             Process: read the full diff in one `gh pr diff` call. Use `Grep`
             across the working tree only when a comment would otherwise be
@@ -108,14 +109,20 @@ jobs:
           # already checked out for `pull_request` events; `gh pr
           # checkout` runs above for comment events).
           #
-          # We deliberately do NOT allow `gh pr comment` (would enable
-          # top-level summaries we've explicitly disabled in the prompt)
-          # or `gh api:*` (supports `-X POST/PATCH/DELETE` so the
-          # wildcard would let Claude mutate any GitHub resource the
-          # workflow's GITHUB_TOKEN can touch — including posting
-          # top-level PR comments via
-          # `gh api repos/.../issues/.../comments`, defeating the same
-          # constraint).
+          # `gh pr comment` is conditionally allow-listed ONLY for
+          # comment-triggered (`@claude`) runs. Per-push auto-runs
+          # remain inline-only — silent-exit is the right default for
+          # routine pushes. Human-triggered runs need a visible
+          # acknowledgement that the action ran and what it concluded;
+          # the prompt above mandates exactly one top-level comment in
+          # that path. The `gh pr comment` blast radius is bounded to
+          # the PR's own discussion thread (the GITHUB_TOKEN can't
+          # touch other resources via this subcommand).
+          #
+          # We still deliberately do NOT allow `gh api:*` (supports
+          # `-X POST/PATCH/DELETE` so the wildcard would let Claude
+          # mutate any GitHub resource the workflow's GITHUB_TOKEN can
+          # touch).
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob${{ github.event_name == 'pull_request' && '' || ',Bash(gh pr comment:*)' }}"
             --max-turns 25


### PR DESCRIPTION
## Summary

Branch the Claude Review action's behaviour on the trigger type so:

- **Auto-runs** (`pull_request`) keep the silent-exit-when-nothing-substantive rule. No top-level summary; inline comments only. The "no marketing-summary spam on every push" intent is preserved.
- **Human-triggered runs** (`issue_comment` / `pull_request_review_comment` containing `@claude`) always post exactly one short top-level acknowledgement via `gh pr comment` — the requester needs to know the action ran and what it concluded.

## Why

On PR #115 a user typed `@claude review PR` and got 27 turns + ~$1.50 of compute, then the action exited silently because the prompt's "exit silently if nothing substantive" rule didn't differentiate trigger types. Silent is right for routine push reviews; for an explicit ping, it's just confusing and wasteful.

## Changes

- Prompt: conditional output-rules paragraph driven by `${{ github.event_name == 'pull_request' && ... || ... }}`. Auto-runs get "exit silently"; human-triggered runs get "always post one top-level summary".
- `--allowedTools`: append `,Bash(gh pr comment:*)` only on the human-triggered path. The standing ban on `gh api:*` (which would allow arbitrary GITHUB_TOKEN mutations) stays.
- Comment block above `claude_args` updated to document the new model.

## Test plan

- [x] `actionlint .github/workflows/claude-review.yml` passes
- [ ] Reviewer: trigger `@claude review PR` on this PR after merge — expect a one-line top-level acknowledgement back
- [ ] Reviewer: confirm the next pushed-commit auto-review still runs silently when there's nothing substantive

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow to vary behavior by trigger: automated PR runs produce inline comments and remain silent when no substantive issues are found.
  * Manual, comment-triggered reviews now post inline comments for real-impact issues and always add a single short top-level summary comment; action permissions adjusted accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->