### PR TITLE
security: close two static-analysis gaps in custom-plugin sandbox

### DIFF
--- a/packages/backend/src/integrations/security/code-analyzer.ts
+++ b/packages/backend/src/integrations/security/code-analyzer.ts
@@ -164,16 +164,43 @@ export class CodeSecurityAnalyzer {
           }
         },
 
-        // Detect .constructor access — Function-constructor escape vector
-        // E.g. (1).constructor.constructor('return process')()
-        MemberExpression: (path: any) => {
-          const prop = path.node.property;
-          const isConstructor =
-            (!path.node.computed && prop.type === 'Identifier' && prop.name === 'constructor') ||
-            (path.node.computed && prop.type === 'StringLiteral' && prop.value === 'constructor');
-          if (isConstructor) {
+        // Detect .constructor access (Function-constructor escape vector) and
+        // dotted dangerous globals (process.binding, require.cache, etc.)
+        // Covers regular member access, optional chaining (obj?.constructor),
+        // string-literal computed (obj['constructor']) and template literals (obj[`constructor`]).
+        'MemberExpression|OptionalMemberExpression': (path: any) => {
+          if (path.parent?.type?.startsWith('TS')) {
+            return;
+          }
+
+          const node = path.node;
+          const prop = node.property;
+          const obj = node.object;
+
+          const isConstructorProp =
+            (!node.computed && prop.type === 'Identifier' && prop.name === 'constructor') ||
+            (node.computed && prop.type === 'StringLiteral' && prop.value === 'constructor') ||
+            (node.computed &&
+              prop.type === 'TemplateLiteral' &&
+              prop.expressions.length === 0 &&
+              prop.quasis.length === 1 &&
+              prop.quasis[0].value.cooked === 'constructor');
+
+          if (isConstructorProp) {
             violations.push('Constructor access not allowed (Function escape risk)');
             risk_level = 'critical';
+            return;
+          }
+
+          // Dotted DANGEROUS_GLOBALS entries (e.g. 'process.binding') — the
+          // Identifier visitor only sees single names, so dotted matches must
+          // be reconstructed here from MemberExpression structure.
+          if (!node.computed && obj.type === 'Identifier' && prop.type === 'Identifier') {
+            const fullName = `${obj.name}.${prop.name}`;
+            if (this.DANGEROUS_GLOBALS.includes(fullName)) {
+              violations.push(`Dangerous global access: ${fullName}`);
+              risk_level = risk_level === 'critical' ? 'critical' : 'high';
+            }
           }
         },
 

--- a/packages/backend/src/integrations/security/code-analyzer.ts
+++ b/packages/backend/src/integrations/security/code-analyzer.ts
@@ -74,7 +74,8 @@ export class CodeSecurityAnalyzer {
     'process.binding',
     '__dirname',
     '__filename',
-    'module.constructor',
+    // 'module.constructor' is intentionally omitted — the .constructor check
+    // below handles it (and every other .constructor access) earlier.
     'require.cache',
     'require.main',
   ];
@@ -177,16 +178,19 @@ export class CodeSecurityAnalyzer {
           const prop = node.property;
           const obj = node.object;
 
-          const isConstructorProp =
-            (!node.computed && prop.type === 'Identifier' && prop.name === 'constructor') ||
-            (node.computed && prop.type === 'StringLiteral' && prop.value === 'constructor') ||
-            (node.computed &&
-              prop.type === 'TemplateLiteral' &&
-              prop.expressions.length === 0 &&
-              prop.quasis.length === 1 &&
-              prop.quasis[0].value.cooked === 'constructor');
+          const propName: string | null =
+            !node.computed && prop.type === 'Identifier'
+              ? prop.name
+              : node.computed && prop.type === 'StringLiteral'
+                ? prop.value
+                : node.computed &&
+                    prop.type === 'TemplateLiteral' &&
+                    prop.expressions.length === 0 &&
+                    prop.quasis.length === 1
+                  ? prop.quasis[0].value.cooked
+                  : null;
 
-          if (isConstructorProp) {
+          if (propName === 'constructor') {
             violations.push('Constructor access not allowed (Function escape risk)');
             risk_level = 'critical';
             return;
@@ -194,9 +198,10 @@ export class CodeSecurityAnalyzer {
 
           // Dotted DANGEROUS_GLOBALS entries (e.g. 'process.binding') — the
           // Identifier visitor only sees single names, so dotted matches must
-          // be reconstructed here from MemberExpression structure.
-          if (!node.computed && obj.type === 'Identifier' && prop.type === 'Identifier') {
-            const fullName = `${obj.name}.${prop.name}`;
+          // be reconstructed here. Both `process.binding` and `process['binding']`
+          // resolve to the same fullName once propName is normalized.
+          if (obj.type === 'Identifier' && propName) {
+            const fullName = `${obj.name}.${propName}`;
             if (this.DANGEROUS_GLOBALS.includes(fullName)) {
               violations.push(`Dangerous global access: ${fullName}`);
               risk_level = risk_level === 'critical' ? 'critical' : 'high';

--- a/packages/backend/src/integrations/security/code-analyzer.ts
+++ b/packages/backend/src/integrations/security/code-analyzer.ts
@@ -40,6 +40,10 @@ const TS_RUNTIME_WRAPPERS = new Set([
   'TSTypeAssertion',
   'TSSatisfiesExpression',
   'TSInstantiationExpression',
+  // TSEnumMember.initializer and TSExportAssignment.expression are runtime
+  // positions despite the TS- prefix.
+  'TSEnumMember',
+  'TSExportAssignment',
 ]);
 
 function isTypeOnlyParent(parentType: string): boolean {

--- a/packages/backend/src/integrations/security/code-analyzer.ts
+++ b/packages/backend/src/integrations/security/code-analyzer.ts
@@ -29,6 +29,24 @@ const ALLOWED_MODULES = [
 ];
 
 /**
+ * TypeScript nodes that wrap a runtime expression. Their child Identifier /
+ * MemberExpression IS evaluated at runtime — these must NOT be skipped by the
+ * "in TS type position" filter, otherwise constructs like `(Function as any)()`
+ * or `obj.constructor!.foo` bypass detection.
+ */
+const TS_RUNTIME_WRAPPERS = new Set([
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+  'TSSatisfiesExpression',
+  'TSInstantiationExpression',
+]);
+
+function isTypeOnlyParent(parentType: string): boolean {
+  return parentType.startsWith('TS') && !TS_RUNTIME_WRAPPERS.has(parentType);
+}
+
+/**
  * Code Security Analyzer
  * Performs static analysis on plugin code to detect security violations
  */
@@ -153,11 +171,11 @@ export class CodeSecurityAnalyzer {
           }
 
           // Function constructor access (any reference, not just `new Function(...)`)
-          // Catches: Function('...')(), const F = Function, etc.
+          // Catches: Function('...')(), const F = Function, (Function as any)(), Function!(), etc.
           if (name === 'Function') {
-            const parentType = path.parent?.type ?? '';
-            // Skip TypeScript type positions (e.g. `(g: Function) => ...`)
-            if (parentType.startsWith('TS')) {
+            // Only skip pure type positions like `(g: Function) => ...`; runtime
+            // wrappers (`as`, `!`, `<T>x`, `satisfies`, `f<T>`) must NOT be skipped.
+            if (isTypeOnlyParent(path.parent?.type ?? '')) {
               return;
             }
             violations.push('Function constructor not allowed');
@@ -170,7 +188,7 @@ export class CodeSecurityAnalyzer {
         // Covers regular member access, optional chaining (obj?.constructor),
         // string-literal computed (obj['constructor']) and template literals (obj[`constructor`]).
         'MemberExpression|OptionalMemberExpression': (path: any) => {
-          if (path.parent?.type?.startsWith('TS')) {
+          if (isTypeOnlyParent(path.parent?.type ?? '')) {
             return;
           }
 

--- a/packages/backend/src/integrations/security/code-analyzer.ts
+++ b/packages/backend/src/integrations/security/code-analyzer.ts
@@ -51,6 +51,34 @@ function isTypeOnlyParent(parentType: string): boolean {
 }
 
 /**
+ * TS expression wrappers that hold their inner runtime expression on `.expression`.
+ * Used to peel `(process as any)`, `process!`, `(0, process)` etc. back to a bare
+ * Identifier when reconstructing dotted-global names.
+ */
+const TS_EXPRESSION_WRAPPERS = new Set([
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+  'TSSatisfiesExpression',
+  'TSInstantiationExpression',
+]);
+
+function unwrapToIdentifier(node: any): { name: string } | null {
+  let cur = node;
+  let safety = 16;
+  while (cur && safety-- > 0) {
+    if (TS_EXPRESSION_WRAPPERS.has(cur.type)) {
+      cur = cur.expression;
+    } else if (cur.type === 'SequenceExpression') {
+      cur = cur.expressions[cur.expressions.length - 1];
+    } else {
+      break;
+    }
+  }
+  return cur && cur.type === 'Identifier' ? cur : null;
+}
+
+/**
  * Code Security Analyzer
  * Performs static analysis on plugin code to detect security violations
  */
@@ -220,10 +248,13 @@ export class CodeSecurityAnalyzer {
 
           // Dotted DANGEROUS_GLOBALS entries (e.g. 'process.binding') — the
           // Identifier visitor only sees single names, so dotted matches must
-          // be reconstructed here. Both `process.binding` and `process['binding']`
-          // resolve to the same fullName once propName is normalized.
-          if (obj.type === 'Identifier' && propName) {
-            const fullName = `${obj.name}.${propName}`;
+          // be reconstructed here. Unwrap the `obj` side through TS expression
+          // wrappers and SequenceExpression so `(process as any).binding`,
+          // `process!.binding`, `(0, process).binding` etc. all resolve to
+          // `process.binding`.
+          const objIdentifier = unwrapToIdentifier(obj);
+          if (objIdentifier && propName) {
+            const fullName = `${objIdentifier.name}.${propName}`;
             if (this.DANGEROUS_GLOBALS.includes(fullName)) {
               violations.push(`Dangerous global access: ${fullName}`);
               risk_level = risk_level === 'critical' ? 'critical' : 'high';

--- a/packages/backend/src/integrations/security/code-analyzer.ts
+++ b/packages/backend/src/integrations/security/code-analyzer.ts
@@ -150,6 +150,31 @@ export class CodeSecurityAnalyzer {
             violations.push(`Dangerous global access: ${name}`);
             risk_level = risk_level === 'critical' ? 'critical' : 'high';
           }
+
+          // Function constructor access (any reference, not just `new Function(...)`)
+          // Catches: Function('...')(), const F = Function, etc.
+          if (name === 'Function') {
+            const parentType = path.parent?.type ?? '';
+            // Skip TypeScript type positions (e.g. `(g: Function) => ...`)
+            if (parentType.startsWith('TS')) {
+              return;
+            }
+            violations.push('Function constructor not allowed');
+            risk_level = 'critical';
+          }
+        },
+
+        // Detect .constructor access — Function-constructor escape vector
+        // E.g. (1).constructor.constructor('return process')()
+        MemberExpression: (path: any) => {
+          const prop = path.node.property;
+          const isConstructor =
+            (!path.node.computed && prop.type === 'Identifier' && prop.name === 'constructor') ||
+            (path.node.computed && prop.type === 'StringLiteral' && prop.value === 'constructor');
+          if (isConstructor) {
+            violations.push('Constructor access not allowed (Function escape risk)');
+            risk_level = 'critical';
+          }
         },
 
         // Detect dynamic imports

--- a/packages/backend/tests/security/code-analyzer.test.ts
+++ b/packages/backend/tests/security/code-analyzer.test.ts
@@ -313,11 +313,9 @@ describe('CodeSecurityAnalyzer', () => {
 
       const result = await analyzer.analyze(code);
 
-      // Note: 'module' as variable name doesn't trigger global check
-      // Only checks for 'module.constructor' as string pattern
-      // This is acceptable - AST traversal looks for identifiers, not member expressions
-      expect(result.safe).toBe(true); // Changed expectation
-      expect(result.risk_level).toBe('low');
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
     });
   });
 
@@ -360,6 +358,96 @@ describe('CodeSecurityAnalyzer', () => {
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dynamic imports (import()) not allowed');
       expect(result.risk_level).toBe('high');
+    });
+  });
+
+  describe('Function Constructor (Indirect)', () => {
+    it('should reject bare Function() call', async () => {
+      const code = `Function("return process")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject Function alias', async () => {
+      const code = `
+        const F = Function;
+        F("return this")();
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should not flag class constructor declarations', async () => {
+      const code = `
+        export class Foo {
+          constructor() {}
+        }
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+  });
+
+  describe('Constructor Access Escape', () => {
+    it('should reject (literal).constructor.constructor pattern', async () => {
+      const code = `(1).constructor.constructor("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject string-literal constructor escape', async () => {
+      const code = `"".constructor.constructor("alert(1)")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject array-literal constructor escape', async () => {
+      const code = `[].constructor.constructor("return process")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject object-literal constructor escape', async () => {
+      const code = `({}).constructor.constructor("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject computed string-literal constructor access', async () => {
+      const code = `obj["constructor"]["constructor"]("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
     });
   });
 

--- a/packages/backend/tests/security/code-analyzer.test.ts
+++ b/packages/backend/tests/security/code-analyzer.test.ts
@@ -523,6 +523,24 @@ describe('CodeSecurityAnalyzer', () => {
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dangerous global access: require.main');
     });
+
+    it("should reject computed bracket access (process['binding'])", async () => {
+      const code = `const natives = process['binding']('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+    });
+
+    it('should reject template-literal access (require[`cache`])', async () => {
+      const code = 'const c = require[`cache`];';
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.cache');
+    });
   });
 
   describe('Code Hash', () => {

--- a/packages/backend/tests/security/code-analyzer.test.ts
+++ b/packages/backend/tests/security/code-analyzer.test.ts
@@ -426,6 +426,26 @@ describe('CodeSecurityAnalyzer', () => {
       expect(result.safe).toBe(true);
       expect(result.violations).toHaveLength(0);
     });
+
+    it('should reject Function used as TS enum member initializer', async () => {
+      const code = `enum Evil { F = Function }`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject `export = Function` (TSExportAssignment)', async () => {
+      const code = `export = Function;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
   });
 
   describe('Constructor Access Escape', () => {
@@ -499,6 +519,16 @@ describe('CodeSecurityAnalyzer', () => {
       expect(result.risk_level).toBe('critical');
     });
 
+    it('should reject combined optional + template-literal constructor access', async () => {
+      const code = '(1)?.[`constructor`]?.[`constructor`]("return this")()';
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
     it('should reject .constructor reflection (intentional strictness for plugin code)', async () => {
       // Plugins have no legitimate need for .constructor access, even for
       // reflection — keep the policy strict instead of adding a whitelist that
@@ -553,6 +583,7 @@ describe('CodeSecurityAnalyzer', () => {
 
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
     });
 
     it('should reject require.cache access', async () => {
@@ -562,6 +593,7 @@ describe('CodeSecurityAnalyzer', () => {
 
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dangerous global access: require.cache');
+      expect(result.risk_level).toBe('high');
     });
 
     it('should reject require.main access', async () => {
@@ -571,6 +603,7 @@ describe('CodeSecurityAnalyzer', () => {
 
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dangerous global access: require.main');
+      expect(result.risk_level).toBe('high');
     });
 
     it("should reject computed bracket access (process['binding'])", async () => {
@@ -580,6 +613,7 @@ describe('CodeSecurityAnalyzer', () => {
 
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
     });
 
     it('should reject template-literal access (require[`cache`])', async () => {
@@ -589,6 +623,7 @@ describe('CodeSecurityAnalyzer', () => {
 
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dangerous global access: require.cache');
+      expect(result.risk_level).toBe('high');
     });
   });
 

--- a/packages/backend/tests/security/code-analyzer.test.ts
+++ b/packages/backend/tests/security/code-analyzer.test.ts
@@ -449,6 +449,80 @@ describe('CodeSecurityAnalyzer', () => {
       expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
       expect(result.risk_level).toBe('critical');
     });
+
+    it('should reject optional-chaining constructor access', async () => {
+      const code = `(1)?.constructor.constructor("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject template-literal constructor access', async () => {
+      const code = '(1)[`constructor`][`constructor`]("return this")()';
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject .constructor reflection (intentional strictness for plugin code)', async () => {
+      // Plugins have no legitimate need for .constructor access, even for
+      // reflection — keep the policy strict instead of adding a whitelist that
+      // attackers could pivot through.
+      const code = `class Foo {} export const factory = () => Foo.constructor.name;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should not flag .constructor inside TypeScript type positions', async () => {
+      const code = `
+        export interface HasCtor { constructor: () => void }
+        export const factory = () => ({});
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+  });
+
+  describe('Dotted Dangerous Globals', () => {
+    it('should reject process.binding access', async () => {
+      const code = `const natives = process.binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+    });
+
+    it('should reject require.cache access', async () => {
+      const code = `delete require.cache;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.cache');
+    });
+
+    it('should reject require.main access', async () => {
+      const code = `const m = require.main;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.main');
+    });
   });
 
   describe('Code Hash', () => {

--- a/packages/backend/tests/security/code-analyzer.test.ts
+++ b/packages/backend/tests/security/code-analyzer.test.ts
@@ -397,6 +397,35 @@ describe('CodeSecurityAnalyzer', () => {
       expect(result.safe).toBe(true);
       expect(result.violations).toHaveLength(0);
     });
+
+    it('should reject Function wrapped in `as any` type assertion', async () => {
+      const code = `(Function as any)("return process")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject Function with non-null assertion', async () => {
+      const code = `Function!("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should still allow Function in TS type-reference position', async () => {
+      const code = `export const factory = (g: Function) => g;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
   });
 
   describe('Constructor Access Escape', () => {
@@ -493,6 +522,26 @@ describe('CodeSecurityAnalyzer', () => {
 
       expect(result.safe).toBe(true);
       expect(result.violations).toHaveLength(0);
+    });
+
+    it('should reject .constructor wrapped in `as any` type assertion', async () => {
+      const code = `(obj.constructor as any).constructor("return process")();`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject .constructor with non-null assertion', async () => {
+      const code = `obj.constructor!.constructor("return this")();`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
     });
   });
 

--- a/packages/backend/tests/security/code-analyzer.test.ts
+++ b/packages/backend/tests/security/code-analyzer.test.ts
@@ -625,6 +625,70 @@ describe('CodeSecurityAnalyzer', () => {
       expect(result.violations).toContain('Dangerous global access: require.cache');
       expect(result.risk_level).toBe('high');
     });
+
+    it('should reject `as any`-wrapped object (process as any).binding', async () => {
+      const code = `(process as any).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject non-null-assertion-wrapped object (process!.binding)', async () => {
+      const code = `process!.binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject angle-bracket type-assertion-wrapped object (<any>process).binding', async () => {
+      const code = `(<any>process).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject `satisfies any`-wrapped object (process satisfies any).binding', async () => {
+      const code = `(process satisfies any).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject sequence-expression-wrapped object (0, process).binding', async () => {
+      const code = `(0, process).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject wrapped require for require.cache / require.main', async () => {
+      const code = `
+        const c = (require as unknown).cache;
+        const m = (require!).main;
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.cache');
+      expect(result.violations).toContain('Dangerous global access: require.main');
+      expect(result.risk_level).toBe('high');
+    });
   });
 
   describe('Code Hash', () => {


### PR DESCRIPTION
## Summary

Layer 1 of the custom-plugin sandbox (static analysis in `code-analyzer.ts`) now also catches two known escape vectors:

- **Bare `Function('...')()` and aliasing** — `const F = Function; F('...')()`. Previously only `new Function(...)` was caught by regex.
- **`.constructor` access** — `obj.constructor` and `obj['constructor']`, the classic Function-constructor escape (e.g. `(1).constructor.constructor('return process')()`).

Both detections live in the AST-traversal pass. TypeScript type positions (`(g: Function) => ...`) are explicitly skipped.

The existing `module.constructor` test was acknowledging the gap as "acceptable" — updated to assert the new rejecting behavior.

## Known remaining gaps (intentional, runtime-handled)

- `obj['cons' + 'tructor']` — string-concat obfuscation, only resolvable at runtime. Layer 2 (isolated-vm with `Function`/`process` nulled on `globalThis`) catches the result.
- `obj[someVar]` where `someVar = 'constructor'` — same reason.

## Test plan

- [x] `pnpm --filter @bugspotter/backend exec vitest run tests/security/code-analyzer.test.ts` — 38/38 passing (8 new)
- [x] `pnpm --filter @bugspotter/backend test:unit` — full suite 2402/2402 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security analyzer now treats Function-constructor usage and any `.constructor` member access as critical violations across direct, computed, optional-chained and indirect forms; dangerous global/member patterns are more reliably detected while honoring TypeScript type-only exemptions.

* **Tests**
  * Expanded test coverage for indirect Function usage, varied `.constructor` access patterns, and TypeScript-specific exemptions, with stricter rejection expectations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/125)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->