### PR TITLE
feat(monitoring): wire Telegram alerts via Alertmanager

### DIFF
--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -410,18 +410,23 @@ jobs:
           scp -r -i ~/.ssh/deploy_key monitoring/. \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring
 
-          # Telegram alert delivery: write bot token to a mounted file
-          # (read by Alertmanager via bot_token_file) and substitute the
-          # chat_id placeholder in alertmanager.yml (must be inline int).
-          # SIGHUP triggers Alertmanager hot-reload if it's already running.
-          echo "${{ secrets.TELEGRAM_BOT_TOKEN }}" > /tmp/telegram_token
-          chmod 600 /tmp/telegram_token
-          scp -i ~/.ssh/deploy_key /tmp/telegram_token \
-            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring/telegram_token
-          rm -f /tmp/telegram_token
+          # Telegram alert delivery: stage both secrets in a private temp
+          # dir (mode 700), scp them to prod, and have the remote shell read
+          # chat_id from the env file. Keeping the secret out of the ssh
+          # command line avoids exposure in `ps`/`/proc/*/cmdline` on the
+          # deploy host. Alertmanager reads bot_token via bot_token_file;
+          # chat_id must be inline so we sed it in. SIGHUP hot-reloads if
+          # alertmanager is already running.
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          printf '%s\n' "${{ secrets.TELEGRAM_BOT_TOKEN }}" > "$tmpdir/telegram_token"
+          printf 'TELEGRAM_ALERT_CHAT_ID=%s\n' "${{ secrets.TELEGRAM_ALERT_CHAT_ID }}" > "$tmpdir/telegram.env"
+          chmod 600 "$tmpdir/telegram_token" "$tmpdir/telegram.env"
+          scp -i ~/.ssh/deploy_key "$tmpdir/telegram_token" "$tmpdir/telegram.env" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring/
           ssh -i ~/.ssh/deploy_key \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
-            "chmod 600 /opt/bugspotter/monitoring/telegram_token && sed -i 's|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}|' /opt/bugspotter/monitoring/alertmanager.yml && (cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true)"
+            'set -a && . /opt/bugspotter/monitoring/telegram.env && set +a && chmod 600 /opt/bugspotter/monitoring/telegram_token && sed -i "s|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: $TELEGRAM_ALERT_CHAT_ID|" /opt/bugspotter/monitoring/alertmanager.yml && rm -f /opt/bugspotter/monitoring/telegram.env && (cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true)'
 
           scp -i ~/.ssh/deploy_key scripts/seed-demo-data.sh scripts/reset-demo-data.sh \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/scripts/

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -445,6 +445,12 @@ jobs:
           ssh -i ~/.ssh/deploy_key \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash -s <<'REMOTE_EOF'
           set -euo pipefail
+          # Install cleanup before anything that can `set -e` out (env-file
+          # source, chat_id validation, sudo/sed failure, marker-drift exit).
+          # Otherwise an early exit would leave the plaintext bot token sitting
+          # in /tmp/telegram_token (mode 600 owned by the deploy user) until
+          # the next successful deploy or a reboot.
+          trap 'rm -f /tmp/telegram_token /tmp/telegram.env' EXIT
           set -a; . /tmp/telegram.env; set +a
           : "${TELEGRAM_ALERT_CHAT_ID:?TELEGRAM_ALERT_CHAT_ID empty in telegram.env}"
 
@@ -468,7 +474,7 @@ jobs:
             exit 1
           fi
           cat "$tmp" > "$am"
-          rm -f "$tmp" /tmp/telegram_token /tmp/telegram.env
+          rm -f "$tmp"
           cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true
           REMOTE_EOF
 

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -417,6 +417,12 @@ jobs:
           # deploy host. Alertmanager reads bot_token via bot_token_file;
           # chat_id must be inline so we sed it in. SIGHUP hot-reloads if
           # alertmanager is already running.
+          # Validate both secrets are non-empty at the workflow level so an
+          # unset / accidentally-cleared secret fails the deploy immediately
+          # rather than shipping an empty bot_token (silent auth failure) or
+          # empty chat_id (caught downstream, but better to fail earlier).
+          [ -n "${{ secrets.TELEGRAM_BOT_TOKEN }}" ] || { echo 'ERROR: TELEGRAM_BOT_TOKEN secret is empty/unset' >&2; exit 1; }
+          [ -n "${{ secrets.TELEGRAM_ALERT_CHAT_ID }}" ] || { echo 'ERROR: TELEGRAM_ALERT_CHAT_ID secret is empty/unset' >&2; exit 1; }
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
           printf '%s\n' "${{ secrets.TELEGRAM_BOT_TOKEN }}" > "$tmpdir/telegram_token"
@@ -445,7 +451,11 @@ jobs:
           # Install bot token: sudo tee writes as root (so it can replace a
           # file currently owned by 65534), preserving inode; chown then
           # hands ownership to alertmanager's uid so it can actually read.
-          sudo tee /opt/bugspotter/monitoring/telegram_token < /tmp/telegram_token > /dev/null
+          # `umask 077` inside the sudo subshell ensures a newly-created file
+          # lands at mode 600 directly — without it, there's a brief world-
+          # readable window between tee creating the file at root's default
+          # umask (mode 644) and the subsequent chmod 600.
+          sudo sh -c 'umask 077 && tee /opt/bugspotter/monitoring/telegram_token > /dev/null' < /tmp/telegram_token
           sudo chmod 600 /opt/bugspotter/monitoring/telegram_token
           sudo chown 65534:65534 /opt/bugspotter/monitoring/telegram_token
 

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -422,21 +422,33 @@ jobs:
           printf '%s\n' "${{ secrets.TELEGRAM_BOT_TOKEN }}" > "$tmpdir/telegram_token"
           printf 'TELEGRAM_ALERT_CHAT_ID=%s\n' "${{ secrets.TELEGRAM_ALERT_CHAT_ID }}" > "$tmpdir/telegram.env"
           chmod 600 "$tmpdir/telegram_token" "$tmpdir/telegram.env"
-          # -p preserves the local 600 mode on the remote, so there's no
-          # world-readable window between scp landing and remote chmod.
+          # Stage secrets in /tmp (always writable by the deploy user) so
+          # subsequent deploys aren't blocked by the final on-disk telegram_token
+          # being owned by uid 65534 (alertmanager's `nobody`). -p preserves
+          # the local 600 mode on the wire so /tmp file isn't world-readable.
           scp -p -i ~/.ssh/deploy_key "$tmpdir/telegram_token" "$tmpdir/telegram.env" \
-            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring/
-          # Remote script via stdin heredoc: validates the chat_id is set
-          # and that the marker actually got replaced (otherwise alertmanager
-          # would silently keep sending to chat_id 0 or hold invalid YAML).
-          # Inode-preserving rewrite of alertmanager.yml so the running
-          # container's bind-mount stays attached to the same file.
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/
+          # Remote script via stdin heredoc:
+          #   - validate chat_id is set
+          #   - sudo tee bot token to final path (preserves inode for the
+          #     running container's bind mount) + chown to 65534:65534 so
+          #     alertmanager (running as `nobody`) can actually read it
+          #   - inode-preserving rewrite of alertmanager.yml with marker-drift
+          #     guard so a missing/empty chat_id or drifted marker fails the
+          #     deploy instead of silently shipping invalid YAML or chat_id 0
           ssh -i ~/.ssh/deploy_key \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash -s <<'REMOTE_EOF'
           set -euo pipefail
-          set -a; . /opt/bugspotter/monitoring/telegram.env; set +a
+          set -a; . /tmp/telegram.env; set +a
           : "${TELEGRAM_ALERT_CHAT_ID:?TELEGRAM_ALERT_CHAT_ID empty in telegram.env}"
-          chmod 600 /opt/bugspotter/monitoring/telegram_token
+
+          # Install bot token: sudo tee writes as root (so it can replace a
+          # file currently owned by 65534), preserving inode; chown then
+          # hands ownership to alertmanager's uid so it can actually read.
+          sudo tee /opt/bugspotter/monitoring/telegram_token < /tmp/telegram_token > /dev/null
+          sudo chmod 600 /opt/bugspotter/monitoring/telegram_token
+          sudo chown 65534:65534 /opt/bugspotter/monitoring/telegram_token
+
           am=/opt/bugspotter/monitoring/alertmanager.yml
           tmp=$(mktemp)
           sed "s|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: ${TELEGRAM_ALERT_CHAT_ID}|" "$am" > "$tmp"
@@ -446,7 +458,7 @@ jobs:
             exit 1
           fi
           cat "$tmp" > "$am"
-          rm -f "$tmp" /opt/bugspotter/monitoring/telegram.env
+          rm -f "$tmp" /tmp/telegram_token /tmp/telegram.env
           cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true
           REMOTE_EOF
 

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -426,7 +426,7 @@ jobs:
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring/
           ssh -i ~/.ssh/deploy_key \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
-            'set -a && . /opt/bugspotter/monitoring/telegram.env && set +a && chmod 600 /opt/bugspotter/monitoring/telegram_token && sed -i "s|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: $TELEGRAM_ALERT_CHAT_ID|" /opt/bugspotter/monitoring/alertmanager.yml && rm -f /opt/bugspotter/monitoring/telegram.env && (cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true)'
+            'set -a && . /opt/bugspotter/monitoring/telegram.env && set +a && chmod 600 /opt/bugspotter/monitoring/telegram_token && am=/opt/bugspotter/monitoring/alertmanager.yml && tmp=$(mktemp) && sed "s|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: $TELEGRAM_ALERT_CHAT_ID|" "$am" > "$tmp" && cat "$tmp" > "$am" && rm -f "$tmp" && rm -f /opt/bugspotter/monitoring/telegram.env && (cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true)'
 
           scp -i ~/.ssh/deploy_key scripts/seed-demo-data.sh scripts/reset-demo-data.sh \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/scripts/

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -409,6 +409,20 @@ jobs:
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/docker-compose.monitoring.yml
           scp -r -i ~/.ssh/deploy_key monitoring/. \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring
+
+          # Telegram alert delivery: write bot token to a mounted file
+          # (read by Alertmanager via bot_token_file) and substitute the
+          # chat_id placeholder in alertmanager.yml (must be inline int).
+          # SIGHUP triggers Alertmanager hot-reload if it's already running.
+          echo "${{ secrets.TELEGRAM_BOT_TOKEN }}" > /tmp/telegram_token
+          chmod 600 /tmp/telegram_token
+          scp -i ~/.ssh/deploy_key /tmp/telegram_token \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring/telegram_token
+          rm -f /tmp/telegram_token
+          ssh -i ~/.ssh/deploy_key \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "chmod 600 /opt/bugspotter/monitoring/telegram_token && sed -i 's|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}|' /opt/bugspotter/monitoring/alertmanager.yml && (cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true)"
+
           scp -i ~/.ssh/deploy_key scripts/seed-demo-data.sh scripts/reset-demo-data.sh \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/scripts/
 

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -422,11 +422,33 @@ jobs:
           printf '%s\n' "${{ secrets.TELEGRAM_BOT_TOKEN }}" > "$tmpdir/telegram_token"
           printf 'TELEGRAM_ALERT_CHAT_ID=%s\n' "${{ secrets.TELEGRAM_ALERT_CHAT_ID }}" > "$tmpdir/telegram.env"
           chmod 600 "$tmpdir/telegram_token" "$tmpdir/telegram.env"
-          scp -i ~/.ssh/deploy_key "$tmpdir/telegram_token" "$tmpdir/telegram.env" \
+          # -p preserves the local 600 mode on the remote, so there's no
+          # world-readable window between scp landing and remote chmod.
+          scp -p -i ~/.ssh/deploy_key "$tmpdir/telegram_token" "$tmpdir/telegram.env" \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring/
+          # Remote script via stdin heredoc: validates the chat_id is set
+          # and that the marker actually got replaced (otherwise alertmanager
+          # would silently keep sending to chat_id 0 or hold invalid YAML).
+          # Inode-preserving rewrite of alertmanager.yml so the running
+          # container's bind-mount stays attached to the same file.
           ssh -i ~/.ssh/deploy_key \
-            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
-            'set -a && . /opt/bugspotter/monitoring/telegram.env && set +a && chmod 600 /opt/bugspotter/monitoring/telegram_token && am=/opt/bugspotter/monitoring/alertmanager.yml && tmp=$(mktemp) && sed "s|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: $TELEGRAM_ALERT_CHAT_ID|" "$am" > "$tmp" && cat "$tmp" > "$am" && rm -f "$tmp" && rm -f /opt/bugspotter/monitoring/telegram.env && (cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true)'
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash -s <<'REMOTE_EOF'
+          set -euo pipefail
+          set -a; . /opt/bugspotter/monitoring/telegram.env; set +a
+          : "${TELEGRAM_ALERT_CHAT_ID:?TELEGRAM_ALERT_CHAT_ID empty in telegram.env}"
+          chmod 600 /opt/bugspotter/monitoring/telegram_token
+          am=/opt/bugspotter/monitoring/alertmanager.yml
+          tmp=$(mktemp)
+          sed "s|chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__|chat_id: ${TELEGRAM_ALERT_CHAT_ID}|" "$am" > "$tmp"
+          if grep -q '__DEPLOY_SUBSTITUTES_CHAT_ID__' "$tmp"; then
+            echo 'ERROR: chat_id placeholder not replaced — marker drifted in alertmanager.yml' >&2
+            rm -f "$tmp"
+            exit 1
+          fi
+          cat "$tmp" > "$am"
+          rm -f "$tmp" /opt/bugspotter/monitoring/telegram.env
+          cd /opt/bugspotter && docker compose exec -T alertmanager kill -HUP 1 2>/dev/null || true
+          REMOTE_EOF
 
           scp -i ~/.ssh/deploy_key scripts/seed-demo-data.sh scripts/reset-demo-data.sh \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ sa-key*.json
 # Generated files
 packages/sdk/src/version.ts
 
+# Alertmanager Telegram bot token — written by deploy workflow from
+# TELEGRAM_BOT_TOKEN secret; never commit. Local dev: create this file
+# manually with your own bot token if you want Telegram delivery.
+monitoring/telegram_token
+
 # Claude AI settings
 .claude/settings.local.json
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -126,9 +126,10 @@ services:
     volumes:
       - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       # bot_token is read from this file; populated by the deploy workflow
-      # from TELEGRAM_BOT_TOKEN. Local dev: create the file with your own
-      # token, or leave it absent and Telegram delivery silently fails
-      # (alertmanager itself still starts).
+      # from TELEGRAM_BOT_TOKEN. The file MUST exist (even if empty) before
+      # the monitoring profile starts — Docker creates a directory at the
+      # bind-mount source path otherwise, and alertmanager fails with "is a
+      # directory". `touch monitoring/telegram_token` is enough for local dev.
       - ./monitoring/telegram_token:/etc/alertmanager/telegram_token:ro
       - alertmanager_data:/alertmanager
     networks:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -125,6 +125,11 @@ services:
       - '--storage.path=/alertmanager'
     volumes:
       - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      # bot_token is read from this file; populated by the deploy workflow
+      # from TELEGRAM_BOT_TOKEN. Local dev: create the file with your own
+      # token, or leave it absent and Telegram delivery silently fails
+      # (alertmanager itself still starts).
+      - ./monitoring/telegram_token:/etc/alertmanager/telegram_token:ro
       - alertmanager_data:/alertmanager
     networks:
       - bugspotter

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -126,10 +126,13 @@ services:
     volumes:
       - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       # bot_token is read from this file; populated by the deploy workflow
-      # from TELEGRAM_BOT_TOKEN. The file MUST exist (even if empty) before
-      # the monitoring profile starts — Docker creates a directory at the
-      # bind-mount source path otherwise, and alertmanager fails with "is a
-      # directory". `touch monitoring/telegram_token` is enough for local dev.
+      # from TELEGRAM_BOT_TOKEN. The file MUST exist before the monitoring
+      # profile starts — Docker creates a directory at the bind-mount source
+      # path otherwise, and alertmanager fails with "is a directory". For
+      # local dev: `printf 'placeholder' > monitoring/telegram_token` (an
+      # empty file lets alertmanager start, but Telegram delivery silently
+      # fails with an empty-body API call; a placeholder string at least
+      # surfaces a clear bad-token error from Telegram).
       - ./monitoring/telegram_token:/etc/alertmanager/telegram_token:ro
       - alertmanager_data:/alertmanager
     networks:

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -6,27 +6,30 @@ route:
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 4h
-  receiver: default
+  receiver: telegram
   routes:
     - match:
         severity: critical
-      receiver: default
+      receiver: telegram
       repeat_interval: 1h
 
 receivers:
-  - name: default
-    # To enable Telegram alerts, replace the 'default' receiver above with:
-    #
-    # - name: default
-    #   telegram_configs:
-    #     - bot_token: '<your-bot-token>'
-    #       chat_id: <your-chat-id>
-    #       parse_mode: HTML
-    #       send_resolved: true
-    #       message: |-
-    #         {{ if eq .Status "firing" }}🚨{{ else }}✅{{ end }} <b>{{ .CommonLabels.alertname }}</b>
-    #         Severity: {{ .CommonLabels.severity }}
-    #         {{ range .Alerts }}
-    #         {{ .Annotations.summary }}
-    #         {{ .Annotations.description }}
-    #         {{ end }}
+  # bot_token comes from /etc/alertmanager/telegram_token (mounted file
+  # populated by the deploy workflow from the TELEGRAM_BOT_TOKEN secret).
+  # chat_id is substituted at deploy time from TELEGRAM_ALERT_CHAT_ID
+  # — the marker comment below is matched by sed; do not edit it.
+  # For local dev: replace both with your own values, or skip the
+  # `monitoring` compose profile if you don't need Telegram delivery.
+  - name: telegram
+    telegram_configs:
+      - bot_token_file: /etc/alertmanager/telegram_token
+        chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__
+        parse_mode: HTML
+        send_resolved: true
+        message: |-
+          {{ if eq .Status "firing" }}🚨{{ else }}✅{{ end }} <b>{{ .CommonLabels.alertname }}</b>
+          Severity: {{ .CommonLabels.severity }}
+          {{ range .Alerts }}
+          {{ .Annotations.summary }}
+          {{ .Annotations.description }}
+          {{ end }}

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -33,11 +33,11 @@ receivers:
         # identical across grouped alerts, so render them once from the
         # first alert and add a count if there are more, rather than
         # repeating the same block per instance.
+        # {{ with }} and {{ end }} are kept inline with content so they
+        # don't introduce stray blank lines in the Telegram output.
         message: |-
           {{ if eq .Status "firing" }}🚨{{ else }}✅{{ end }} <b>{{ .CommonLabels.alertname | html }}</b>
-          Severity: {{ .CommonLabels.severity | html }}
-          {{ with index .Alerts 0 }}
+          Severity: {{ .CommonLabels.severity | html }}{{ with index .Alerts 0 }}
           {{ .Annotations.summary | html }}
-          {{ .Annotations.description | html }}
-          {{ end }}
-          {{ if gt (len .Alerts) 1 }}({{ len .Alerts }} occurrences){{ end }}
+          {{ .Annotations.description | html }}{{ end }}{{ if gt (len .Alerts) 1 }}
+          ({{ len .Alerts }} occurrences){{ end }}

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -37,8 +37,8 @@ receivers:
         # don't introduce stray blank lines in the Telegram output.
         message: |-
           {{ if eq .Status "firing" }}🚨{{ else }}✅{{ end }} <b>{{ .CommonLabels.alertname | html }}</b>
-          Severity: {{ .CommonLabels.severity | html }}{{ with index .Alerts 0 }}
+          Severity: {{ .CommonLabels.severity | html }}{{ if .Alerts }}{{ with index .Alerts 0 }}
           {{ .Annotations.summary | html }}
-          {{ .Annotations.description | html }}{{ end }}{{ if gt (len .Alerts) 1 }}
+          {{ .Annotations.description | html }}{{ end }}{{ end }}{{ if gt (len .Alerts) 1 }}
           ({{ len .Alerts }} occurrences){{ end }}
           <a href="{{ .ExternalURL | html }}">View in Alertmanager</a>

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -26,10 +26,13 @@ receivers:
         chat_id: 0  # __DEPLOY_SUBSTITUTES_CHAT_ID__
         parse_mode: HTML
         send_resolved: true
+        # parse_mode is HTML, so any <, >, & in alertname/severity/summary/
+        # description would break Telegram's strict HTML parser and the
+        # message would be dropped. The `| html` pipe escapes them.
         message: |-
-          {{ if eq .Status "firing" }}🚨{{ else }}✅{{ end }} <b>{{ .CommonLabels.alertname }}</b>
-          Severity: {{ .CommonLabels.severity }}
+          {{ if eq .Status "firing" }}🚨{{ else }}✅{{ end }} <b>{{ .CommonLabels.alertname | html }}</b>
+          Severity: {{ .CommonLabels.severity | html }}
           {{ range .Alerts }}
-          {{ .Annotations.summary }}
-          {{ .Annotations.description }}
+          {{ .Annotations.summary | html }}
+          {{ .Annotations.description | html }}
           {{ end }}

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -29,10 +29,15 @@ receivers:
         # parse_mode is HTML, so any <, >, & in alertname/severity/summary/
         # description would break Telegram's strict HTML parser and the
         # message would be dropped. The `| html` pipe escapes them.
+        # Summary/description come from the rule's annotations and are
+        # identical across grouped alerts, so render them once from the
+        # first alert and add a count if there are more, rather than
+        # repeating the same block per instance.
         message: |-
           {{ if eq .Status "firing" }}🚨{{ else }}✅{{ end }} <b>{{ .CommonLabels.alertname | html }}</b>
           Severity: {{ .CommonLabels.severity | html }}
-          {{ range .Alerts }}
+          {{ with index .Alerts 0 }}
           {{ .Annotations.summary | html }}
           {{ .Annotations.description | html }}
           {{ end }}
+          {{ if gt (len .Alerts) 1 }}({{ len .Alerts }} occurrences){{ end }}

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -41,3 +41,4 @@ receivers:
           {{ .Annotations.summary | html }}
           {{ .Annotations.description | html }}{{ end }}{{ if gt (len .Alerts) 1 }}
           ({{ len .Alerts }} occurrences){{ end }}
+          <a href="{{ .ExternalURL | html }}">View in Alertmanager</a>

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -41,4 +41,3 @@ receivers:
           {{ .Annotations.summary | html }}
           {{ .Annotations.description | html }}{{ end }}{{ end }}{{ if gt (len .Alerts) 1 }}
           ({{ len .Alerts }} occurrences){{ end }}
-          <a href="{{ .ExternalURL | html }}">View in Alertmanager</a>


### PR DESCRIPTION
Existing Prometheus stack already had intelligence alert rules in `prometheus-rules.yml`, but `alertmanager.yml` only had a commented-out Telegram template. This activates it: receiver uses `bot_token_file` (mounted from `TELEGRAM_BOT_TOKEN` secret) and `chat_id` substituted at deploy time. SIGHUPs Alertmanager after the substitution so config hot-reloads without restart.

Pairs with apex-bridge/bugspotter-intelligence#30 which adds `/metrics` so the `IntelligenceServiceDown` and `HighErrorRate` rules actually have data to evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Telegram-based production alerting.
  * Critical alerts now route to Telegram with hourly repeat intervals.
  * Notifications show formatted status, key fields, and grouped-occurrence counts.
  * Deployment securely stages and uploads the Telegram bot token, enforces restrictive permissions, and triggers an Alertmanager reload.
  * Local setup notes added so the monitoring token path is predictable for development.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/133)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->