### PR TITLE
fix(api): drop redundant system-RBAC gate on project-scoped integration_rules routes

### DIFF
--- a/packages/backend/src/api/routes/integration-rules.ts
+++ b/packages/backend/src/api/routes/integration-rules.ts
@@ -8,7 +8,7 @@ import type { DatabaseClient } from '../../db/client.js';
 import { sendSuccess, sendCreated } from '../utils/response.js';
 import { checkProjectAccess, findOrThrow } from '../utils/resource.js';
 import { AppError } from '../middleware/error.js';
-import { requireAuth, requirePermission, requireProjectRole } from '../middleware/auth.js';
+import { requireAuth, requireProjectRole } from '../middleware/auth.js';
 import { requireProjectAccess } from '../middleware/project-access.js';
 import { getLogger } from '../../logger.js';
 import { getCacheService } from '../../cache/index.js';
@@ -153,16 +153,21 @@ export async function registerIntegrationRuleRoutes(
   /**
    * List all rules for an integration
    * GET /api/v1/integrations/:platform/:projectId/rules
+   *
+   * Access gate: project membership at any role (viewer+). Integration
+   * rules are project-scoped resources — listing them should not require
+   * system-level read permission, because system role and project role
+   * are independent dimensions. A project viewer can already see the
+   * integration card on the project page; hiding its rules behind a
+   * separate system-role check creates confusing 403s for org-owners
+   * who happen to have system role 'viewer' (e.g. SaaS tenants where
+   * platform admin = BugSpotter staff, not customer).
    */
   server.get<{ Params: { platform: string; projectId: string } }>(
     '/api/v1/integrations/:platform/:projectId/rules',
     {
       schema: listIntegrationRulesSchema,
-      preHandler: [
-        requireAuth,
-        requirePermission(db, 'integration_rules', 'read'),
-        requireProjectAccess(db, { paramName: 'projectId' }),
-      ],
+      preHandler: [requireAuth, requireProjectAccess(db, { paramName: 'projectId' })],
     },
     async (request, reply) => {
       const { platform, projectId } = request.params;
@@ -193,6 +198,16 @@ export async function registerIntegrationRuleRoutes(
   /**
    * Create a new integration rule
    * POST /api/v1/integrations/:platform/:projectId/rules
+   *
+   * Access gate: project-admin (via `requireProjectRole('admin')`).
+   * `requireProjectRole` resolves the effective role through
+   * `lookupInheritedProjectRole` + `pickHigherProjectRole`, so org-owners
+   * inherit admin and pass even when their explicit project_members row
+   * is 'viewer' or absent. The previous `requirePermission(...,
+   * 'integration_rules', 'create')` system-level check was redundant on a
+   * project-scoped resource and actively wrong for SaaS deployments
+   * where customer org-owners hold system role 'viewer' (platform admin
+   * is a BugSpotter-staff role, not a customer-tenant concept).
    */
   server.post<{ Params: { platform: string; projectId: string }; Body: CreateRuleBody }>(
     '/api/v1/integrations/:platform/:projectId/rules',
@@ -200,7 +215,6 @@ export async function registerIntegrationRuleRoutes(
       schema: createIntegrationRuleSchema,
       preHandler: [
         requireAuth,
-        requirePermission(db, 'integration_rules', 'create'),
         requireProjectAccess(db, { paramName: 'projectId' }),
         requireProjectRole('admin'),
       ],
@@ -269,6 +283,9 @@ export async function registerIntegrationRuleRoutes(
   /**
    * Update an integration rule
    * PATCH /api/v1/integrations/:platform/:projectId/rules/:ruleId
+   *
+   * Access gate: project-admin via effective role (same rationale as
+   * POST /rules above — no redundant system-level check).
    */
   server.patch<{
     Params: { platform: string; projectId: string; ruleId: string };
@@ -279,7 +296,6 @@ export async function registerIntegrationRuleRoutes(
       schema: updateIntegrationRuleSchema,
       preHandler: [
         requireAuth,
-        requirePermission(db, 'integration_rules', 'update'),
         requireProjectAccess(db, { paramName: 'projectId' }),
         requireProjectRole('admin'),
       ],
@@ -317,6 +333,13 @@ export async function registerIntegrationRuleRoutes(
   /**
    * Delete an integration rule
    * DELETE /api/v1/integrations/:platform/:projectId/rules/:ruleId
+   *
+   * Access gate: project-admin via effective role. Previously, the
+   * system-level `requirePermission(..., 'delete')` blocked all
+   * non-platform-admins outright because the permissions seed grants
+   * `delete` only to system role 'admin'. That left project-admins
+   * unable to delete rules in their own project — wrong for a
+   * project-scoped resource.
    */
   server.delete<{ Params: { platform: string; projectId: string; ruleId: string } }>(
     '/api/v1/integrations/:platform/:projectId/rules/:ruleId',
@@ -324,7 +347,6 @@ export async function registerIntegrationRuleRoutes(
       schema: deleteIntegrationRuleSchema,
       preHandler: [
         requireAuth,
-        requirePermission(db, 'integration_rules', 'delete'),
         requireProjectAccess(db, { paramName: 'projectId' }),
         requireProjectRole('admin'),
       ],
@@ -374,7 +396,6 @@ export async function registerIntegrationRuleRoutes(
       schema: copyIntegrationRuleSchema,
       preHandler: [
         requireAuth,
-        requirePermission(db, 'integration_rules', 'create'),
         requireProjectAccess(db, { paramName: 'projectId' }),
         // Source project requires `member` role minimum (closes
         // GH-96: cross-tenant exfiltration). Without this, a user

--- a/packages/backend/tests/integration/integration-rules-permissions.test.ts
+++ b/packages/backend/tests/integration/integration-rules-permissions.test.ts
@@ -71,18 +71,17 @@ describe('Integration Rules Permissions - E2E', () => {
     testProject = await createTestProject(db, { created_by: adminUser.id });
     cleanup.trackProject(testProject.id);
 
-    // Add regular user as project admin. The create / update routes use
-    // `requireProjectRole('admin')` (integration-rules.ts:203, 269), so
-    // `member` would 403. The COPY route enforces admin on the TARGET
-    // project only (inline `checkProjectAccess` in the handler at
-    // integration-rules.ts:370-380); its preHandler (line 361) uses
-    // `requireProjectAccess` with no minProjectRole, so the SOURCE
-    // project just needs membership. We grant admin on the source anyway
-    // for symmetry. Platform role stays `user`, so these tests still
-    // verify that a non-platform-admin can do these ops when their
-    // project role is sufficient. DELETE is excluded — see the rename
-    // in the DELETE describe-block (platform `user` lacks
-    // `integration_rules:delete` in the permissions seed).
+    // Add regular user as project admin. The create / update / delete
+    // routes use `requireProjectRole('admin')` (effective role
+    // composed with org-inheritance — `pickHigherProjectRole`). The
+    // COPY route enforces admin on the TARGET project only (inline
+    // `checkProjectAccess` in the handler at ~integration-rules.ts:
+    // 405-418); its preHandler uses `requireProjectRole('member')`,
+    // so the SOURCE project just needs membership. We grant admin on
+    // the source anyway for symmetry. Platform role stays `user`, so
+    // these tests verify a non-platform-admin can do these ops when
+    // their project role is sufficient — including DELETE, after the
+    // system-level `requirePermission(..., 'delete')` was removed.
     await db.projectMembers.addMember(testProject.id, regularUser.id, 'admin');
 
     // Add viewer user as member
@@ -289,18 +288,18 @@ describe('Integration Rules Permissions - E2E', () => {
         },
       });
 
+      // After dropping the redundant system-level `requirePermission` on
+      // project-scoped routes, viewers are denied by the project-role
+      // gate (`requireProjectRole('admin')`) instead. Outcome unchanged
+      // (still 403); error message reflects the new binding constraint.
       expect(response.statusCode).toBe(403);
-      expect(JSON.parse(response.body).message).toContain(
-        'Insufficient permissions to create integration_rules'
-      );
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
     });
 
     // Coverage: a project `member` (not `admin`) is denied at the
-    // `requireProjectRole('admin')` gate, NOT at requirePermission.
-    // Without this test, a regression that relaxes the project-role
-    // requirement back to 'member' (or removes the guard entirely)
-    // would only be caught for the platform-permission gate via the
-    // viewer/outsider tests above. Distinguished by the error message.
+    // `requireProjectRole('admin')` gate. This is now the only deny
+    // path for non-admins on a project they belong to — the previous
+    // `requirePermission` system-level check has been removed.
     it('should deny project member (with create permission) from creating rules', async () => {
       const { jwt: memberJwt } = await loginAsProjectRole(testProject.id, 'member');
 
@@ -317,8 +316,7 @@ describe('Integration Rules Permissions - E2E', () => {
       });
 
       expect(response.statusCode).toBe(403);
-      // Platform `user` HAS `integration_rules:create`, so requirePermission
-      // passes — the denial comes from `requireProjectRole('admin')`.
+      // Denial comes from `requireProjectRole('admin')`.
       expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
     });
 
@@ -392,16 +390,16 @@ describe('Integration Rules Permissions - E2E', () => {
         },
       });
 
+      // After dropping system-level `requirePermission` on PATCH,
+      // viewer denial routes through `requireProjectRole('admin')`.
       expect(response.statusCode).toBe(403);
-      expect(JSON.parse(response.body).message).toContain(
-        'Insufficient permissions to update integration_rules'
-      );
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
     });
 
-    // Locks in the project-role gate on PATCH (integration-rules.ts:269).
-    // Without this, the gate could be relaxed back to `member` and only
-    // viewer/outsider tests would still pass — both stop at the
-    // platform-permission check before reaching `requireProjectRole`.
+    // Locks in the project-role gate on PATCH. Project member is the
+    // only non-admin path that reaches this gate (viewer would be
+    // denied here too now that the system-level gate is gone, but the
+    // outcome is identical so the member test is the canonical guard).
     it('should deny project member (with update permission) from updating rules', async () => {
       const { jwt: memberJwt } = await loginAsProjectRole(testProject.id, 'member');
 
@@ -413,8 +411,7 @@ describe('Integration Rules Permissions - E2E', () => {
       });
 
       expect(response.statusCode).toBe(403);
-      // Platform `user` HAS `integration_rules:update`, so requirePermission
-      // passes — denial comes from `requireProjectRole('admin')`.
+      // Denial comes from `requireProjectRole('admin')`.
       expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
     });
 
@@ -434,11 +431,10 @@ describe('Integration Rules Permissions - E2E', () => {
   });
 
   describe('DELETE - Delete Rule (DELETE /api/v1/integrations/:platform/:projectId/rules/:ruleId)', () => {
-    // The permissions seed (db/migrations/001_initial_schema.sql) gives
-    // platform role `user` create/read/update on integration_rules but
-    // explicitly NOT delete — delete is admin-only at the system level.
-    // So this case can only verify the platform-admin path; project-admin
-    // alone is insufficient. Renamed accordingly.
+    // With the system-level `requirePermission(..., 'delete')` gate
+    // removed (PR backend/drop-redundant-system-perm-on-project-scoped-routes),
+    // delete is now gated solely by `requireProjectRole('admin')` —
+    // project-admin is sufficient regardless of platform role.
     it('should allow platform admin to delete rules for their project', async () => {
       // Create a rule to delete
       const createResponse = await server.inject({
@@ -484,39 +480,50 @@ describe('Integration Rules Permissions - E2E', () => {
         headers: { authorization: `Bearer ${viewerUserJwt}` },
       });
 
+      // Viewer denial now comes from `requireProjectRole('admin')` —
+      // the only gate, since the system-level check was removed.
       expect(response.statusCode).toBe(403);
-      expect(JSON.parse(response.body).message).toContain(
-        'Insufficient permissions to delete integration_rules'
-      );
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
     });
 
-    // Verifies the platform-permission gate is the binding constraint:
-    // a project admin (platform `user` role) is denied because the
-    // permissions seed grants `user` only create/read/update on
-    // integration_rules — not :delete (migrations/001:565-572). This
-    // pins the platform/project boundary so a future relaxation of
-    // the platform gate can't slip through covered only by the viewer
-    // case (which fails for an unrelated reason — viewer also lacks
-    // :read on integration_rules at the platform level... actually,
-    // viewer DOES have :read but not anything else; the failure path
-    // is the same `requirePermission` gate).
-    it('should deny project admin (platform user) from deleting rules', async () => {
+    // Behavior flip: previously a project-admin with platform role
+    // `user` got 403 here because the permissions seed didn't grant
+    // `user` the `integration_rules:delete` action. That was the bug —
+    // delete on a project-scoped resource shouldn't be gated by a
+    // system-level permission. Now project-admin alone is sufficient.
+    it('should allow project admin (platform user) to delete rules', async () => {
       const { jwt: projectAdminJwt } = await loginAsProjectRole(testProject.id, 'admin');
+
+      // Create a fresh rule to delete so we don't churn the shared
+      // `ruleId` used by other tests in this suite.
+      const createResp = await server.inject({
+        method: 'POST',
+        url: `/api/v1/integrations/jira/${testProject.id}/rules`,
+        headers: { authorization: `Bearer ${projectAdminJwt}` },
+        payload: {
+          name: 'Rule created by project-admin for delete-test',
+          enabled: true,
+          filters: [{ field: 'os', operator: 'equals', value: 'linux' }],
+          auto_create: false,
+        },
+      });
+      expect(createResp.statusCode).toBe(201);
+      const targetRuleId = JSON.parse(createResp.body).data.id;
 
       const response = await server.inject({
         method: 'DELETE',
-        url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}`,
+        url: `/api/v1/integrations/jira/${testProject.id}/rules/${targetRuleId}`,
         headers: { authorization: `Bearer ${projectAdminJwt}` },
       });
 
-      expect(response.statusCode).toBe(403);
-      // Platform `user` lacks `integration_rules:delete`, so requirePermission
-      // denies BEFORE requireProjectAccess/requireProjectRole runs — same
-      // path as the viewer/outsider deny tests above. Project-admin role
-      // doesn't compensate for the missing platform permission.
-      expect(JSON.parse(response.body).message).toContain(
-        'Insufficient permissions to delete integration_rules'
-      );
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).message).toContain('deleted successfully');
+
+      // Verify deletion in DB
+      const deleted = await db.query('SELECT id FROM integration_rules WHERE id = $1', [
+        targetRuleId,
+      ]);
+      expect(deleted.rows).toHaveLength(0);
     });
 
     it('should deny outsider from deleting rules', async () => {
@@ -526,31 +533,21 @@ describe('Integration Rules Permissions - E2E', () => {
         headers: { authorization: `Bearer ${outsiderJwt}` },
       });
 
-      // Outsider has platform role `user`, which doesn't carry
-      // `integration_rules:delete` in the permissions table. They're denied
-      // by `requirePermission` BEFORE `requireProjectAccess` runs — same
-      // 403 path as the viewer test above. The previous "Access denied"
-      // assertion expected a `requireProjectAccess` rejection, but middleware
-      // ordering means that path is unreachable for any platform role
-      // lacking the system permission. Either denial is correct; pin to
-      // the current actual message.
+      // Without the system-level gate, outsider denial now comes from
+      // `requireProjectAccess` (no project membership), which throws
+      // "Access denied". This is the more accurate error path for an
+      // outsider: the issue is project access, not system permission.
       expect(response.statusCode).toBe(403);
-      expect(JSON.parse(response.body).message).toContain(
-        'Insufficient permissions to delete integration_rules'
-      );
+      expect(JSON.parse(response.body).message).toContain('Access denied');
     });
 
-    // Verifies the platform-admin bypass on `requireProjectRole('admin')`.
-    // claude flagged on PR-94 that under the current permissions seed the
-    // `requireProjectRole('admin')` guard at integration-rules.ts:313 is
-    // never the binding constraint on DELETE — only platform admins reach
-    // it (everyone else is stopped earlier by `requirePermission`), and
-    // platform admins bypass it via `isPlatformAdmin()` in `checkProjectAccess`
-    // and `requireProjectRole`. If a future migration grants `:delete` to a
-    // non-platform-admin role, the project-role gate suddenly becomes
-    // load-bearing without warning. This positive test pins the bypass:
-    // a platform admin who is NOT a project admin (or member) can still
-    // delete, proving the bypass is wired correctly.
+    // Pins the platform-admin bypass on `requireProjectAccess` +
+    // `requireProjectRole('admin')`: a platform admin who is NOT a
+    // project member can still delete. After the system-level
+    // `requirePermission(..., 'delete')` was removed (this PR), the
+    // project-role gate is the only remaining check besides project
+    // access — both short-circuit on `isPlatformAdmin`, so platform
+    // admins reach the handler regardless of project membership.
     it('should allow platform admin (not a project member) to delete rules', async () => {
       // Create a rule to delete — a fresh one so we don't churn the
       // shared `ruleId` used by other tests in the suite.
@@ -669,7 +666,7 @@ describe('Integration Rules Permissions - E2E', () => {
       await db.query('DELETE FROM integration_rules WHERE id = $1', [responseBody.data.rule.id]);
     });
 
-    it('should deny viewer from copying rules (requires create permission)', async () => {
+    it('should deny viewer from copying rules', async () => {
       const response = await server.inject({
         method: 'POST',
         url: `/api/v1/integrations/jira/${testProject.id}/rules/${ruleId}/copy`,
@@ -679,10 +676,11 @@ describe('Integration Rules Permissions - E2E', () => {
         },
       });
 
+      // Viewer has explicit project.role='viewer' on testProject. The
+      // copy route's preHandler requires `member`+ on source — viewer
+      // fails there with the project-role error.
       expect(response.statusCode).toBe(403);
-      expect(JSON.parse(response.body).message).toContain(
-        'Insufficient permissions to create integration_rules'
-      );
+      expect(JSON.parse(response.body).message).toContain('Insufficient project permissions');
     });
 
     it('should deny outsider from copying rules', async () => {


### PR DESCRIPTION
## Summary
- Removes the system-level \`requirePermission(db, 'integration_rules', X)\` middleware from all 5 integration_rules routes (list / create / update / delete / copy). Project-scoped resources should be gated by project-level RBAC, not system-level — the latter is for genuinely platform-wide resources.
- Concrete impact: a project-admin with system role 'user' can now delete rules in their own project (was 403). Customer org-owners in SaaS (system role 'viewer') can now manage rules on org-inherited projects (was 403 before this + #134).
- Project-level enforcement (\`requireProjectAccess\` + \`requireProjectRole('admin')\` or \`'member'\` for COPY source) is now the single source of truth. Cross-org guard in COPY stays intact.

## Test plan
- [x] \`pnpm --filter @bugspotter/backend test:unit\` — 89 files / 2453 tests pass.
- [x] \`pnpm exec vitest run --config vitest.integration.config.ts tests/integration/integration-rules-permissions.test.ts\` — 27/27 pass against testcontainers Postgres.
- [x] \`pnpm --filter @bugspotter/backend typecheck\` — clean for src/.
- [x] \`pnpm --filter @bugspotter/backend lint\` — clean.
- [ ] Manual verification post-deploy: demo-login (org-owner, system viewer) creates an integration rule on their project — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated integration rules access control to enforce project-scoped permissions, requiring viewer+ access for viewing, admin access for creating/updating/deleting, and member+ access for copying rules.

* **Tests**
  * Updated integration rules permission tests to verify correct enforcement of project-scoped role requirements across all operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->