### PR TITLE
fix(admin): SDK snippet endpoint = current origin (subdomain), not API_BASE_URL

### DIFF
--- a/apps/admin/src/components/onboarding/sdk-snippet-dialog.tsx
+++ b/apps/admin/src/components/onboarding/sdk-snippet-dialog.tsx
@@ -6,7 +6,6 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Button } from '../ui/button';
 import { SnippetTabs } from '../ui/snippet-tabs';
 import { buildSdkInstallSnippets } from './sdk-install-snippets';
-import { API_BASE_URL } from '../../lib/api-client';
 
 interface SdkSnippetDialogProps {
   open: boolean;
@@ -14,25 +13,23 @@ interface SdkSnippetDialogProps {
 }
 
 /**
- * The endpoint the SDK needs to point at — the *API* host, not the
- * admin UI host. These can be the same origin on some deployments
- * (admin's nginx proxies `/api/*`), but in cross-origin setups (SaaS
- * prod has admin at `[org].kz.bugspotter.io` and API at
- * `api.kz.bugspotter.io`; local dev runs admin on `:5173` and API on
- * `:3000`) `window.location.origin` is the admin UI host and would
- * misdirect the SDK.
+ * Use the current page origin as the SDK endpoint. On every supported
+ * deployment, the admin host proxies `/api/*` to the backend:
+ *   - SaaS prod: `[org].kz.bugspotter.io` (admin nginx → backend) —
+ *     and the subdomain is the URL the user already knows from the
+ *     dashboard, so it's also the most discoverable endpoint to
+ *     hand them.
+ *   - Self-hosted: admin and API typically same-origin behind one
+ *     reverse proxy.
+ *   - Local dev: `vite.config.ts` proxies `/api/*` to `:3000`.
  *
- * `API_BASE_URL` (`lib/api-client.ts:16`) is exactly the value
- * `axios.create({ baseURL })` uses for this admin's own API calls,
- * so the SDK ends up pointed at the same place the admin agrees on.
- *
- * Falls back to `null` when `API_BASE_URL` is empty (local dev with
- * same-origin proxy — there's no absolute URL to hand the SDK in
- * that case, so the snippet shows a placeholder for the user to
- * replace by hand).
+ * Picking the API host directly (e.g. `api.kz.bugspotter.io`) would
+ * be technically equivalent on SaaS but contradicts the explicit
+ * product decision to surface the tenant subdomain everywhere
+ * customer-visible. SSR-safe via the `typeof window` guard.
  */
 function currentEndpoint(): string | null {
-  return API_BASE_URL || null;
+  return typeof window === 'undefined' ? null : window.location.origin;
 }
 
 export function SdkSnippetDialog({ open, onOpenChange }: SdkSnippetDialogProps) {

--- a/apps/admin/src/components/onboarding/sdk-snippet-dialog.tsx
+++ b/apps/admin/src/components/onboarding/sdk-snippet-dialog.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Button } from '../ui/button';
 import { SnippetTabs } from '../ui/snippet-tabs';
 import { buildSdkInstallSnippets } from './sdk-install-snippets';
+import { INSTANCE_ORIGIN } from '../../lib/api-client';
 
 interface SdkSnippetDialogProps {
   open: boolean;
@@ -13,28 +14,20 @@ interface SdkSnippetDialogProps {
 }
 
 /**
- * Use the current page origin as the SDK endpoint. On every supported
- * deployment, the admin host proxies `/api/*` to the backend:
- *   - SaaS prod: `[org].kz.bugspotter.io` (admin nginx → backend) —
- *     and the subdomain is the URL the user already knows from the
- *     dashboard, so it's also the most discoverable endpoint to
- *     hand them.
- *   - Self-hosted: admin and API typically same-origin behind one
- *     reverse proxy.
- *   - Local dev: `vite.config.ts` proxies `/api/*` to `:3000`.
+ * Use the tenant's own origin as the SDK endpoint. On every supported
+ * deployment, the admin host proxies `/api/*` to the backend (SaaS
+ * nginx → backend, self-hosted reverse proxy, local-dev vite). The
+ * subdomain is also the URL the user already knows from the
+ * dashboard, so it's the most discoverable endpoint to hand them.
  *
- * Picking the API host directly (e.g. `api.kz.bugspotter.io`) would
- * be technically equivalent on SaaS but contradicts the explicit
- * product decision to surface the tenant subdomain everywhere
- * customer-visible. SSR-safe via the `typeof window` guard.
+ * `buildSdkInstallSnippets` accepts `null` to mean "show a
+ * placeholder", so normalise the SSR-empty-string case here.
  */
-function currentEndpoint(): string | null {
-  return typeof window === 'undefined' ? null : window.location.origin;
-}
+const SDK_ENDPOINT: string | null = INSTANCE_ORIGIN || null;
 
 export function SdkSnippetDialog({ open, onOpenChange }: SdkSnippetDialogProps) {
   const { t } = useTranslation();
-  const tabs = useMemo(() => buildSdkInstallSnippets(currentEndpoint()), []);
+  const tabs = useMemo(() => buildSdkInstallSnippets(SDK_ENDPOINT), []);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/admin/src/lib/api-client.ts
+++ b/apps/admin/src/lib/api-client.ts
@@ -2,10 +2,13 @@ import axios, { AxiosError } from 'axios';
 import { API_ENDPOINTS } from './api-constants';
 
 // Runtime configuration from /config.js (injected by docker-entrypoint.sh)
-// Falls back to build-time env var for local development
-// Type definition in src/types/window.d.ts
+// Falls back to build-time env var for local development.
+// Type definition in src/types/window.d.ts.
+// Typeof-window guard so this module is import-safe from non-browser
+// contexts (SSR, tooling) — without it, INSTANCE_ORIGIN's own guard
+// at line 25 would never get a chance to run.
 const getRuntimeConfig = () => {
-  return window.__RUNTIME_CONFIG__ || {};
+  return typeof window === 'undefined' ? {} : window.__RUNTIME_CONFIG__ || {};
 };
 
 /**

--- a/apps/admin/src/lib/api-client.ts
+++ b/apps/admin/src/lib/api-client.ts
@@ -15,6 +15,15 @@ const getRuntimeConfig = () => {
  */
 export const API_BASE_URL = getRuntimeConfig().apiUrl || import.meta.env.VITE_API_URL || '';
 
+/**
+ * Current page origin (e.g. `https://acme.kz.bugspotter.io` on SaaS,
+ * `http://localhost:3001` in local dev). Single source of truth for
+ * surfaces that need to show or hand the user their tenant's URL —
+ * SDK install snippet, Chrome-extension instance hint, etc. Empty
+ * string in non-browser contexts so callers can `||` to a placeholder.
+ */
+export const INSTANCE_ORIGIN = typeof window === 'undefined' ? '' : window.location.origin;
+
 // Re-export API constants for convenience
 export { API_VERSION, API_ENDPOINTS } from './api-constants';
 

--- a/apps/admin/src/pages/onboarding.tsx
+++ b/apps/admin/src/pages/onboarding.tsx
@@ -8,7 +8,7 @@ import { Button } from '../components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
 import { useAuth } from '../contexts/auth-context';
 import { authService } from '../services/api';
-import { handleApiError } from '../lib/api-client';
+import { handleApiError, INSTANCE_ORIGIN } from '../lib/api-client';
 import type { User } from '../types';
 
 /**
@@ -36,15 +36,14 @@ const CHROME_WEB_STORE_URL =
   'https://chromewebstore.google.com/detail/bugspotter/mpefobgognkodaknpalkaohkaniddmhj';
 
 /**
- * Instance URL the extension's Options page accepts. Use the
- * tenant's own origin (e.g. `https://acme.kz.bugspotter.io`) — the
- * admin's nginx proxies `/api/*` to the backend, and the API key
- * still identifies the tenant, so requests succeed same-origin.
- * That's better UX than a generic `api.*` host the user has never
- * seen before, since they're already viewing the dashboard at this
- * URL.
+ * Local alias for the shared `INSTANCE_ORIGIN` from `lib/api-client.ts`.
+ * Same value as the SDK install snippet's endpoint and as the URL the
+ * Chrome-extension Options page expects — the tenant's own origin
+ * (e.g. `https://acme.kz.bugspotter.io`). Admin nginx proxies
+ * `/api/*` to backend, so requests succeed same-origin and the API
+ * key identifies the tenant.
  */
-const INSTANCE_URL = typeof window === 'undefined' ? '' : window.location.origin;
+const INSTANCE_URL = INSTANCE_ORIGIN;
 
 /**
  * Normalize a base64-encoded querystring value so `atob` accepts it.

--- a/apps/admin/src/pages/onboarding.tsx
+++ b/apps/admin/src/pages/onboarding.tsx
@@ -8,7 +8,7 @@ import { Button } from '../components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
 import { useAuth } from '../contexts/auth-context';
 import { authService } from '../services/api';
-import { handleApiError, API_BASE_URL } from '../lib/api-client';
+import { handleApiError } from '../lib/api-client';
 import type { User } from '../types';
 
 /**
@@ -288,13 +288,15 @@ export default function OnboardingPage() {
       // already encodes which projects it can write to via its
       // `allowed_projects` server-side scope.
       //
-      // `endpoint` uses `API_BASE_URL`, NOT `INSTANCE_URL` (the admin
-      // origin). The SDK runs in the customer's own app — a
-      // different origin from the admin UI — so it needs the actual
-      // API host, not whatever URL the admin happens to be served
-      // from. `INSTANCE_URL` below stays right for the Chrome
-      // extension card because the extension talks back to the
-      // admin's nginx (which proxies `/api/*` same-origin).
+      // `endpoint` is the tenant's own origin (`INSTANCE_URL`) — on
+      // SaaS that's the org subdomain (`[org].kz.bugspotter.io`),
+      // which is the URL the user already knows from the dashboard
+      // and the right surface to point the SDK at per product
+      // decision. The admin host proxies `/api/*` to the backend on
+      // every supported deployment (SaaS nginx, self-hosted reverse
+      // proxy, local-dev vite), so SDK requests reach the API
+      // through the same origin. The same value powers the Chrome
+      // extension card below.
       //
       // `JSON.stringify` so single-quotes, backslashes, or newlines
       // in a key / origin (unlikely, but cheap defense) don't break
@@ -303,7 +305,7 @@ export default function OnboardingPage() {
 
 BugSpotter.init({
   apiKey: ${JSON.stringify(handoff.api_key)},
-  endpoint: ${JSON.stringify(API_BASE_URL || '<your BugSpotter API URL>')},
+  endpoint: ${JSON.stringify(INSTANCE_URL || '<your BugSpotter URL>')},
 });`,
     [handoff.api_key]
   );


### PR DESCRIPTION
## Summary

The SDK install snippet (sidebar quick-setup + post-signup onboarding) is supposed to hand the user their tenant subdomain (`[org].kz.bugspotter.io` on SaaS) — the URL they already know from the dashboard, per the explicit product decision made earlier.

PR #119 silently overrode that. I'd switched the endpoint source from \`window.location.origin\` to \`API_BASE_URL\` based on a Claude-bot review flagging a hypothetical local-dev cross-origin issue. That review was wrong in context: \`vite.config.ts\` already proxies \`/api/*\` to \`:3000\` in dev, the SaaS admin nginx proxies \`/api/*\` to backend, and self-hosted admins are typically same-origin — so \`window.location.origin\` works on every supported deployment.

## Concrete failure pre-fix

On the deployed admin (with empty \`API_BASE_URL\` because of the same-origin nginx proxy), the snippet renders the literal placeholder \`<your BugSpotter URL>\` — confirmed on \`try-it-inc.kz.bugspotter.io\` and \`app.kz.bugspotter.io\`.

## Test plan

- [x] typecheck ✓, lint ✓ (0 warnings)
- [x] 864 admin tests passing (no behavior tests pinned the previous \`API_BASE_URL\` source)
- [ ] Reviewer (post-merge): on \`[org].kz.bugspotter.io\`, open quick-setup → SDK snippet → expect \`endpoint: 'https://[org].kz.bugspotter.io'\`
- [ ] Reviewer (post-merge): same on the post-signup onboarding install card

## Notes

The Chrome-extension card in \`onboarding.tsx\` already used \`INSTANCE_URL\` (= \`window.location.origin\`) for exactly this reason; this PR brings the SDK snippet inline with it. \`API_BASE_URL\` is no longer imported by either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SDK install snippets in the onboarding flow now consistently derive the SDK endpoint from the instance origin, resolving inconsistent endpoint selection across SaaS, self-hosted, and local setups.

* **New**
  * Improved handling for non-browser/SSR contexts so onboarding surfaces no longer break when an absolute origin can't be determined.

* **Documentation**
  * Clarified onboarding/snippet docs to explain tenant-origin proxying and SSR-safe placeholder behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/122)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->