### PR TITLE
fix(admin): cap AdminOrgFilter org-list at 100 to match backend schema

### DIFF
--- a/apps/admin/src/components/admin-org-filter.tsx
+++ b/apps/admin/src/components/admin-org-filter.tsx
@@ -9,20 +9,22 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 const ALL_ORGS_VALUE = '__all__';
 
 /**
- * Bumped from 100 to 500 because:
- *   - 100 silently truncates: anything past the 100th org is invisible
- *     and a deep-linked `?organizationId=<missing>` resolves to a
- *     `<SelectItem>` that doesn't exist, leaving the trigger in a
- *     blank/unmatched state with no recovery path through the UI.
- *   - 500 covers the realistic mid-term tenant count for this product
- *     without paging or typeahead. We can revisit (search-backed
- *     lookup, virtualised list) when actual scale demands it.
+ * Capped at 100 because the backend's `GET /api/v1/organizations`
+ * schema rejects `limit > 100` with 400 (organization-schema.ts:260,
+ * `maximum: 100`). PR #119 originally set this to 500 to cover the
+ * realistic mid-term tenant count, but that fired schema-validation
+ * 400s in prod and broke the entire admin shell for any platform
+ * admin (the sidebar widget is mounted by `<DashboardLayout>` which
+ * wraps every admin route).
  *
- * The `<MissingOrgFallback>` below provides a synthetic item for the
- * deep-link case so the trigger always shows SOMETHING for the
- * resolved id, even if the org isn't in the fetched window.
+ * The synthetic disabled item below already covers the case where a
+ * deep-linked org is past the fetched window — the trigger renders
+ * "Unknown organization (id)" with no crash. Restoring full
+ * dropdown access for >100 tenants requires either bumping the
+ * backend cap (tracked on issue #120) or adding a search-backed
+ * picker; both are follow-ups.
  */
-const ORG_LIST_LIMIT = 500;
+const ORG_LIST_LIMIT = 100;
 
 /**
  * Sidebar widget that lets a platform admin scope the four cross-org

--- a/apps/admin/src/tests/components/admin-org-filter.test.tsx
+++ b/apps/admin/src/tests/components/admin-org-filter.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
@@ -20,16 +20,27 @@ vi.mock('../../services/organization-service', () => ({
   organizationService: { list: vi.fn() },
 }));
 
-function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return (
-    <MemoryRouter initialEntries={['/projects']}>
-      <QueryClientProvider client={client}>{children}</QueryClientProvider>
-    </MemoryRouter>
-  );
+function makeWrapper(initialEntries: string[]) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return (
+      <MemoryRouter initialEntries={initialEntries}>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
 }
+
+const wrapper = makeWrapper(['/projects']);
+
+const adminUser = {
+  id: 'admin',
+  email: 'admin@x.com',
+  role: 'admin',
+  security: { is_platform_admin: true },
+};
 
 describe('<AdminOrgFilter>', () => {
   beforeEach(() => {
@@ -56,16 +67,51 @@ describe('<AdminOrgFilter>', () => {
   });
 
   it('renders the dropdown for platform admins', () => {
-    useAuthMock.mockReturnValue({
-      user: {
-        id: 'admin',
-        email: 'admin@x.com',
-        role: 'admin',
-        security: { is_platform_admin: true },
-      },
-    });
+    useAuthMock.mockReturnValue({ user: adminUser });
     render(<AdminOrgFilter />, { wrapper });
     expect(screen.getByTestId('admin-org-filter')).toBeDefined();
     expect(screen.getByLabelText('adminOrgFilter.label')).toBeDefined();
+  });
+
+  // The synthetic disabled "Unknown organization (id)" item is the
+  // ONLY UI recovery path for a platform admin who deep-links to an
+  // org outside the fetched window — orgs past index 100 (after
+  // ORG_LIST_LIMIT was capped to match the backend schema), or orgs
+  // that have since been deleted. Without it the trigger renders
+  // blank and the user is stuck. These two tests pin the contract
+  // until the >100-tenant case gets a real fix (issue #120).
+
+  it('renders the synthetic "Unknown organization" item once the query resolves with the deep-linked org missing', async () => {
+    useAuthMock.mockReturnValue({ user: adminUser });
+    render(<AdminOrgFilter />, {
+      wrapper: makeWrapper(['/projects?organizationId=ghost']),
+    });
+
+    // The trigger uses <SelectValue> which displays the matched
+    // <SelectItem>'s text content for the current value. A synthetic
+    // item with value="ghost" renders the unknown-org label, so the
+    // trigger ends up showing it. If the synthetic item were never
+    // rendered (regression), the trigger would be blank.
+    await waitFor(() => {
+      const trigger = screen.getByLabelText('adminOrgFilter.label');
+      expect(trigger.textContent).toContain('adminOrgFilter.unknownOrg');
+    });
+  });
+
+  it('does NOT flash the synthetic item while the query is pending', () => {
+    // Pending forever — orgsResponse stays undefined, `selectedIsMissing`
+    // must be false until the fetch resolves. Without the `!!orgsResponse`
+    // gate, EVERY initial render with a deep-linked org would briefly
+    // show the synthetic item even for valid orgs that just haven't
+    // arrived yet.
+    vi.mocked(organizationService.list).mockReturnValue(new Promise(() => {}));
+    useAuthMock.mockReturnValue({ user: adminUser });
+
+    render(<AdminOrgFilter />, {
+      wrapper: makeWrapper(['/projects?organizationId=acme']),
+    });
+
+    const trigger = screen.getByLabelText('adminOrgFilter.label');
+    expect(trigger.textContent).not.toContain('adminOrgFilter.unknownOrg');
   });
 });


### PR DESCRIPTION
## Summary

PR #119 set `ORG_LIST_LIMIT = 500` in `AdminOrgFilter`, but the backend's `GET /api/v1/organizations` schema rejects `limit > 100` with 400 ([organization-schema.ts:260](packages/backend/src/api/schemas/organization-schema.ts#L260), `maximum: 100`).

In prod (`https://app.kz.bugspotter.io/api/v1/organizations?limit=500` → 400) this broke the entire admin shell for platform admins — the widget is mounted by `<DashboardLayout>` which wraps every admin route.

This drops the limit back to 100. The synthetic disabled \"Unknown organization (id)\" item in the widget already handles deep-links to orgs past the fetched window without crashing.

## Test plan

- [x] typecheck ✓, lint ✓ (0 warnings)
- [x] Existing widget tests still pass (assertions don't pin the limit value)
- [ ] Reviewer (post-merge): platform-admin login → expect dropdown to render with up to 100 orgs and no console 400
- [ ] Reviewer (post-merge): deep-link to `?organizationId=<id-not-in-window>` → expect synthetic disabled item visible, no crash

## Follow-up

Restoring full dropdown access for >100 tenants needs either bumping the backend cap or adding a search-backed picker — tracked on #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organization selector now respects backend limits (fetch window reduced), preventing errors when loading large org lists.
  * Deep-linked or unknown organizations are handled gracefully: a clear "Unknown organization" entry appears after loading, and does not show while the list is still loading.

* **Tests**
  * Improved tests cover loading and deep-link behaviors for the organization selector.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/121)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->