### PR TITLE
security: harden static analyzer for custom-plugin sandbox

### DIFF
--- a/packages/backend/src/integrations/security/code-analyzer.ts
+++ b/packages/backend/src/integrations/security/code-analyzer.ts
@@ -29,6 +29,56 @@ const ALLOWED_MODULES = [
 ];
 
 /**
+ * TypeScript nodes that wrap a runtime expression. Their child Identifier /
+ * MemberExpression IS evaluated at runtime — these must NOT be skipped by the
+ * "in TS type position" filter, otherwise constructs like `(Function as any)()`
+ * or `obj.constructor!.foo` bypass detection.
+ */
+const TS_RUNTIME_WRAPPERS = new Set([
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+  'TSSatisfiesExpression',
+  'TSInstantiationExpression',
+  // TSEnumMember.initializer and TSExportAssignment.expression are runtime
+  // positions despite the TS- prefix.
+  'TSEnumMember',
+  'TSExportAssignment',
+]);
+
+function isTypeOnlyParent(parentType: string): boolean {
+  return parentType.startsWith('TS') && !TS_RUNTIME_WRAPPERS.has(parentType);
+}
+
+/**
+ * TS expression wrappers that hold their inner runtime expression on `.expression`.
+ * Used to peel `(process as any)`, `process!`, `(0, process)` etc. back to a bare
+ * Identifier when reconstructing dotted-global names.
+ */
+const TS_EXPRESSION_WRAPPERS = new Set([
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+  'TSSatisfiesExpression',
+  'TSInstantiationExpression',
+]);
+
+function unwrapToIdentifier(node: any): { name: string } | null {
+  let cur = node;
+  let safety = 16;
+  while (cur && safety-- > 0) {
+    if (TS_EXPRESSION_WRAPPERS.has(cur.type)) {
+      cur = cur.expression;
+    } else if (cur.type === 'SequenceExpression') {
+      cur = cur.expressions[cur.expressions.length - 1];
+    } else {
+      break;
+    }
+  }
+  return cur && cur.type === 'Identifier' ? cur : null;
+}
+
+/**
  * Code Security Analyzer
  * Performs static analysis on plugin code to detect security violations
  */
@@ -74,7 +124,8 @@ export class CodeSecurityAnalyzer {
     'process.binding',
     '__dirname',
     '__filename',
-    'module.constructor',
+    // 'module.constructor' is intentionally omitted — the .constructor check
+    // below handles it (and every other .constructor access) earlier.
     'require.cache',
     'require.main',
   ];
@@ -149,6 +200,65 @@ export class CodeSecurityAnalyzer {
           if (this.DANGEROUS_GLOBALS.includes(name)) {
             violations.push(`Dangerous global access: ${name}`);
             risk_level = risk_level === 'critical' ? 'critical' : 'high';
+          }
+
+          // Function constructor access (any reference, not just `new Function(...)`)
+          // Catches: Function('...')(), const F = Function, (Function as any)(), Function!(), etc.
+          if (name === 'Function') {
+            // Only skip pure type positions like `(g: Function) => ...`; runtime
+            // wrappers (`as`, `!`, `<T>x`, `satisfies`, `f<T>`) must NOT be skipped.
+            if (isTypeOnlyParent(path.parent?.type ?? '')) {
+              return;
+            }
+            violations.push('Function constructor not allowed');
+            risk_level = 'critical';
+          }
+        },
+
+        // Detect .constructor access (Function-constructor escape vector) and
+        // dotted dangerous globals (process.binding, require.cache, etc.)
+        // Covers regular member access, optional chaining (obj?.constructor),
+        // string-literal computed (obj['constructor']) and template literals (obj[`constructor`]).
+        'MemberExpression|OptionalMemberExpression': (path: any) => {
+          if (isTypeOnlyParent(path.parent?.type ?? '')) {
+            return;
+          }
+
+          const node = path.node;
+          const prop = node.property;
+          const obj = node.object;
+
+          const propName: string | null =
+            !node.computed && prop.type === 'Identifier'
+              ? prop.name
+              : node.computed && prop.type === 'StringLiteral'
+                ? prop.value
+                : node.computed &&
+                    prop.type === 'TemplateLiteral' &&
+                    prop.expressions.length === 0 &&
+                    prop.quasis.length === 1
+                  ? prop.quasis[0].value.cooked
+                  : null;
+
+          if (propName === 'constructor') {
+            violations.push('Constructor access not allowed (Function escape risk)');
+            risk_level = 'critical';
+            return;
+          }
+
+          // Dotted DANGEROUS_GLOBALS entries (e.g. 'process.binding') — the
+          // Identifier visitor only sees single names, so dotted matches must
+          // be reconstructed here. Unwrap the `obj` side through TS expression
+          // wrappers and SequenceExpression so `(process as any).binding`,
+          // `process!.binding`, `(0, process).binding` etc. all resolve to
+          // `process.binding`.
+          const objIdentifier = unwrapToIdentifier(obj);
+          if (objIdentifier && propName) {
+            const fullName = `${objIdentifier.name}.${propName}`;
+            if (this.DANGEROUS_GLOBALS.includes(fullName)) {
+              violations.push(`Dangerous global access: ${fullName}`);
+              risk_level = risk_level === 'critical' ? 'critical' : 'high';
+            }
           }
         },
 

--- a/packages/backend/tests/security/code-analyzer.test.ts
+++ b/packages/backend/tests/security/code-analyzer.test.ts
@@ -313,11 +313,9 @@ describe('CodeSecurityAnalyzer', () => {
 
       const result = await analyzer.analyze(code);
 
-      // Note: 'module' as variable name doesn't trigger global check
-      // Only checks for 'module.constructor' as string pattern
-      // This is acceptable - AST traversal looks for identifiers, not member expressions
-      expect(result.safe).toBe(true); // Changed expectation
-      expect(result.risk_level).toBe('low');
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
     });
   });
 
@@ -359,6 +357,336 @@ describe('CodeSecurityAnalyzer', () => {
 
       expect(result.safe).toBe(false);
       expect(result.violations).toContain('Dynamic imports (import()) not allowed');
+      expect(result.risk_level).toBe('high');
+    });
+  });
+
+  describe('Function Constructor (Indirect)', () => {
+    it('should reject bare Function() call', async () => {
+      const code = `Function("return process")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject Function alias', async () => {
+      const code = `
+        const F = Function;
+        F("return this")();
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should not flag class constructor declarations', async () => {
+      const code = `
+        export class Foo {
+          constructor() {}
+        }
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('should reject Function wrapped in `as any` type assertion', async () => {
+      const code = `(Function as any)("return process")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject Function with non-null assertion', async () => {
+      const code = `Function!("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should still allow Function in TS type-reference position', async () => {
+      const code = `export const factory = (g: Function) => g;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('should reject Function used as TS enum member initializer', async () => {
+      const code = `enum Evil { F = Function }`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject `export = Function` (TSExportAssignment)', async () => {
+      const code = `export = Function;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Function constructor not allowed');
+      expect(result.risk_level).toBe('critical');
+    });
+  });
+
+  describe('Constructor Access Escape', () => {
+    it('should reject (literal).constructor.constructor pattern', async () => {
+      const code = `(1).constructor.constructor("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject string-literal constructor escape', async () => {
+      const code = `"".constructor.constructor("alert(1)")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject array-literal constructor escape', async () => {
+      const code = `[].constructor.constructor("return process")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject object-literal constructor escape', async () => {
+      const code = `({}).constructor.constructor("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject computed string-literal constructor access', async () => {
+      const code = `obj["constructor"]["constructor"]("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject optional-chaining constructor access', async () => {
+      const code = `(1)?.constructor.constructor("return this")()`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject template-literal constructor access', async () => {
+      const code = '(1)[`constructor`][`constructor`]("return this")()';
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject combined optional + template-literal constructor access', async () => {
+      const code = '(1)?.[`constructor`]?.[`constructor`]("return this")()';
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject .constructor reflection (intentional strictness for plugin code)', async () => {
+      // Plugins have no legitimate need for .constructor access, even for
+      // reflection — keep the policy strict instead of adding a whitelist that
+      // attackers could pivot through.
+      const code = `class Foo {} export const factory = () => Foo.constructor.name;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should not flag .constructor inside TypeScript type positions', async () => {
+      const code = `
+        export interface HasCtor { constructor: () => void }
+        export const factory = () => ({});
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('should reject .constructor wrapped in `as any` type assertion', async () => {
+      const code = `(obj.constructor as any).constructor("return process")();`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+
+    it('should reject .constructor with non-null assertion', async () => {
+      const code = `obj.constructor!.constructor("return this")();`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Constructor access not allowed (Function escape risk)');
+      expect(result.risk_level).toBe('critical');
+    });
+  });
+
+  describe('Dotted Dangerous Globals', () => {
+    it('should reject process.binding access', async () => {
+      const code = `const natives = process.binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject require.cache access', async () => {
+      const code = `delete require.cache;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.cache');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject require.main access', async () => {
+      const code = `const m = require.main;`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.main');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it("should reject computed bracket access (process['binding'])", async () => {
+      const code = `const natives = process['binding']('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject template-literal access (require[`cache`])', async () => {
+      const code = 'const c = require[`cache`];';
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.cache');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject `as any`-wrapped object (process as any).binding', async () => {
+      const code = `(process as any).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject non-null-assertion-wrapped object (process!.binding)', async () => {
+      const code = `process!.binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject angle-bracket type-assertion-wrapped object (<any>process).binding', async () => {
+      const code = `(<any>process).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject `satisfies any`-wrapped object (process satisfies any).binding', async () => {
+      const code = `(process satisfies any).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject sequence-expression-wrapped object (0, process).binding', async () => {
+      const code = `(0, process).binding('natives');`;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: process.binding');
+      expect(result.risk_level).toBe('high');
+    });
+
+    it('should reject wrapped require for require.cache / require.main', async () => {
+      const code = `
+        const c = (require as unknown).cache;
+        const m = (require!).main;
+      `;
+
+      const result = await analyzer.analyze(code);
+
+      expect(result.safe).toBe(false);
+      expect(result.violations).toContain('Dangerous global access: require.cache');
+      expect(result.violations).toContain('Dangerous global access: require.main');
       expect(result.risk_level).toBe('high');
     });
   });


### PR DESCRIPTION
## Summary

Layer 1 (static analysis) of the custom plugin sandbox closes a class of Function-constructor and dangerous-global escapes that previously slipped past the AST visitors. Each item below was a working bypass against the prior analyzer; tests lock the regressions.

### Function constructor

- Bare `Function('...')()` and aliasing (`const F = Function; F('...')()`), not just `new Function(...)`. Caught via Identifier visitor.

### `.constructor` access (Function-constructor escape)

- Regular member (`obj.constructor`), optional chaining (`obj?.constructor`), computed string-literal (`obj['constructor']`), and zero-expression template literal (`` obj[`constructor`] ``).
- `Foo.constructor.name`-style reflection is intentionally rejected for plugin code — no whitelist for reflection, prevents pivot points; documented with an explicit test.
- Visitor registered for both `MemberExpression` and `OptionalMemberExpression` since Babel's default mode (no estree plugin) emits the latter directly rather than wrapping in `ChainExpression`.

### TS type-position filter

The old `parentType.startsWith('TS')` was too broad — it skipped runtime wrapper expressions (`as any`, `!`, `<T>x`, `satisfies`, `f<T>`) whose child IS evaluated at runtime, plus `TSEnumMember.initializer` and `TSExportAssignment.expression`. Replaced with `isTypeOnlyParent`, which uses an explicit `TS_RUNTIME_WRAPPERS` Set as an allowlist of runtime nodes that must fall through. Pure type positions (`TSTypeReference`, `TSPropertySignature`, `TSInterfaceDeclaration`, …) still skip.

### Dotted `DANGEROUS_GLOBALS` (`process.binding`, `require.cache`, `require.main`)

The Identifier visitor only sees single names, so dotted entries in the array never matched — pre-existing dead config. Reconstruct the dotted name from `MemberExpression` structure:

- Property side normalised across `Identifier` (`process.binding`), `StringLiteral` (`process['binding']`) and zero-expression `TemplateLiteral` (`` require[`cache`] ``).
- Object side unwrapped through TS expression wrappers and `SequenceExpression` via `unwrapToIdentifier`, so `(process as any).binding`, `process!.binding`, `(<any>process).binding`, `(process satisfies any).binding`, `(0, process).binding`, `(require as unknown).cache`, `(require!).main` all resolve to the canonical name and match.
- `'module.constructor'` removed from the array — the `.constructor` check fires earlier and returns, so the dotted entry was unreachable.

### Out of scope (tracked separately)

The existing `process.exit` / `process.kill` / `process.env =` regexes in `FORBIDDEN_PATTERNS` have the same TS-wrapper bypass class but live at the string level rather than the AST. Not in this PR.

## Test plan

- [x] `pnpm --filter @bugspotter/backend exec vitest run tests/security/code-analyzer.test.ts` — 61/61 passing
- [x] `pnpm --filter @bugspotter/backend test:unit` — full suite 2402/2402 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection of dangerous global access patterns (e.g., `process.binding`, `require.cache`)
  * Improved identification of constructor access patterns as security risks

* **New Features**
  * Function constructor usage now flagged as a forbidden runtime construct during security analysis
  * Strengthened type-aware context detection to reduce false positives in TypeScript code

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->