### PR TITLE
fix(api+admin): org-admin-accessible integration summary endpoint

### DIFF
--- a/apps/admin/src/hooks/use-integration-config.ts
+++ b/apps/admin/src/hooks/use-integration-config.ts
@@ -112,6 +112,9 @@ export function useIntegrationConfig<T = Record<string, unknown>>({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['integrations'] });
       queryClient.invalidateQueries({ queryKey: ['integration', type] });
+      // Org-wide QuickSetup count — see project-integration-config.tsx
+      // for the rationale.
+      queryClient.invalidateQueries({ queryKey: ['integrations-summary'] });
       onSaveSuccess?.();
     },
   });

--- a/apps/admin/src/hooks/use-onboarding-status.ts
+++ b/apps/admin/src/hooks/use-onboarding-status.ts
@@ -75,9 +75,17 @@ export function useOnboardingStatus(): OnboardingState {
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: integrations = [] } = useQuery({
-    queryKey: ['integrations'],
-    queryFn: integrationService.list,
+  // `integrationService.summary()` is the org-admin-accessible sibling
+  // of `list()` — same tenant scope, but `list()` hits the
+  // platform-admin-only `/admin/integrations` and silently 403s for
+  // org owners. That used to leave `integrationCount === 0` permanently
+  // for any non-platform-admin user, so the "Connect Jira" CTA never
+  // disappeared after they actually connected Jira. The summary endpoint
+  // projects through `getUserAccessibleProjects` so the count reflects
+  // what the caller can see.
+  const { data: integrationSummary } = useQuery({
+    queryKey: ['integrations-summary'],
+    queryFn: integrationService.summary,
     enabled: canConfigure && hasOrganization,
     staleTime: 60 * 1000,
   });
@@ -87,6 +95,6 @@ export function useOnboardingStatus(): OnboardingState {
     hasProject: projects.length >= 1,
     projectCount: projects.length,
     primaryProjectId: projects[0]?.id ?? null,
-    integrationCount: integrations.length,
+    integrationCount: integrationSummary?.total ?? 0,
   };
 }

--- a/apps/admin/src/hooks/use-onboarding-status.ts
+++ b/apps/admin/src/hooks/use-onboarding-status.ts
@@ -51,19 +51,25 @@ export function useOnboardingStatus(): OnboardingState {
   const { isSystemAdmin, orgRole } = usePermissions();
   const canConfigure = isSystemAdmin || orgRole === 'admin' || orgRole === 'owner';
 
-  // Plain `['projects']` / `['integrations']` keys to dedupe with every
-  // other consumer in the admin (notification dialogs, channels-list,
-  // integrations overview, …). Both queries reflect the user's CURRENT
-  // tenant context (subdomain on SaaS), not the platform-admin sidebar
-  // filter — the QuickSetup CTAs that consume this hook are tied to
-  // "what does THIS tenant have set up", and threading the sidebar
-  // filter only into the projects query was internally inconsistent
-  // (integrationService.list takes no org arg, so `integrationCount`
-  // would stay global, breaking predicates like
-  // `hasProject && integrationCount === 0` for any platform admin
-  // with the sidebar filter set). Either both signals follow the
-  // filter or neither does; "neither" is the only option without a
-  // backend change to `integrationService.list`.
+  // Plain `['projects']` key to dedupe with every other consumer in
+  // the admin (notification dialogs, channels-list, integrations
+  // overview, …) — same shape, same fetch.
+  //
+  // The integrations query below uses its own `['integrations-summary']`
+  // namespace because the cached value is `{ total, by_platform }`, NOT
+  // the array of `Integration` rows that other consumers of
+  // `['integrations']` expect; sharing the key would let the wrong shape
+  // win whichever query resolved first.
+  //
+  // Both queries reflect the user's CURRENT tenant context (subdomain
+  // on SaaS), not the platform-admin sidebar filter — the QuickSetup
+  // CTAs that consume this hook are tied to "what does THIS tenant
+  // have set up". Threading the sidebar filter through this hook was
+  // tried and reverted (PR #119/#123): half-scoping was internally
+  // inconsistent because integration count couldn't be filtered the
+  // same way as projects without a separate backend route, breaking
+  // predicates like `hasProject && integrationCount === 0`.
+  //
   // Wrap `getAll()` in an arrow to drop React Query's context arg —
   // the service's first param is `organizationId?: string`, so passing
   // the query context through would be a type error and (worse) send

--- a/apps/admin/src/lib/api-constants.ts
+++ b/apps/admin/src/lib/api-constants.ts
@@ -96,6 +96,7 @@ export const API_ENDPOINTS = {
   // Integration endpoints (admin)
   integrations: {
     list: () => `${API_VERSION}/admin/integrations`,
+    summary: () => `${API_VERSION}/integrations/summary`,
     create: () => `${API_VERSION}/admin/integrations`,
     analyzeCode: () => `${API_VERSION}/admin/integrations/analyze-code`,
     getDetails: (type: string) => `${API_VERSION}/admin/integrations/${type}`,

--- a/apps/admin/src/lib/api-constants.ts
+++ b/apps/admin/src/lib/api-constants.ts
@@ -93,7 +93,10 @@ export const API_ENDPOINTS = {
       `${API_VERSION}/projects/${projectId}/members/${userId}`,
   },
 
-  // Integration endpoints (admin)
+  // Integration endpoints — mostly platform-admin (`/admin/integrations`)
+  // with the exception of `summary`, which is org-admin-accessible
+  // (any authenticated user sees aggregate counts for projects they
+  // can access). Grouped together for discoverability.
   integrations: {
     list: () => `${API_VERSION}/admin/integrations`,
     summary: () => `${API_VERSION}/integrations/summary`,

--- a/apps/admin/src/pages/integrations/edit.tsx
+++ b/apps/admin/src/pages/integrations/edit.tsx
@@ -108,6 +108,9 @@ export default function IntegrationEditPage() {
 
       queryClient.invalidateQueries({ queryKey: ['integration', type] });
       queryClient.invalidateQueries({ queryKey: ['integrations'] });
+      // Org-wide QuickSetup count — see project-integration-config.tsx
+      // for the rationale.
+      queryClient.invalidateQueries({ queryKey: ['integrations-summary'] });
       toast.success('Integration updated successfully');
       navigate('/integrations');
     } catch (error) {

--- a/apps/admin/src/pages/integrations/overview.tsx
+++ b/apps/admin/src/pages/integrations/overview.tsx
@@ -39,7 +39,12 @@ const IntegrationsOverview: React.FC = () => {
 
   const deleteMutation = useMutation({
     mutationFn: (type: string) => integrationService.delete(type),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['integrations'] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['integrations'] });
+      // Org-wide QuickSetup count — see project-integration-config.tsx
+      // for the rationale.
+      qc.invalidateQueries({ queryKey: ['integrations-summary'] });
+    },
   });
 
   if (isLoading) {

--- a/apps/admin/src/pages/project-integration-config.tsx
+++ b/apps/admin/src/pages/project-integration-config.tsx
@@ -176,6 +176,11 @@ export default function ProjectIntegrationConfigPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['project-integration', platform, projectId] });
       queryClient.invalidateQueries({ queryKey: ['project-integrations', projectId] });
+      // QuickSetup CTA reads `integrationCount` from this org-wide
+      // summary; without invalidation it stays cached for staleTime
+      // (60s) so users who just connected Jira would still see
+      // "Connect Jira" in the top bar until the cache expires.
+      queryClient.invalidateQueries({ queryKey: ['integrations-summary'] });
       toast.success('Configuration saved successfully!');
       navigate(`/projects/${projectId}/integrations`);
     },
@@ -194,6 +199,7 @@ export default function ProjectIntegrationConfigPage() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['project-integrations', projectId] });
+      queryClient.invalidateQueries({ queryKey: ['integrations-summary'] });
       toast.success('Configuration deleted successfully!');
       navigate(`/projects/${projectId}/integrations`);
     },

--- a/apps/admin/src/services/integration-service.ts
+++ b/apps/admin/src/services/integration-service.ts
@@ -1,10 +1,31 @@
 import { api, API_ENDPOINTS } from '../lib/api-client';
 import type { Integration, CreateIntegrationRequest, SecurityAnalysisResult } from '../types';
 
+/**
+ * Aggregate integration counts the caller can see, scoped through the
+ * backend's `getUserAccessibleProjects`. Used by `useOnboardingStatus`
+ * (and any future surface that needs "is this org connected to X?").
+ *
+ * Distinct from `list()` which hits the platform-admin-only
+ * `/admin/integrations` endpoint — that one 403s for org owners and
+ * leaves consumers stuck thinking the count is 0.
+ */
+export interface IntegrationSummary {
+  total: number;
+  by_platform: Record<string, number>;
+}
+
 export const integrationService = {
   list: async () => {
     const res = await api.get<{ success: boolean; data: Integration[] }>(
       API_ENDPOINTS.integrations.list()
+    );
+    return res.data.data;
+  },
+
+  summary: async (): Promise<IntegrationSummary> => {
+    const res = await api.get<{ success: boolean; data: IntegrationSummary }>(
+      API_ENDPOINTS.integrations.summary()
     );
     return res.data.data;
   },

--- a/apps/admin/src/tests/hooks/use-onboarding-status.test.tsx
+++ b/apps/admin/src/tests/hooks/use-onboarding-status.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../../services/api', () => ({
 }));
 
 vi.mock('../../services/integration-service', () => ({
-  integrationService: { list: vi.fn() },
+  integrationService: { summary: vi.fn() },
 }));
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -45,7 +45,7 @@ describe('useOnboardingStatus', () => {
     useOrganizationMock.mockReset();
     usePermissionsMock.mockReset();
     vi.mocked(projectService.getAll).mockReset();
-    vi.mocked(integrationService.list).mockReset();
+    vi.mocked(integrationService.summary).mockReset();
     vi.mocked(bugReportService.getAll).mockReset();
   });
 
@@ -65,7 +65,7 @@ describe('useOnboardingStatus', () => {
     useOrganizationMock.mockReturnValue({ currentOrganization: ORG, hasOrganization: true });
     usePermissionsMock.mockReturnValue({ isSystemAdmin: false, orgRole: role });
     vi.mocked(projectService.getAll).mockResolvedValue([]);
-    vi.mocked(integrationService.list).mockResolvedValue([]);
+    vi.mocked(integrationService.summary).mockResolvedValue({ total: 0, by_platform: {} });
 
     const { result } = renderHook(() => useOnboardingStatus(), { wrapper });
 
@@ -76,7 +76,7 @@ describe('useOnboardingStatus', () => {
     useOrganizationMock.mockReturnValue({ currentOrganization: ORG, hasOrganization: true });
     usePermissionsMock.mockReturnValue({ isSystemAdmin: true, orgRole: null });
     vi.mocked(projectService.getAll).mockResolvedValue([]);
-    vi.mocked(integrationService.list).mockResolvedValue([]);
+    vi.mocked(integrationService.summary).mockResolvedValue({ total: 0, by_platform: {} });
 
     const { result } = renderHook(() => useOnboardingStatus(), { wrapper });
 
@@ -95,7 +95,7 @@ describe('useOnboardingStatus', () => {
     renderHook(() => useOnboardingStatus(), { wrapper });
 
     expect(projectService.getAll).not.toHaveBeenCalled();
-    expect(integrationService.list).not.toHaveBeenCalled();
+    expect(integrationService.summary).not.toHaveBeenCalled();
   });
 
   it('does not fire downstream queries when no organization is active', () => {
@@ -105,20 +105,20 @@ describe('useOnboardingStatus', () => {
     renderHook(() => useOnboardingStatus(), { wrapper });
 
     expect(projectService.getAll).not.toHaveBeenCalled();
-    expect(integrationService.list).not.toHaveBeenCalled();
+    expect(integrationService.summary).not.toHaveBeenCalled();
   });
 
   it('fires both downstream queries for an org admin in an active org', async () => {
     useOrganizationMock.mockReturnValue({ currentOrganization: ORG, hasOrganization: true });
     usePermissionsMock.mockReturnValue({ isSystemAdmin: false, orgRole: 'admin' });
     vi.mocked(projectService.getAll).mockResolvedValue([{ id: 'p-1' } as never]);
-    vi.mocked(integrationService.list).mockResolvedValue([]);
+    vi.mocked(integrationService.summary).mockResolvedValue({ total: 0, by_platform: {} });
 
     renderHook(() => useOnboardingStatus(), { wrapper });
 
     await waitFor(() => {
       expect(projectService.getAll).toHaveBeenCalledTimes(1);
-      expect(integrationService.list).toHaveBeenCalledTimes(1);
+      expect(integrationService.summary).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -131,7 +131,7 @@ describe('useOnboardingStatus', () => {
       { id: 'first' } as never,
       { id: 'second' } as never,
     ]);
-    vi.mocked(integrationService.list).mockResolvedValue([]);
+    vi.mocked(integrationService.summary).mockResolvedValue({ total: 0, by_platform: {} });
 
     const { result } = renderHook(() => useOnboardingStatus(), { wrapper });
 
@@ -153,7 +153,7 @@ describe('useOnboardingStatus', () => {
     useOrganizationMock.mockReturnValue({ currentOrganization: ORG, hasOrganization: true });
     usePermissionsMock.mockReturnValue({ isSystemAdmin: false, orgRole: 'admin' });
     vi.mocked(projectService.getAll).mockResolvedValue([]);
-    vi.mocked(integrationService.list).mockResolvedValue([]);
+    vi.mocked(integrationService.summary).mockResolvedValue({ total: 0, by_platform: {} });
 
     const { result } = renderHook(() => useOnboardingStatus(), { wrapper });
 
@@ -164,14 +164,14 @@ describe('useOnboardingStatus', () => {
     expect(result.current.projectCount).toBe(0);
   });
 
-  it('reports integrationCount from the integrations list length', async () => {
+  it('reports integrationCount from the summary endpoint total field', async () => {
     useOrganizationMock.mockReturnValue({ currentOrganization: ORG, hasOrganization: true });
     usePermissionsMock.mockReturnValue({ isSystemAdmin: false, orgRole: 'admin' });
     vi.mocked(projectService.getAll).mockResolvedValue([{ id: 'p-1' } as never]);
-    vi.mocked(integrationService.list).mockResolvedValue([
-      { type: 'jira' } as never,
-      { type: 'slack' } as never,
-    ]);
+    vi.mocked(integrationService.summary).mockResolvedValue({
+      total: 2,
+      by_platform: { jira: 1, slack: 1 },
+    });
 
     const { result } = renderHook(() => useOnboardingStatus(), { wrapper });
 

--- a/apps/admin/src/tests/pages/project-integration-config-invalidation.test.tsx
+++ b/apps/admin/src/tests/pages/project-integration-config-invalidation.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Regression test for the QuickSetup CTA invalidation contract added
+ * in PR #123 follow-up.
+ *
+ * `useOnboardingStatus` reads `integrationCount` from a React Query
+ * cache entry keyed `['integrations-summary']` with a 60s `staleTime`.
+ * When a user saves a project integration on this page, the on-success
+ * handler must invalidate that key — otherwise the QuickSetup
+ * "Connect Jira" CTA stays visible for up to 60s after they connect
+ * Jira (the exact failure mode PR #123 was meant to close).
+ *
+ * Pin only the `project-integration-config.tsx` save handler — the
+ * three other mutation sites (`integrations/edit.tsx`, `integrations/
+ * overview.tsx`, `use-integration-config.ts`) follow the same pattern
+ * and are covered by code review. This is the org-onboarding entry
+ * point — the path the PR exists to fix — so it's the highest-value
+ * place to anchor the contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import ProjectIntegrationConfigPage from '../../pages/project-integration-config';
+import { projectIntegrationService } from '../../services/project-integration-service';
+
+// Mocks ---------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+  Trans: ({ children, i18nKey }: { children?: ReactNode; i18nKey?: string }) =>
+    (children as ReactNode) ?? i18nKey ?? null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Single shared service object backing both the named and default
+// exports — the page imports the default export, this test asserts on
+// the named one. Without sharing they'd be different vi.fn() instances
+// and the test would never see the page's call. `vi.hoisted` so the
+// declaration survives vitest's mock-factory hoisting.
+const serviceMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  configure: vi.fn(),
+  delete: vi.fn(),
+  testConnection: vi.fn(),
+}));
+vi.mock('../../services/project-integration-service', () => ({
+  projectIntegrationService: serviceMock,
+  default: serviceMock,
+}));
+
+vi.mock('../../hooks/use-project-permissions', () => ({
+  useProjectPermissions: () => ({ canManageIntegrations: true }),
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+// ---------------------------------------------------------------------
+
+describe('ProjectIntegrationConfigPage — QuickSetup invalidation contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // No existing config — page renders the empty form. The default
+    // export is what the page imports; the named export is what this
+    // test imports for assertion. Both the named and default mocks
+    // share the same vi.fn() instances per the mock factory above.
+    vi.mocked(projectIntegrationService.get).mockResolvedValue(null as never);
+    vi.mocked(projectIntegrationService.configure).mockResolvedValue({
+      success: true,
+    } as never);
+  });
+
+  it('invalidates the [integrations-summary] cache on successful save', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    // Spy on the live instance — the page reads it via `useQueryClient()`
+    // from the same provider, so our spy is exactly the method the
+    // on-success handler calls.
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/projects/proj-1/integrations/jira/configure']}>
+          <Routes>
+            <Route
+              path="/projects/:projectId/integrations/:platform/configure"
+              element={<ProjectIntegrationConfigPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Wait for the save button (only renders after the loading branch
+    // resolves — `useQuery` resolves to `null` per the mock above).
+    const saveButton = await screen.findByTestId('save-config-button');
+    await user.click(saveButton);
+
+    // configure() resolves → onSuccess runs → invalidateQueries fires.
+    await waitFor(() => {
+      expect(projectIntegrationService.configure).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      const calls = invalidateSpy.mock.calls.map((call) => call[0]);
+      expect(calls).toContainEqual({ queryKey: ['integrations-summary'] });
+    });
+  });
+});

--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -112,7 +112,7 @@ export async function registerIntegrationRoutes(
    * surfaces ask "is Jira connected specifically?" without a new
    * endpoint.
    */
-  server.get<{ Querystring: { organization_id?: string } }>(
+  server.get<{ Querystring: { organization_id?: string | string[] } }>(
     '/api/v1/integrations/summary',
     {
       preHandler: [requireUser],
@@ -120,9 +120,18 @@ export async function registerIntegrationRoutes(
     async (request, reply) => {
       let projects: Array<{ id: string }>;
       if (isPlatformAdmin(request)) {
-        const orgScope = request.organizationId ?? request.query.organization_id;
+        // `firstString` matches the pattern used elsewhere in this file
+        // — Fastify's default parser returns `string[]` when the same
+        // key appears twice. Without coercion the array would flow
+        // straight to `findAll` and either crash or trigger pg's
+        // unsafe-cast path.
+        const orgScope = request.organizationId ?? firstString(request.query.organization_id);
         projects = await db.projects.findAll(orgScope);
       } else {
+        // Regular users are always scoped by the tenant subdomain
+        // (`request.organizationId`) — they cannot pass
+        // `?organization_id=` to widen scope. This mirrors the pattern
+        // in `projects.ts:108`; the query param is platform-admin-only.
         projects = await db.projects.getUserAccessibleProjects(
           request.authUser!.id,
           request.organizationId

--- a/packages/backend/src/api/routes/integrations.ts
+++ b/packages/backend/src/api/routes/integrations.ts
@@ -8,7 +8,12 @@ import type { FastifyInstance } from 'fastify';
 import type { DatabaseClient } from '../../db/client.js';
 import { sendSuccess, sendCreated } from '../utils/response.js';
 import { AppError } from '../middleware/error.js';
-import { requireAuth, requireProjectRole } from '../middleware/auth.js';
+import {
+  requireAuth,
+  requireProjectRole,
+  requireUser,
+  isPlatformAdmin,
+} from '../middleware/auth.js';
 import { requireProjectAccess } from '../middleware/project-access.js';
 import type { PluginRegistry } from '../../integrations/plugin-registry.js';
 import { getEncryptionService } from '../../utils/encryption.js';
@@ -83,6 +88,60 @@ export async function registerIntegrationRoutes(
     const platforms = registry.listPlugins();
     return sendSuccess(reply, platforms);
   });
+
+  /**
+   * Org-scoped integration summary.
+   * GET /api/v1/integrations/summary
+   *
+   * Returns aggregate counts of currently-active project integrations
+   * across the projects the caller can see. Powers the QuickSetup
+   * "Connect Jira" CTA in the admin UI: that CTA used to read from
+   * `GET /api/v1/admin/integrations`, which is `requirePlatformAdmin`-
+   * gated and silently 403s for org owners — leaving the CTA stuck on
+   * "0 integrations" forever and never disappearing after the user
+   * actually connected Jira.
+   *
+   * Scope rules mirror `GET /api/v1/projects` (projects.ts:84):
+   * platform admins see all projects in the current org context (or
+   * `?organization_id=` on the hub domain), regular users see the
+   * intersection of their org's projects and their own membership.
+   *
+   * Response shape is `{ total, by_platform: { [type]: count } }` —
+   * the predicate currently only needs `total === 0`, but per-platform
+   * counts cost nothing extra (single GROUP BY) and let future
+   * surfaces ask "is Jira connected specifically?" without a new
+   * endpoint.
+   */
+  server.get<{ Querystring: { organization_id?: string } }>(
+    '/api/v1/integrations/summary',
+    {
+      preHandler: [requireUser],
+    },
+    async (request, reply) => {
+      let projects: Array<{ id: string }>;
+      if (isPlatformAdmin(request)) {
+        const orgScope = request.organizationId ?? request.query.organization_id;
+        projects = await db.projects.findAll(orgScope);
+      } else {
+        projects = await db.projects.getUserAccessibleProjects(
+          request.authUser!.id,
+          request.organizationId
+        );
+      }
+
+      const projectIds = projects.map((p) => p.id);
+      const rows = await db.projectIntegrations.summarizeByPlatformForProjects(projectIds);
+
+      const by_platform: Record<string, number> = {};
+      let total = 0;
+      for (const row of rows) {
+        by_platform[row.type] = row.count;
+        total += row.count;
+      }
+
+      return sendSuccess(reply, { total, by_platform });
+    }
+  );
 
   /**
    * Test integration connection with provided config

--- a/packages/backend/src/db/project-integration.repository.ts
+++ b/packages/backend/src/db/project-integration.repository.ts
@@ -7,7 +7,17 @@ import type { Pool, PoolClient } from 'pg';
 import { BaseRepository } from './repositories/base-repository.js';
 
 /**
- * Project integration entity
+ * Project integration entity. Mirrors `application.project_integrations`
+ * as defined in migration 001 — keep in sync if the schema changes.
+ *
+ * The circuit-breaker fields (`error_count`, `last_error*`, `disabled_*`)
+ * and `last_sync_at` are managed by the worker / dispatch path, not by
+ * route handlers. They're still surfaced on the read shape so consumers
+ * (and SQL filters like `summarizeByPlatformForProjects` below, which
+ * gates on `disabled_at IS NULL`) have a typed view of the actual row.
+ * `ProjectIntegrationInsert` / `ProjectIntegrationUpdate` intentionally
+ * exclude them so route code can't flip them through the typed API —
+ * the worker reaches in via raw SQL.
  */
 export interface ProjectIntegration {
   id: string;
@@ -16,6 +26,14 @@ export interface ProjectIntegration {
   enabled: boolean;
   config: Record<string, unknown>;
   encrypted_credentials: string | null;
+  // Circuit-breaker state — schema enforces a CHECK that
+  // `disabled_at` and `disabled_reason` are both null or both set.
+  error_count: number;
+  last_error: string | null;
+  last_error_at: Date | null;
+  disabled_at: Date | null;
+  disabled_reason: string | null;
+  last_sync_at: Date | null;
   created_at: Date;
   updated_at: Date;
 }

--- a/packages/backend/src/db/project-integration.repository.ts
+++ b/packages/backend/src/db/project-integration.repository.ts
@@ -299,7 +299,7 @@ export class ProjectIntegrationRepository extends BaseRepository<
    */
   async findEnabledByProjectWithType(projectId: string): Promise<ProjectIntegrationWithType[]> {
     const query = `
-      SELECT 
+      SELECT
         pi.*,
         i.type as integration_type
       FROM ${this.schema}.${this.tableName} pi
@@ -310,5 +310,37 @@ export class ProjectIntegrationRepository extends BaseRepository<
 
     const result = await this.getClient().query<ProjectIntegrationWithType>(query, [projectId]);
     return this.deserializeMany(result.rows) as ProjectIntegrationWithType[];
+  }
+
+  /**
+   * Aggregate per-platform counts of ENABLED integrations across the
+   * given project ids. Used by `GET /api/v1/integrations/summary` to
+   * answer "does this user already have an integration set up?"
+   * without forcing the caller to be a platform admin (the
+   * `/admin/integrations` endpoint is gated to platform admins and
+   * silently 403s for org owners).
+   *
+   * Empty input array short-circuits — pg's `= ANY($1)` works on
+   * empty arrays but returning early avoids the round-trip.
+   */
+  async summarizeByPlatformForProjects(
+    projectIds: string[]
+  ): Promise<Array<{ type: string; count: number }>> {
+    if (projectIds.length === 0) {
+      return [];
+    }
+    const query = `
+      SELECT i.type, COUNT(*)::int as count
+      FROM ${this.schema}.${this.tableName} pi
+      INNER JOIN ${this.schema}.integrations i ON i.id = pi.integration_id
+      WHERE pi.project_id = ANY($1::uuid[])
+        AND pi.enabled = TRUE
+        AND pi.disabled_at IS NULL
+      GROUP BY i.type
+    `;
+    const result = await this.getClient().query<{ type: string; count: number }>(query, [
+      projectIds,
+    ]);
+    return result.rows;
   }
 }

--- a/packages/backend/tests/api/integration-summary.test.ts
+++ b/packages/backend/tests/api/integration-summary.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for `GET /api/v1/integrations/summary`.
+ *
+ * The QuickSetup CTA in the admin UI used to read integration count
+ * from `GET /api/v1/admin/integrations`, which is platform-admin-only
+ * and silently 403s for org owners — leaving the "Connect Jira" CTA
+ * stuck on "0 integrations" forever even after the user connected
+ * Jira. This route is the org-admin-accessible replacement; tests pin:
+ *
+ *   1. Empty org returns zero counts (the predicate's "no integrations
+ *      yet, show CTA" base case).
+ *   2. After creating an enabled project_integration, total + per-type
+ *      count both reflect it.
+ *   3. Disabled integrations don't count (CTA should re-appear if the
+ *      user disabled their only integration).
+ *   4. An org owner only sees their own org's integrations — no
+ *      cross-tenant leak via this endpoint (PR #115's security boundary
+ *      doesn't apply here directly because this endpoint isn't
+ *      `?organization_id=`-filterable; the projection through
+ *      `getUserAccessibleProjects` is the guard).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { createServer } from '../../src/api/server.js';
+import { createDatabaseClient } from '../../src/db/client.js';
+import type { DatabaseClient } from '../../src/db/client.js';
+import { resetDeploymentConfig } from '../../src/saas/config.js';
+import { createMockPluginRegistry, createMockStorage, createAdminUser } from '../test-helpers.js';
+
+describe('GET /api/v1/integrations/summary', () => {
+  let server: FastifyInstance;
+  let db: DatabaseClient;
+  let ownerToken: string;
+  let ownerUserId: string;
+  let orgId: string;
+  let orgSubdomain: string;
+  let projectId: string;
+
+  const originalDeploymentMode = process.env.DEPLOYMENT_MODE;
+
+  beforeAll(async () => {
+    process.env.DEPLOYMENT_MODE = 'saas';
+    resetDeploymentConfig();
+
+    const testDbUrl = process.env.DATABASE_URL || 'postgresql://localhost:5432/bugspotter_test';
+    db = createDatabaseClient(testDbUrl);
+    server = await createServer({
+      db,
+      storage: createMockStorage(),
+      pluginRegistry: createMockPluginRegistry(),
+    });
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    if (originalDeploymentMode === undefined) {
+      delete process.env.DEPLOYMENT_MODE;
+    } else {
+      process.env.DEPLOYMENT_MODE = originalDeploymentMode;
+    }
+    resetDeploymentConfig();
+    await server.close();
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    const timestamp = Date.now();
+    const randomId = Math.random().toString(36).substring(7);
+
+    const owner = await createAdminUser(server, db, 'integ-summary');
+    ownerToken = owner.token;
+    ownerUserId = owner.user.id;
+
+    orgSubdomain = `summary-${timestamp}-${randomId}`;
+    const org = await db.organizations.create({
+      name: `Summary Org ${randomId}`,
+      subdomain: orgSubdomain,
+      subscription_status: 'trial',
+    });
+    orgId = org.id;
+
+    const now = new Date();
+    const thirtyDaysLater = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    await db.subscriptions.create({
+      organization_id: orgId,
+      plan_name: 'starter',
+      status: 'trial',
+      current_period_start: now,
+      current_period_end: thirtyDaysLater,
+      quotas: { max_projects: 10, max_bug_reports: 1000, max_storage_mb: 500 },
+    });
+
+    await db.organizationMembers.createWithUser(orgId, ownerUserId, 'owner');
+
+    const project = await db.projects.create({
+      name: `Summary Project ${randomId}`,
+      organization_id: orgId,
+      created_by: ownerUserId,
+      settings: {},
+    });
+    projectId = project.id;
+  });
+
+  function call() {
+    return server.inject({
+      method: 'GET',
+      url: '/api/v1/integrations/summary',
+      headers: {
+        authorization: `Bearer ${ownerToken}`,
+        host: `${orgSubdomain}.example.com`,
+      },
+    });
+  }
+
+  it('returns zero counts when the org has no integrations', async () => {
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+  });
+
+  it('counts an enabled project integration', async () => {
+    await db.projectIntegrations.upsert(projectId, 'jira', {
+      enabled: true,
+      config: { projectKey: 'KAN' },
+      encrypted_credentials: '',
+    });
+
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual({ total: 1, by_platform: { jira: 1 } });
+  });
+
+  it('does not count disabled integrations', async () => {
+    await db.projectIntegrations.upsert(projectId, 'jira', {
+      enabled: false,
+      config: { projectKey: 'KAN' },
+      encrypted_credentials: '',
+    });
+
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+  });
+
+  it('does not leak integrations from other organizations', async () => {
+    // Create a separate org with its own project + Jira integration.
+    // Our owner is NOT a member, so the summary should ignore it.
+    const otherOrg = await db.organizations.create({
+      name: 'Other Org',
+      subdomain: `other-${Date.now()}`,
+      subscription_status: 'trial',
+    });
+    const otherProject = await db.projects.create({
+      name: 'Other Project',
+      organization_id: otherOrg.id,
+      created_by: ownerUserId, // creator field; membership is what matters
+      settings: {},
+    });
+    await db.projectIntegrations.upsert(otherProject.id, 'jira', {
+      enabled: true,
+      config: { projectKey: 'OTHER' },
+      encrypted_credentials: '',
+    });
+
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    // Owner is not a member of `otherOrg`, so its project isn't in
+    // `getUserAccessibleProjects` → its Jira integration shouldn't
+    // surface in the summary.
+    expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+  });
+});

--- a/packages/backend/tests/api/integration-summary.test.ts
+++ b/packages/backend/tests/api/integration-summary.test.ts
@@ -295,15 +295,18 @@ describe('GET /api/v1/integrations/summary', () => {
         encrypted_credentials: '',
       });
 
-      // Hub domain: 2-part host, so tenant middleware does NOT set
-      // organizationId. Platform admin uses the query param to scope
-      // the lookup to the test org.
+      // Hub domain: 2-part host so `extractSubdomain` returns null
+      // and tenant middleware leaves `request.organizationId` unset.
+      // (Anything with 3+ parts is treated as a tenant subdomain and
+      // will 404 if no matching org exists — `hub.example.com` looks
+      // like the subdomain `hub`, not the hub itself.) Platform admin
+      // then uses `?organization_id=` to scope the lookup.
       const res = await server.inject({
         method: 'GET',
         url: `/api/v1/integrations/summary?organization_id=${orgId}`,
         headers: {
           authorization: `Bearer ${platformAdmin.token}`,
-          host: 'hub.example.com',
+          host: 'example.com',
         },
       });
       expect(res.statusCode).toBe(200);

--- a/packages/backend/tests/api/integration-summary.test.ts
+++ b/packages/backend/tests/api/integration-summary.test.ts
@@ -5,28 +5,54 @@
  * from `GET /api/v1/admin/integrations`, which is platform-admin-only
  * and silently 403s for org owners — leaving the "Connect Jira" CTA
  * stuck on "0 integrations" forever even after the user connected
- * Jira. This route is the org-admin-accessible replacement; tests pin:
+ * Jira. This route is the org-admin-accessible replacement.
  *
- *   1. Empty org returns zero counts (the predicate's "no integrations
- *      yet, show CTA" base case).
- *   2. After creating an enabled project_integration, total + per-type
- *      count both reflect it.
- *   3. Disabled integrations don't count (CTA should re-appear if the
- *      user disabled their only integration).
- *   4. An org owner only sees their own org's integrations — no
- *      cross-tenant leak via this endpoint (PR #115's security boundary
- *      doesn't apply here directly because this endpoint isn't
- *      `?organization_id=`-filterable; the projection through
- *      `getUserAccessibleProjects` is the guard).
+ * The handler has two branches by caller role:
+ *   - Platform admin → `db.projects.findAll(orgScope)`. orgScope comes
+ *     from the tenant subdomain (`request.organizationId`) or, on the
+ *     hub domain, from `?organization_id=`.
+ *   - Regular user → `db.projects.getUserAccessibleProjects(userId, orgId)`.
+ *     The query param is intentionally NOT honored for them; their
+ *     visible scope is whatever the tenant subdomain resolved.
+ *
+ * Both branches are exercised below. Crucially, the org-owner tests
+ * use a `role: 'user'` user (otherwise `isPlatformAdmin()`'s legacy
+ * `role === 'admin'` fallback would silently steer them through the
+ * platform-admin branch and these tests would pass for the wrong
+ * reason).
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import bcrypt from 'bcrypt';
 import type { FastifyInstance } from 'fastify';
 import { createServer } from '../../src/api/server.js';
 import { createDatabaseClient } from '../../src/db/client.js';
 import type { DatabaseClient } from '../../src/db/client.js';
 import { resetDeploymentConfig } from '../../src/saas/config.js';
 import { createMockPluginRegistry, createMockStorage, createAdminUser } from '../test-helpers.js';
+
+/**
+ * Create a regular (non-platform-admin) user with `role: 'user'`.
+ * `createAdminUser` from test-helpers.ts uses `role: 'admin'`, which
+ * `isPlatformAdmin()` accepts via the legacy fallback — wrong shape
+ * for tests that want to exercise the org-owner branch.
+ */
+async function createRegularUser(
+  server: FastifyInstance,
+  db: DatabaseClient,
+  emailPrefix: string
+): Promise<{ token: string; user: { id: string; email: string } }> {
+  const timestamp = Date.now();
+  const randomId = Math.random().toString(36).substring(7);
+  const passwordHash = await bcrypt.hash('password123', 10);
+  const user = await db.users.create({
+    email: `${emailPrefix}-${timestamp}-${randomId}@example.com`,
+    password_hash: passwordHash,
+    role: 'user',
+  });
+  const token = server.jwt.sign({ userId: user.id, role: 'user' }, { expiresIn: '1h' });
+  return { token, user: { id: user.id, email: user.email } };
+}
 
 describe('GET /api/v1/integrations/summary', () => {
   let server: FastifyInstance;
@@ -68,7 +94,7 @@ describe('GET /api/v1/integrations/summary', () => {
     const timestamp = Date.now();
     const randomId = Math.random().toString(36).substring(7);
 
-    const owner = await createAdminUser(server, db, 'integ-summary');
+    const owner = await createRegularUser(server, db, 'integ-summary-owner');
     ownerToken = owner.token;
     ownerUserId = owner.user.id;
 
@@ -102,7 +128,7 @@ describe('GET /api/v1/integrations/summary', () => {
     projectId = project.id;
   });
 
-  function call() {
+  function callAsOwner() {
     return server.inject({
       method: 'GET',
       url: '/api/v1/integrations/summary',
@@ -113,61 +139,175 @@ describe('GET /api/v1/integrations/summary', () => {
     });
   }
 
-  it('returns zero counts when the org has no integrations', async () => {
-    const res = await call();
-    expect(res.statusCode).toBe(200);
-    expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+  describe('regular org user (the bug-fix path)', () => {
+    it('returns zero counts when the org has no integrations', async () => {
+      const res = await callAsOwner();
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+    });
+
+    it('counts an enabled project integration', async () => {
+      await db.projectIntegrations.upsert(projectId, 'jira', {
+        enabled: true,
+        config: { projectKey: 'KAN' },
+        encrypted_credentials: '',
+      });
+
+      const res = await callAsOwner();
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data).toEqual({ total: 1, by_platform: { jira: 1 } });
+    });
+
+    it('does not count `enabled=false` integrations', async () => {
+      await db.projectIntegrations.upsert(projectId, 'jira', {
+        enabled: false,
+        config: { projectKey: 'KAN' },
+        encrypted_credentials: '',
+      });
+
+      const res = await callAsOwner();
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+    });
+
+    it('does not count soft-deleted integrations (`disabled_at` set)', async () => {
+      // The repo aggregation excludes both `enabled = FALSE` AND
+      // `disabled_at IS NOT NULL`. The previous test covers the former;
+      // this one covers the latter. `upsert()` doesn't expose
+      // `disabled_at`, so flip it directly via SQL after creating an
+      // otherwise-enabled row.
+      const inserted = await db.projectIntegrations.upsert(projectId, 'jira', {
+        enabled: true,
+        config: { projectKey: 'KAN' },
+        encrypted_credentials: '',
+      });
+      await db.query(
+        `UPDATE application.project_integrations
+            SET disabled_at = CURRENT_TIMESTAMP, disabled_reason = 'test soft-delete'
+          WHERE id = $1`,
+        [inserted.id]
+      );
+
+      const res = await callAsOwner();
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+    });
+
+    it('does not leak integrations from other organizations', async () => {
+      // Create a separate org with its own project + Jira integration.
+      // Our owner is NOT a member, so the summary should ignore it.
+      const otherOrg = await db.organizations.create({
+        name: 'Other Org',
+        subdomain: `other-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+        subscription_status: 'trial',
+      });
+      const otherProject = await db.projects.create({
+        name: 'Other Project',
+        organization_id: otherOrg.id,
+        created_by: ownerUserId, // creator field; membership is what matters
+        settings: {},
+      });
+      await db.projectIntegrations.upsert(otherProject.id, 'jira', {
+        enabled: true,
+        config: { projectKey: 'OTHER' },
+        encrypted_credentials: '',
+      });
+
+      const res = await callAsOwner();
+      expect(res.statusCode).toBe(200);
+      // Owner is not a member of `otherOrg`, so its project isn't in
+      // `getUserAccessibleProjects` → its Jira integration shouldn't
+      // surface in the summary.
+      expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+    });
+
+    it('ignores `?organization_id=` from regular users (no scope-widening)', async () => {
+      // Create a sibling org with an integration. The regular user's
+      // attempt to widen scope to it via the query param must be a
+      // no-op — they keep their tenant-subdomain scope (their own org,
+      // which is empty).
+      const sibling = await db.organizations.create({
+        name: 'Sibling Org',
+        subdomain: `sibling-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+        subscription_status: 'trial',
+      });
+      const siblingProject = await db.projects.create({
+        name: 'Sibling Project',
+        organization_id: sibling.id,
+        created_by: ownerUserId,
+        settings: {},
+      });
+      await db.projectIntegrations.upsert(siblingProject.id, 'jira', {
+        enabled: true,
+        config: { projectKey: 'SIB' },
+        encrypted_credentials: '',
+      });
+
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/integrations/summary?organization_id=${sibling.id}`,
+        headers: {
+          authorization: `Bearer ${ownerToken}`,
+          host: `${orgSubdomain}.example.com`,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data).toEqual({ total: 0, by_platform: {} });
+    });
   });
 
-  it('counts an enabled project integration', async () => {
-    await db.projectIntegrations.upsert(projectId, 'jira', {
-      enabled: true,
-      config: { projectKey: 'KAN' },
-      encrypted_credentials: '',
+  describe('platform admin', () => {
+    it("on a tenant subdomain: sees that org's integrations", async () => {
+      // Create platform admin (createAdminUser sets role:'admin' which
+      // satisfies isPlatformAdmin via the legacy fallback). They're
+      // hitting the test-org subdomain; tenant middleware sets
+      // request.organizationId so the route's platform-admin branch
+      // calls findAll(orgScope = test-org-id).
+      const platformAdmin = await createAdminUser(server, db, 'integ-summary-platadmin');
+      // Membership is required by the cross-tenant guard middleware
+      // (admins of other orgs can't act on a foreign tenant subdomain).
+      await db.organizationMembers.createWithUser(orgId, platformAdmin.user.id, 'admin');
+
+      await db.projectIntegrations.upsert(projectId, 'jira', {
+        enabled: true,
+        config: { projectKey: 'KAN' },
+        encrypted_credentials: '',
+      });
+
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/v1/integrations/summary',
+        headers: {
+          authorization: `Bearer ${platformAdmin.token}`,
+          host: `${orgSubdomain}.example.com`,
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data).toEqual({ total: 1, by_platform: { jira: 1 } });
     });
 
-    const res = await call();
-    expect(res.statusCode).toBe(200);
-    expect(res.json().data).toEqual({ total: 1, by_platform: { jira: 1 } });
-  });
+    it('on the hub domain: honors `?organization_id=` to query arbitrary orgs', async () => {
+      const platformAdmin = await createAdminUser(server, db, 'integ-summary-hubadmin');
 
-  it('does not count disabled integrations', async () => {
-    await db.projectIntegrations.upsert(projectId, 'jira', {
-      enabled: false,
-      config: { projectKey: 'KAN' },
-      encrypted_credentials: '',
-    });
+      await db.projectIntegrations.upsert(projectId, 'jira', {
+        enabled: true,
+        config: { projectKey: 'KAN' },
+        encrypted_credentials: '',
+      });
 
-    const res = await call();
-    expect(res.statusCode).toBe(200);
-    expect(res.json().data).toEqual({ total: 0, by_platform: {} });
-  });
-
-  it('does not leak integrations from other organizations', async () => {
-    // Create a separate org with its own project + Jira integration.
-    // Our owner is NOT a member, so the summary should ignore it.
-    const otherOrg = await db.organizations.create({
-      name: 'Other Org',
-      subdomain: `other-${Date.now()}`,
-      subscription_status: 'trial',
+      // Hub domain: 2-part host, so tenant middleware does NOT set
+      // organizationId. Platform admin uses the query param to scope
+      // the lookup to the test org.
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/integrations/summary?organization_id=${orgId}`,
+        headers: {
+          authorization: `Bearer ${platformAdmin.token}`,
+          host: 'hub.example.com',
+        },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data).toEqual({ total: 1, by_platform: { jira: 1 } });
     });
-    const otherProject = await db.projects.create({
-      name: 'Other Project',
-      organization_id: otherOrg.id,
-      created_by: ownerUserId, // creator field; membership is what matters
-      settings: {},
-    });
-    await db.projectIntegrations.upsert(otherProject.id, 'jira', {
-      enabled: true,
-      config: { projectKey: 'OTHER' },
-      encrypted_credentials: '',
-    });
-
-    const res = await call();
-    expect(res.statusCode).toBe(200);
-    // Owner is not a member of `otherOrg`, so its project isn't in
-    // `getUserAccessibleProjects` → its Jira integration shouldn't
-    // surface in the summary.
-    expect(res.json().data).toEqual({ total: 0, by_platform: {} });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the QuickSetup \"Connect Jira\" CTA never disappearing for org owners after they've connected Jira (reported: try-it-inc.kz.bugspotter.io showed the CTA permanently despite Jira being saved).

## The bug

\`useOnboardingStatus\` derived \`integrationCount\` from \`integrationService.list()\` → \`GET /api/v1/admin/integrations\`. That route is gated \`requirePlatformAdmin()\`, so for any non-platform-admin user it 403s, React Query swallows the error, \`integrations = []\`, and the predicate \`integrationCount === 0\` stays true forever.

## The fix

1. **Backend** — new \`GET /api/v1/integrations/summary\` route. Auth: regular \`requireUser\`. Resolves the caller's accessible projects the same way \`GET /api/v1/projects\` does (platform admin → all in scope; regular user → \`getUserAccessibleProjects\`), aggregates \`enabled = TRUE AND disabled_at IS NULL\` rows in \`project_integrations\` joined to platform name, returns \`{ total, by_platform: { [type]: count } }\`. Per-platform counts cost nothing extra (single GROUP BY) and let future surfaces ask \"is Jira connected specifically?\" without a new endpoint.

2. **Backend repo** — \`summarizeByPlatformForProjects(projectIds)\` on \`ProjectIntegrationRepository\`.

3. **Frontend** — \`integrationService.summary()\` mirrors the new shape. \`useOnboardingStatus\` swaps \`list()\` → \`summary()\`, reads \`integrationCount = summary.total ?? 0\`. Query key changed to \`['integrations-summary']\` so it doesn't accidentally wire to existing \`list()\` consumers.

## Test plan

- [x] backend build ✓
- [x] admin tsc ✓, lint ✓
- [x] 864 admin tests passing
- [x] validate:i18n ✓
- New \`tests/api/integration-summary.test.ts\` (4 cases): empty org, enabled counted, disabled excluded, no cross-org leak. **CI runs these against testcontainers Postgres** (local Docker not exercised here).
- [ ] Reviewer (post-merge): on \`try-it-inc.kz.bugspotter.io\` (org with existing Jira), expect Connect Jira CTA to be hidden in the QuickSetup top bar.
- [ ] Reviewer (post-merge): on a fresh org with no integration, expect Connect Jira CTA to be visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an integrations summary endpoint returning aggregate counts by platform and a total.

* **Performance**
  * Onboarding status now derives integration count from the aggregated summary for lighter queries.

* **Improvements**
  * Admin UI now refreshes the org-wide integrations summary after creating, updating, or deleting integrations/config.

* **Tests**
  * Added tests covering tenant scoping, platform-admin behavior, exclusion of disabled/soft-deleted integrations, and cross-organization isolation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/123)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->