### PR TITLE
security: guard plugin execution timeout against NaN env var

### DIFF
--- a/packages/backend/src/integrations/security/plugin-executor.ts
+++ b/packages/backend/src/integrations/security/plugin-executor.ts
@@ -13,6 +13,10 @@ import { ERROR_CODES } from '../plugin-utils/errors.js';
 
 const logger = getLogger();
 
+function isPositiveFinite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
 /**
  * Script to disable unsafe global APIs in isolated-vm context
  * Prevents plugins from bypassing RPC bridge security controls
@@ -74,14 +78,15 @@ export class SecurePluginExecutor {
 
   constructor(options?: ExecutionOptions) {
     this.analyzer = new CodeSecurityAnalyzer();
-    // Default 15 s (allows 10 s HTTP timeout + overhead). Reject NaN, ≤ 0, and
-    // non-finite values from a misconfigured env var — a non-numeric string
-    // like "15s" would otherwise produce NaN and silently disable the
-    // wall-clock kill that bounds plugin execution.
+    // Validate every numeric source — env var AND constructor options. NaN, ≤ 0,
+    // and non-finite values must all fall back to the safe defaults; otherwise a
+    // misconfigured env var ("15s" → NaN) or a typed-any caller passing
+    // `options.timeout = NaN` would silently disable the wall-clock kill /
+    // memory cap that bound plugin execution.
     const envParsed = Number(process.env.PLUGIN_EXECUTION_TIMEOUT_MS);
-    const envTimeout = Number.isFinite(envParsed) && envParsed > 0 ? envParsed : 15000;
-    this.defaultTimeout = options?.timeout ?? envTimeout;
-    this.defaultMemoryLimit = options?.memoryLimit ?? 128; // 128 MB
+    const envTimeout = isPositiveFinite(envParsed) ? envParsed : 15000;
+    this.defaultTimeout = isPositiveFinite(options?.timeout) ? options!.timeout! : envTimeout;
+    this.defaultMemoryLimit = isPositiveFinite(options?.memoryLimit) ? options!.memoryLimit! : 128;
   }
 
   /**

--- a/packages/backend/src/integrations/security/plugin-executor.ts
+++ b/packages/backend/src/integrations/security/plugin-executor.ts
@@ -13,7 +13,14 @@ import { ERROR_CODES } from '../plugin-utils/errors.js';
 
 const logger = getLogger();
 
-function isPositiveFinite(value: unknown): value is number {
+// 15 s allows 10 s HTTP timeout (Layer 3) + 5 s overhead. Picked after a 5 s
+// default killed plugins mid-flight on slow tracker APIs.
+const DEFAULT_TIMEOUT_MS = 15000;
+// isolated-vm's lower bound is 8 MB; 128 MB is comfortable for plugin code
+// without giving any single plugin enough headroom to displace the host.
+const DEFAULT_MEMORY_LIMIT_MB = 128;
+
+function isPositiveSafeInteger(value: unknown): value is number {
   // Timeouts (ms) and memory limits (MB) are integer-domain config values —
   // accepting fractional inputs like `1.5` is almost always a typo. Reject
   // anything that isn't a positive safe integer; fall back to the default.
@@ -87,10 +94,12 @@ export class SecurePluginExecutor {
     // `options.timeout = NaN` would silently disable the wall-clock kill /
     // memory cap that bound plugin execution.
     const envParsed = Number(process.env.PLUGIN_EXECUTION_TIMEOUT_MS);
-    const envTimeout = isPositiveFinite(envParsed) ? envParsed : 15000;
+    const envTimeout = isPositiveSafeInteger(envParsed) ? envParsed : DEFAULT_TIMEOUT_MS;
     const { timeout, memoryLimit } = options ?? {};
-    this.defaultTimeout = isPositiveFinite(timeout) ? timeout : envTimeout;
-    this.defaultMemoryLimit = isPositiveFinite(memoryLimit) ? memoryLimit : 128;
+    this.defaultTimeout = isPositiveSafeInteger(timeout) ? timeout : envTimeout;
+    this.defaultMemoryLimit = isPositiveSafeInteger(memoryLimit)
+      ? memoryLimit
+      : DEFAULT_MEMORY_LIMIT_MB;
   }
 
   /**

--- a/packages/backend/src/integrations/security/plugin-executor.ts
+++ b/packages/backend/src/integrations/security/plugin-executor.ts
@@ -74,9 +74,12 @@ export class SecurePluginExecutor {
 
   constructor(options?: ExecutionOptions) {
     this.analyzer = new CodeSecurityAnalyzer();
-    const envTimeout = process.env.PLUGIN_EXECUTION_TIMEOUT_MS
-      ? parseInt(process.env.PLUGIN_EXECUTION_TIMEOUT_MS, 10)
-      : 15000; // Default 15 seconds (allows 10s HTTP timeout + overhead)
+    // Default 15 s (allows 10 s HTTP timeout + overhead). Reject NaN, ≤ 0, and
+    // non-finite values from a misconfigured env var — a non-numeric string
+    // like "15s" would otherwise produce NaN and silently disable the
+    // wall-clock kill that bounds plugin execution.
+    const envParsed = Number(process.env.PLUGIN_EXECUTION_TIMEOUT_MS);
+    const envTimeout = Number.isFinite(envParsed) && envParsed > 0 ? envParsed : 15000;
     this.defaultTimeout = options?.timeout ?? envTimeout;
     this.defaultMemoryLimit = options?.memoryLimit ?? 128; // 128 MB
   }

--- a/packages/backend/src/integrations/security/plugin-executor.ts
+++ b/packages/backend/src/integrations/security/plugin-executor.ts
@@ -14,7 +14,10 @@ import { ERROR_CODES } from '../plugin-utils/errors.js';
 const logger = getLogger();
 
 function isPositiveFinite(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+  // Timeouts (ms) and memory limits (MB) are integer-domain config values —
+  // accepting fractional inputs like `1.5` is almost always a typo. Reject
+  // anything that isn't a positive safe integer; fall back to the default.
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
 }
 
 /**
@@ -85,8 +88,9 @@ export class SecurePluginExecutor {
     // memory cap that bound plugin execution.
     const envParsed = Number(process.env.PLUGIN_EXECUTION_TIMEOUT_MS);
     const envTimeout = isPositiveFinite(envParsed) ? envParsed : 15000;
-    this.defaultTimeout = isPositiveFinite(options?.timeout) ? options!.timeout! : envTimeout;
-    this.defaultMemoryLimit = isPositiveFinite(options?.memoryLimit) ? options!.memoryLimit! : 128;
+    const { timeout, memoryLimit } = options ?? {};
+    this.defaultTimeout = isPositiveFinite(timeout) ? timeout : envTimeout;
+    this.defaultMemoryLimit = isPositiveFinite(memoryLimit) ? memoryLimit : 128;
   }
 
   /**

--- a/packages/backend/tests/integrations/plugin-executor-config.test.ts
+++ b/packages/backend/tests/integrations/plugin-executor-config.test.ts
@@ -89,4 +89,63 @@ describe('SecurePluginExecutor — constructor timeout config', () => {
     const executor = new SecurePluginExecutor({ timeout: 3000 });
     expect((executor as any).defaultTimeout).toBe(3000);
   });
+
+  // Same NaN-class bug, different input source — caller passes invalid options
+  // through the typed API. `options.timeout ?? envTimeout` doesn't catch NaN
+  // because NaN isn't nullish.
+  it('falls back to env/default when options.timeout is NaN', () => {
+    const executor = new SecurePluginExecutor({ timeout: NaN });
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to env/default when options.timeout is zero', () => {
+    const executor = new SecurePluginExecutor({ timeout: 0 });
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to env/default when options.timeout is negative', () => {
+    const executor = new SecurePluginExecutor({ timeout: -1 });
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to env/default when options.timeout is Infinity', () => {
+    const executor = new SecurePluginExecutor({ timeout: Infinity });
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+});
+
+describe('SecurePluginExecutor — constructor memoryLimit config', () => {
+  const DEFAULT_MEMORY = 128;
+
+  it('uses default 128 MB when no options', () => {
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultMemoryLimit).toBe(DEFAULT_MEMORY);
+  });
+
+  it('honours a valid options.memoryLimit', () => {
+    const executor = new SecurePluginExecutor({ memoryLimit: 64 });
+    expect((executor as any).defaultMemoryLimit).toBe(64);
+  });
+
+  // Same NaN-class bug as timeout — `options.memoryLimit ?? 128` doesn't catch
+  // NaN, and isolated-vm's behaviour with `memoryLimit: NaN` is unspecified.
+  it('falls back to 128 MB when options.memoryLimit is NaN', () => {
+    const executor = new SecurePluginExecutor({ memoryLimit: NaN });
+    expect((executor as any).defaultMemoryLimit).toBe(DEFAULT_MEMORY);
+  });
+
+  it('falls back to 128 MB when options.memoryLimit is zero', () => {
+    const executor = new SecurePluginExecutor({ memoryLimit: 0 });
+    expect((executor as any).defaultMemoryLimit).toBe(DEFAULT_MEMORY);
+  });
+
+  it('falls back to 128 MB when options.memoryLimit is negative', () => {
+    const executor = new SecurePluginExecutor({ memoryLimit: -1 });
+    expect((executor as any).defaultMemoryLimit).toBe(DEFAULT_MEMORY);
+  });
+
+  it('falls back to 128 MB when options.memoryLimit is Infinity', () => {
+    const executor = new SecurePluginExecutor({ memoryLimit: Infinity });
+    expect((executor as any).defaultMemoryLimit).toBe(DEFAULT_MEMORY);
+  });
 });

--- a/packages/backend/tests/integrations/plugin-executor-config.test.ts
+++ b/packages/backend/tests/integrations/plugin-executor-config.test.ts
@@ -112,6 +112,26 @@ describe('SecurePluginExecutor — constructor timeout config', () => {
     const executor = new SecurePluginExecutor({ timeout: Infinity });
     expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
   });
+
+  // Fractional-domain rejection: timeouts are integer milliseconds.
+  it('falls back when options.timeout is a fractional value', () => {
+    const executor = new SecurePluginExecutor({ timeout: 1.5 });
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back when env var parses to a fractional number', () => {
+    process.env[ENV_KEY] = '15000.5';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  // Fallback-chain check: when options.timeout is invalid, env must still
+  // win over the hard-coded default.
+  it('falls back to valid env timeout when options.timeout is invalid', () => {
+    process.env[ENV_KEY] = '8000';
+    const executor = new SecurePluginExecutor({ timeout: NaN });
+    expect((executor as any).defaultTimeout).toBe(8000);
+  });
 });
 
 describe('SecurePluginExecutor — constructor memoryLimit config', () => {

--- a/packages/backend/tests/integrations/plugin-executor-config.test.ts
+++ b/packages/backend/tests/integrations/plugin-executor-config.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Constructor-level config tests for SecurePluginExecutor.
+ *
+ * Specifically guards against regressions where a misconfigured
+ * `PLUGIN_EXECUTION_TIMEOUT_MS` env var could silently disable the
+ * wall-clock kill that bounds plugin execution.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SecurePluginExecutor } from '../../src/integrations/security/plugin-executor.js';
+
+const ENV_KEY = 'PLUGIN_EXECUTION_TIMEOUT_MS';
+const DEFAULT_TIMEOUT = 15000;
+
+describe('SecurePluginExecutor — constructor timeout config', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalEnv;
+    }
+  });
+
+  it('uses default 15s when env var is unset', () => {
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('honours a valid numeric env var', () => {
+    process.env[ENV_KEY] = '8000';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(8000);
+  });
+
+  it('falls back to 15s when env var is non-numeric (NaN guard)', () => {
+    // The bug this guards against: parseInt("15s", 10) === NaN, which would
+    // make script.run({ timeout: NaN }) undefined-behaviour and silently
+    // disable the wall-clock kill.
+    process.env[ENV_KEY] = '15s';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to 15s when env var is whitespace', () => {
+    process.env[ENV_KEY] = '   ';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to 15s when env var is the empty string', () => {
+    process.env[ENV_KEY] = '';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to 15s when env var is zero', () => {
+    process.env[ENV_KEY] = '0';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to 15s when env var is negative', () => {
+    process.env[ENV_KEY] = '-100';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('falls back to 15s when env var is Infinity', () => {
+    process.env[ENV_KEY] = 'Infinity';
+    const executor = new SecurePluginExecutor();
+    expect((executor as any).defaultTimeout).toBe(DEFAULT_TIMEOUT);
+  });
+
+  it('options.timeout takes precedence over env var', () => {
+    process.env[ENV_KEY] = '8000';
+    const executor = new SecurePluginExecutor({ timeout: 3000 });
+    expect((executor as any).defaultTimeout).toBe(3000);
+  });
+
+  it('options.timeout takes precedence even when env var is malformed', () => {
+    process.env[ENV_KEY] = 'not-a-number';
+    const executor = new SecurePluginExecutor({ timeout: 3000 });
+    expect((executor as any).defaultTimeout).toBe(3000);
+  });
+});


### PR DESCRIPTION
## Summary

`PLUGIN_EXECUTION_TIMEOUT_MS` was parsed via `parseInt(env, 10)` behind a truthy check on the env string. A non-numeric value (`"15s"`, whitespace, anything not starting with a digit) produced `NaN`, which propagated through `options?.timeout ?? envTimeout` — `NaN` is not nullish, so `??` doesn't fall back — and ended up as `script.run({ timeout: NaN })`. That's undefined behaviour in isolated-vm and likely disables the wall-clock kill that bounds plugin execution. The 15-second timeout is one of Layer 2's two enforcement mechanisms (the other is the 128 MB memory cap), so a misconfigured deployment could silently lose half its runtime defence.

## Fix

Replace `parseInt` + truthy guard with `Number()` + `Number.isFinite() && > 0`. Rejects NaN, infinities, zero, and negatives, falling back to the 15-second default whenever the env var isn't a positive finite number.

```diff
-    const envTimeout = process.env.PLUGIN_EXECUTION_TIMEOUT_MS
-      ? parseInt(process.env.PLUGIN_EXECUTION_TIMEOUT_MS, 10)
-      : 15000;
+    const envParsed = Number(process.env.PLUGIN_EXECUTION_TIMEOUT_MS);
+    const envTimeout = Number.isFinite(envParsed) && envParsed > 0 ? envParsed : 15000;
```

## Test plan

- [x] 10 new constructor-config test cases in `tests/integrations/plugin-executor-config.test.ts`: unset / empty string / whitespace / non-numeric / zero / negative / Infinity / `options.timeout` precedence (with valid and malformed env)
- [x] Full unit suite: 2402/2402 passing
- [x] No other call sites — `grep -rn parseInt(process.env packages/backend/src/integrations/security` returned only the fixed line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened validation for plugin execution timeout and memory-limit inputs: non-finite, zero, negative, fractional or malformed values are rejected and reliably fall back to safe defaults; validated constructor options take precedence when appropriate.

* **Tests**
  * Added tests covering timeout and memory-limit defaults, env-var and option precedence, and handling of malformed or edge-case values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/127)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->