### PR TITLE
chore(deps): pin isolated-vm to exact 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "packageManager": "pnpm@9.14.4",
   "engines": {
-    "node": ">=20.17"
+    "node": ">=22.0.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs}": [

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "@babel/traverse": "^7.28.4",
     "@babel/types": "^7.28.4",
     "browser-sync": "^3.0.4",
-    "isolated-vm": "^6.0.2"
+    "isolated-vm": "6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "packageManager": "pnpm@9.14.4",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs}": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -60,7 +60,7 @@
     "fastify-plugin": "^5.1.0",
     "handlebars": "^4.7.9",
     "ioredis": "^5.8.1",
-    "isolated-vm": "^6.0.2",
+    "isolated-vm": "6.0.2",
     "md-to-adf": "^0.6.4",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       isolated-vm:
-        specifier: ^6.0.2
+        specifier: 6.0.2
         version: 6.0.2
     devDependencies:
       '@eslint/js':
@@ -325,7 +325,7 @@ importers:
         specifier: ^5.8.1
         version: 5.8.1
       isolated-vm:
-        specifier: ^6.0.2
+        specifier: 6.0.2
         version: 6.0.2
       md-to-adf:
         specifier: ^0.6.4


### PR DESCRIPTION
## Summary

Pin `isolated-vm` to exact `6.0.2` (drop the caret) in both root and backend `package.json`. The library is in [maintenance mode](https://github.com/laverdet/isolated-vm/#installation) and coupled to V8 internals — minor version bumps can introduce breaking changes that unit tests won't catch until CI hits a different lockfile resolution. (`bcrypt` and `sharp` are also native, but N-API-stable; not the same risk profile.) The cost of a silent bump for a security-critical dependency is high; future upgrades become a deliberate PR with a test pass, not a transitive surprise.

Also bumps `engines.node` to `>=22.12.0` — `isolated-vm@6` requires Node 22, `vite@7` (transitive via vitest) requires `^20.19.0 || >=22.12.0`, and our Dockerfiles already pin `node:22.12.0-alpine`. The field was stuck at `>=20.17`; aligning it with deployment reality surfaces install-time mismatches cleanly at the root rather than via a downstream package's engines check.

## Diff

- `package.json`: `isolated-vm: ^6.0.2` → `6.0.2`; `engines.node: >=20.17` → `>=22.12.0`
- `packages/backend/package.json`: `isolated-vm: ^6.0.2` → `6.0.2`
- `pnpm-lock.yaml`: specifier strings only; resolved version unchanged at `6.0.2`

No source-code changes.

## Test plan

- [x] `pnpm install --no-frozen-lockfile` clean
- [x] `pnpm --filter @bugspotter/backend test:unit` — 2402/2402 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
