### PR TITLE
feat(backend): Linear integration plugin

### DIFF
--- a/packages/backend/src/db/migrations/020_seed_linear_integration.sql
+++ b/packages/backend/src/db/migrations/020_seed_linear_integration.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- SEED LINEAR INTEGRATION
+-- ============================================================================
+-- Registers the built-in Linear plugin in the `integrations` catalogue so:
+--   1. `GET /api/v1/integrations/platforms` lists it as a supported platform.
+--   2. `project_integrations.integration_id` FK can target it when an org
+--      configures a Linear integration.
+--   3. The admin UI's "Add integration" picker offers Linear alongside Jira.
+--
+-- Mirrors the Jira seed in migration 001. Idempotent (ON CONFLICT DO
+-- NOTHING) so re-running on an already-seeded DB is a no-op.
+--
+-- Status is `not_configured` because the row represents the *plugin type*,
+-- not a tenant's configuration — each `project_integrations` row carries
+-- per-project credentials and enabled flag.
+-- ============================================================================
+
+INSERT INTO integrations (type, name, description, status, config, has_rules)
+VALUES ('linear', 'Linear', 'Linear issue tracker integration', 'not_configured', '{}', TRUE)
+ON CONFLICT (type) DO NOTHING;

--- a/packages/backend/src/integrations/linear/client.ts
+++ b/packages/backend/src/integrations/linear/client.ts
@@ -1,0 +1,533 @@
+/**
+ * Linear Client
+ *
+ * Handles communication with Linear's GraphQL API. Single endpoint
+ * (`POST /graphql`), single fixed host (`api.linear.app`), one auth scheme
+ * in v1 (personal API key in `Authorization` header — without `Bearer`).
+ *
+ * Why a hand-rolled client instead of `@linear/sdk`:
+ *   - The SDK pulls a heavy GraphQL codegen runtime we don't need for the
+ *     ~6 operations we use.
+ *   - Mirrors `JiraClient` patterns (DNS pinning, explicit timeouts, no
+ *     redirect following) so security review can apply the same checklist.
+ *   - Lets us own the retry / 429 handling rather than rely on SDK defaults.
+ */
+
+import { request as httpsRequest } from 'https';
+import { getLogger } from '../../logger.js';
+import { pinHostnameToIp } from '../security/hardened-http.js';
+import {
+  LINEAR_API_HOST,
+  LINEAR_API_URL,
+  type LinearIssueInput,
+  type LinearIssue,
+  type LinearTeam,
+  type LinearProject,
+  type LinearUser,
+  type LinearViewer,
+  type LinearAttachment,
+  type LinearFileUpload,
+  type LinearGraphQLError,
+} from './types.js';
+
+const logger = getLogger();
+
+const GRAPHQL_PATH = '/graphql';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Linear caps `teams` paging at 50 by default; the cursor would let us page
+ * further, but the wizard only needs the first page (consistent with the
+ * Jira project picker's behaviour).
+ */
+const TEAMS_PAGE_SIZE = 50;
+const USERS_PAGE_SIZE = 20;
+const PROJECTS_PAGE_SIZE = 50;
+
+/**
+ * Maximum retries on transient errors (429, 5xx). Total wall-clock retries
+ * are bounded by `DEFAULT_TIMEOUT_MS` per attempt + the backoff sleeps.
+ */
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: LinearGraphQLError[];
+}
+
+interface RequestResult<T> {
+  data: T;
+  statusCode: number;
+}
+
+/**
+ * Linear's wire-level error contract is "200 OK with `errors[]` in body"
+ * for most failures (validation, missing scope, ...). Only auth/transport
+ * issues surface as HTTP 4xx/5xx. We normalize both into a single thrown
+ * Error with the most useful message we can reconstruct.
+ */
+function formatGraphQLError(errors: LinearGraphQLError[]): string {
+  return errors
+    .map((e) => e.extensions?.userPresentableMessage ?? e.message)
+    .filter((m) => m && m.length > 0)
+    .join('; ');
+}
+
+/**
+ * Sleep helper used between retries. Pulled out so tests can patch it via
+ * fake timers without dragging in lower-level injection.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class LinearClient {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    if (!apiKey || apiKey.trim().length === 0) {
+      throw new Error('Linear API key is required');
+    }
+    this.apiKey = apiKey.trim();
+  }
+
+  /**
+   * Execute a GraphQL operation against Linear.
+   *
+   * Retries transient failures (HTTP 429, 5xx). Honours `Retry-After` when
+   * present; otherwise applies exponential backoff capped at `MAX_RETRIES`.
+   *
+   * On GraphQL-level errors (HTTP 200 + `errors[]`) we do NOT retry —
+   * those are deterministic and would only burn rate budget.
+   */
+  private async graphql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const { data, statusCode } = await this.executeRequest<T>(query, variables);
+
+        // Successful response with parsed data — return.
+        if (data) {
+          return data;
+        }
+
+        // Defensive: executeRequest should have thrown if no data and no
+        // recoverable status. If we land here, treat as terminal.
+        throw new Error(`Linear API returned no data (status ${statusCode})`);
+      } catch (error) {
+        lastError = error as Error;
+        const retryAfter = (error as Error & { retryAfterMs?: number }).retryAfterMs;
+        const isTransient = (error as Error & { transient?: boolean }).transient === true;
+
+        if (!isTransient || attempt === MAX_RETRIES) {
+          throw error;
+        }
+
+        const delay = retryAfter ?? RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+        logger.warn('Linear API transient error, retrying', {
+          attempt: attempt + 1,
+          maxRetries: MAX_RETRIES,
+          delayMs: delay,
+          error: (error as Error).message,
+        });
+        await sleep(delay);
+      }
+    }
+
+    // Unreachable — the loop either returns or throws — but TypeScript
+    // can't see that.
+    throw lastError ?? new Error('Linear API request failed');
+  }
+
+  /**
+   * Single request attempt. Separated from retry orchestration so the
+   * retry logic stays linear and testable.
+   *
+   * Returns the parsed GraphQL data + status. Throws on HTTP errors,
+   * GraphQL errors, or JSON parse failures. Transient errors are flagged
+   * via `error.transient` so the caller decides retry.
+   */
+  private async executeRequest<T>(
+    query: string,
+    variables?: Record<string, unknown>
+  ): Promise<RequestResult<T>> {
+    // DNS rebinding defense — same pattern as `JiraClient`. Linear's
+    // hostname is fixed but DNS is still a trust boundary.
+    const { lookup } = await pinHostnameToIp(LINEAR_API_HOST);
+    const body = JSON.stringify({ query, variables: variables ?? {} });
+
+    return new Promise<RequestResult<T>>((resolve, reject) => {
+      const req = httpsRequest(
+        {
+          hostname: LINEAR_API_HOST,
+          port: 443,
+          path: GRAPHQL_PATH,
+          method: 'POST',
+          headers: {
+            // Personal API keys: raw header value, no Bearer prefix.
+            // OAuth would use `Bearer <token>` — we don't accept those yet.
+            Authorization: this.apiKey,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'Content-Length': Buffer.byteLength(body).toString(),
+          },
+          lookup,
+        },
+        (res) => {
+          let raw = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk: string) => {
+            raw += chunk;
+          });
+          res.on('end', () => {
+            const statusCode = res.statusCode ?? 0;
+
+            // HTTP-level error handling. 429 and 5xx are transient.
+            if (statusCode >= 400) {
+              const transient = statusCode === 429 || statusCode >= 500;
+              const retryAfterHeader = res.headers['retry-after'];
+              const retryAfterMs = parseRetryAfter(retryAfterHeader);
+              const errorMsg = `Linear API HTTP ${statusCode}: ${raw.slice(0, 500)}`;
+              const err = new Error(errorMsg) as Error & {
+                transient?: boolean;
+                retryAfterMs?: number;
+                statusCode?: number;
+              };
+              err.transient = transient;
+              err.retryAfterMs = retryAfterMs;
+              err.statusCode = statusCode;
+              logger.error('Linear API HTTP error', {
+                statusCode,
+                transient,
+                retryAfterMs,
+                bodyPreview: raw.slice(0, 200),
+              });
+              return reject(err);
+            }
+
+            // Parse GraphQL response.
+            let parsed: GraphQLResponse<T>;
+            try {
+              parsed = JSON.parse(raw) as GraphQLResponse<T>;
+            } catch {
+              return reject(new Error('Linear API returned malformed JSON'));
+            }
+
+            if (parsed.errors && parsed.errors.length > 0) {
+              const msg = formatGraphQLError(parsed.errors);
+              logger.error('Linear GraphQL error', {
+                errorCount: parsed.errors.length,
+                firstError: parsed.errors[0],
+              });
+              return reject(new Error(`Linear API error: ${msg}`));
+            }
+
+            if (parsed.data === undefined) {
+              return reject(new Error('Linear API returned no data'));
+            }
+
+            resolve({ data: parsed.data, statusCode });
+          });
+        }
+      );
+
+      req.on('error', (error) => {
+        // Network-level errors (DNS, ECONNRESET, etc) are treated as transient.
+        const err = new Error(`Linear API network error: ${error.message}`) as Error & {
+          transient?: boolean;
+        };
+        err.transient = true;
+        reject(err);
+      });
+
+      req.setTimeout(DEFAULT_TIMEOUT_MS, () => {
+        req.destroy();
+        const err = new Error('Linear API request timeout') as Error & {
+          transient?: boolean;
+        };
+        err.transient = true;
+        reject(err);
+      });
+
+      req.write(body);
+      req.end();
+    });
+  }
+
+  /**
+   * Identify the calling user — used by `testConnection` to validate the
+   * API key without side effects. Cheaper and more reliable than touching
+   * a specific team / project.
+   */
+  async viewer(): Promise<LinearViewer> {
+    const query = `query Viewer {
+      viewer {
+        id
+        name
+        email
+        organization { id name urlKey }
+      }
+    }`;
+    const result = await this.graphql<{ viewer: LinearViewer }>(query);
+    return result.viewer;
+  }
+
+  /**
+   * List teams visible to the authenticated user.
+   *
+   * Backs the wizard's first picker step. Linear has no separate "project
+   * search" endpoint at the team level — `teams` already returns the small
+   * (single-org) set most users care about. We expose `query` as an
+   * optional substring filter applied to `name` (Linear's API also lets
+   * us filter on `key`, but a unified substring match keeps the UI simple).
+   */
+  async teams(query?: string, first = TEAMS_PAGE_SIZE): Promise<LinearTeam[]> {
+    const trimmed = query?.trim();
+    const filter = trimmed ? `filter: { name: { containsIgnoreCase: $q } }` : '';
+    const args = `first: $first${filter ? `, ${filter}` : ''}`;
+    const params = trimmed ? '$q: String!, $first: Int!' : '$first: Int!';
+
+    const gql = `query Teams(${params}) {
+      teams(${args}) {
+        nodes { id key name }
+      }
+    }`;
+    const variables: Record<string, unknown> = { first };
+    if (trimmed) {
+      variables.q = trimmed;
+    }
+
+    const result = await this.graphql<{ teams: { nodes: LinearTeam[] } }>(gql, variables);
+    return result.teams.nodes;
+  }
+
+  /**
+   * List Linear Projects within a team. Used for the optional second-step
+   * picker in the wizard (Team → Project → save).
+   */
+  async projectsForTeam(
+    teamId: string,
+    query?: string,
+    first = PROJECTS_PAGE_SIZE
+  ): Promise<LinearProject[]> {
+    const trimmed = query?.trim();
+    const filter = trimmed ? `, filter: { name: { containsIgnoreCase: $q } }` : '';
+    const params = trimmed
+      ? '$teamId: String!, $first: Int!, $q: String!'
+      : '$teamId: String!, $first: Int!';
+
+    const gql = `query TeamProjects(${params}) {
+      team(id: $teamId) {
+        projects(first: $first${filter}) {
+          nodes { id name description state }
+        }
+      }
+    }`;
+    const variables: Record<string, unknown> = { teamId, first };
+    if (trimmed) {
+      variables.q = trimmed;
+    }
+
+    const result = await this.graphql<{ team: { projects: { nodes: LinearProject[] } } | null }>(
+      gql,
+      variables
+    );
+    return result.team?.projects.nodes ?? [];
+  }
+
+  /**
+   * User search — backs assignee autocomplete in rule-form UI.
+   *
+   * Linear filters on `name` / `displayName` / `email` via the `or`
+   * combinator. The Jira plugin returns a flat `{accountId, displayName,
+   * emailAddress, avatarUrls}` shape; we adapt at the service layer.
+   */
+  async searchUsers(query: string, first = USERS_PAGE_SIZE): Promise<LinearUser[]> {
+    const trimmed = query.trim();
+    if (trimmed.length === 0) {
+      return [];
+    }
+
+    const gql = `query SearchUsers($q: String!, $first: Int!) {
+      users(
+        first: $first,
+        filter: {
+          or: [
+            { name: { containsIgnoreCase: $q } },
+            { displayName: { containsIgnoreCase: $q } },
+            { email: { containsIgnoreCase: $q } }
+          ]
+        }
+      ) {
+        nodes { id name displayName email avatarUrl active }
+      }
+    }`;
+    const result = await this.graphql<{ users: { nodes: LinearUser[] } }>(gql, {
+      q: trimmed,
+      first,
+    });
+    return result.users.nodes;
+  }
+
+  /**
+   * Create an issue. Returns the canonical web URL Linear assigns — no
+   * client-side URL templating, unlike Jira.
+   */
+  async createIssue(input: LinearIssueInput): Promise<LinearIssue> {
+    const gql = `mutation CreateIssue($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { id identifier url title }
+      }
+    }`;
+    const result = await this.graphql<{
+      issueCreate: { success: boolean; issue: LinearIssue | null };
+    }>(gql, { input });
+
+    if (!result.issueCreate.success || !result.issueCreate.issue) {
+      throw new Error('Linear issueCreate returned success=false');
+    }
+    return result.issueCreate.issue;
+  }
+
+  /**
+   * Two-step file upload (step 1 of 2).
+   *
+   * Linear doesn't accept multipart on issue creation — instead we ask for
+   * a presigned asset URL, PUT the bytes there with whatever headers
+   * Linear returns, and either reference `assetUrl` from an
+   * `attachmentCreate` or embed it inline in the issue description.
+   *
+   * `size` is required by Linear (the API uses it to plan storage and to
+   * reject oversize uploads up-front), which is why the service layer has
+   * to know the screenshot's byte length before calling this — we can't
+   * just stream blind.
+   */
+  async fileUpload(filename: string, contentType: string, size: number): Promise<LinearFileUpload> {
+    const gql = `mutation FileUpload($filename: String!, $contentType: String!, $size: Int!) {
+      fileUpload(filename: $filename, contentType: $contentType, size: $size) {
+        success
+        uploadFile {
+          uploadUrl
+          assetUrl
+          headers { key value }
+        }
+      }
+    }`;
+    const result = await this.graphql<{
+      fileUpload: {
+        success: boolean;
+        uploadFile: LinearFileUpload | null;
+      };
+    }>(gql, { filename, contentType, size });
+
+    if (!result.fileUpload.success || !result.fileUpload.uploadFile) {
+      throw new Error('Linear fileUpload returned success=false');
+    }
+    return result.fileUpload.uploadFile;
+  }
+
+  /**
+   * PUT the actual bytes to the presigned URL (step 2 of 2).
+   *
+   * Implemented as a separate method so callers can choose between
+   * buffered and streamed uploads. We use the global `fetch` here rather
+   * than `https.request` because the upload target is an asset host
+   * (S3-style), not Linear itself — DNS pinning is less critical and
+   * fetch's streaming body support is simpler. We do NOT follow
+   * redirects (`redirect: 'error'`) to keep the upload destination
+   * exactly what Linear returned.
+   */
+  async uploadAssetBytes(
+    upload: LinearFileUpload,
+    body: Buffer | NodeJS.ReadableStream,
+    contentType: string
+  ): Promise<void> {
+    const headers: Record<string, string> = { 'Content-Type': contentType };
+    for (const { key, value } of upload.headers) {
+      headers[key] = value;
+    }
+
+    // `fetch` accepts Buffer and ReadableStream as body. We use the global
+    // fetch (Node 18+); duplex hint is required for streamed bodies.
+    // Cast: the global `RequestInit['body']` type doesn't include Node
+    // streams in lib.dom.d.ts, but undici (Node's fetch implementation)
+    // accepts them at runtime.
+    const init: RequestInit & { duplex?: 'half' } = {
+      method: 'PUT',
+      headers,
+      body: body as unknown as RequestInit['body'],
+      redirect: 'error',
+    };
+    if (!Buffer.isBuffer(body)) {
+      init.duplex = 'half';
+    }
+
+    const response = await fetch(upload.uploadUrl, init);
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Linear asset upload failed: HTTP ${response.status} ${text.slice(0, 200)}`);
+    }
+  }
+
+  /**
+   * Create an attachment that references an already-uploaded asset URL
+   * (or any external URL). Distinct from file upload — this is the
+   * GraphQL record that ties the file to an issue.
+   */
+  async createAttachment(issueId: string, url: string, title: string): Promise<LinearAttachment> {
+    const gql = `mutation AttachmentCreate($issueId: String!, $url: String!, $title: String!) {
+      attachmentCreate(input: { issueId: $issueId, url: $url, title: $title }) {
+        success
+        attachment { id title url }
+      }
+    }`;
+    const result = await this.graphql<{
+      attachmentCreate: { success: boolean; attachment: LinearAttachment | null };
+    }>(gql, { issueId, url, title });
+
+    if (!result.attachmentCreate.success || !result.attachmentCreate.attachment) {
+      throw new Error('Linear attachmentCreate returned success=false');
+    }
+    return result.attachmentCreate.attachment;
+  }
+
+  /**
+   * Construct a fallback issue URL when the API hasn't returned one.
+   * Used only as a safety net — `issueCreate` already gives us `url`.
+   */
+  static getIssueUrl(orgUrlKey: string, identifier: string): string {
+    return `${'https://linear.app'}/${orgUrlKey}/issue/${identifier}`;
+  }
+}
+
+/**
+ * Parse `Retry-After` header into milliseconds. Linear typically returns
+ * an integer number of seconds; the HTTP spec also allows a date.
+ *
+ * Returns `undefined` when the header is missing or unparseable so the
+ * caller falls back to exponential backoff.
+ */
+function parseRetryAfter(header: string | string[] | undefined): number | undefined {
+  if (!header) {
+    return undefined;
+  }
+  const value = Array.isArray(header) ? header[0] : header;
+  const asInt = parseInt(value, 10);
+  if (Number.isFinite(asInt) && asInt >= 0) {
+    return asInt * 1000;
+  }
+  const asDate = Date.parse(value);
+  if (Number.isFinite(asDate)) {
+    const diff = asDate - Date.now();
+    return diff > 0 ? diff : 0;
+  }
+  return undefined;
+}
+
+// Test-only export — see client.test.ts.
+export const __test = { parseRetryAfter, formatGraphQLError };
+
+export { LINEAR_API_URL };

--- a/packages/backend/src/integrations/linear/client.ts
+++ b/packages/backend/src/integrations/linear/client.ts
@@ -19,6 +19,7 @@ import { pinHostnameToIp } from '../security/hardened-http.js';
 import {
   LINEAR_API_HOST,
   LINEAR_API_URL,
+  LINEAR_WEB_HOST,
   type LinearIssueInput,
   type LinearIssue,
   type LinearTeam,
@@ -50,6 +51,12 @@ const PROJECTS_PAGE_SIZE = 50;
  */
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 500;
+/**
+ * Upper bound on a single retry sleep. A pathological `Retry-After` from
+ * the server (minutes, hours) would otherwise pin the worker indefinitely
+ * — we'd rather give up and let the outbox retry policy take over.
+ */
+const MAX_RETRY_DELAY_MS = 30_000;
 
 interface GraphQLResponse<T> {
   data?: T;
@@ -89,6 +96,13 @@ export class LinearClient {
     if (!apiKey || apiKey.trim().length === 0) {
       throw new Error('Linear API key is required');
     }
+    // Reject CRLF / NUL on the raw value, not on the trimmed one — node
+    // may also reject these at request time, but catching them at
+    // construction time gives a clearer error and rules out any chance
+    // of header injection via the Authorization line.
+    if (/[\r\n\0]/.test(apiKey)) {
+      throw new Error('Linear API key contains illegal control characters');
+    }
     this.apiKey = apiKey.trim();
   }
 
@@ -106,16 +120,10 @@ export class LinearClient {
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        const { data, statusCode } = await this.executeRequest<T>(query, variables);
-
-        // Successful response with parsed data — return.
-        if (data) {
-          return data;
-        }
-
-        // Defensive: executeRequest should have thrown if no data and no
-        // recoverable status. If we land here, treat as terminal.
-        throw new Error(`Linear API returned no data (status ${statusCode})`);
+        // executeRequest throws if `parsed.data` is undefined, so a
+        // returned value always carries usable data — no extra guard.
+        const { data } = await this.executeRequest<T>(query, variables);
+        return data;
       } catch (error) {
         lastError = error as Error;
         const retryAfter = (error as Error & { retryAfterMs?: number }).retryAfterMs;
@@ -125,11 +133,16 @@ export class LinearClient {
           throw error;
         }
 
-        const delay = retryAfter ?? RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+        // Cap server-supplied delay so a hostile/buggy Retry-After can't
+        // stall the worker. The outbox layer will retry later on its own
+        // schedule if we give up here.
+        const requested = retryAfter ?? RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+        const delay = Math.min(requested, MAX_RETRY_DELAY_MS);
         logger.warn('Linear API transient error, retrying', {
           attempt: attempt + 1,
           maxRetries: MAX_RETRIES,
           delayMs: delay,
+          requestedDelayMs: requested,
           error: (error as Error).message,
         });
         await sleep(delay);
@@ -304,6 +317,22 @@ export class LinearClient {
   }
 
   /**
+   * Fetch a single team by id. Returns `null` when the team isn't visible
+   * to this API key (Linear returns `team: null` for non-existent or
+   * inaccessible ids — no separate 404).
+   *
+   * Used by `LinearConfigManager.validate` instead of `teams()` so the
+   * check doesn't break for orgs with more than one page (~50) of teams.
+   */
+  async getTeam(teamId: string): Promise<LinearTeam | null> {
+    const gql = `query GetTeam($teamId: String!) {
+      team(id: $teamId) { id key name }
+    }`;
+    const result = await this.graphql<{ team: LinearTeam | null }>(gql, { teamId });
+    return result.team;
+  }
+
+  /**
    * List Linear Projects within a team. Used for the optional second-step
    * picker in the wizard (Team → Project → save).
    */
@@ -445,6 +474,20 @@ export class LinearClient {
     body: Buffer | NodeJS.ReadableStream,
     contentType: string
   ): Promise<void> {
+    // The presigned URL comes from a successful `fileUpload` response, so
+    // it's already trusted in principle — but a misconfigured Linear
+    // response or an MITM during an incident could downgrade us. Reject
+    // anything that isn't HTTPS at the call site.
+    let parsedUploadUrl: URL;
+    try {
+      parsedUploadUrl = new URL(upload.uploadUrl);
+    } catch {
+      throw new Error('Linear asset uploadUrl is not a valid URL');
+    }
+    if (parsedUploadUrl.protocol !== 'https:') {
+      throw new Error(`Linear asset uploadUrl must use https, got ${parsedUploadUrl.protocol}`);
+    }
+
     const headers: Record<string, string> = { 'Content-Type': contentType };
     for (const { key, value } of upload.headers) {
       headers[key] = value;
@@ -455,17 +498,22 @@ export class LinearClient {
     // Cast: the global `RequestInit['body']` type doesn't include Node
     // streams in lib.dom.d.ts, but undici (Node's fetch implementation)
     // accepts them at runtime.
+    //
+    // Timeout: this is the only outbound fetch that doesn't go through
+    // `httpsRequest` (which has `req.setTimeout`). A stalled presigned
+    // PUT would otherwise hang issue creation indefinitely.
     const init: RequestInit & { duplex?: 'half' } = {
       method: 'PUT',
       headers,
       body: body as unknown as RequestInit['body'],
       redirect: 'error',
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
     };
     if (!Buffer.isBuffer(body)) {
       init.duplex = 'half';
     }
 
-    const response = await fetch(upload.uploadUrl, init);
+    const response = await fetch(parsedUploadUrl, init);
     if (!response.ok) {
       const text = await response.text().catch(() => '');
       throw new Error(`Linear asset upload failed: HTTP ${response.status} ${text.slice(0, 200)}`);
@@ -499,7 +547,7 @@ export class LinearClient {
    * Used only as a safety net — `issueCreate` already gives us `url`.
    */
   static getIssueUrl(orgUrlKey: string, identifier: string): string {
-    return `${'https://linear.app'}/${orgUrlKey}/issue/${identifier}`;
+    return `${LINEAR_WEB_HOST}/${orgUrlKey}/issue/${identifier}`;
   }
 }
 

--- a/packages/backend/src/integrations/linear/config.ts
+++ b/packages/backend/src/integrations/linear/config.ts
@@ -1,0 +1,394 @@
+/**
+ * Linear Configuration Manager
+ *
+ * Mirrors `JiraConfigManager` in shape so the surrounding plumbing
+ * (project_integrations table, encryption, route validation) doesn't need
+ * any platform branches — just a different config-manager instance.
+ *
+ * Differences from Jira:
+ *   - Single credential field (`apiKey`), no email/host pair.
+ *   - Host is fixed (api.linear.app); no per-tenant URL validation.
+ *   - Issue scope is a Team (`teamId` UUID + `teamKey` like "ENG") rather
+ *     than a Jira project key.
+ */
+
+import type { ProjectIntegrationRepository } from '../../db/project-integration.repository.js';
+import { getLogger } from '../../logger.js';
+import { getEncryptionService } from '../../utils/encryption.js';
+import { LinearClient } from './client.js';
+import type {
+  LinearConfig,
+  LinearCredentials,
+  LinearProjectConfig,
+  LinearConnectionTestResult,
+} from './types.js';
+
+const logger = getLogger();
+
+const PLATFORM = 'linear';
+
+/**
+ * Linear team keys are uppercase short identifiers (e.g. "ENG", "PROD-A").
+ * We don't enforce a strict regex — Linear lets teams choose their own
+ * key format, including non-uppercase characters in older orgs. The API
+ * rejects malformed keys server-side with a clear error, which is what we
+ * surface to the user.
+ */
+const TEAM_KEY_MIN_LENGTH = 1;
+const TEAM_KEY_MAX_LENGTH = 64;
+
+export class LinearConfigManager {
+  private integrationRepo: ProjectIntegrationRepository;
+  private encryptionService = getEncryptionService();
+
+  constructor(integrationRepo: ProjectIntegrationRepository) {
+    this.integrationRepo = integrationRepo;
+  }
+
+  /**
+   * Decrypt and parse Linear credentials.
+   *
+   * `contextId` is only used for log breadcrumbs — same convention as
+   * `JiraConfigManager.decryptCredentials`.
+   */
+  private decryptCredentials(
+    encryptedCredentials: string,
+    contextId: string
+  ): LinearCredentials | null {
+    try {
+      const decrypted = this.encryptionService.decrypt(encryptedCredentials);
+      const parsed = JSON.parse(decrypted) as LinearCredentials;
+      if (!parsed.apiKey || typeof parsed.apiKey !== 'string') {
+        logger.error('Linear credentials decrypted but apiKey missing/invalid', { contextId });
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      logger.error('Failed to decrypt Linear credentials', {
+        contextId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Build a runtime `LinearConfig` from the persisted plaintext config
+   * and the decrypted credentials. Returns `null` if essential fields are
+   * missing — the caller surfaces a 404 / disabled-integration error.
+   */
+  private buildConfig(
+    config: LinearProjectConfig,
+    credentials: LinearCredentials,
+    enabled: boolean,
+    contextId: string
+  ): LinearConfig | null {
+    if (!config.teamId || !config.teamKey) {
+      logger.error('Linear integration missing teamId/teamKey in config', { contextId });
+      return null;
+    }
+
+    return {
+      apiKey: credentials.apiKey,
+      teamId: config.teamId,
+      teamKey: config.teamKey,
+      projectId: config.projectId,
+      projectName: config.projectName,
+      defaultLabels: config.defaultLabels,
+      enabled,
+      ...(config.templateConfig ? { templateConfig: config.templateConfig } : {}),
+    };
+  }
+
+  /**
+   * Load Linear configuration from environment variables.
+   *
+   * Provided for parity with Jira's `fromEnvironment` so a single
+   * self-hosted instance can seed a default Linear integration without
+   * UI configuration. Optional — most users will configure via the admin
+   * panel and ignore this path.
+   */
+  static fromEnvironment(): LinearConfig | null {
+    const apiKey = process.env.LINEAR_API_KEY;
+    const teamId = process.env.LINEAR_TEAM_ID;
+    const teamKey = process.env.LINEAR_TEAM_KEY;
+
+    if (!apiKey || !teamId || !teamKey) {
+      logger.debug('Linear environment configuration incomplete', {
+        hasApiKey: !!apiKey,
+        hasTeamId: !!teamId,
+        hasTeamKey: !!teamKey,
+      });
+      return null;
+    }
+
+    const config: LinearConfig = {
+      apiKey,
+      teamId,
+      teamKey,
+      projectId: process.env.LINEAR_PROJECT_ID,
+      projectName: process.env.LINEAR_PROJECT_NAME,
+      enabled: true,
+    };
+
+    logger.info('Loaded Linear configuration from environment', {
+      teamKey,
+      hasProject: !!config.projectId,
+    });
+
+    return config;
+  }
+
+  /**
+   * Load Linear configuration for a project from the database.
+   */
+  async fromDatabase(projectId: string): Promise<LinearConfig | null> {
+    try {
+      const integration = await this.integrationRepo.findEnabledByProjectAndPlatform(
+        projectId,
+        PLATFORM
+      );
+
+      if (!integration) {
+        logger.debug('No Linear integration found for project', { projectId });
+        return null;
+      }
+
+      if (!integration.encrypted_credentials) {
+        logger.error('Linear integration missing encrypted credentials', { projectId });
+        return null;
+      }
+
+      const credentials = this.decryptCredentials(integration.encrypted_credentials, projectId);
+      if (!credentials) {
+        return null;
+      }
+
+      const config = integration.config as unknown as LinearProjectConfig;
+      return this.buildConfig(config, credentials, integration.enabled, projectId);
+    } catch (error) {
+      logger.error('Error loading Linear configuration from database', {
+        projectId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Persist a `LinearConfig` to the database. Validates first; encrypts
+   * credentials; stores config + encrypted_credentials atomically via
+   * `ProjectIntegrationRepository.upsert`.
+   */
+  async saveToDatabase(projectId: string, config: LinearConfig): Promise<void> {
+    try {
+      const validation = await LinearConfigManager.validate(config);
+      if (!validation.valid) {
+        throw new Error(`Invalid Linear configuration: ${validation.error}`);
+      }
+
+      const credentials: LinearCredentials = { apiKey: config.apiKey };
+
+      const projectConfig: LinearProjectConfig = {
+        teamId: config.teamId,
+        teamKey: config.teamKey,
+        projectId: config.projectId,
+        projectName: config.projectName,
+        defaultLabels: config.defaultLabels,
+        autoCreate: true,
+        syncStatus: false,
+        syncComments: false,
+        ...(config.templateConfig ? { templateConfig: config.templateConfig } : {}),
+      };
+
+      const encryptedCredentials = this.encryptionService.encrypt(JSON.stringify(credentials));
+
+      await this.integrationRepo.upsert(projectId, PLATFORM, {
+        enabled: config.enabled,
+        config: projectConfig as unknown as Record<string, unknown>,
+        encrypted_credentials: encryptedCredentials,
+      });
+
+      logger.info('Saved Linear configuration to database', {
+        projectId,
+        teamKey: config.teamKey,
+        hasLinearProject: !!config.projectId,
+        enabled: config.enabled,
+      });
+    } catch (error) {
+      logger.error('Failed to save Linear configuration', {
+        projectId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  async deleteFromDatabase(projectId: string): Promise<void> {
+    try {
+      const deleted = await this.integrationRepo.deleteByProjectAndPlatform(projectId, PLATFORM);
+      if (!deleted) {
+        logger.warn('No Linear configuration found to delete', { projectId });
+      }
+      logger.info('Deleted Linear configuration from database', { projectId });
+    } catch (error) {
+      logger.error('Failed to delete Linear configuration', {
+        projectId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  async setEnabled(projectId: string, enabled: boolean): Promise<void> {
+    try {
+      const updated = await this.integrationRepo.setEnabled(projectId, PLATFORM, enabled);
+      if (!updated) {
+        throw new Error('Linear integration not found for project');
+      }
+      logger.info('Updated Linear integration status', { projectId, enabled });
+    } catch (error) {
+      logger.error('Failed to update Linear integration status', {
+        projectId,
+        enabled,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Get config for a project, trying DB first then environment.
+   * Identical fallback policy to `JiraConfigManager.getConfig`.
+   */
+  async getConfig(projectId: string): Promise<LinearConfig | null> {
+    const dbConfig = await this.fromDatabase(projectId);
+    if (dbConfig) {
+      return dbConfig;
+    }
+
+    const envConfig = LinearConfigManager.fromEnvironment();
+    if (envConfig) {
+      logger.debug('Using environment Linear configuration', { projectId });
+      return envConfig;
+    }
+    return null;
+  }
+
+  /**
+   * Load config by specific integration row id — required when a project
+   * has multiple integrations and the caller wants to disambiguate.
+   * Mirrors `JiraConfigManager.getConfigByIntegrationId`.
+   */
+  async getConfigByIntegrationId(integrationId: string): Promise<LinearConfig | null> {
+    try {
+      const integration = await this.integrationRepo.findByIdWithType(integrationId);
+      if (!integration || !integration.enabled) {
+        logger.debug('No enabled Linear integration found', { integrationId });
+        return null;
+      }
+
+      if (integration.integration_type !== PLATFORM) {
+        logger.error('Integration is not a Linear integration', {
+          integrationId,
+          platform: integration.integration_type,
+        });
+        return null;
+      }
+
+      if (!integration.encrypted_credentials) {
+        logger.error('Linear integration missing encrypted credentials', { integrationId });
+        return null;
+      }
+
+      const credentials = this.decryptCredentials(integration.encrypted_credentials, integrationId);
+      if (!credentials) {
+        return null;
+      }
+
+      const config = integration.config as unknown as LinearProjectConfig;
+      return this.buildConfig(config, credentials, integration.enabled, integrationId);
+    } catch (error) {
+      logger.error('Error loading Linear configuration by integration ID', {
+        integrationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  // ============================================================================
+  // VALIDATION
+  // ============================================================================
+
+  /**
+   * Validate a `LinearConfig` shape and reachability.
+   *
+   * Format checks are cheap and run first. The connection test (`viewer`
+   * query) is the expensive step — gated behind format checks so we don't
+   * burn rate budget on obviously-invalid inputs.
+   */
+  static async validate(config: LinearConfig): Promise<LinearConnectionTestResult> {
+    if (!config.apiKey || config.apiKey.trim().length === 0) {
+      return { valid: false, error: 'Linear API key is required' };
+    }
+    if (!config.teamId || config.teamId.trim().length === 0) {
+      return { valid: false, error: 'Linear teamId is required' };
+    }
+    if (!config.teamKey || config.teamKey.trim().length === 0) {
+      return { valid: false, error: 'Linear teamKey is required' };
+    }
+    if (
+      config.teamKey.length < TEAM_KEY_MIN_LENGTH ||
+      config.teamKey.length > TEAM_KEY_MAX_LENGTH
+    ) {
+      return {
+        valid: false,
+        error: `Team key length must be between ${TEAM_KEY_MIN_LENGTH} and ${TEAM_KEY_MAX_LENGTH} characters`,
+      };
+    }
+
+    try {
+      const client = new LinearClient(config.apiKey);
+      const viewer = await client.viewer();
+
+      // Verify the team is reachable for this key. We don't run a separate
+      // `team(id)` query if `teams` already includes it — Linear's `viewer`
+      // doesn't carry team membership, so a dedicated `teams` call is the
+      // cheapest reliable check.
+      const teams = await client.teams();
+      const teamExists = teams.some((t) => t.id === config.teamId);
+
+      if (!teamExists) {
+        return {
+          valid: false,
+          error: `Team "${config.teamKey}" not found or you don't have access`,
+          details: {
+            viewerEmail: viewer.email,
+            organizationName: viewer.organization?.name,
+            teamExists: false,
+          },
+        };
+      }
+
+      logger.info('Linear configuration validated', {
+        teamKey: config.teamKey,
+        viewerEmail: viewer.email,
+        organization: viewer.organization?.name,
+      });
+
+      return {
+        valid: true,
+        details: {
+          viewerEmail: viewer.email,
+          organizationName: viewer.organization?.name,
+          teamExists: true,
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('Linear configuration validation failed', { error: message });
+      return { valid: false, error: `Connection test failed: ${message}` };
+    }
+  }
+}

--- a/packages/backend/src/integrations/linear/config.ts
+++ b/packages/backend/src/integrations/linear/config.ts
@@ -107,8 +107,18 @@ export class LinearConfigManager {
    * self-hosted instance can seed a default Linear integration without
    * UI configuration. Optional — most users will configure via the admin
    * panel and ignore this path.
+   *
+   * Refuses to return env config in SaaS mode: env vars are shared
+   * infrastructure-level secrets, and a project without explicit DB
+   * config falling back to them would silently leak credentials across
+   * tenants. In SaaS, every project must configure Linear explicitly or
+   * not at all.
    */
   static fromEnvironment(): LinearConfig | null {
+    if (process.env.DEPLOYMENT_MODE === 'saas') {
+      return null;
+    }
+
     const apiKey = process.env.LINEAR_API_KEY;
     const teamId = process.env.LINEAR_TEAM_ID;
     const teamKey = process.env.LINEAR_TEAM_KEY;
@@ -352,14 +362,12 @@ export class LinearConfigManager {
       const client = new LinearClient(config.apiKey);
       const viewer = await client.viewer();
 
-      // Verify the team is reachable for this key. We don't run a separate
-      // `team(id)` query if `teams` already includes it — Linear's `viewer`
-      // doesn't carry team membership, so a dedicated `teams` call is the
-      // cheapest reliable check.
-      const teams = await client.teams();
-      const teamExists = teams.some((t) => t.id === config.teamId);
+      // Direct `team(id)` lookup instead of paging through `teams` —
+      // orgs with more than one page of teams (~50) would otherwise
+      // see a valid teamId rejected as not found.
+      const team = await client.getTeam(config.teamId);
 
-      if (!teamExists) {
+      if (!team) {
         return {
           valid: false,
           error: `Team "${config.teamKey}" not found or you don't have access`,
@@ -371,9 +379,11 @@ export class LinearConfigManager {
         };
       }
 
+      // `viewer.email` deliberately omitted from log payload — PII
+      // retention in server logs without a real use case. Caller still
+      // gets it in the returned `details` if needed.
       logger.info('Linear configuration validated', {
         teamKey: config.teamKey,
-        viewerEmail: viewer.email,
         organization: viewer.organization?.name,
       });
 

--- a/packages/backend/src/integrations/linear/default-template.ts
+++ b/packages/backend/src/integrations/linear/default-template.ts
@@ -1,0 +1,31 @@
+/**
+ * Default Linear description template applied to newly-created auto-create
+ * rules when the caller does not provide one.
+ *
+ * Linear renders Markdown natively, so we use a plain Markdown body (no
+ * ADF). Variables follow the same mustache convention as the Jira default
+ * template — handled by `renderCustomTemplate`.
+ */
+export const LINEAR_DEFAULT_DESCRIPTION_TEMPLATE = `## {{title}}
+
+{{description}}
+
+---
+
+### Environment
+
+| Field    | Value          |
+| -------- | -------------- |
+| Priority | {{priority}}   |
+| Browser  | {{browser}}    |
+| OS       | {{os}}         |
+| Page URL | {{url}}        |
+
+### Session Replay
+
+[Watch session replay]({{replay_url}})
+
+### Screenshot
+
+[View screenshot]({{screenshot_url}})
+`;

--- a/packages/backend/src/integrations/linear/field-mappings.ts
+++ b/packages/backend/src/integrations/linear/field-mappings.ts
@@ -1,0 +1,159 @@
+/**
+ * Linear Field Mappings
+ *
+ * Applies per-rule field overrides to a `LinearIssueInput` before it goes
+ * to `issueCreate`. Mirrors `jira/field-mappings.ts` in surface — same
+ * `Record<string, unknown>` input shape — but the supported keys differ
+ * because Linear has a fixed schema (no Jira-style custom fields).
+ *
+ * Supported keys:
+ *   - `assignee`      : `{ id: string }` or string UUID
+ *   - `assigneeId`    : string UUID
+ *   - `labels`        : `string[]` of label UUIDs
+ *   - `labelIds`      : alias for `labels`
+ *   - `priority`      : number 0..4 (Linear's wire format)
+ *   - `projectId`     : Linear-side project (epic-grouping) UUID
+ *   - `stateId`       : workflow-state UUID
+ *   - `dueDate`       : ISO date string
+ *   - `estimate`      : number (Linear estimate points)
+ *
+ * Unknown keys are ignored — unlike Jira, there's no `customfield_*`
+ * pass-through, because the Linear API rejects unknown fields outright.
+ */
+
+import type { LinearIssueInput, LinearPriority } from './types.js';
+
+function isLinearPriority(value: number): value is LinearPriority {
+  return value === 0 || value === 1 || value === 2 || value === 3 || value === 4;
+}
+
+export function applyFieldMappings(
+  issueInput: LinearIssueInput,
+  fieldMappings: Record<string, unknown>
+): void {
+  Object.entries(fieldMappings).forEach(([fieldName, fieldValue]) => {
+    if (fieldValue === null || fieldValue === undefined) {
+      return;
+    }
+
+    switch (fieldName) {
+      case 'assignee': {
+        if (typeof fieldValue === 'string') {
+          issueInput.assigneeId = fieldValue;
+        } else if (typeof fieldValue === 'object') {
+          const id = (fieldValue as Record<string, unknown>).id;
+          // Accept `accountId` too — the rule-form UI uses Jira's field
+          // name for cross-platform compatibility. Treating it as the
+          // Linear user UUID is documented in service.ts (`searchUsers`).
+          const accountId = (fieldValue as Record<string, unknown>).accountId;
+          if (typeof id === 'string') {
+            issueInput.assigneeId = id;
+          } else if (typeof accountId === 'string') {
+            issueInput.assigneeId = accountId;
+          }
+        }
+        break;
+      }
+
+      case 'assigneeId': {
+        if (typeof fieldValue === 'string') {
+          issueInput.assigneeId = fieldValue;
+        }
+        break;
+      }
+
+      case 'labels':
+      case 'labelIds': {
+        if (Array.isArray(fieldValue)) {
+          const ids = fieldValue.filter((l): l is string => typeof l === 'string');
+          issueInput.labelIds = [...(issueInput.labelIds ?? []), ...ids];
+        }
+        break;
+      }
+
+      case 'priority': {
+        // Accept both `{ name: 'High' }` (Jira-style, for rule-form UI
+        // compatibility) and a raw integer. Named priorities map onto
+        // Linear's integer scheme; unknown names fall through unchanged.
+        if (typeof fieldValue === 'number' && isLinearPriority(fieldValue)) {
+          issueInput.priority = fieldValue;
+        } else if (typeof fieldValue === 'object') {
+          const name = (fieldValue as Record<string, unknown>).name;
+          if (typeof name === 'string') {
+            const mapped = priorityNameToLinear(name);
+            if (mapped !== null) {
+              issueInput.priority = mapped;
+            }
+          }
+        }
+        break;
+      }
+
+      case 'projectId': {
+        if (typeof fieldValue === 'string') {
+          issueInput.projectId = fieldValue;
+        }
+        break;
+      }
+
+      case 'stateId': {
+        if (typeof fieldValue === 'string') {
+          issueInput.stateId = fieldValue;
+        }
+        break;
+      }
+
+      case 'dueDate': {
+        if (typeof fieldValue === 'string') {
+          issueInput.dueDate = fieldValue;
+        }
+        break;
+      }
+
+      case 'estimate': {
+        if (typeof fieldValue === 'number' && Number.isFinite(fieldValue)) {
+          issueInput.estimate = fieldValue;
+        }
+        break;
+      }
+
+      case 'description': {
+        if (typeof fieldValue === 'string') {
+          issueInput.description = fieldValue;
+        }
+        break;
+      }
+
+      default:
+        // Drop unknown keys silently — Linear rejects unknown input
+        // fields server-side, and we'd rather skip than make the whole
+        // ticket creation fail because a stale rule references a removed
+        // field name.
+        break;
+    }
+  });
+}
+
+function priorityNameToLinear(name: string): LinearPriority | null {
+  const normalized = name.toLowerCase().trim();
+  switch (normalized) {
+    case 'urgent':
+    case 'highest':
+    case 'critical':
+      return 1;
+    case 'high':
+      return 2;
+    case 'medium':
+    case 'normal':
+      return 3;
+    case 'low':
+    case 'lowest':
+    case 'minor':
+      return 4;
+    case 'none':
+    case 'no priority':
+      return 0;
+    default:
+      return null;
+  }
+}

--- a/packages/backend/src/integrations/linear/field-mappings.ts
+++ b/packages/backend/src/integrations/linear/field-mappings.ts
@@ -66,7 +66,9 @@ export function applyFieldMappings(
       case 'labelIds': {
         if (Array.isArray(fieldValue)) {
           const ids = fieldValue.filter((l): l is string => typeof l === 'string');
-          issueInput.labelIds = [...(issueInput.labelIds ?? []), ...ids];
+          // De-dupe: config defaults + per-rule labels can overlap, and
+          // Linear treats duplicate labelIds as an error on issueCreate.
+          issueInput.labelIds = Array.from(new Set([...(issueInput.labelIds ?? []), ...ids]));
         }
         break;
       }
@@ -104,8 +106,15 @@ export function applyFieldMappings(
       }
 
       case 'dueDate': {
+        // Reject malformed dates so one stale rule can't fail the whole
+        // issueCreate mutation. Linear accepts ISO `YYYY-MM-DD`; we
+        // additionally call `Date.parse` to catch syntactically valid
+        // patterns that don't resolve to a real date (e.g. 2026-13-40).
         if (typeof fieldValue === 'string') {
-          issueInput.dueDate = fieldValue;
+          const isIsoDate = /^\d{4}-\d{2}-\d{2}$/.test(fieldValue);
+          if (isIsoDate && Number.isFinite(Date.parse(fieldValue))) {
+            issueInput.dueDate = fieldValue;
+          }
         }
         break;
       }

--- a/packages/backend/src/integrations/linear/index.ts
+++ b/packages/backend/src/integrations/linear/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Linear Integration Module
+ *
+ * Public surface of the Linear plugin. The `default` export is what
+ * `PluginRegistry.loadFromFilesystem` looks for when a route asks for the
+ * platform by name without a pre-registered plugin.
+ */
+
+import { linearPlugin } from './plugin.js';
+
+export { LinearClient } from './client.js';
+export { LinearBugReportMapper, mapPriorityToLinear } from './mapper.js';
+export { LinearConfigManager } from './config.js';
+export {
+  LinearIntegrationService,
+  buildLinearAllowedAvatarDomains,
+  LINEAR_TRUSTED_AVATAR_DOMAINS,
+} from './service.js';
+export { LINEAR_DEFAULT_DESCRIPTION_TEMPLATE } from './default-template.js';
+export { linearPlugin } from './plugin.js';
+
+export type {
+  LinearConfig,
+  LinearCredentials,
+  LinearProjectConfig,
+  LinearPriority,
+  LinearTemplateConfig,
+  LinearIssueInput,
+  LinearIssue,
+  LinearTeam,
+  LinearProject,
+  LinearUser,
+  LinearViewer,
+  LinearAttachment,
+  LinearFileUpload,
+  LinearConnectionTestResult,
+  LinearIntegrationResult,
+  LinearGraphQLError,
+} from './types.js';
+
+export default linearPlugin;

--- a/packages/backend/src/integrations/linear/mapper.ts
+++ b/packages/backend/src/integrations/linear/mapper.ts
@@ -1,0 +1,268 @@
+/**
+ * Linear Bug Report Mapper
+ *
+ * Converts a `BugReport` into the input payload Linear's `issueCreate`
+ * mutation expects. Linear consumes Markdown for `description`, so this
+ * mapper is dramatically simpler than the Jira mapper (which has to
+ * produce ADF). No formatter classes; just string assembly.
+ */
+
+import type { BugReport } from '../../db/types.js';
+import { getLogger } from '../../logger.js';
+import type {
+  LinearConfig,
+  LinearIssueInput,
+  LinearPriority,
+  LinearTemplateConfig,
+} from './types.js';
+import { renderCustomTemplate } from './template-renderer.js';
+import { applyFieldMappings } from './field-mappings.js';
+
+const logger = getLogger();
+
+const MAX_TITLE_LENGTH = 255;
+
+/**
+ * Default template config. Console/network sections are off by default
+ * for the same reason as Jira's mapper — the shared replay link already
+ * carries them, and Linear's UI is poor at handling huge code blocks.
+ */
+const DEFAULT_TEMPLATE_CONFIG: Required<LinearTemplateConfig> = {
+  includeConsoleLogs: false,
+  consoleLogLimit: 10,
+  includeNetworkLogs: false,
+  networkLogFilter: 'failures',
+  networkLogLimit: 10,
+  includeShareReplay: true,
+  shareReplayExpiration: 720,
+  shareReplayPassword: null,
+};
+
+/**
+ * BugSpotter priority strings → Linear's integer priority scheme.
+ * Linear: 0=No priority, 1=Urgent, 2=High, 3=Medium, 4=Low.
+ */
+export function mapPriorityToLinear(priority?: string): LinearPriority {
+  const normalized = (priority ?? '').toLowerCase();
+  switch (normalized) {
+    case 'critical':
+      return 1;
+    case 'high':
+      return 2;
+    case 'medium':
+      return 3;
+    case 'low':
+    case 'minor':
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+interface ConsoleLogEntry {
+  level?: string;
+  message?: string;
+  timestamp?: string | number;
+}
+
+interface NetworkLogEntry {
+  method?: string;
+  url?: string;
+  status?: number;
+  duration?: number;
+}
+
+function isConsoleLogEntry(value: unknown): value is ConsoleLogEntry {
+  return value !== null && typeof value === 'object';
+}
+
+function isNetworkLogEntry(value: unknown): value is NetworkLogEntry {
+  return value !== null && typeof value === 'object';
+}
+
+function buildConsoleSection(
+  metadata: Record<string, unknown> | undefined,
+  config: Required<LinearTemplateConfig>
+): string {
+  const consoleData = metadata?.console;
+  if (!Array.isArray(consoleData)) {
+    return '';
+  }
+
+  const entries = consoleData.filter(isConsoleLogEntry).slice(-config.consoleLogLimit);
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const lines = entries.map((e) => {
+    const lvl = (e.level ?? 'log').toUpperCase();
+    const msg = String(e.message ?? '');
+    return `- **[${lvl}]** ${msg}`;
+  });
+
+  return `### Console (last ${entries.length})\n\n${lines.join('\n')}\n`;
+}
+
+function buildNetworkSection(
+  metadata: Record<string, unknown> | undefined,
+  config: Required<LinearTemplateConfig>
+): string {
+  const networkData = metadata?.network;
+  if (!Array.isArray(networkData)) {
+    return '';
+  }
+
+  let entries = networkData.filter(isNetworkLogEntry);
+  if (config.networkLogFilter === 'failures') {
+    entries = entries.filter((e) => typeof e.status === 'number' && e.status >= 400);
+  }
+  entries = entries.slice(-config.networkLogLimit);
+  if (entries.length === 0) {
+    return '';
+  }
+
+  const lines = entries.map(
+    (e) =>
+      `- \`${e.method ?? 'GET'}\` ${e.url ?? ''} → **${e.status ?? '?'}**` +
+      (typeof e.duration === 'number' ? ` (${e.duration}ms)` : '')
+  );
+
+  return `### Network (${entries.length})\n\n${lines.join('\n')}\n`;
+}
+
+function buildEnvironmentSection(bugReport: BugReport): string {
+  const meta = bugReport.metadata ?? {};
+  const get = (k: string): string => {
+    const v = (meta as Record<string, unknown>)[k];
+    return typeof v === 'string' || typeof v === 'number' ? String(v) : '';
+  };
+
+  const rows: Array<[string, string]> = [
+    ['Priority', bugReport.priority ?? 'medium'],
+    ['Browser', get('browser') || 'Unknown'],
+    ['OS', get('os') || 'Unknown'],
+    ['Page URL', get('url')],
+  ];
+
+  const body = rows
+    .filter(([, v]) => v.length > 0)
+    .map(([k, v]) => `| ${k} | ${v} |`)
+    .join('\n');
+
+  return `### Environment\n\n| Field | Value |\n| --- | --- |\n${body}\n`;
+}
+
+function buildAttachmentsSection(bugReport: BugReport, shareReplayUrl?: string): string {
+  const parts: string[] = [];
+  if (shareReplayUrl) {
+    parts.push(`- [Watch session replay](${shareReplayUrl})`);
+  }
+  if (bugReport.screenshot_url) {
+    parts.push(`- [View screenshot](${bugReport.screenshot_url})`);
+  }
+  if (parts.length === 0) {
+    return '';
+  }
+  return `### Attachments\n\n${parts.join('\n')}\n`;
+}
+
+/**
+ * Build the default Markdown description body when no custom template is
+ * provided. Matches the structure of the Jira default but in Markdown.
+ */
+function buildDefaultDescription(
+  bugReport: BugReport,
+  config: Required<LinearTemplateConfig>,
+  shareReplayUrl?: string
+): string {
+  const sections: string[] = [];
+
+  if (bugReport.description) {
+    sections.push(bugReport.description);
+  }
+
+  if (config.includeConsoleLogs) {
+    const s = buildConsoleSection(bugReport.metadata, config);
+    if (s) {
+      sections.push(s);
+    }
+  }
+  if (config.includeNetworkLogs) {
+    const s = buildNetworkSection(bugReport.metadata, config);
+    if (s) {
+      sections.push(s);
+    }
+  }
+
+  sections.push(buildEnvironmentSection(bugReport));
+
+  const effectiveShareUrl = config.includeShareReplay ? shareReplayUrl : undefined;
+  const attachments = buildAttachmentsSection(bugReport, effectiveShareUrl);
+  if (attachments) {
+    sections.push(attachments);
+  }
+
+  sections.push('\n---\n_Created by BugSpotter_');
+
+  return sections.join('\n\n');
+}
+
+export class LinearBugReportMapper {
+  private config: LinearConfig;
+  private templateConfig: Required<LinearTemplateConfig>;
+
+  constructor(config: LinearConfig, templateConfig?: Partial<LinearTemplateConfig>) {
+    this.config = config;
+    this.templateConfig = { ...DEFAULT_TEMPLATE_CONFIG, ...templateConfig };
+  }
+
+  /**
+   * Build the `LinearIssueInput` for a bug report.
+   *
+   * `fieldMappings` are applied last so per-rule overrides (e.g. assignee,
+   * stateId from an integration rule) win over defaults. `descriptionTemplate`
+   * — when present — replaces the entire description body; otherwise we
+   * generate the default Markdown body.
+   */
+  toLinearIssueInput(
+    bugReport: BugReport,
+    shareReplayUrl?: string,
+    fieldMappings?: Record<string, unknown> | null,
+    descriptionTemplate?: string | null
+  ): LinearIssueInput {
+    // Linear has no hard title length cap but a 255-char ceiling keeps
+    // URLs and tracking-tool integrations sane. Same threshold as Jira.
+    const title =
+      bugReport.title.length > MAX_TITLE_LENGTH
+        ? bugReport.title.substring(0, MAX_TITLE_LENGTH - 3) + '...'
+        : bugReport.title;
+
+    const description = descriptionTemplate
+      ? renderCustomTemplate(descriptionTemplate, bugReport, shareReplayUrl)
+      : buildDefaultDescription(bugReport, this.templateConfig, shareReplayUrl);
+
+    const input: LinearIssueInput = {
+      teamId: this.config.teamId,
+      title,
+      description,
+      priority: mapPriorityToLinear(bugReport.priority),
+    };
+
+    if (this.config.projectId) {
+      input.projectId = this.config.projectId;
+    }
+    if (this.config.defaultLabels && this.config.defaultLabels.length > 0) {
+      input.labelIds = [...this.config.defaultLabels];
+    }
+
+    if (fieldMappings && typeof fieldMappings === 'object') {
+      logger.debug('Applying field mappings to Linear issue', {
+        bugReportId: bugReport.id,
+        mappingKeys: Object.keys(fieldMappings),
+      });
+      applyFieldMappings(input, fieldMappings);
+    }
+
+    return input;
+  }
+}

--- a/packages/backend/src/integrations/linear/plugin.ts
+++ b/packages/backend/src/integrations/linear/plugin.ts
@@ -1,0 +1,35 @@
+/**
+ * Linear Integration Plugin
+ *
+ * Plugin wrapper for the Linear integration service. Registered via
+ * `plugin-loader.ts` alongside the Jira plugin.
+ */
+
+import type { IntegrationPlugin } from '../plugin.types.js';
+import { LinearIntegrationService } from './service.js';
+import { LINEAR_DEFAULT_DESCRIPTION_TEMPLATE } from './default-template.js';
+
+export const linearPlugin: IntegrationPlugin = {
+  metadata: {
+    name: 'Linear Integration',
+    platform: 'linear',
+    version: '1.0.0',
+    description: 'Create and sync issues with Linear',
+    author: 'BugSpotter Team',
+    // ENCRYPTION_KEY is shared infrastructure — already declared by the
+    // Jira plugin; listed here too so the registry warns if a deployment
+    // somehow lands without it before Jira is loaded.
+    requiredEnvVars: ['ENCRYPTION_KEY'],
+    isBuiltIn: true,
+    defaultDescriptionTemplate: LINEAR_DEFAULT_DESCRIPTION_TEMPLATE,
+  },
+
+  factory: (context) => {
+    return new LinearIntegrationService(
+      context.db.bugReports,
+      context.db.projectIntegrations,
+      context.db,
+      context.storage
+    );
+  },
+};

--- a/packages/backend/src/integrations/linear/service.ts
+++ b/packages/backend/src/integrations/linear/service.ts
@@ -405,7 +405,10 @@ export class LinearIntegrationService implements IntegrationService {
       defaultLabels: Array.isArray(raw.defaultLabels)
         ? raw.defaultLabels.filter((l): l is string => typeof l === 'string')
         : undefined,
-      enabled: raw.enabled ?? true,
+      // Strict boolean check — `raw.enabled ?? true` would let a
+      // stringly-typed `"false"` pass through as truthy, silently
+      // re-enabling an integration the caller explicitly disabled.
+      enabled: typeof raw.enabled === 'boolean' ? raw.enabled : true,
       templateConfig: raw.templateConfig,
     };
   }

--- a/packages/backend/src/integrations/linear/service.ts
+++ b/packages/backend/src/integrations/linear/service.ts
@@ -1,0 +1,552 @@
+/**
+ * Linear Integration Service
+ *
+ * Orchestrates bug-report → Linear issue creation. Structurally parallel
+ * to `JiraIntegrationService` so the surrounding routes / worker /
+ * outbox plumbing treats both identically.
+ *
+ * Key behavioural differences from Jira:
+ *   - GraphQL transport (single endpoint, fixed host).
+ *   - Two-step screenshot upload: `fileUpload` → PUT → `attachmentCreate`.
+ *     Each step can fail independently; we tolerate attachment failures
+ *     and still report a successful issue (same policy as Jira's mapper).
+ *   - `listProjects()` returns Linear *teams* (not Linear projects) —
+ *     teams are what issues belong to. Linear projects (epic-grouping)
+ *     are exposed via a separate non-contract method.
+ *   - No `searchUsers`-style account IDs: we return Linear user UUIDs in
+ *     the `accountId` field of the shared contract. The field name is
+ *     Jira-flavoured but semantic ("opaque external user id") matches.
+ */
+
+import type { BugReportRepository } from '../../db/repositories.js';
+import type { ProjectIntegrationRepository } from '../../db/project-integration.repository.js';
+import type { DatabaseClient } from '../../db/client.js';
+import type { IStorageService } from '../../storage/types.js';
+import { TICKET_STATUS, type BugReport, type TicketStatus } from '../../db/types.js';
+import type {
+  IntegrationService,
+  IntegrationResult,
+  TicketCreationMetadata,
+} from '../base-integration.service.js';
+import { getLogger } from '../../logger.js';
+import { config as appConfig } from '../../config.js';
+import { AppError, ValidationError } from '../../api/middleware/error.js';
+import { generateShareToken } from '../../utils/token-generator.js';
+import { LinearConfigManager } from './config.js';
+import { LinearClient } from './client.js';
+import { LinearBugReportMapper } from './mapper.js';
+import type {
+  LinearConfig,
+  LinearAttachment,
+  LinearIntegrationResult,
+  LinearTeam,
+  LinearProject,
+  LinearCredentials,
+} from './types.js';
+import { SHARE_TOKEN_EXPIRATION_HOURS } from './types.js';
+
+const logger = getLogger();
+
+const PLATFORM_NAME = 'linear';
+const DEFAULT_TICKET_STATUS: TicketStatus = TICKET_STATUS.OPEN;
+const DEFAULT_SCREENSHOT_FILENAME = 'screenshot.png';
+const SCREENSHOT_CONTENT_TYPE = 'image/png';
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+/**
+ * Domains we'll proxy avatars from for the admin UI's user picker.
+ * Linear hosts avatars on their own subdomain and on S3-style asset
+ * domains; Gravatar appears when users haven't uploaded one.
+ */
+export const LINEAR_TRUSTED_AVATAR_DOMAINS = [
+  '*.linear.app',
+  'public.linear.app',
+  'uploads.linear.app',
+  'secure.gravatar.com',
+] as const;
+
+export function buildLinearAllowedAvatarDomains(_config: Record<string, unknown>): string[] {
+  // Unlike Jira, Linear's instance host is fixed, so no per-config
+  // hostname extraction is needed. The list is static.
+  return [...LINEAR_TRUSTED_AVATAR_DOMAINS];
+}
+
+/**
+ * Raw config shape from frontend admin / wizard forms. Tolerates both
+ * the canonical `apiKey` field and an `authentication.token` nested
+ * shape (the wizard's ConnectionStep stores credentials under
+ * `authentication`).
+ */
+type RawLinearConfig = Partial<LinearConfig> & {
+  authentication?: { type?: string; token?: string };
+};
+
+export class LinearIntegrationService implements IntegrationService {
+  readonly platform = PLATFORM_NAME;
+
+  private db: DatabaseClient;
+  private storage: IStorageService;
+  private configManager: LinearConfigManager;
+
+  /**
+   * Constructor accepts `bugReportRepo` for symmetry with
+   * `JiraIntegrationService` (the plugin factory passes it
+   * unconditionally), but we don't store it — Linear's flow operates on
+   * the bug-report row already supplied by the worker / route layer.
+   */
+  constructor(
+    _bugReportRepo: BugReportRepository,
+    integrationRepo: ProjectIntegrationRepository,
+    db: DatabaseClient,
+    storage: IStorageService
+  ) {
+    this.db = db;
+    this.storage = storage;
+    this.configManager = new LinearConfigManager(integrationRepo);
+  }
+
+  // ============================================================================
+  // CORE CONTRACT
+  // ============================================================================
+
+  async createFromBugReport(
+    bugReport: BugReport,
+    projectId: string,
+    integrationId: string,
+    metadata?: TicketCreationMetadata
+  ): Promise<IntegrationResult> {
+    const result = await this.createInternal(bugReport, projectId, integrationId, metadata);
+    return {
+      externalId: result.issueIdentifier,
+      externalUrl: result.issueUrl,
+      platform: PLATFORM_NAME,
+      metadata: {
+        issueId: result.issueId,
+        attachments: result.attachments,
+      },
+    };
+  }
+
+  async testConnection(projectId: string): Promise<boolean> {
+    const config = await this.configManager.getConfig(projectId);
+    if (!config) {
+      return false;
+    }
+    const result = await LinearConfigManager.validate(config);
+    return result.valid;
+  }
+
+  async validateConfig(
+    config: Record<string, unknown>
+  ): Promise<{ valid: boolean; error?: string; details?: Record<string, unknown> }> {
+    const normalized = this.normalizeConfig(config);
+    const result = await LinearConfigManager.validate(normalized);
+    return {
+      valid: result.valid,
+      error: result.error,
+      details: result.details as Record<string, unknown> | undefined,
+    };
+  }
+
+  // ============================================================================
+  // INTERNAL ORCHESTRATION
+  // ============================================================================
+
+  /**
+   * Create the issue, attach screenshot if present, persist the ticket
+   * row. Mirrors `JiraIntegrationService.createTicketFromBugReportInternal`
+   * step-for-step.
+   */
+  private async createInternal(
+    bugReport: BugReport,
+    projectId: string,
+    integrationId: string,
+    metadata?: TicketCreationMetadata
+  ): Promise<LinearIntegrationResult> {
+    logger.info('Creating Linear issue from bug report', {
+      bugReportId: bugReport.id,
+      projectId,
+      integrationId,
+      ruleId: metadata?.ruleId,
+      createdAutomatically: metadata?.createdAutomatically,
+    });
+
+    const config = await this.loadConfig(integrationId);
+    const shareReplayUrl = await this.generateShareTokenIfNeeded(bugReport, config);
+
+    const mapper = new LinearBugReportMapper(config, config.templateConfig);
+    const input = mapper.toLinearIssueInput(
+      bugReport,
+      shareReplayUrl,
+      metadata?.fieldMappings,
+      metadata?.descriptionTemplate
+    );
+
+    const client = new LinearClient(config.apiKey);
+    const issue = await client.createIssue(input);
+
+    logger.info('Linear issue created', {
+      bugReportId: bugReport.id,
+      issueIdentifier: issue.identifier,
+      issueUrl: issue.url,
+    });
+
+    const attachments = await this.uploadScreenshotIfPresent(client, bugReport, issue.id);
+
+    await this.saveTicketReference(
+      bugReport.id,
+      issue.identifier,
+      issue.url,
+      integrationId,
+      metadata?.ruleId,
+      metadata?.createdAutomatically
+    );
+
+    return {
+      issueId: issue.id,
+      issueIdentifier: issue.identifier,
+      issueUrl: issue.url,
+      attachments,
+    };
+  }
+
+  /**
+   * Load + verify config for the specified integration row.
+   * Throws `AppError` shapes matching the Jira service so route error
+   * handling stays uniform.
+   */
+  private async loadConfig(integrationId: string): Promise<LinearConfig> {
+    const config = await this.configManager.getConfigByIntegrationId(integrationId);
+    if (!config) {
+      throw new AppError(
+        `Linear not configured for integration: ${integrationId}`,
+        404,
+        'NotFound'
+      );
+    }
+    if (!config.enabled) {
+      throw new AppError(
+        `Linear integration disabled: ${integrationId}`,
+        403,
+        'IntegrationDisabled'
+      );
+    }
+    return config;
+  }
+
+  /**
+   * Generate / reuse a share token for the replay link, if applicable.
+   *
+   * Logic is identical to `JiraIntegrationService.generateShareTokenIfNeeded`
+   * — same idempotency invariant (re-use existing active tokens), same
+   * graceful degradation (warn-and-continue if token creation fails).
+   * Kept inline rather than extracted because both plugins are the only
+   * callers and lifting now would require touching Jira.
+   */
+  private async generateShareTokenIfNeeded(
+    bugReport: BugReport,
+    config: LinearConfig
+  ): Promise<string | undefined> {
+    const includeShareReplay = config.templateConfig?.includeShareReplay ?? true;
+    if (!bugReport.replay_key || !includeShareReplay) {
+      return undefined;
+    }
+
+    try {
+      if (!appConfig.frontend.url) {
+        throw new AppError(
+          'FRONTEND_URL environment variable is required for generating share replay links',
+          500,
+          'ConfigurationError'
+        );
+      }
+
+      const existingTokens = await this.db.shareTokens.findByBugReportId(bugReport.id, true);
+      if (existingTokens.length > 0) {
+        const existingToken = existingTokens.reduce((latest, current) =>
+          current.expires_at > latest.expires_at ? current : latest
+        );
+        return `${appConfig.frontend.url}/shared/${existingToken.token}`;
+      }
+
+      const token = generateShareToken();
+      const expirationHours =
+        config.templateConfig?.shareReplayExpiration ?? SHARE_TOKEN_EXPIRATION_HOURS;
+      const expiresAt = new Date(Date.now() + expirationHours * MS_PER_HOUR);
+
+      const shareToken = await this.db.shareTokens.create({
+        bug_report_id: bugReport.id,
+        token,
+        created_by: null,
+        expires_at: expiresAt,
+        password_hash: null,
+      });
+
+      return `${appConfig.frontend.url}/shared/${shareToken.token}`;
+    } catch (error) {
+      logger.warn('Failed to generate share token for Linear replay', {
+        bugReportId: bugReport.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  /**
+   * Two-phase screenshot upload. Failures here are downgraded to warnings
+   * — the issue itself is already created, and missing an attachment is
+   * a softer failure than failing the whole bug report.
+   */
+  private async uploadScreenshotIfPresent(
+    client: LinearClient,
+    bugReport: BugReport,
+    issueId: string
+  ): Promise<LinearAttachment[]> {
+    if (!bugReport.screenshot_key) {
+      return [];
+    }
+
+    try {
+      // Linear's fileUpload requires the byte size upfront, so we have to
+      // headObject before streaming. For local storage this is cheap; for
+      // S3 it's one extra HEAD request.
+      const head = await this.storage.headObject(bugReport.screenshot_key);
+      if (!head) {
+        logger.warn('Screenshot key references missing object', {
+          bugReportId: bugReport.id,
+          screenshotKey: bugReport.screenshot_key,
+        });
+        return [];
+      }
+
+      const filename = bugReport.screenshot_key.split('/').pop() || DEFAULT_SCREENSHOT_FILENAME;
+      const contentType = head.contentType ?? SCREENSHOT_CONTENT_TYPE;
+
+      // Step 1 — ask Linear for a presigned upload URL.
+      const upload = await client.fileUpload(filename, contentType, head.size);
+
+      // Step 2 — PUT bytes to the presigned URL.
+      const stream = await this.storage.getObject(bugReport.screenshot_key);
+      await client.uploadAssetBytes(upload, stream, contentType);
+
+      // Step 3 — record the attachment against the issue.
+      const attachment = await client.createAttachment(issueId, upload.assetUrl, filename);
+
+      logger.info('Screenshot attached to Linear issue', {
+        bugReportId: bugReport.id,
+        issueId,
+        filename,
+        attachmentId: attachment.id,
+      });
+      return [attachment];
+    } catch (error) {
+      logger.warn('Failed to attach screenshot to Linear issue', {
+        bugReportId: bugReport.id,
+        issueId,
+        screenshotKey: bugReport.screenshot_key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Atomic write to both `tickets` (queryable) and `bug_reports.external_*`
+   * (denormalized fast path). Same pattern as Jira's service.
+   */
+  private async saveTicketReference(
+    bugReportId: string,
+    externalId: string,
+    externalUrl: string,
+    integrationId?: string,
+    ruleId?: string,
+    createdAutomatically?: boolean
+  ): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.tickets.createTicket(bugReportId, externalId, PLATFORM_NAME, DEFAULT_TICKET_STATUS, {
+        integrationId,
+        ruleId,
+        createdAutomatically,
+        externalUrl,
+      });
+      await tx.bugReports.updateExternalIntegration(bugReportId, externalId, externalUrl);
+    });
+  }
+
+  // ============================================================================
+  // CONFIG NORMALIZATION (route entry points)
+  // ============================================================================
+
+  /**
+   * Coerce a wire-shape config (from admin UI or wizard) into a
+   * `LinearConfig`. Tolerates both `apiKey` and the wizard's nested
+   * `authentication.token` placement so the same payload can be sent to
+   * `/test`, `/projects`, and persistence routes without reshaping at
+   * each call site.
+   *
+   * `enabled` defaults to `true`; the route layer is responsible for
+   * overriding when the caller explicitly disables.
+   */
+  private normalizeConfig(config: Record<string, unknown>): LinearConfig {
+    const raw = config as RawLinearConfig;
+    const apiKey =
+      typeof raw.apiKey === 'string' && raw.apiKey.trim().length > 0
+        ? raw.apiKey.trim()
+        : typeof raw.authentication?.token === 'string'
+          ? raw.authentication.token.trim()
+          : '';
+
+    return {
+      apiKey,
+      teamId: typeof raw.teamId === 'string' ? raw.teamId.trim() : '',
+      teamKey: typeof raw.teamKey === 'string' ? raw.teamKey.trim() : '',
+      projectId: typeof raw.projectId === 'string' ? raw.projectId.trim() : undefined,
+      projectName: typeof raw.projectName === 'string' ? raw.projectName.trim() : undefined,
+      defaultLabels: Array.isArray(raw.defaultLabels)
+        ? raw.defaultLabels.filter((l): l is string => typeof l === 'string')
+        : undefined,
+      enabled: raw.enabled ?? true,
+      templateConfig: raw.templateConfig,
+    };
+  }
+
+  /**
+   * Validate credentials supplied by the caller (no DB read) and produce
+   * a runtime `LinearConfig` for `searchUsers` / `listProjects`. Throws
+   * `ValidationError` with a combined diagnostic — mirrors
+   * `JiraIntegrationService.validateAndNormalizeCredentials`.
+   */
+  private validateAndNormalizeCredentials(config: Record<string, unknown>): {
+    apiKey: string;
+    teamId?: string;
+    teamKey?: string;
+  } {
+    const normalized = this.normalizeConfig(config);
+    if (!normalized.apiKey) {
+      throw new ValidationError('Linear configuration incomplete: missing apiKey');
+    }
+    return {
+      apiKey: normalized.apiKey,
+      teamId: normalized.teamId || undefined,
+      teamKey: normalized.teamKey || undefined,
+    };
+  }
+
+  // ============================================================================
+  // OPTIONAL CONTRACT METHODS
+  // ============================================================================
+
+  /**
+   * Return Linear teams in the contract's `{id, key, name}` shape so the
+   * generic wizard project picker can render them without branching on
+   * platform.
+   */
+  async listProjects(
+    config: Record<string, unknown>,
+    query?: string,
+    maxResults?: number
+  ): Promise<{ id: string; key: string; name: string }[]> {
+    const { apiKey } = this.validateAndNormalizeCredentials(config);
+
+    const requested =
+      typeof maxResults === 'number' && Number.isFinite(maxResults)
+        ? Math.max(1, Math.min(Math.floor(maxResults), 50))
+        : 50;
+
+    const client = new LinearClient(apiKey);
+    const teams: LinearTeam[] = await client.teams(query, requested);
+    return teams.map((t) => ({ id: t.id, key: t.key, name: t.name }));
+  }
+
+  /**
+   * List Linear-side projects (epic-grouping) inside a given team.
+   *
+   * NOT part of the `IntegrationService` contract — this is Linear-specific
+   * and surfaced through a dedicated route (or wired into a future contract
+   * extension). Today the admin UI calls it directly via the plugin handle.
+   */
+  async listLinearProjectsForTeam(
+    config: Record<string, unknown>,
+    teamId: string,
+    query?: string,
+    maxResults = 50
+  ): Promise<LinearProject[]> {
+    if (!teamId || teamId.trim().length === 0) {
+      throw new ValidationError('teamId is required');
+    }
+    const { apiKey } = this.validateAndNormalizeCredentials(config);
+    const client = new LinearClient(apiKey);
+    return client.projectsForTeam(teamId.trim(), query, maxResults);
+  }
+
+  /**
+   * Search Linear users for assignee autocomplete. Returns the shared
+   * cross-platform shape — `accountId` carries Linear's user UUID.
+   */
+  async searchUsers(
+    config: Record<string, unknown>,
+    query: string,
+    maxResults?: number
+  ): Promise<
+    Array<{
+      accountId: string;
+      displayName: string;
+      emailAddress?: string;
+      avatarUrls?: Record<string, string>;
+    }>
+  > {
+    if (!query || query.trim().length === 0) {
+      return [];
+    }
+    const { apiKey } = this.validateAndNormalizeCredentials(config);
+    const client = new LinearClient(apiKey);
+    const users = await client.searchUsers(query, maxResults ?? 20);
+
+    return users.map((u) => ({
+      accountId: u.id,
+      displayName: u.displayName || u.name,
+      emailAddress: u.email,
+      // Linear returns a single avatar URL, not a size-keyed map. We expose
+      // it under all the standard size keys the shared UI components
+      // already expect, rather than touching the contract.
+      ...(u.avatarUrl
+        ? {
+            avatarUrls: {
+              '16x16': u.avatarUrl,
+              '24x24': u.avatarUrl,
+              '32x32': u.avatarUrl,
+              '48x48': u.avatarUrl,
+            },
+          }
+        : {}),
+    }));
+  }
+
+  getAllowedAvatarDomains(config: Record<string, unknown>): string[] {
+    return buildLinearAllowedAvatarDomains(config);
+  }
+
+  // ============================================================================
+  // DIRECT CONFIG OPERATIONS (used by tests and admin flows)
+  // ============================================================================
+
+  async saveConfiguration(projectId: string, config: LinearConfig): Promise<void> {
+    await this.configManager.saveToDatabase(projectId, config);
+  }
+
+  async getConfiguration(projectId: string): Promise<LinearConfig | null> {
+    return this.configManager.getConfig(projectId);
+  }
+
+  async deleteConfiguration(projectId: string): Promise<void> {
+    await this.configManager.deleteFromDatabase(projectId);
+  }
+
+  async setEnabled(projectId: string, enabled: boolean): Promise<void> {
+    await this.configManager.setEnabled(projectId, enabled);
+  }
+}
+
+// Re-exported so tests can construct fake credentials without poking
+// through internals.
+export type { LinearCredentials };

--- a/packages/backend/src/integrations/linear/template-renderer.ts
+++ b/packages/backend/src/integrations/linear/template-renderer.ts
@@ -1,0 +1,117 @@
+/**
+ * Linear Template Renderer
+ *
+ * Variable substitution for custom description templates. Logic is
+ * deliberately a verbatim copy of the Jira renderer — it's pure, has no
+ * Jira-specific dependencies, and we don't want Linear to import across
+ * plugin boundaries. When a third plugin lands, both copies should move
+ * to `integrations/shared/`.
+ */
+
+import type { BugReport } from '../../db/types.js';
+
+function getMeta(metadata: Record<string, unknown> | undefined, key: string): string {
+  if (!metadata) {
+    return '';
+  }
+  const value = metadata[key];
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return '';
+}
+
+function getNestedMeta(metadata: Record<string, unknown> | undefined, path: string): string {
+  if (!metadata) {
+    return '';
+  }
+  const parts = path.split('.');
+  let current: unknown = metadata;
+  for (const part of parts) {
+    if (current && typeof current === 'object' && part in current) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return '';
+    }
+  }
+  if (typeof current === 'string' || typeof current === 'number') {
+    return String(current);
+  }
+  return '';
+}
+
+function addMetadataVariables(
+  metadata: Record<string, unknown>,
+  variables: Record<string, string>
+): void {
+  Object.entries(metadata).forEach(([key, value]) => {
+    if (typeof value === 'string' || typeof value === 'number') {
+      variables[`metadata.${key}`] = String(value);
+    } else if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.entries(value).forEach(([nestedKey, nestedValue]) => {
+        if (typeof nestedValue === 'string' || typeof nestedValue === 'number') {
+          variables[`metadata.${key}.${nestedKey}`] = String(nestedValue);
+        }
+      });
+    }
+  });
+}
+
+export function renderCustomTemplate(
+  template: string,
+  bugReport: BugReport,
+  shareReplayUrl?: string
+): string {
+  let rendered = template;
+  const meta = bugReport.metadata;
+
+  const variables: Record<string, string> = {
+    'error.message': getNestedMeta(meta, 'error.message'),
+    'error.type': getNestedMeta(meta, 'error.type'),
+    stack_trace: getNestedMeta(meta, 'error.stack'),
+
+    user_email:
+      getMeta(meta, 'user_email') || getNestedMeta(meta, 'metadata.user_email') || 'Unknown',
+    session_id: getMeta(meta, 'session_id') || getNestedMeta(meta, 'metadata.session_id') || 'N/A',
+
+    browser: getMeta(meta, 'browser') || getNestedMeta(meta, 'metadata.browser') || 'Unknown',
+    browser_version:
+      getMeta(meta, 'browser_version') || getNestedMeta(meta, 'metadata.browser_version'),
+    os: getMeta(meta, 'os') || getNestedMeta(meta, 'metadata.os') || 'Unknown',
+    viewport_width:
+      getMeta(meta, 'viewport_width') || getNestedMeta(meta, 'metadata.viewport_width'),
+    viewport_height:
+      getMeta(meta, 'viewport_height') || getNestedMeta(meta, 'metadata.viewport_height'),
+
+    url: getMeta(meta, 'url') || getNestedMeta(meta, 'metadata.url'),
+    referrer: getMeta(meta, 'referrer') || getNestedMeta(meta, 'metadata.referrer'),
+
+    priority: bugReport.priority || 'medium',
+    timestamp: bugReport.created_at.toISOString(),
+    title: bugReport.title || '',
+    description: bugReport.description || '',
+
+    source: getMeta(meta, 'source') || 'api',
+    api_key_prefix: getMeta(meta, 'apiKeyPrefix'),
+
+    replay_url: shareReplayUrl || bugReport.replay_url || '',
+    screenshot_url: bugReport.screenshot_url || '',
+  };
+
+  if (meta && typeof meta === 'object') {
+    addMetadataVariables(meta, variables);
+  }
+
+  Object.entries(variables).forEach(([key, value]) => {
+    rendered = rendered.replaceAll(`{{${key}}}`, value);
+  });
+
+  rendered = rendered.replace(/\{\{[^}]+\}\}/g, '');
+  rendered = rendered.replace(/\[([^\]]+)\]\(\s*\)/g, '');
+  rendered = rendered.replace(/\[\s*\]\([^)]+\)/g, '');
+
+  return rendered;
+}

--- a/packages/backend/src/integrations/linear/types.ts
+++ b/packages/backend/src/integrations/linear/types.ts
@@ -1,0 +1,240 @@
+/**
+ * Linear Integration Types
+ * Type definitions for Linear GraphQL API
+ */
+
+/**
+ * Default share token expiration in hours (30 days)
+ * Mirrors the Jira plugin's default so the user-facing semantics stay consistent.
+ */
+export const SHARE_TOKEN_EXPIRATION_HOURS = 720;
+
+/**
+ * Linear's fixed GraphQL endpoint. Linear is SaaS-only and ships a single
+ * public API origin, so unlike Jira we don't accept a user-supplied host
+ * (and therefore don't need a URL-string SSRF allowlist — only DNS-rebind
+ * pinning via `pinHostnameToIp`).
+ */
+export const LINEAR_API_HOST = 'api.linear.app';
+export const LINEAR_API_URL = `https://${LINEAR_API_HOST}/graphql`;
+
+/**
+ * Linear's web origin for building issue URLs when the API response is
+ * abbreviated. Real `issueCreate` responses already include the canonical
+ * `url`; this is only a fallback.
+ */
+export const LINEAR_WEB_HOST = 'https://linear.app';
+
+/**
+ * Template configuration for Linear issue formatting.
+ * Mirrors `JiraTemplateConfig` 1:1 so rule UIs can share the underlying
+ * settings shape — the rendered output differs only in serialization
+ * (Markdown vs ADF).
+ */
+export interface LinearTemplateConfig {
+  includeConsoleLogs?: boolean;
+  consoleLogLimit?: number;
+  includeNetworkLogs?: boolean;
+  networkLogFilter?: 'all' | 'failures';
+  networkLogLimit?: number;
+  includeShareReplay?: boolean;
+  shareReplayExpiration?: number;
+  shareReplayPassword?: string | null;
+}
+
+/**
+ * Linear configuration for a project (post-decryption, ready for client use).
+ *
+ * `teamId` is the GraphQL-required UUID; `teamKey` is the human identifier
+ * (e.g. "ENG") shown in URLs and pickers. We persist both because Linear
+ * `issueCreate` mutations require the UUID, but the wizard, admin UI, and
+ * audit logs are far more readable with the key.
+ */
+export interface LinearConfig {
+  apiKey: string;
+  teamId: string;
+  teamKey: string;
+  // Optional Linear Project (epic-level grouping inside a Team). Independent
+  // of BugSpotter's `project_id` — confusing terminology, but `projectId`
+  // here is what Linear calls it on the wire.
+  projectId?: string;
+  projectName?: string;
+  defaultLabels?: string[];
+  enabled: boolean;
+  templateConfig?: Partial<LinearTemplateConfig>;
+}
+
+/**
+ * Linear credentials (sensitive — encrypted at rest).
+ *
+ * Single field today (personal API key). Kept as an object so a future
+ * OAuth path can add `accessToken` / `refreshToken` / `expiresAt` without
+ * a schema migration of the encrypted blob.
+ */
+export interface LinearCredentials {
+  apiKey: string;
+}
+
+/**
+ * Linear configuration as persisted in `project_integrations.config`
+ * (non-sensitive). Credentials live in the encrypted blob next to it.
+ */
+export interface LinearProjectConfig {
+  teamId: string;
+  teamKey: string;
+  projectId?: string;
+  projectName?: string;
+  defaultLabels?: string[];
+  autoCreate: boolean;
+  syncStatus: boolean;
+  syncComments: boolean;
+  templateConfig?: Partial<LinearTemplateConfig>;
+}
+
+/**
+ * Linear priority. Wire format is the integer; we keep the enum mostly for
+ * readability at call sites.
+ *   0 = No priority
+ *   1 = Urgent
+ *   2 = High
+ *   3 = Medium (Linear UI label: "Medium")
+ *   4 = Low
+ */
+export type LinearPriority = 0 | 1 | 2 | 3 | 4;
+
+/**
+ * Input payload for `issueCreate` mutation.
+ * Mirrors Linear's `IssueCreateInput` GraphQL type, narrowed to what we
+ * actually send. `[key: string]: unknown` allows field-mapping pass-through.
+ */
+export interface LinearIssueInput {
+  teamId: string;
+  title: string;
+  description?: string; // Markdown
+  priority?: LinearPriority;
+  assigneeId?: string;
+  labelIds?: string[];
+  projectId?: string;
+  stateId?: string;
+  parentId?: string;
+  dueDate?: string; // ISO date
+  estimate?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Issue node returned by `issueCreate.issue { ... }`.
+ */
+export interface LinearIssue {
+  id: string; // Linear UUID
+  identifier: string; // "ENG-123" — what humans cite
+  url: string; // Canonical web URL, returned by API
+  title: string;
+}
+
+/**
+ * Team node from the `teams` query.
+ */
+export interface LinearTeam {
+  id: string;
+  key: string;
+  name: string;
+}
+
+/**
+ * Project node (Linear-side epic-grouping, not BugSpotter project) from the
+ * `team(id).projects` query.
+ */
+export interface LinearProject {
+  id: string;
+  name: string;
+  description?: string;
+  state?: string;
+}
+
+/**
+ * User node from the `users` query.
+ */
+export interface LinearUser {
+  id: string;
+  name: string;
+  displayName: string;
+  email?: string;
+  avatarUrl?: string;
+  active: boolean;
+}
+
+/**
+ * `viewer` query result — used by `testConnection` to verify the API key
+ * is valid and identifies a real Linear user.
+ */
+export interface LinearViewer {
+  id: string;
+  name: string;
+  email: string;
+  organization?: {
+    id: string;
+    name: string;
+    urlKey: string;
+  };
+}
+
+/**
+ * Attachment created via `attachmentCreate`. Linear treats attachments as
+ * first-class entities referencing an arbitrary URL — for screenshots we
+ * upload to Linear's asset storage first via `fileUpload`, then point an
+ * attachment at the returned asset URL.
+ */
+export interface LinearAttachment {
+  id: string;
+  title: string;
+  url: string;
+}
+
+/**
+ * `fileUpload` mutation result. The client PUTs the file to `uploadUrl`
+ * with `headers`, then references `assetUrl` from either an
+ * `attachmentCreate` or inline in issue description Markdown.
+ */
+export interface LinearFileUpload {
+  uploadUrl: string;
+  assetUrl: string;
+  headers: Array<{ key: string; value: string }>;
+}
+
+/**
+ * Connection test result for `LinearConfigManager.validate`.
+ */
+export interface LinearConnectionTestResult {
+  valid: boolean;
+  error?: string;
+  details?: {
+    viewerEmail: string;
+    organizationName?: string;
+    teamExists?: boolean;
+  };
+}
+
+/**
+ * Linear integration result returned from `createFromBugReport` to callers
+ * who want the raw issue fields (analogue of `JiraIntegrationResult`).
+ */
+export interface LinearIntegrationResult {
+  issueId: string; // Linear UUID
+  issueIdentifier: string; // "ENG-123"
+  issueUrl: string;
+  attachments: LinearAttachment[];
+}
+
+/**
+ * Shape of GraphQL error entries returned by Linear.
+ */
+export interface LinearGraphQLError {
+  message: string;
+  extensions?: {
+    code?: string;
+    type?: string;
+    userPresentableMessage?: string;
+  };
+  path?: Array<string | number>;
+}

--- a/packages/backend/src/integrations/plugin-loader.ts
+++ b/packages/backend/src/integrations/plugin-loader.ts
@@ -5,6 +5,7 @@
 
 import type { PluginRegistry } from './plugin-registry.js';
 import { jiraPlugin } from './jira/plugin.js';
+import { linearPlugin } from './linear/plugin.js';
 import { getLogger } from '../logger.js';
 
 const logger = getLogger();
@@ -16,6 +17,7 @@ const logger = getLogger();
 export async function loadIntegrationPlugins(registry: PluginRegistry): Promise<void> {
   const plugins = [
     jiraPlugin,
+    linearPlugin,
     // Add more plugins here as they are implemented
   ];
 

--- a/packages/backend/tests/integrations/linear/client.test.ts
+++ b/packages/backend/tests/integrations/linear/client.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Linear Client Tests
+ *
+ * Focused on the pure helpers exposed via `__test`. Full GraphQL
+ * roundtrip tests would require mocking `https.request` + DNS resolution
+ * — left to integration/E2E tests where they're cheaper to maintain.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LinearClient, __test } from '../../../src/integrations/linear/client.js';
+
+describe('LinearClient constructor', () => {
+  it('rejects empty API key', () => {
+    expect(() => new LinearClient('')).toThrow(/required/i);
+    expect(() => new LinearClient('   ')).toThrow(/required/i);
+  });
+
+  it('trims the API key', () => {
+    // No public accessor; we just verify it doesn't throw with whitespace.
+    expect(() => new LinearClient('  lin_api_xxx  ')).not.toThrow();
+  });
+});
+
+describe('parseRetryAfter', () => {
+  const { parseRetryAfter } = __test;
+
+  it('parses integer seconds into milliseconds', () => {
+    expect(parseRetryAfter('30')).toBe(30_000);
+    expect(parseRetryAfter('0')).toBe(0);
+  });
+
+  it('parses HTTP-date format relative to now', () => {
+    const future = new Date(Date.now() + 5_000).toUTCString();
+    const ms = parseRetryAfter(future);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(5_000);
+  });
+
+  it('returns undefined for missing or unparseable values', () => {
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+    expect(parseRetryAfter('garbage')).toBeUndefined();
+  });
+
+  it('takes first value when given an array header', () => {
+    expect(parseRetryAfter(['10', '20'])).toBe(10_000);
+  });
+});
+
+describe('formatGraphQLError', () => {
+  const { formatGraphQLError } = __test;
+
+  it('prefers userPresentableMessage when present', () => {
+    const out = formatGraphQLError([
+      {
+        message: 'Internal',
+        extensions: { userPresentableMessage: 'You lack permission' },
+      },
+    ]);
+    expect(out).toBe('You lack permission');
+  });
+
+  it('falls back to message when userPresentableMessage is missing', () => {
+    const out = formatGraphQLError([{ message: 'GraphQL error' }]);
+    expect(out).toBe('GraphQL error');
+  });
+
+  it('joins multiple errors with a separator', () => {
+    const out = formatGraphQLError([{ message: 'First' }, { message: 'Second' }]);
+    expect(out).toBe('First; Second');
+  });
+});
+
+describe('LinearClient.getIssueUrl', () => {
+  it('builds a fallback issue URL from org urlKey and identifier', () => {
+    const url = LinearClient.getIssueUrl('acme', 'ENG-42');
+    expect(url).toBe('https://linear.app/acme/issue/ENG-42');
+  });
+});

--- a/packages/backend/tests/integrations/linear/client.test.ts
+++ b/packages/backend/tests/integrations/linear/client.test.ts
@@ -19,6 +19,12 @@ describe('LinearClient constructor', () => {
     // No public accessor; we just verify it doesn't throw with whitespace.
     expect(() => new LinearClient('  lin_api_xxx  ')).not.toThrow();
   });
+
+  it('rejects API keys containing CRLF (header injection guard)', () => {
+    expect(() => new LinearClient('lin_api_xxx\r\nX-Injected: y')).toThrow(/control/i);
+    expect(() => new LinearClient('lin_api_xxx\n')).toThrow(/control/i);
+    expect(() => new LinearClient('lin_api_xxx\0')).toThrow(/control/i);
+  });
 });
 
 describe('parseRetryAfter', () => {

--- a/packages/backend/tests/integrations/linear/field-mappings.test.ts
+++ b/packages/backend/tests/integrations/linear/field-mappings.test.ts
@@ -93,7 +93,7 @@ describe('applyFieldMappings', () => {
     expect(input.priority).toBeUndefined();
   });
 
-  it('passes stateId and dueDate through unchanged', () => {
+  it('passes stateId and well-formed dueDate through', () => {
     const input = base();
     applyFieldMappings(input, {
       stateId: 'state-uuid',
@@ -105,5 +105,20 @@ describe('applyFieldMappings', () => {
     expect(input.dueDate).toBe('2026-12-31');
     expect(input.estimate).toBe(5);
     expect(input.projectId).toBe('linear-project-uuid');
+  });
+
+  it('skips malformed dueDate so a stale rule does not fail issueCreate', () => {
+    const cases = ['not-a-date', '2026/12/31', '2026-13-40', ''];
+    for (const v of cases) {
+      const input = base();
+      applyFieldMappings(input, { dueDate: v });
+      expect(input.dueDate, `dueDate "${v}"`).toBeUndefined();
+    }
+  });
+
+  it('dedupes labelIds when defaults and rule-mapping labels overlap', () => {
+    const input: LinearIssueInput = { ...base(), labelIds: ['a', 'b'] };
+    applyFieldMappings(input, { labels: ['b', 'c', 'b'] });
+    expect(input.labelIds).toEqual(['a', 'b', 'c']);
   });
 });

--- a/packages/backend/tests/integrations/linear/field-mappings.test.ts
+++ b/packages/backend/tests/integrations/linear/field-mappings.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Linear Field Mapping Tests
+ *
+ * Covers the per-rule override layer that lives between the mapper's
+ * default field selection and the GraphQL call. Pure function, no I/O.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { applyFieldMappings } from '../../../src/integrations/linear/field-mappings.js';
+import type { LinearIssueInput } from '../../../src/integrations/linear/types.js';
+
+function base(): LinearIssueInput {
+  return { teamId: 'team-uuid', title: 'T' };
+}
+
+describe('applyFieldMappings', () => {
+  it('sets assigneeId from a bare string', () => {
+    const input = base();
+    applyFieldMappings(input, { assignee: 'user-uuid' });
+    expect(input.assigneeId).toBe('user-uuid');
+  });
+
+  it('sets assigneeId from { id }', () => {
+    const input = base();
+    applyFieldMappings(input, { assignee: { id: 'user-uuid' } });
+    expect(input.assigneeId).toBe('user-uuid');
+  });
+
+  it('accepts Jira-flavoured { accountId } shape from rule-form UI', () => {
+    const input = base();
+    applyFieldMappings(input, { assignee: { accountId: 'user-uuid' } });
+    expect(input.assigneeId).toBe('user-uuid');
+  });
+
+  it('accepts direct assigneeId string', () => {
+    const input = base();
+    applyFieldMappings(input, { assigneeId: 'user-uuid' });
+    expect(input.assigneeId).toBe('user-uuid');
+  });
+
+  it('appends labels to existing labelIds', () => {
+    const input: LinearIssueInput = { ...base(), labelIds: ['existing'] };
+    applyFieldMappings(input, { labels: ['new-1', 'new-2'] });
+    expect(input.labelIds).toEqual(['existing', 'new-1', 'new-2']);
+  });
+
+  it('accepts labelIds as alias for labels', () => {
+    const input = base();
+    applyFieldMappings(input, { labelIds: ['a', 'b'] });
+    expect(input.labelIds).toEqual(['a', 'b']);
+  });
+
+  it('accepts integer priority directly', () => {
+    const input = base();
+    applyFieldMappings(input, { priority: 1 });
+    expect(input.priority).toBe(1);
+  });
+
+  it('maps named priorities (Jira-style) onto Linear integers', () => {
+    const cases: Array<[string, number]> = [
+      ['urgent', 1],
+      ['highest', 1],
+      ['high', 2],
+      ['medium', 3],
+      ['normal', 3],
+      ['low', 4],
+      ['lowest', 4],
+      ['none', 0],
+    ];
+    for (const [name, expected] of cases) {
+      const input = base();
+      applyFieldMappings(input, { priority: { name } });
+      expect(input.priority, `priority "${name}"`).toBe(expected);
+    }
+  });
+
+  it('rejects out-of-range integer priorities', () => {
+    const input = base();
+    applyFieldMappings(input, { priority: 99 });
+    expect(input.priority).toBeUndefined();
+  });
+
+  it('silently ignores unknown field names (no customfield_* pass-through)', () => {
+    const input = base();
+    applyFieldMappings(input, { customfield_10001: 'jira-only' });
+    expect((input as Record<string, unknown>).customfield_10001).toBeUndefined();
+  });
+
+  it('skips null and undefined values', () => {
+    const input = base();
+    applyFieldMappings(input, { assigneeId: null, priority: undefined });
+    expect(input.assigneeId).toBeUndefined();
+    expect(input.priority).toBeUndefined();
+  });
+
+  it('passes stateId and dueDate through unchanged', () => {
+    const input = base();
+    applyFieldMappings(input, {
+      stateId: 'state-uuid',
+      dueDate: '2026-12-31',
+      estimate: 5,
+      projectId: 'linear-project-uuid',
+    });
+    expect(input.stateId).toBe('state-uuid');
+    expect(input.dueDate).toBe('2026-12-31');
+    expect(input.estimate).toBe(5);
+    expect(input.projectId).toBe('linear-project-uuid');
+  });
+});

--- a/packages/backend/tests/integrations/linear/mapper.test.ts
+++ b/packages/backend/tests/integrations/linear/mapper.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Linear Mapper Tests
+ *
+ * Verifies bug-report → LinearIssueInput conversion. No network — the
+ * mapper is pure.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LinearBugReportMapper,
+  mapPriorityToLinear,
+} from '../../../src/integrations/linear/mapper.js';
+import type { LinearConfig } from '../../../src/integrations/linear/types.js';
+import type { BugReport } from '../../../src/db/types.js';
+
+const baseConfig: LinearConfig = {
+  apiKey: 'lin_api_xxx',
+  teamId: 'team-uuid',
+  teamKey: 'ENG',
+  enabled: true,
+};
+
+function makeBugReport(overrides: Partial<BugReport> = {}): BugReport {
+  return {
+    id: 'bug-1',
+    organization_id: 'org-1',
+    project_id: 'project-1',
+    title: 'Something broke',
+    description: 'Steps: click, observe',
+    priority: 'high',
+    status: 'open',
+    metadata: {
+      browser: 'Chrome',
+      os: 'macOS',
+      url: 'https://example.com/page',
+    },
+    screenshot_url: 'https://example.com/screenshot.png',
+    screenshot_key: 'screenshots/abc.png',
+    replay_url: null,
+    replay_key: null,
+    replay_upload_status: 'pending',
+    external_id: null,
+    external_url: null,
+    duplicate_of: null,
+    created_at: new Date('2026-05-11T10:00:00Z'),
+    updated_at: new Date('2026-05-11T10:00:00Z'),
+    ...overrides,
+  } as BugReport;
+}
+
+describe('mapPriorityToLinear', () => {
+  it('maps priorities to Linear integers', () => {
+    expect(mapPriorityToLinear('critical')).toBe(1);
+    expect(mapPriorityToLinear('high')).toBe(2);
+    expect(mapPriorityToLinear('medium')).toBe(3);
+    expect(mapPriorityToLinear('low')).toBe(4);
+    expect(mapPriorityToLinear('minor')).toBe(4);
+  });
+
+  it('returns 0 (no priority) for unknown or missing input', () => {
+    expect(mapPriorityToLinear(undefined)).toBe(0);
+    expect(mapPriorityToLinear('weird')).toBe(0);
+  });
+});
+
+describe('LinearBugReportMapper.toLinearIssueInput', () => {
+  it('produces a minimal valid input', () => {
+    const mapper = new LinearBugReportMapper(baseConfig);
+    const input = mapper.toLinearIssueInput(makeBugReport());
+
+    expect(input.teamId).toBe('team-uuid');
+    expect(input.title).toBe('Something broke');
+    expect(input.priority).toBe(2);
+    expect(input.description).toContain('Steps: click, observe');
+    expect(input.description).toContain('### Environment');
+    expect(input.description).toContain('Chrome');
+  });
+
+  it('truncates titles longer than 255 chars', () => {
+    const longTitle = 'x'.repeat(300);
+    const mapper = new LinearBugReportMapper(baseConfig);
+    const input = mapper.toLinearIssueInput(makeBugReport({ title: longTitle }));
+
+    expect(input.title.length).toBeLessThanOrEqual(255);
+    expect(input.title.endsWith('...')).toBe(true);
+  });
+
+  it('applies config-level defaults: projectId and labels', () => {
+    const mapper = new LinearBugReportMapper({
+      ...baseConfig,
+      projectId: 'linear-project-uuid',
+      defaultLabels: ['label-bug', 'label-auto'],
+    });
+    const input = mapper.toLinearIssueInput(makeBugReport());
+
+    expect(input.projectId).toBe('linear-project-uuid');
+    expect(input.labelIds).toEqual(['label-bug', 'label-auto']);
+  });
+
+  it('uses custom template when provided, bypassing default body', () => {
+    const mapper = new LinearBugReportMapper(baseConfig);
+    const input = mapper.toLinearIssueInput(
+      makeBugReport(),
+      undefined,
+      undefined,
+      '# {{title}}\n\n{{description}}'
+    );
+
+    expect(input.description).toBe('# Something broke\n\nSteps: click, observe');
+    // No default Environment section under a custom template.
+    expect(input.description).not.toContain('### Environment');
+  });
+
+  it('embeds share replay URL into the default body when supplied', () => {
+    const mapper = new LinearBugReportMapper(baseConfig);
+    const input = mapper.toLinearIssueInput(makeBugReport(), 'https://app/shared/abc');
+
+    expect(input.description).toContain('https://app/shared/abc');
+    expect(input.description).toContain('### Attachments');
+  });
+
+  it('applies field-mapping overrides (assignee, labels, priority)', () => {
+    const mapper = new LinearBugReportMapper({
+      ...baseConfig,
+      defaultLabels: ['label-bug'],
+    });
+    const input = mapper.toLinearIssueInput(makeBugReport(), undefined, {
+      assigneeId: 'user-uuid',
+      labels: ['label-urgent'],
+      priority: { name: 'urgent' },
+    });
+
+    expect(input.assigneeId).toBe('user-uuid');
+    // Field-mapping labels are appended to config defaults, not replacing
+    expect(input.labelIds).toContain('label-bug');
+    expect(input.labelIds).toContain('label-urgent');
+    expect(input.priority).toBe(1);
+  });
+
+  it('respects raw integer priority from field-mappings', () => {
+    const mapper = new LinearBugReportMapper(baseConfig);
+    const input = mapper.toLinearIssueInput(makeBugReport(), undefined, { priority: 1 });
+    expect(input.priority).toBe(1);
+  });
+});

--- a/packages/backend/tests/integrations/linear/plugin.test.ts
+++ b/packages/backend/tests/integrations/linear/plugin.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Linear Plugin Tests
+ *
+ * Verifies the plugin definition (metadata, factory) and the
+ * route-facing `validateConfig` entry point. The expensive part of
+ * validation — `viewer()` and `teams()` calls — is mocked at the client
+ * level so the test runs hermetically.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../src/integrations/linear/client.js', () => ({
+  LinearClient: vi.fn().mockImplementation(() => ({
+    viewer: vi.fn().mockResolvedValue({
+      id: 'viewer-id',
+      name: 'Test Viewer',
+      email: 'viewer@example.com',
+      organization: { id: 'org-1', name: 'Test Org', urlKey: 'test' },
+    }),
+    teams: vi.fn().mockResolvedValue([{ id: 'team-uuid', key: 'ENG', name: 'Engineering' }]),
+  })),
+}));
+
+import { linearPlugin } from '../../../src/integrations/linear/plugin.js';
+import { LINEAR_DEFAULT_DESCRIPTION_TEMPLATE } from '../../../src/integrations/linear/default-template.js';
+import type { PluginContext } from '../../../src/integrations/plugin.types.js';
+
+describe('linearPlugin', () => {
+  let mockContext: PluginContext;
+
+  beforeEach(() => {
+    mockContext = {
+      db: {
+        bugReports: {},
+        projectIntegrations: {},
+        tickets: {},
+      } as never,
+      storage: {} as never,
+    } as PluginContext;
+  });
+
+  describe('metadata', () => {
+    it('has correct metadata', () => {
+      expect(linearPlugin.metadata).toEqual({
+        name: 'Linear Integration',
+        platform: 'linear',
+        version: '1.0.0',
+        description: 'Create and sync issues with Linear',
+        author: 'BugSpotter Team',
+        requiredEnvVars: ['ENCRYPTION_KEY'],
+        isBuiltIn: true,
+        defaultDescriptionTemplate: LINEAR_DEFAULT_DESCRIPTION_TEMPLATE,
+      });
+    });
+
+    it('declares ENCRYPTION_KEY env requirement', () => {
+      expect(linearPlugin.metadata.requiredEnvVars).toContain('ENCRYPTION_KEY');
+    });
+
+    it('ships a Markdown default description template', () => {
+      // Markdown sanity check — make sure we didn't accidentally ship ADF.
+      const tpl = linearPlugin.metadata.defaultDescriptionTemplate ?? '';
+      expect(tpl).toContain('## {{title}}');
+      expect(tpl).not.toContain('"type":"doc"'); // ADF marker
+    });
+  });
+
+  describe('factory', () => {
+    it('creates LinearIntegrationService instance', () => {
+      const service = linearPlugin.factory(mockContext);
+
+      expect(service).toBeDefined();
+      expect(service.platform).toBe('linear');
+      expect(service.createFromBugReport).toBeDefined();
+      expect(service.testConnection).toBeDefined();
+      expect(service.validateConfig).toBeDefined();
+    });
+
+    it('exposes listProjects and searchUsers (optional methods)', () => {
+      const service = linearPlugin.factory(mockContext);
+      expect(service.listProjects).toBeDefined();
+      expect(service.searchUsers).toBeDefined();
+      expect(service.getAllowedAvatarDomains).toBeDefined();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('does not declare lifecycle hooks', () => {
+      // Plugin loading should be synchronous; lifecycle hooks would add
+      // async startup latency. Linear doesn't need any.
+      expect('lifecycle' in linearPlugin).toBe(false);
+    });
+  });
+
+  describe('validateConfig', () => {
+    it('returns valid:true for a well-formed config', async () => {
+      const service = linearPlugin.factory(mockContext);
+      const result = await service.validateConfig({
+        apiKey: 'lin_api_xxx',
+        teamId: 'team-uuid',
+        teamKey: 'ENG',
+      });
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('accepts apiKey nested under authentication.token (wizard shape)', async () => {
+      const service = linearPlugin.factory(mockContext);
+      const result = await service.validateConfig({
+        authentication: { type: 'apiKey', token: 'lin_api_xxx' },
+        teamId: 'team-uuid',
+        teamKey: 'ENG',
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('fails on missing apiKey', async () => {
+      const service = linearPlugin.factory(mockContext);
+      const result = await service.validateConfig({
+        teamId: 'team-uuid',
+        teamKey: 'ENG',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error?.toLowerCase()).toContain('api key');
+    });
+
+    it('fails on missing teamId', async () => {
+      const service = linearPlugin.factory(mockContext);
+      const result = await service.validateConfig({
+        apiKey: 'lin_api_xxx',
+        teamKey: 'ENG',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('teamId');
+    });
+
+    it('fails when team is not reachable for this key', async () => {
+      const service = linearPlugin.factory(mockContext);
+      const result = await service.validateConfig({
+        apiKey: 'lin_api_xxx',
+        teamId: 'wrong-team-uuid',
+        teamKey: 'WRONG',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/not found|access/i);
+    });
+  });
+});

--- a/packages/backend/tests/integrations/linear/plugin.test.ts
+++ b/packages/backend/tests/integrations/linear/plugin.test.ts
@@ -17,7 +17,16 @@ vi.mock('../../../src/integrations/linear/client.js', () => ({
       email: 'viewer@example.com',
       organization: { id: 'org-1', name: 'Test Org', urlKey: 'test' },
     }),
-    teams: vi.fn().mockResolvedValue([{ id: 'team-uuid', key: 'ENG', name: 'Engineering' }]),
+    // `getTeam` returns the team only for the canonical id used in tests;
+    // anything else resolves to null (matches Linear's behaviour for
+    // unknown / inaccessible team ids).
+    getTeam: vi
+      .fn()
+      .mockImplementation((teamId: string) =>
+        Promise.resolve(
+          teamId === 'team-uuid' ? { id: 'team-uuid', key: 'ENG', name: 'Engineering' } : null
+        )
+      ),
   })),
 }));
 

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -60,6 +60,11 @@ export default defineConfig({
       'tests/integrations/jira/service-list-projects.test.ts',
       'tests/integrations/jira/template-renderer.test.ts',
       'tests/integrations/jira/formatters/base-formatter.test.ts',
+      // Linear plugin tests (pure unit, no database, no real HTTP)
+      'tests/integrations/linear/plugin.test.ts',
+      'tests/integrations/linear/mapper.test.ts',
+      'tests/integrations/linear/client.test.ts',
+      'tests/integrations/linear/field-mappings.test.ts',
       // Intelligence tests (pure unit, mocked dependencies)
       'tests/api/utils/mitigation-trigger.test.ts',
       'tests/api/utils/resolution-sync-trigger.test.ts',


### PR DESCRIPTION
## Summary
- Built-in Linear plugin alongside Jira: GraphQL transport, personal API key auth, Markdown descriptions, two-step screenshot upload.
- Plumbs through the existing plugin registry — no changes to routes, worker, outbox, or avatar proxy. Touches `plugin-loader.ts` (+2 lines) and ships a single additive seed migration.
- Admin UI follows in a separate PR.

## Test plan
- [ ] `pnpm --filter @bugspotter/backend test:unit` — 88 files / 2444 tests pass (42 new for Linear).
- [ ] `pnpm --filter @bugspotter/backend typecheck` — clean for src/ (pre-existing tests/ noise unchanged).
- [ ] `pnpm --filter @bugspotter/backend lint` — clean.
- [ ] Migration 020 applies cleanly and is idempotent on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class Linear integration: create issues from bug reports with team/project selection, priority mapping, assignee support, attachments (screenshots), and share-replay links.
  * Admin/config support: save/manage Linear credentials and project configs; validate and test connections.
* **Tests**
  * New integration tests covering client helpers, field mappings, mapper, and plugin behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/129)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->