### PR TITLE
feat(integrations): pre-file dedup gate for ticket outbox

### DIFF
--- a/packages/backend/src/db/migrations/021_outbox_dedup_grace.sql
+++ b/packages/backend/src/db/migrations/021_outbox_dedup_grace.sql
@@ -1,0 +1,31 @@
+SET search_path TO application;
+
+-- Pre-file deduplication support for the ticket creation outbox.
+--
+-- The async intelligence dedup pipeline sets bug_reports.duplicate_of after a
+-- ticket has already been filed externally, producing duplicate Jira/Linear
+-- tickets. This migration lets the outbox worker (a) defer processing until a
+-- per-org grace window has elapsed, giving intelligence time to populate
+-- duplicate_of, and (b) record a 'skipped' terminal state for entries that
+-- were intentionally not filed because the bug turned out to be a duplicate.
+--
+-- All additions are nullable / opt-in: dedup_grace_until is NULL for entries
+-- created before this feature is enabled per org, in which case the worker
+-- behaves exactly as before.
+
+ALTER TABLE ticket_creation_outbox
+  DROP CONSTRAINT IF EXISTS ticket_creation_outbox_status_check;
+
+ALTER TABLE ticket_creation_outbox
+  ADD CONSTRAINT ticket_creation_outbox_status_check
+  CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'dead_letter', 'skipped'));
+
+ALTER TABLE ticket_creation_outbox
+  ADD COLUMN IF NOT EXISTS dedup_grace_until TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS skipped_reason TEXT;
+
+COMMENT ON COLUMN ticket_creation_outbox.dedup_grace_until IS
+  'Worker defers filing until NOW() >= dedup_grace_until, then re-checks bug_reports.duplicate_of before calling the external platform. NULL = no grace (legacy immediate-file behavior). Source: OrgIntelligenceSettings.pre_file_dedup_grace_ms.';
+
+COMMENT ON COLUMN ticket_creation_outbox.skipped_reason IS
+  'Reason an entry was set to status=skipped (e.g. "duplicate_of_set"). NULL for non-skipped entries.';

--- a/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
+++ b/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
@@ -30,7 +30,13 @@ abstract class BaseRepository {
 // TYPES
 // ============================================================================
 
-export type OutboxStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'dead_letter';
+export type OutboxStatus =
+  | 'pending'
+  | 'processing'
+  | 'completed'
+  | 'failed'
+  | 'dead_letter'
+  | 'skipped';
 
 export interface TicketCreationOutboxEntry {
   id: string;
@@ -52,6 +58,8 @@ export interface TicketCreationOutboxEntry {
   updated_at: Date;
   processed_at: Date | null;
   idempotency_key: string;
+  dedup_grace_until: Date | null;
+  skipped_reason: string | null;
 }
 
 export interface CreateOutboxEntryData {
@@ -63,6 +71,7 @@ export interface CreateOutboxEntryData {
   payload: Record<string, unknown>;
   scheduled_at?: Date;
   max_retries?: number;
+  dedup_grace_until?: Date | null;
 }
 
 export interface OutboxProcessingResult {
@@ -96,8 +105,9 @@ export class TicketCreationOutboxRepository extends BaseRepository {
         payload,
         scheduled_at,
         max_retries,
-        idempotency_key
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        idempotency_key,
+        dedup_grace_until
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
       RETURNING *
     `;
 
@@ -111,6 +121,7 @@ export class TicketCreationOutboxRepository extends BaseRepository {
       data.scheduled_at || new Date(),
       data.max_retries || 3,
       idempotencyKey,
+      data.dedup_grace_until ?? null,
     ];
 
     const result = await this.pool.query<TicketCreationOutboxEntry>(query, values);
@@ -176,6 +187,56 @@ export class TicketCreationOutboxRepository extends BaseRepository {
         id,
       });
     }
+  }
+
+  /**
+   * Push scheduled_at into the future without changing status or retry_count.
+   *
+   * Used by the worker to honor a pre-file dedup grace window: when the entry
+   * is dequeued before dedup_grace_until, we reset scheduled_at so the poller
+   * re-picks it up after the grace window closes. The entry stays in 'pending'
+   * (not 'failed'), so this does not consume a retry attempt.
+   *
+   * Bounded by status='pending' to avoid clobbering entries another worker
+   * has already claimed via markProcessing.
+   */
+  async deferUntil(id: string, until: Date): Promise<boolean> {
+    const query = `
+      UPDATE ticket_creation_outbox
+      SET scheduled_at = $2,
+          updated_at = NOW()
+      WHERE id = $1
+        AND status = 'pending'
+    `;
+
+    const result = await this.pool.query(query, [id, until]);
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Mark entry as 'skipped' — terminal state for entries the worker
+   * intentionally did not file (e.g. bug turned out to be a duplicate).
+   * Idempotent: only transitions from 'processing'.
+   */
+  async markSkipped(id: string, reason: string): Promise<void> {
+    const query = `
+      UPDATE ticket_creation_outbox
+      SET status = 'skipped',
+          skipped_reason = $2,
+          processed_at = NOW(),
+          updated_at = NOW()
+      WHERE id = $1
+        AND status = 'processing'
+    `;
+
+    const result = await this.pool.query(query, [id, reason]);
+
+    if (result.rowCount === 0) {
+      logger.warn('Failed to mark outbox entry as skipped (not in processing state)', { id });
+      return;
+    }
+
+    logger.info('Outbox entry marked as skipped', { id, reason });
   }
 
   /**
@@ -351,6 +412,10 @@ export class TicketCreationOutboxRepository extends BaseRepository {
       created_at: new Date(row.created_at as string | number | Date),
       updated_at: new Date(row.updated_at as string | number | Date),
       processed_at: row.processed_at ? new Date(row.processed_at as string | number | Date) : null,
+      dedup_grace_until: row.dedup_grace_until
+        ? new Date(row.dedup_grace_until as string | number | Date)
+        : null,
+      skipped_reason: row.skipped_reason ?? null,
     };
   }
 }

--- a/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
+++ b/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
@@ -199,33 +199,6 @@ export class TicketCreationOutboxRepository extends BaseRepository {
   }
 
   /**
-   * Push scheduled_at into the future without changing status or retry_count.
-   *
-   * Used by the worker to honor a pre-file dedup grace window: when the entry
-   * is dequeued before dedup_grace_until, we reset scheduled_at so the poller
-   * re-picks it up after the grace window closes. Status and retry_count are
-   * left alone, so this does not consume a retry attempt.
-   *
-   * Accepts both 'pending' and 'failed' so a retry that fires within the
-   * grace window is also deferred (relevant when the window is long and the
-   * first attempt failed quickly). Bounded to those two statuses to avoid
-   * clobbering entries another worker has already claimed via markProcessing
-   * or that have reached a terminal state.
-   */
-  async deferUntil(id: string, until: Date): Promise<boolean> {
-    const query = `
-      UPDATE ticket_creation_outbox
-      SET scheduled_at = $2,
-          updated_at = NOW()
-      WHERE id = $1
-        AND status IN ('pending', 'failed')
-    `;
-
-    const result = await this.pool.query(query, [id, until]);
-    return (result.rowCount ?? 0) > 0;
-  }
-
-  /**
    * Mark entry as 'skipped' — terminal state for entries the worker
    * intentionally did not file (e.g. bug turned out to be a duplicate).
    * Idempotent: only transitions from 'processing'.

--- a/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
+++ b/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
@@ -169,24 +169,33 @@ export class TicketCreationOutboxRepository extends BaseRepository {
   }
 
   /**
-   * Mark entry as processing (prevents duplicate processing)
+   * Atomically claim an outbox entry by transitioning it to 'processing'.
+   *
+   * Returns the claimed row when this caller successfully transitioned the
+   * entry (so the worker can read its state without a second `findById`),
+   * or `null` when the entry was already claimed/processed by another worker
+   * or moved to a terminal state.
    */
-  async markProcessing(id: string): Promise<void> {
+  async markProcessing(id: string): Promise<TicketCreationOutboxEntry | null> {
     const query = `
       UPDATE ticket_creation_outbox
       SET status = 'processing',
           updated_at = NOW()
       WHERE id = $1
         AND status IN ('pending', 'failed')
+      RETURNING *
     `;
 
-    const result = await this.pool.query(query, [id]);
+    const result = await this.pool.query<TicketCreationOutboxEntry>(query, [id]);
 
     if (result.rowCount === 0) {
       logger.warn('Failed to mark outbox entry as processing (already processed or not found)', {
         id,
       });
+      return null;
     }
+
+    return this.parseOutboxEntry(result.rows[0]);
   }
 
   /**
@@ -194,11 +203,14 @@ export class TicketCreationOutboxRepository extends BaseRepository {
    *
    * Used by the worker to honor a pre-file dedup grace window: when the entry
    * is dequeued before dedup_grace_until, we reset scheduled_at so the poller
-   * re-picks it up after the grace window closes. The entry stays in 'pending'
-   * (not 'failed'), so this does not consume a retry attempt.
+   * re-picks it up after the grace window closes. Status and retry_count are
+   * left alone, so this does not consume a retry attempt.
    *
-   * Bounded by status='pending' to avoid clobbering entries another worker
-   * has already claimed via markProcessing.
+   * Accepts both 'pending' and 'failed' so a retry that fires within the
+   * grace window is also deferred (relevant when the window is long and the
+   * first attempt failed quickly). Bounded to those two statuses to avoid
+   * clobbering entries another worker has already claimed via markProcessing
+   * or that have reached a terminal state.
    */
   async deferUntil(id: string, until: Date): Promise<boolean> {
     const query = `
@@ -206,7 +218,7 @@ export class TicketCreationOutboxRepository extends BaseRepository {
       SET scheduled_at = $2,
           updated_at = NOW()
       WHERE id = $1
-        AND status = 'pending'
+        AND status IN ('pending', 'failed')
     `;
 
     const result = await this.pool.query(query, [id, until]);

--- a/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
+++ b/packages/backend/src/db/repositories/ticket-creation-outbox.repository.ts
@@ -374,6 +374,7 @@ export class TicketCreationOutboxRepository extends BaseRepository {
     completed: number;
     failed: number;
     dead_letter: number;
+    skipped: number;
     avg_retry_count: number;
   }> {
     const query = `
@@ -383,6 +384,7 @@ export class TicketCreationOutboxRepository extends BaseRepository {
         COUNT(*) FILTER (WHERE status = 'completed') as completed,
         COUNT(*) FILTER (WHERE status = 'failed') as failed,
         COUNT(*) FILTER (WHERE status = 'dead_letter') as dead_letter,
+        COUNT(*) FILTER (WHERE status = 'skipped') as skipped,
         COALESCE(AVG(retry_count) FILTER (WHERE status IN ('failed', 'dead_letter')), 0) as avg_retry_count
       FROM ticket_creation_outbox
     `;
@@ -394,6 +396,7 @@ export class TicketCreationOutboxRepository extends BaseRepository {
       completed: parseInt(result.rows[0].completed, 10),
       failed: parseInt(result.rows[0].failed, 10),
       dead_letter: parseInt(result.rows[0].dead_letter, 10),
+      skipped: parseInt(result.rows[0].skipped, 10),
       avg_retry_count: parseFloat(result.rows[0].avg_retry_count),
     };
   }

--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -713,6 +713,10 @@ export interface OrganizationSettings {
   intelligence_similarity_threshold?: number | null;
   intelligence_dedup_enabled?: boolean;
   intelligence_dedup_action?: 'flag' | 'auto_close' | null;
+  // Pre-file dedup grace window (ms). 0 / unset = file immediately (legacy behavior).
+  // When > 0, the ticket outbox worker defers external filing until the grace window
+  // elapses, then re-checks bug_reports.duplicate_of to suppress redundant tickets.
+  intelligence_pre_file_dedup_grace_ms?: number | null;
   intelligence_self_service_enabled?: boolean;
   intelligence_api_key_provisioned_at?: string | null;
   intelligence_api_key_provisioned_by?: string | null;

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -23,6 +23,7 @@ import { Queue } from 'bullmq';
 import type { IJobHandle } from '@bugspotter/message-broker';
 import { getLogger } from '../../../logger.js';
 import type { DatabaseClient } from '../../../db/client.js';
+import type { BugReport } from '../../../db/types.js';
 import type { PluginRegistry } from '../../../integrations/plugin-registry.js';
 import type { TicketCreationOutboxEntry } from '../../../db/repositories/ticket-creation-outbox.repository.js';
 
@@ -131,9 +132,10 @@ export class TicketCreationOutboxProcessor {
         return;
       }
 
-      // Step 3: Create ticket on external platform
+      // Step 3: Create ticket on external platform. Pass the already-fetched bugReport
+      // to avoid a second findById round-trip inside createExternalTicket.
       // Note: Integration service handles database updates (tickets table + bug_reports table)
-      const ticketResult = await this.createExternalTicket(entry);
+      const ticketResult = await this.createExternalTicket(entry, bugReport);
 
       // Step 4: Mark outbox entry as completed
       await this.db.ticketOutbox.markCompleted(outboxEntryId, {
@@ -182,10 +184,14 @@ export class TicketCreationOutboxProcessor {
   }
 
   /**
-   * Create ticket on external platform using plugin registry
+   * Create ticket on external platform using plugin registry.
+   *
+   * Optionally accepts a pre-fetched bug report to avoid an extra DB round-trip
+   * when the caller has already loaded it (e.g. the dedup gate above).
    */
   private async createExternalTicket(
-    entry: TicketCreationOutboxEntry
+    entry: TicketCreationOutboxEntry,
+    preloadedBugReport?: BugReport | null
   ): Promise<{ externalId: string; externalUrl: string }> {
     const { platform, integration_id, project_id, bug_report_id, rule_id } = entry;
 
@@ -219,8 +225,8 @@ export class TicketCreationOutboxProcessor {
       outboxEntryId: entry.id,
     });
 
-    // Fetch bug report (needed for full context)
-    const bugReport = await this.db.bugReports.findById(bug_report_id);
+    // Fetch bug report (needed for full context), unless the caller already loaded it.
+    const bugReport = preloadedBugReport ?? (await this.db.bugReports.findById(bug_report_id));
     if (!bugReport) {
       throw new Error(`Bug report not found: ${bug_report_id}`);
     }

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -58,6 +58,31 @@ export class TicketCreationOutboxProcessor {
     });
 
     try {
+      // Step 0: If the entry has a pre-file dedup grace window that hasn't elapsed yet,
+      // push scheduled_at forward and exit cleanly. The poller will re-enqueue the
+      // entry after the grace window closes. Done BEFORE markProcessing so we don't
+      // burn a retry attempt on an entry that simply isn't due yet.
+      const pre = await this.db.ticketOutbox.findById(outboxEntryId);
+      if (!pre) {
+        logger.error('Outbox entry not found in database', { outboxEntryId, jobId: job.id });
+        throw new Error(`Outbox entry not found: ${outboxEntryId}`);
+      }
+      if (pre.dedup_grace_until && new Date() < pre.dedup_grace_until && pre.status === 'pending') {
+        const deferred = await this.db.ticketOutbox.deferUntil(
+          outboxEntryId,
+          pre.dedup_grace_until
+        );
+        if (deferred) {
+          logger.debug('Outbox entry deferred for pre-file dedup grace', {
+            outboxEntryId,
+            graceUntil: pre.dedup_grace_until,
+          });
+          return;
+        }
+        // Race: status changed between findById and deferUntil — fall through to
+        // the normal processing path so the other observer's state wins.
+      }
+
       // Step 1: Mark entry as processing (prevents duplicate processing)
       await this.db.ticketOutbox.markProcessing(outboxEntryId);
 
@@ -88,6 +113,23 @@ export class TicketCreationOutboxProcessor {
         retryCount: entry.retry_count,
         scheduledAt: entry.scheduled_at,
       });
+
+      // Step 2.5: Pre-file dedup gate. If the async intelligence pipeline has flagged
+      // this bug as a duplicate of another (duplicate_of != null), don't create a
+      // redundant external ticket — mark the outbox row 'skipped' instead. This is a
+      // pure suppression: bug_reports.duplicate_of is set elsewhere (dedup-service),
+      // and Jira/Linear clients don't expose addComment/closeIssue methods yet, so
+      // we can only avoid the new ticket, not cross-link to the canonical one.
+      const bugReport = await this.db.bugReports.findById(entry.bug_report_id);
+      if (bugReport?.duplicate_of) {
+        logger.info('Skipping external ticket creation — bug flagged as duplicate', {
+          outboxEntryId,
+          bugReportId: entry.bug_report_id,
+          duplicateOf: bugReport.duplicate_of,
+        });
+        await this.db.ticketOutbox.markSkipped(outboxEntryId, 'duplicate_of_set');
+        return;
+      }
 
       // Step 3: Create ticket on external platform
       // Note: Integration service handles database updates (tickets table + bug_reports table)

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -122,7 +122,13 @@ export class TicketCreationOutboxProcessor {
       // and Jira/Linear clients don't expose addComment/closeIssue methods yet, so
       // we can only avoid the new ticket, not cross-link to the canonical one.
       const bugReport = await this.db.bugReports.findById(entry.bug_report_id);
-      if (bugReport?.duplicate_of) {
+      if (!bugReport) {
+        // Match createExternalTicket's contract — surface the missing bug as a hard
+        // failure so the outbox retry path takes over (vs. silently falling through
+        // and triggering a second findById inside createExternalTicket).
+        throw new Error(`Bug report not found: ${entry.bug_report_id}`);
+      }
+      if (bugReport.duplicate_of) {
         logger.info('Skipping external ticket creation — bug flagged as duplicate', {
           outboxEntryId,
           bugReportId: entry.bug_report_id,
@@ -191,7 +197,7 @@ export class TicketCreationOutboxProcessor {
    */
   private async createExternalTicket(
     entry: TicketCreationOutboxEntry,
-    preloadedBugReport?: BugReport | null
+    preloadedBugReport?: BugReport
   ): Promise<{ externalId: string; externalUrl: string }> {
     const { platform, integration_id, project_id, bug_report_id, rule_id } = entry;
 

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -62,13 +62,15 @@ export class TicketCreationOutboxProcessor {
       // Step 0: If the entry has a pre-file dedup grace window that hasn't elapsed yet,
       // push scheduled_at forward and exit cleanly. The poller will re-enqueue the
       // entry after the grace window closes. Done BEFORE markProcessing so we don't
-      // burn a retry attempt on an entry that simply isn't due yet.
+      // burn a retry attempt on an entry that simply isn't due yet. The check covers
+      // both 'pending' and 'failed' (retry) statuses so a long grace window also
+      // catches retries triggered by an early failure.
       const pre = await this.db.ticketOutbox.findById(outboxEntryId);
       if (!pre) {
         logger.error('Outbox entry not found in database', { outboxEntryId, jobId: job.id });
         throw new Error(`Outbox entry not found: ${outboxEntryId}`);
       }
-      if (pre.dedup_grace_until && new Date() < pre.dedup_grace_until && pre.status === 'pending') {
+      if (pre.dedup_grace_until && new Date() < pre.dedup_grace_until) {
         const deferred = await this.db.ticketOutbox.deferUntil(
           outboxEntryId,
           pre.dedup_grace_until
@@ -77,33 +79,23 @@ export class TicketCreationOutboxProcessor {
           logger.debug('Outbox entry deferred for pre-file dedup grace', {
             outboxEntryId,
             graceUntil: pre.dedup_grace_until,
+            status: pre.status,
           });
           return;
         }
-        // Race: status changed between findById and deferUntil — fall through to
-        // the normal processing path so the other observer's state wins.
+        // Race: another worker claimed the entry between our findById and
+        // deferUntil — fall through to the normal claim path so its state wins.
       }
 
-      // Step 1: Mark entry as processing (prevents duplicate processing)
-      await this.db.ticketOutbox.markProcessing(outboxEntryId);
-
-      // Step 2: Fetch outbox entry
-      const entry = await this.db.ticketOutbox.findById(outboxEntryId);
-
+      // Step 1: Atomically claim the entry via UPDATE ... RETURNING *. A null
+      // result means another worker beat us to it (or the entry hit a terminal
+      // state); either way we exit cleanly. Folding claim + fetch into one
+      // round-trip avoids the prior pattern of markProcessing followed by a
+      // defensive findById to read post-claim state.
+      const entry = await this.db.ticketOutbox.markProcessing(outboxEntryId);
       if (!entry) {
-        logger.error('Outbox entry not found in database', {
-          outboxEntryId,
-          jobId: job.id,
-        });
-        throw new Error(`Outbox entry not found: ${outboxEntryId}`);
-      }
-
-      if (entry.status !== 'processing') {
-        logger.warn('Outbox entry already processed or failed', {
-          outboxEntryId,
-          status: entry.status,
-        });
-        return; // Already handled by another worker
+        logger.warn('Outbox entry already processed or failed', { outboxEntryId });
+        return;
       }
 
       logger.debug('Fetched outbox entry details', {

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -59,39 +59,17 @@ export class TicketCreationOutboxProcessor {
     });
 
     try {
-      // Step 0: If the entry has a pre-file dedup grace window that hasn't elapsed yet,
-      // push scheduled_at forward and exit cleanly. The poller will re-enqueue the
-      // entry after the grace window closes. Done BEFORE markProcessing so we don't
-      // burn a retry attempt on an entry that simply isn't due yet. The check covers
-      // both 'pending' and 'failed' (retry) statuses so a long grace window also
-      // catches retries triggered by an early failure.
-      const pre = await this.db.ticketOutbox.findById(outboxEntryId);
-      if (!pre) {
-        logger.error('Outbox entry not found in database', { outboxEntryId, jobId: job.id });
-        throw new Error(`Outbox entry not found: ${outboxEntryId}`);
-      }
-      if (pre.dedup_grace_until && new Date() < pre.dedup_grace_until) {
-        const deferred = await this.db.ticketOutbox.deferUntil(
-          outboxEntryId,
-          pre.dedup_grace_until
-        );
-        if (deferred) {
-          logger.debug('Outbox entry deferred for pre-file dedup grace', {
-            outboxEntryId,
-            graceUntil: pre.dedup_grace_until,
-            status: pre.status,
-          });
-          return;
-        }
-        // Race: another worker claimed the entry between our findById and
-        // deferUntil — fall through to the normal claim path so its state wins.
-      }
-
       // Step 1: Atomically claim the entry via UPDATE ... RETURNING *. A null
       // result means another worker beat us to it (or the entry hit a terminal
-      // state); either way we exit cleanly. Folding claim + fetch into one
-      // round-trip avoids the prior pattern of markProcessing followed by a
-      // defensive findById to read post-claim state.
+      // state); either way we exit cleanly.
+      //
+      // Note on pre-file dedup grace: the grace window is enforced at row-creation
+      // time by setting `scheduled_at = dedup_grace_until` (see AutoTicketService),
+      // so the poller naturally waits before the worker ever runs. We deliberately
+      // do NOT re-defer here: BullMQ deduplicates `queue.add()` against retained
+      // completed jobs with the same `jobId`, so a worker-side defer that ends in
+      // `return` would silently drop the next poll's re-enqueue. The grace is
+      // best-effort; the duplicate_of check below is the actual suppression.
       const entry = await this.db.ticketOutbox.markProcessing(outboxEntryId);
       if (!entry) {
         logger.warn('Outbox entry already processed or failed', { outboxEntryId });
@@ -115,10 +93,16 @@ export class TicketCreationOutboxProcessor {
       // we can only avoid the new ticket, not cross-link to the canonical one.
       const bugReport = await this.db.bugReports.findById(entry.bug_report_id);
       if (!bugReport) {
-        // Match createExternalTicket's contract — surface the missing bug as a hard
-        // failure so the outbox retry path takes over (vs. silently falling through
-        // and triggering a second findById inside createExternalTicket).
-        throw new Error(`Bug report not found: ${entry.bug_report_id}`);
+        // The bug was hard-deleted (CASCADE would normally clean the outbox row
+        // too, but races and soft-delete shadows can leave us here). Throwing
+        // would just burn retries against a permanently missing row, so move
+        // the entry to the terminal 'skipped' state instead.
+        logger.warn('Skipping external ticket creation — bug report not found', {
+          outboxEntryId,
+          bugReportId: entry.bug_report_id,
+        });
+        await this.db.ticketOutbox.markSkipped(outboxEntryId, 'bug_report_not_found');
+        return;
       }
       if (bugReport.duplicate_of) {
         logger.info('Skipping external ticket creation — bug flagged as duplicate', {

--- a/packages/backend/src/services/integrations/auto-ticket-service.ts
+++ b/packages/backend/src/services/integrations/auto-ticket-service.ts
@@ -174,7 +174,12 @@ export class AutoTicketService {
           title: bugReport.title,
           description: bugReport.description,
         },
-        scheduled_at: new Date(), // Process immediately
+        // When a grace window is set, schedule the row to fire at the end of the
+        // window so the poller naturally waits — saves one worker cycle that
+        // would otherwise just call deferUntil. The worker still re-checks
+        // dedup_grace_until as a safety net (e.g. on retry, or if org settings
+        // were tightened after the row was enqueued).
+        scheduled_at: graceUntil ?? new Date(),
         max_retries: 3, // 3 retries with exponential backoff
         dedup_grace_until: graceUntil,
       });

--- a/packages/backend/src/services/integrations/auto-ticket-service.ts
+++ b/packages/backend/src/services/integrations/auto-ticket-service.ts
@@ -26,6 +26,7 @@
 import { getLogger } from '../../logger.js';
 import type { DatabaseClient } from '../../db/client.js';
 import type { BugReport } from '../../db/types.js';
+import { getOrgIntelligenceSettings } from '../intelligence/tenant-config.js';
 import { RuleEvaluator } from './rule-evaluator.js';
 import { ThrottleChecker } from './throttle-checker.js';
 
@@ -146,6 +147,13 @@ export class AutoTicketService {
         priority: rule.priority,
       });
 
+      // Resolve per-org pre-file dedup grace window. When > 0, the outbox worker
+      // defers filing until this timestamp, then re-checks duplicate_of so the
+      // async intelligence pipeline can suppress redundant tickets. NULL =
+      // legacy immediate-file behavior. Failures (missing org, DB error) fall
+      // back to legacy behavior — never block ticket creation.
+      const graceUntil = await this.resolveDedupGraceUntil(bugReport);
+
       // Step 2: Create outbox entry in database transaction (TRANSACTIONAL OUTBOX PATTERN)
       // This ensures atomicity - if DB transaction fails, no external ticket is created
       // Background worker will process the outbox entry asynchronously
@@ -168,6 +176,7 @@ export class AutoTicketService {
         },
         scheduled_at: new Date(), // Process immediately
         max_retries: 3, // 3 retries with exponential backoff
+        dedup_grace_until: graceUntil,
       });
 
       logger.info('Automatic ticket creation queued (outbox)', {
@@ -199,6 +208,28 @@ export class AutoTicketService {
         success: false,
         error: error instanceof Error ? error.message : String(error),
       };
+    }
+  }
+
+  private async resolveDedupGraceUntil(bugReport: BugReport): Promise<Date | null> {
+    if (!bugReport.organization_id) {
+      // Self-hosted / org-less projects: skip pre-file dedup.
+      return null;
+    }
+    try {
+      const settings = await getOrgIntelligenceSettings(this.db, bugReport.organization_id);
+      const graceMs = settings.intelligence_pre_file_dedup_grace_ms;
+      if (graceMs <= 0) {
+        return null;
+      }
+      return new Date(Date.now() + graceMs);
+    } catch (error) {
+      logger.warn('Failed to resolve dedup grace; falling back to immediate filing', {
+        bugReportId: bugReport.id,
+        organizationId: bugReport.organization_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
     }
   }
 }

--- a/packages/backend/src/services/intelligence/tenant-config.ts
+++ b/packages/backend/src/services/intelligence/tenant-config.ts
@@ -27,10 +27,30 @@ export interface OrgIntelligenceSettings {
   intelligence_similarity_threshold: number;
   intelligence_dedup_enabled: boolean;
   intelligence_dedup_action: 'flag' | 'auto_close';
+  /**
+   * Grace window (ms) the ticket-outbox worker waits before filing an external
+   * ticket, giving the async intelligence pipeline a chance to populate
+   * `bug_reports.duplicate_of`. 0 = file immediately (legacy behavior).
+   */
+  intelligence_pre_file_dedup_grace_ms: number;
   intelligence_self_service_enabled: boolean;
   intelligence_api_key_provisioned_at: string | null;
   intelligence_api_key_provisioned_by: string | null;
   intelligence_auto_enrich: boolean;
+}
+
+/**
+ * Maximum tolerated grace window for pre-file dedup. Capping at 5 minutes keeps
+ * end-user-visible filing latency bounded even when an admin misconfigures the
+ * setting; values above 300_000 are clamped to this ceiling.
+ */
+const MAX_PRE_FILE_DEDUP_GRACE_MS = 5 * 60 * 1000;
+
+function clampGraceMs(raw: number | null | undefined): number {
+  if (raw == null || typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) {
+    return 0;
+  }
+  return Math.min(Math.floor(raw), MAX_PRE_FILE_DEDUP_GRACE_MS);
 }
 
 export const INTELLIGENCE_SETTINGS_DEFAULTS: OrgIntelligenceSettings = {
@@ -41,6 +61,7 @@ export const INTELLIGENCE_SETTINGS_DEFAULTS: OrgIntelligenceSettings = {
   intelligence_similarity_threshold: 0.75,
   intelligence_dedup_enabled: true,
   intelligence_dedup_action: 'flag',
+  intelligence_pre_file_dedup_grace_ms: 0,
   intelligence_self_service_enabled: true,
   intelligence_api_key_provisioned_at: null,
   intelligence_api_key_provisioned_by: null,
@@ -75,6 +96,9 @@ export function resolveOrgIntelligenceSettings(
     intelligence_dedup_action:
       settings.intelligence_dedup_action ??
       INTELLIGENCE_SETTINGS_DEFAULTS.intelligence_dedup_action,
+    intelligence_pre_file_dedup_grace_ms: clampGraceMs(
+      settings.intelligence_pre_file_dedup_grace_ms
+    ),
     intelligence_self_service_enabled:
       settings.intelligence_self_service_enabled ??
       INTELLIGENCE_SETTINGS_DEFAULTS.intelligence_self_service_enabled,

--- a/packages/backend/tests/api/utils/enrichment-trigger.test.ts
+++ b/packages/backend/tests/api/utils/enrichment-trigger.test.ts
@@ -87,6 +87,7 @@ describe('triggerBugEnrichment', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
   });
 
@@ -166,6 +167,7 @@ describe('triggerBugEnrichment', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
 
     const db = createMockDb();
@@ -188,6 +190,7 @@ describe('triggerBugEnrichment', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
 
     const db = createMockDb();
@@ -210,6 +213,7 @@ describe('triggerBugEnrichment', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
 
     const db = createMockDb();

--- a/packages/backend/tests/api/utils/mitigation-trigger.test.ts
+++ b/packages/backend/tests/api/utils/mitigation-trigger.test.ts
@@ -77,6 +77,7 @@ describe('triggerBugMitigation', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
   });
 
@@ -168,6 +169,7 @@ describe('triggerBugMitigation', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
 
     const db = createMockDb();
@@ -191,6 +193,7 @@ describe('triggerBugMitigation', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
 
     const db = createMockDb();
@@ -213,6 +216,7 @@ describe('triggerBugMitigation', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
 
     const db = createMockDb();

--- a/packages/backend/tests/api/utils/resolution-sync-trigger.test.ts
+++ b/packages/backend/tests/api/utils/resolution-sync-trigger.test.ts
@@ -69,6 +69,7 @@ describe('triggerResolutionSync', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
   });
 
@@ -149,6 +150,7 @@ describe('triggerResolutionSync', () => {
       intelligence_dedup_action: 'flag',
       intelligence_api_key_provisioned_at: null,
       intelligence_api_key_provisioned_by: null,
+      intelligence_pre_file_dedup_grace_ms: 0,
     });
 
     const db = createMockDb();

--- a/packages/backend/tests/queue/ticket-creation-outbox.test.ts
+++ b/packages/backend/tests/queue/ticket-creation-outbox.test.ts
@@ -850,11 +850,14 @@ describe('Ticket Creation Outbox System', () => {
         },
       });
 
-      // Delete bug report
+      // Delete the bug report — FK ON DELETE CASCADE drops the outbox row too.
       await db.query('DELETE FROM bug_reports WHERE id = $1', [testBugReportId]);
 
-      // Processing should fail gracefully - outbox entry deleted by cascade
-      await expect(processor.process(createJob(outboxEntry.id))).rejects.toThrow();
+      // Worker should exit cleanly: markProcessing returns null (row gone),
+      // no throw, no external API call. Throwing here would just burn a retry
+      // against a row that no longer exists.
+      await expect(processor.process(createJob(outboxEntry.id))).resolves.toBeUndefined();
+      expect(mockService.createFromBugReport).not.toHaveBeenCalled();
 
       const updated = await db.ticketOutbox.findById(outboxEntry.id);
       // Entry should be null due to cascade delete from bug_reports
@@ -915,7 +918,10 @@ describe('Ticket Creation Outbox System', () => {
     it('should handle processing non-existent outbox entry', async () => {
       const fakeId = '00000000-0000-0000-0000-000000000000';
 
-      await expect(processor.process(createJob(fakeId))).rejects.toThrow();
+      // markProcessing's UPDATE matches no rows → returns null → worker exits
+      // cleanly without making external API calls. No throw, no retry burn.
+      await expect(processor.process(createJob(fakeId))).resolves.toBeUndefined();
+      expect(mockService.createFromBugReport).not.toHaveBeenCalled();
     });
 
     it('should detect and mark invalid platforms during polling - production fix', async () => {

--- a/packages/backend/tests/services/auto-ticket-service.test.ts
+++ b/packages/backend/tests/services/auto-ticket-service.test.ts
@@ -330,4 +330,95 @@ describe('AutoTicketService', () => {
       expect(result.error).toBe('Database connection lost');
     });
   });
+
+  describe('pre-file dedup grace window', () => {
+    const mockRule = {
+      id: 'rule-1',
+      project_id: 'project-456',
+      integration_id: 'integration-789',
+      name: 'Auto Create Critical',
+      enabled: true,
+      priority: 100,
+      auto_create: true,
+      filters: [{ field: 'priority', operator: 'equals', value: 'critical' }],
+      throttle: null,
+      field_mappings: null,
+      description_template: null,
+      attachment_config: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+
+    beforeEach(() => {
+      (mockDb.integrationRules.findAutoCreateRules as Mock).mockResolvedValue([mockRule]);
+      (mockDb.tickets.countByRuleSince as Mock).mockResolvedValue(0);
+    });
+
+    it('passes dedup_grace_until=null when bug has no organization_id', async () => {
+      // No organization_id on the bug => self-hosted/orgless flow => skip pre-file dedup.
+      mockBugReport.organization_id = null;
+
+      await service.tryCreateTicket(mockBugReport, 'project-456', 'integration-789', 'jira');
+
+      expect(mockDb.ticketOutbox.create).toHaveBeenCalledWith(
+        expect.objectContaining({ dedup_grace_until: null })
+      );
+    });
+
+    it('passes dedup_grace_until=null when org has grace_ms = 0 (feature off)', async () => {
+      mockBugReport.organization_id = 'org-1';
+      (mockDb as any).organizations = {
+        findById: vi.fn().mockResolvedValue({
+          id: 'org-1',
+          settings: { intelligence_pre_file_dedup_grace_ms: 0 },
+        }),
+      };
+
+      await service.tryCreateTicket(mockBugReport, 'project-456', 'integration-789', 'jira');
+
+      expect(mockDb.ticketOutbox.create).toHaveBeenCalledWith(
+        expect.objectContaining({ dedup_grace_until: null })
+      );
+    });
+
+    it('passes a future dedup_grace_until when org has grace_ms > 0', async () => {
+      mockBugReport.organization_id = 'org-1';
+      (mockDb as any).organizations = {
+        findById: vi.fn().mockResolvedValue({
+          id: 'org-1',
+          settings: { intelligence_pre_file_dedup_grace_ms: 30_000 },
+        }),
+      };
+      const before = Date.now();
+
+      await service.tryCreateTicket(mockBugReport, 'project-456', 'integration-789', 'jira');
+
+      const call = (mockDb.ticketOutbox.create as Mock).mock.calls[0][0];
+      expect(call.dedup_grace_until).toBeInstanceOf(Date);
+      const graceMs = call.dedup_grace_until.getTime() - before;
+      // Allow up to 1s of jitter for test scheduling.
+      expect(graceMs).toBeGreaterThanOrEqual(29_500);
+      expect(graceMs).toBeLessThanOrEqual(30_500);
+    });
+
+    it('falls back to dedup_grace_until=null when settings lookup throws', async () => {
+      mockBugReport.organization_id = 'org-1';
+      (mockDb as any).organizations = {
+        findById: vi.fn().mockRejectedValue(new Error('DB down')),
+      };
+
+      const result = await service.tryCreateTicket(
+        mockBugReport,
+        'project-456',
+        'integration-789',
+        'jira'
+      );
+
+      // Failure to read settings must not block ticket creation.
+      expect(result.success).toBe(true);
+      expect(mockDb.ticketOutbox.create).toHaveBeenCalledWith(
+        expect.objectContaining({ dedup_grace_until: null })
+      );
+    });
+  });
 });

--- a/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
+++ b/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
@@ -1,13 +1,15 @@
 /**
  * Unit tests for the pre-file dedup gate in the ticket-creation outbox worker.
  *
- * Three paths are covered:
- *   1. dedup_grace_until still in the future → entry is deferred (scheduled_at
- *      pushed forward via deferUntil), no markProcessing, no external API call.
- *   2. duplicate_of set on the bug report by the time the entry is dequeued →
- *      outbox row is markSkipped("duplicate_of_set"), no external API call.
- *   3. Grace window has elapsed and bug is not a duplicate → existing happy
- *      path runs unchanged (markProcessing → createIssue → markCompleted).
+ * The grace window itself is enforced at row-creation time via `scheduled_at`,
+ * so the worker has no defer/retry path to test — only the gate checks that
+ * matter at dequeue time:
+ *   1. duplicate_of set on the bug report → markSkipped("duplicate_of_set").
+ *   2. bug report missing (hard-delete / soft-delete) → markSkipped
+ *      ("bug_report_not_found") — terminal, not a retry-burning throw.
+ *   3. duplicate_of null and bug present → happy path (markProcessing →
+ *      createIssue → markCompleted).
+ *   4. markProcessing returns null (peer worker already claimed) → exit clean.
  *
  * All DB and plugin-registry calls are mocked; no Postgres / BullMQ required.
  */
@@ -82,9 +84,7 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
 
     db = {
       ticketOutbox: {
-        findById: vi.fn(),
-        deferUntil: vi.fn().mockResolvedValue(true),
-        // markProcessing now returns the claimed row (or null if not claimed).
+        // markProcessing returns the claimed row (or null if not claimed).
         markProcessing: vi.fn(),
         markSkipped: vi.fn().mockResolvedValue(undefined),
         markCompleted: vi.fn().mockResolvedValue(undefined),
@@ -98,24 +98,8 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
     processor = new TicketCreationOutboxProcessor(db, registry);
   });
 
-  it('defers the entry when dedup_grace_until is in the future', async () => {
-    const graceUntil = new Date(Date.now() + 30_000);
-    const entry = buildEntry({ dedup_grace_until: graceUntil, status: 'pending' });
-    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
-
-    await processor.process(buildJob('outbox-1') as never);
-
-    expect(db.ticketOutbox.deferUntil).toHaveBeenCalledWith('outbox-1', graceUntil);
-    expect(db.ticketOutbox.markProcessing).not.toHaveBeenCalled();
-    expect(db.bugReports.findById).not.toHaveBeenCalled();
-    expect(createFromBugReport).not.toHaveBeenCalled();
-    expect(db.ticketOutbox.markCompleted).not.toHaveBeenCalled();
-    expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
-  });
-
   it('skips ticket creation when the bug is already flagged as a duplicate', async () => {
     const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
-    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
     (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
       ...entry,
       status: 'processing',
@@ -131,13 +115,10 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
     expect(db.ticketOutbox.markSkipped).toHaveBeenCalledWith('outbox-1', 'duplicate_of_set');
     expect(createFromBugReport).not.toHaveBeenCalled();
     expect(db.ticketOutbox.markCompleted).not.toHaveBeenCalled();
-    expect(db.ticketOutbox.deferUntil).not.toHaveBeenCalled();
   });
 
-  it('files the ticket normally when grace has elapsed and the bug is not a duplicate', async () => {
-    const grace = new Date(Date.now() - 1000); // already expired
-    const entry = buildEntry({ dedup_grace_until: grace, status: 'pending' });
-    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+  it('files the ticket normally when the bug is not a duplicate', async () => {
+    const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
     (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
       ...entry,
       status: 'processing',
@@ -146,7 +127,6 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
 
     await processor.process(buildJob('outbox-1') as never);
 
-    expect(db.ticketOutbox.deferUntil).not.toHaveBeenCalled();
     expect(db.ticketOutbox.markProcessing).toHaveBeenCalledWith('outbox-1');
     expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
     expect(createFromBugReport).toHaveBeenCalledTimes(1);
@@ -156,51 +136,25 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
     );
   });
 
-  it('fails fast when the bug report no longer exists', async () => {
+  it('marks the entry skipped when the bug report no longer exists', async () => {
     const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
-    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
     (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
       ...entry,
       status: 'processing',
     });
     (db.bugReports.findById as Mock).mockResolvedValueOnce(null);
-    (db.ticketOutbox.markFailed as Mock).mockResolvedValueOnce({ ...entry, status: 'failed' });
-
-    await expect(processor.process(buildJob('outbox-1') as never)).rejects.toThrow(
-      /Bug report not found/
-    );
-
-    // Hard-fail flows through the catch → markFailed (not markSkipped), and
-    // no external ticket is created.
-    expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
-    expect(createFromBugReport).not.toHaveBeenCalled();
-    expect(db.ticketOutbox.markFailed).toHaveBeenCalledWith(
-      'outbox-1',
-      expect.stringMatching(/Bug report not found/)
-    );
-  });
-
-  it('files immediately when dedup_grace_until is NULL (legacy behavior)', async () => {
-    const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
-    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
-    (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
-      ...entry,
-      status: 'processing',
-    });
-    (db.bugReports.findById as Mock).mockResolvedValue({ id: 'bug-1', duplicate_of: null });
 
     await processor.process(buildJob('outbox-1') as never);
 
-    expect(db.ticketOutbox.deferUntil).not.toHaveBeenCalled();
-    expect(createFromBugReport).toHaveBeenCalledTimes(1);
-    expect(db.ticketOutbox.markCompleted).toHaveBeenCalledTimes(1);
+    // Missing bug is terminal — no throw, no external API call, no retry burn.
+    expect(db.ticketOutbox.markSkipped).toHaveBeenCalledWith('outbox-1', 'bug_report_not_found');
+    expect(db.ticketOutbox.markFailed).not.toHaveBeenCalled();
+    expect(createFromBugReport).not.toHaveBeenCalled();
   });
 
   it('exits cleanly when another worker has already claimed the entry', async () => {
-    // pre-check still loads the entry; markProcessing returns null because
-    // a peer worker has already transitioned it out of pending/failed.
-    const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
-    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+    // markProcessing returns null because a peer worker has already
+    // transitioned the row out of pending/failed.
     (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce(null);
 
     await processor.process(buildJob('outbox-1') as never);
@@ -209,22 +163,5 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
     expect(createFromBugReport).not.toHaveBeenCalled();
     expect(db.ticketOutbox.markCompleted).not.toHaveBeenCalled();
     expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
-  });
-
-  it('defers a failed retry that fires inside an unexpired grace window', async () => {
-    const graceUntil = new Date(Date.now() + 30_000);
-    const entry = buildEntry({
-      dedup_grace_until: graceUntil,
-      status: 'failed',
-      retry_count: 1,
-    });
-    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
-
-    await processor.process(buildJob('outbox-1') as never);
-
-    // Grace window still applies even though the entry is on a retry path.
-    expect(db.ticketOutbox.deferUntil).toHaveBeenCalledWith('outbox-1', graceUntil);
-    expect(db.ticketOutbox.markProcessing).not.toHaveBeenCalled();
-    expect(createFromBugReport).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
+++ b/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
@@ -154,6 +154,28 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
     );
   });
 
+  it('fails fast when the bug report no longer exists', async () => {
+    const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
+    (db.ticketOutbox.findById as Mock)
+      .mockResolvedValueOnce(entry)
+      .mockResolvedValueOnce({ ...entry, status: 'processing' });
+    (db.bugReports.findById as Mock).mockResolvedValueOnce(null);
+    (db.ticketOutbox.markFailed as Mock).mockResolvedValueOnce({ ...entry, status: 'failed' });
+
+    await expect(processor.process(buildJob('outbox-1') as never)).rejects.toThrow(
+      /Bug report not found/
+    );
+
+    // Hard-fail flows through the catch → markFailed (not markSkipped), and
+    // no external ticket is created.
+    expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
+    expect(createFromBugReport).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.markFailed).toHaveBeenCalledWith(
+      'outbox-1',
+      expect.stringMatching(/Bug report not found/)
+    );
+  });
+
   it('files immediately when dedup_grace_until is NULL (legacy behavior)', async () => {
     const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
     (db.ticketOutbox.findById as Mock)

--- a/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
+++ b/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the pre-file dedup gate in the ticket-creation outbox worker.
+ *
+ * Three paths are covered:
+ *   1. dedup_grace_until still in the future → entry is deferred (scheduled_at
+ *      pushed forward via deferUntil), no markProcessing, no external API call.
+ *   2. duplicate_of set on the bug report by the time the entry is dequeued →
+ *      outbox row is markSkipped("duplicate_of_set"), no external API call.
+ *   3. Grace window has elapsed and bug is not a duplicate → existing happy
+ *      path runs unchanged (markProcessing → createIssue → markCompleted).
+ *
+ * All DB and plugin-registry calls are mocked; no Postgres / BullMQ required.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { TicketCreationOutboxProcessor } from '../../../src/queue/workers/outbox/ticket-creation-outbox.worker.js';
+import type { DatabaseClient } from '../../../src/db/client.js';
+import type { PluginRegistry } from '../../../src/integrations/plugin-registry.js';
+import type {
+  TicketCreationOutboxEntry,
+  OutboxStatus,
+} from '../../../src/db/repositories/ticket-creation-outbox.repository.js';
+
+type JobHandleMock = {
+  id: string;
+  data: { outboxEntryId: string };
+  attemptsMade: number;
+};
+
+function buildEntry(overrides: Partial<TicketCreationOutboxEntry> = {}): TicketCreationOutboxEntry {
+  const base: TicketCreationOutboxEntry = {
+    id: 'outbox-1',
+    bug_report_id: 'bug-1',
+    project_id: 'project-1',
+    integration_id: 'integration-1',
+    platform: 'jira',
+    rule_id: 'rule-1',
+    payload: {},
+    status: 'pending' as OutboxStatus,
+    retry_count: 0,
+    max_retries: 3,
+    scheduled_at: new Date(),
+    next_retry_at: null,
+    external_ticket_id: null,
+    external_ticket_url: null,
+    error_message: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    processed_at: null,
+    idempotency_key: 'bug-1:rule-1:1',
+    dedup_grace_until: null,
+    skipped_reason: null,
+  };
+  return { ...base, ...overrides };
+}
+
+function buildJob(outboxEntryId: string): JobHandleMock {
+  return {
+    id: `job-${outboxEntryId}`,
+    data: { outboxEntryId },
+    attemptsMade: 0,
+  };
+}
+
+describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
+  let db: DatabaseClient;
+  let registry: PluginRegistry;
+  let createFromBugReport: Mock;
+  let processor: TicketCreationOutboxProcessor;
+
+  beforeEach(() => {
+    createFromBugReport = vi.fn().mockResolvedValue({
+      externalId: 'JIRA-1',
+      externalUrl: 'https://jira.example.com/browse/JIRA-1',
+    });
+
+    registry = {
+      get: vi.fn().mockReturnValue({ createFromBugReport }),
+      getSupportedPlatforms: vi.fn().mockReturnValue(['jira']),
+      isSupported: vi.fn().mockReturnValue(true),
+    } as unknown as PluginRegistry;
+
+    db = {
+      ticketOutbox: {
+        findById: vi.fn(),
+        deferUntil: vi.fn().mockResolvedValue(true),
+        markProcessing: vi.fn().mockResolvedValue(undefined),
+        markSkipped: vi.fn().mockResolvedValue(undefined),
+        markCompleted: vi.fn().mockResolvedValue(undefined),
+        markFailed: vi.fn(),
+      },
+      bugReports: {
+        findById: vi.fn(),
+      },
+    } as unknown as DatabaseClient;
+
+    processor = new TicketCreationOutboxProcessor(db, registry);
+  });
+
+  it('defers the entry when dedup_grace_until is in the future', async () => {
+    const graceUntil = new Date(Date.now() + 30_000);
+    const entry = buildEntry({ dedup_grace_until: graceUntil, status: 'pending' });
+    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+
+    await processor.process(buildJob('outbox-1') as never);
+
+    expect(db.ticketOutbox.deferUntil).toHaveBeenCalledWith('outbox-1', graceUntil);
+    expect(db.ticketOutbox.markProcessing).not.toHaveBeenCalled();
+    expect(db.bugReports.findById).not.toHaveBeenCalled();
+    expect(createFromBugReport).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.markCompleted).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
+  });
+
+  it('skips ticket creation when the bug is already flagged as a duplicate', async () => {
+    const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
+    // Pre-grace findById + post-markProcessing findById both return the same entry,
+    // but the second call reflects the post-claim status.
+    (db.ticketOutbox.findById as Mock)
+      .mockResolvedValueOnce(entry)
+      .mockResolvedValueOnce({ ...entry, status: 'processing' });
+    (db.bugReports.findById as Mock).mockResolvedValueOnce({
+      id: 'bug-1',
+      duplicate_of: 'bug-canonical',
+    });
+
+    await processor.process(buildJob('outbox-1') as never);
+
+    expect(db.ticketOutbox.markProcessing).toHaveBeenCalledWith('outbox-1');
+    expect(db.ticketOutbox.markSkipped).toHaveBeenCalledWith('outbox-1', 'duplicate_of_set');
+    expect(createFromBugReport).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.markCompleted).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.deferUntil).not.toHaveBeenCalled();
+  });
+
+  it('files the ticket normally when grace has elapsed and the bug is not a duplicate', async () => {
+    const grace = new Date(Date.now() - 1000); // already expired
+    const entry = buildEntry({ dedup_grace_until: grace, status: 'pending' });
+    (db.ticketOutbox.findById as Mock)
+      .mockResolvedValueOnce(entry)
+      .mockResolvedValueOnce({ ...entry, status: 'processing' });
+    // bugReports.findById is called twice: dedup gate + inside createExternalTicket.
+    (db.bugReports.findById as Mock).mockResolvedValue({ id: 'bug-1', duplicate_of: null });
+
+    await processor.process(buildJob('outbox-1') as never);
+
+    expect(db.ticketOutbox.deferUntil).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.markProcessing).toHaveBeenCalledWith('outbox-1');
+    expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
+    expect(createFromBugReport).toHaveBeenCalledTimes(1);
+    expect(db.ticketOutbox.markCompleted).toHaveBeenCalledWith(
+      'outbox-1',
+      expect.objectContaining({ external_ticket_id: 'JIRA-1' })
+    );
+  });
+
+  it('files immediately when dedup_grace_until is NULL (legacy behavior)', async () => {
+    const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
+    (db.ticketOutbox.findById as Mock)
+      .mockResolvedValueOnce(entry)
+      .mockResolvedValueOnce({ ...entry, status: 'processing' });
+    (db.bugReports.findById as Mock).mockResolvedValue({ id: 'bug-1', duplicate_of: null });
+
+    await processor.process(buildJob('outbox-1') as never);
+
+    expect(db.ticketOutbox.deferUntil).not.toHaveBeenCalled();
+    expect(createFromBugReport).toHaveBeenCalledTimes(1);
+    expect(db.ticketOutbox.markCompleted).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
+++ b/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
@@ -84,7 +84,8 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
       ticketOutbox: {
         findById: vi.fn(),
         deferUntil: vi.fn().mockResolvedValue(true),
-        markProcessing: vi.fn().mockResolvedValue(undefined),
+        // markProcessing now returns the claimed row (or null if not claimed).
+        markProcessing: vi.fn(),
         markSkipped: vi.fn().mockResolvedValue(undefined),
         markCompleted: vi.fn().mockResolvedValue(undefined),
         markFailed: vi.fn(),
@@ -114,11 +115,11 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
 
   it('skips ticket creation when the bug is already flagged as a duplicate', async () => {
     const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
-    // Pre-grace findById + post-markProcessing findById both return the same entry,
-    // but the second call reflects the post-claim status.
-    (db.ticketOutbox.findById as Mock)
-      .mockResolvedValueOnce(entry)
-      .mockResolvedValueOnce({ ...entry, status: 'processing' });
+    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+    (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
+      ...entry,
+      status: 'processing',
+    });
     (db.bugReports.findById as Mock).mockResolvedValueOnce({
       id: 'bug-1',
       duplicate_of: 'bug-canonical',
@@ -136,10 +137,11 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
   it('files the ticket normally when grace has elapsed and the bug is not a duplicate', async () => {
     const grace = new Date(Date.now() - 1000); // already expired
     const entry = buildEntry({ dedup_grace_until: grace, status: 'pending' });
-    (db.ticketOutbox.findById as Mock)
-      .mockResolvedValueOnce(entry)
-      .mockResolvedValueOnce({ ...entry, status: 'processing' });
-    // bugReports.findById is called twice: dedup gate + inside createExternalTicket.
+    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+    (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
+      ...entry,
+      status: 'processing',
+    });
     (db.bugReports.findById as Mock).mockResolvedValue({ id: 'bug-1', duplicate_of: null });
 
     await processor.process(buildJob('outbox-1') as never);
@@ -156,9 +158,11 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
 
   it('fails fast when the bug report no longer exists', async () => {
     const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
-    (db.ticketOutbox.findById as Mock)
-      .mockResolvedValueOnce(entry)
-      .mockResolvedValueOnce({ ...entry, status: 'processing' });
+    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+    (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
+      ...entry,
+      status: 'processing',
+    });
     (db.bugReports.findById as Mock).mockResolvedValueOnce(null);
     (db.ticketOutbox.markFailed as Mock).mockResolvedValueOnce({ ...entry, status: 'failed' });
 
@@ -178,9 +182,11 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
 
   it('files immediately when dedup_grace_until is NULL (legacy behavior)', async () => {
     const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
-    (db.ticketOutbox.findById as Mock)
-      .mockResolvedValueOnce(entry)
-      .mockResolvedValueOnce({ ...entry, status: 'processing' });
+    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+    (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
+      ...entry,
+      status: 'processing',
+    });
     (db.bugReports.findById as Mock).mockResolvedValue({ id: 'bug-1', duplicate_of: null });
 
     await processor.process(buildJob('outbox-1') as never);
@@ -188,5 +194,37 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
     expect(db.ticketOutbox.deferUntil).not.toHaveBeenCalled();
     expect(createFromBugReport).toHaveBeenCalledTimes(1);
     expect(db.ticketOutbox.markCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('exits cleanly when another worker has already claimed the entry', async () => {
+    // pre-check still loads the entry; markProcessing returns null because
+    // a peer worker has already transitioned it out of pending/failed.
+    const entry = buildEntry({ dedup_grace_until: null, status: 'pending' });
+    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+    (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce(null);
+
+    await processor.process(buildJob('outbox-1') as never);
+
+    expect(db.bugReports.findById).not.toHaveBeenCalled();
+    expect(createFromBugReport).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.markCompleted).not.toHaveBeenCalled();
+    expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
+  });
+
+  it('defers a failed retry that fires inside an unexpired grace window', async () => {
+    const graceUntil = new Date(Date.now() + 30_000);
+    const entry = buildEntry({
+      dedup_grace_until: graceUntil,
+      status: 'failed',
+      retry_count: 1,
+    });
+    (db.ticketOutbox.findById as Mock).mockResolvedValueOnce(entry);
+
+    await processor.process(buildJob('outbox-1') as never);
+
+    // Grace window still applies even though the entry is on a retry path.
+    expect(db.ticketOutbox.deferUntil).toHaveBeenCalledWith('outbox-1', graceUntil);
+    expect(db.ticketOutbox.markProcessing).not.toHaveBeenCalled();
+    expect(createFromBugReport).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/tests/services/intelligence/dedup-service.test.ts
+++ b/packages/backend/tests/services/intelligence/dedup-service.test.ts
@@ -128,6 +128,7 @@ describe('IntelligenceDedupService', () => {
         intelligence_self_service_enabled: true,
         intelligence_api_key_provisioned_at: null,
         intelligence_api_key_provisioned_by: null,
+        intelligence_pre_file_dedup_grace_ms: 0,
       });
 
       const db = createMockDb(1);
@@ -209,6 +210,7 @@ describe('IntelligenceDedupService', () => {
         intelligence_self_service_enabled: true,
         intelligence_api_key_provisioned_at: null,
         intelligence_api_key_provisioned_by: null,
+        intelligence_pre_file_dedup_grace_ms: 0,
       });
 
       const db = createMockDb(1);
@@ -290,6 +292,7 @@ describe('IntelligenceDedupService', () => {
         intelligence_self_service_enabled: true,
         intelligence_api_key_provisioned_at: null,
         intelligence_api_key_provisioned_by: null,
+        intelligence_pre_file_dedup_grace_ms: 0,
       });
 
       const db = createMockDb(1);

--- a/packages/backend/tests/services/intelligence/key-provisioning.test.ts
+++ b/packages/backend/tests/services/intelligence/key-provisioning.test.ts
@@ -302,6 +302,7 @@ describe('IntelligenceKeyProvisioning', () => {
         intelligence_dedup_action: 'flag' as const,
         intelligence_api_key_provisioned_at: '2026-01-01T00:00:00Z',
         intelligence_api_key_provisioned_by: 'user-1',
+        intelligence_pre_file_dedup_grace_ms: 0,
       };
 
       const status = await provisioning.getKeyStatus('org-1', preloaded);

--- a/packages/backend/tests/services/intelligence/self-service.test.ts
+++ b/packages/backend/tests/services/intelligence/self-service.test.ts
@@ -305,6 +305,7 @@ describe('SelfServiceResolutionService', () => {
         intelligence_self_service_enabled: true,
         intelligence_api_key_provisioned_at: null,
         intelligence_api_key_provisioned_by: null,
+        intelligence_pre_file_dedup_grace_ms: 0,
       });
 
       const { db } = createMockDb();
@@ -331,6 +332,7 @@ describe('SelfServiceResolutionService', () => {
         intelligence_self_service_enabled: false,
         intelligence_api_key_provisioned_at: null,
         intelligence_api_key_provisioned_by: null,
+        intelligence_pre_file_dedup_grace_ms: 0,
       });
 
       const { db } = createMockDb();

--- a/packages/backend/tests/services/intelligence/tenant-config.test.ts
+++ b/packages/backend/tests/services/intelligence/tenant-config.test.ts
@@ -92,6 +92,37 @@ describe('resolveOrgIntelligenceSettings', () => {
     expect(result.intelligence_similarity_threshold).toBe(0.75);
     expect(result.intelligence_dedup_action).toBe('flag');
   });
+
+  describe('intelligence_pre_file_dedup_grace_ms', () => {
+    it('defaults to 0 (feature off)', () => {
+      expect(resolveOrgIntelligenceSettings({}).intelligence_pre_file_dedup_grace_ms).toBe(0);
+    });
+
+    it('accepts positive integers', () => {
+      const result = resolveOrgIntelligenceSettings({
+        intelligence_pre_file_dedup_grace_ms: 30_000,
+      });
+      expect(result.intelligence_pre_file_dedup_grace_ms).toBe(30_000);
+    });
+
+    it('clamps negative or NaN values to 0', () => {
+      expect(
+        resolveOrgIntelligenceSettings({ intelligence_pre_file_dedup_grace_ms: -1 })
+          .intelligence_pre_file_dedup_grace_ms
+      ).toBe(0);
+      expect(
+        resolveOrgIntelligenceSettings({ intelligence_pre_file_dedup_grace_ms: NaN as never })
+          .intelligence_pre_file_dedup_grace_ms
+      ).toBe(0);
+    });
+
+    it('clamps absurdly large values to the 5-minute ceiling', () => {
+      const result = resolveOrgIntelligenceSettings({
+        intelligence_pre_file_dedup_grace_ms: 60 * 60 * 1000, // 1h
+      });
+      expect(result.intelligence_pre_file_dedup_grace_ms).toBe(5 * 60 * 1000);
+    });
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
Async intelligence dedup runs after the outbox fires, so duplicate bug reports produce duplicate Jira/Linear tickets today. Adds an opt-in per-org grace window (`intelligence_pre_file_dedup_grace_ms`, default 0) that defers the outbox worker until `bug_reports.duplicate_of` has had a chance to settle, then suppresses the external API call if the bug was flagged as a duplicate. Jira/Linear clients still lack `addComment`/`closeIssue`, so retroactive cleanup of already-filed duplicates is a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-organization pre-filing deduplication grace window to defer ticket filing and re-check duplicates.
  * Outbox entries support a terminal "skipped" state and record a skip reason.

* **Behavior**
  * Worker defers processing during active grace windows, re-checks duplicates, skips entries for missing/duplicate reports, and tracks skipped counts in stats.

* **Tests**
  * Added/updated tests covering grace deferral, skipping, duplicate handling, and related edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/138)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->