### PR TITLE
chore(ci): cut Claude review cost ~12x — drop per-push trigger, ignore docs, Haiku on auto-runs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -161,4 +161,4 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob${{ github.event_name != 'pull_request' && ',Bash(gh pr comment:*)' || '' }}"
             --max-turns 25
-            --model ${{ github.event_name == 'pull_request' && 'claude-haiku-4-5' || 'claude-opus-4-7' }}
+            --model ${{ github.event_name == 'pull_request' && 'claude-haiku-4-5-20251001' || 'claude-opus-4-7' }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,8 +5,27 @@ name: Claude PR Review
 # workflow; failures here don't gate merges.
 
 on:
+  # Auto-review the PR ONCE on open / ready-for-review / reopen.
+  # `synchronize` (per-push) is intentionally excluded — the previous
+  # configuration was firing a fresh review on every commit pushed to
+  # an open PR, which dominated the action's spend (~$15/day at peak).
+  # Reviews on a stale revision aren't useful anyway; if a PR moves
+  # significantly during review, the requester can re-run via
+  # `@claude review PR` (handled below) and that path is rate-limited
+  # by being human-driven.
+  #
+  # `paths-ignore` skips reviews on changes that don't benefit from
+  # one: documentation, workflow YAML (the action's own validation
+  # guardrail rejects modified workflows from PR branches anyway),
+  # marketing HTML, etc.
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
+      - '*.html'
+      - 'apps/**/*.html'
   # @claude mentions in PR comments and review threads. The `if:` guard
   # below keeps the workflow from running on issue-comments outside of
   # PRs and on comments that don't address Claude.
@@ -131,6 +150,15 @@ jobs:
           # (`'' || ',Bash(...)'` evaluates to the fallback). Keep the
           # expression in this form: condition true → non-empty branch
           # appended; condition false → `''` as the fallback.
+          #
+          # Model selection: Haiku for auto-runs (per-PR sanity check,
+          # cheap), Opus for human-triggered `@claude review` pings
+          # (deeper read on demand). Haiku is roughly 1/12 the cost of
+          # Opus per token and finishes well inside the 25-turn budget
+          # for typical diffs. Both branches of this conditional are
+          # non-empty model ids, so the `&& A || B` ternary is safe
+          # here (unlike the allowedTools line above).
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob${{ github.event_name != 'pull_request' && ',Bash(gh pr comment:*)' || '' }}"
             --max-turns 25
+            --model ${{ github.event_name == 'pull_request' && 'claude-haiku-4-5' || 'claude-opus-4-7' }}


### PR DESCRIPTION
## Summary

Action spend was ~$15/day, dominated by per-push auto-reviews on active PRs. Three orthogonal cost cuts in one workflow file:

| # | Change | Saves |
|---|---|---|
| 1 | Drop `synchronize` from `pull_request: types` | ~80% (per-PR cost: N reviews → 1) |
| 2 | `paths-ignore` for `**.md`, `docs/**`, `.github/**`, `*.html` | small but symbolic |
| 3 | Haiku for auto-runs, Opus only for `@claude` triggers | ~12x per-token on auto-runs |

Stacked: from ~$15/day → under $1/day if the per-push auto-runs were the main driver.

## What still works

- Auto-review on PR open / ready-for-review / reopen.
- On-demand re-review via `@claude review PR` (uses Opus, posts top-level acknowledgement per #116).
- `concurrency: cancel-in-progress` still cancels stale runs when a push comes during a review.

## What changes from a contributor's perspective

- Pushing a follow-up commit to an open PR no longer auto-fires a new review. If you want one, comment `@claude review PR`.
- Doc-only / workflow-only / HTML-only PRs skip the review entirely (the action's own validation guardrail rejects modified workflows from PR branches anyway, so reviews on those were always wasted compute).

## Notes for the future

- The `&& A || B` ternary in the `--model` line is safe because both model id branches are non-empty truthy strings. The neighbouring `allowedTools` line uses `!= ... && truthy || ''` because the empty branch goes there — keep the inversion if you ever modify it; an inline comment in the file warns the next maintainer.
- If on-demand `@claude` reviews start to dominate spend (likely if a sidebar widget or chatbot ever invokes them), the next lever is to also drop `--model` from the human-triggered path so it inherits the action's default (currently Sonnet — middle ground).

## Test plan

- [x] `actionlint .github/workflows/claude-review.yml` passes
- [ ] Reviewer (post-merge): push a commit to an unrelated open PR → expect no auto-review
- [ ] Reviewer (post-merge): comment `@claude review PR` on an open PR → expect Opus-quality review with a top-level acknowledgement
- [ ] Watch the daily Claude API spend after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Auto-review automation now runs only on PR opened/ready_for_review/reopened and ignores doc/site-only changes, resulting in fewer auto-reviews for documentation or HTML-only edits.
  * Separate AI model selection for automated runs vs manually-triggered review runs, so auto and human-initiated reviews use different models.
  * No changes to public APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->