### PR TITLE
feat(integrations): platform-neutral ticket capabilities (addComment, transition, getStatus)

### DIFF
--- a/packages/backend/src/integrations/capabilities.ts
+++ b/packages/backend/src/integrations/capabilities.ts
@@ -1,0 +1,136 @@
+/**
+ * Platform-neutral capability interface for ticket integrations.
+ *
+ * The first wave of integration plugins (Jira, Linear) only needed to *create*
+ * tickets from bug reports — that's the `createFromBugReport` method on
+ * `IntegrationService`. The dedup rule engine (and the upcoming Phase 0.5
+ * automations: notify-on-dedup, counter-on-canonical, auto-reopen) needs
+ * three more things from each plugin:
+ *
+ *   - comment on an existing ticket
+ *   - transition an existing ticket to a different status
+ *   - read the current status of an existing ticket
+ *
+ * Two design choices worth flagging:
+ *
+ * 1) **Canonical statuses at the capability boundary.** `transition(...)`
+ *    accepts a `CanonicalStatus` (`'open' | 'in_progress' | 'closed' |
+ *    'wont_fix'`) rather than a Jira transition-id or a Linear state UUID.
+ *    Each plugin is responsible for mapping that to its own world — Jira
+ *    does discovery via `/transitions`, Linear queries `team.states`. This
+ *    keeps the rule engine (and the future NL parser) platform-neutral; the
+ *    cost is one extra API call per transition, which is fine for the
+ *    cadence of dedup automations.
+ *
+ * 2) **All three are optional.** A plugin can implement zero, one, or all
+ *    three. The rule engine checks via `pluginRegistry.supports(...)` before
+ *    dispatching an action. A plugin that only implements `addComment` will
+ *    have its `transition` actions silently skipped (with a warning log) —
+ *    rules don't break when a plugin is partial.
+ */
+
+import type { IntegrationService } from './base-integration.service.js';
+
+// ============================================================================
+// Canonical status
+// ============================================================================
+
+/**
+ * Platform-neutral ticket status used by the rule engine.
+ *
+ * Mapping notes per platform (implementer's responsibility):
+ *
+ *   Jira:    derived from `statusCategory.key` — new → open, indeterminate →
+ *            in_progress, done → closed. `wont_fix` is detected by status
+ *            *name* (Won't Fix / Cancelled / Duplicate) since Jira lumps
+ *            them into the `done` category.
+ *
+ *   Linear:  derived from `state.type` — triage/backlog/unstarted → open,
+ *            started → in_progress, completed → closed, canceled → wont_fix.
+ */
+export type CanonicalStatus = 'open' | 'in_progress' | 'closed' | 'wont_fix';
+
+export const CANONICAL_STATUSES: readonly CanonicalStatus[] = [
+  'open',
+  'in_progress',
+  'closed',
+  'wont_fix',
+] as const;
+
+export function isCanonicalStatus(value: unknown): value is CanonicalStatus {
+  return typeof value === 'string' && (CANONICAL_STATUSES as readonly string[]).includes(value);
+}
+
+/**
+ * Statuses we consider "the ticket is effectively closed" — used by the
+ * auto-reopen rule to decide whether a new duplicate is a regression.
+ */
+export function isTerminalStatus(status: CanonicalStatus): boolean {
+  return status === 'closed' || status === 'wont_fix';
+}
+
+// ============================================================================
+// Capability methods
+// ============================================================================
+
+/**
+ * Optional capability methods a ticket integration plugin may implement.
+ *
+ * Each is keyed by `externalId` (the ticket identifier the plugin returned
+ * from `createFromBugReport`) and `projectId` (BugSpotter project) so the
+ * plugin can resolve credentials and per-project config.
+ */
+export interface TicketIntegrationCapabilities extends IntegrationService {
+  /**
+   * Append a comment to an existing ticket.
+   *
+   * @param externalId Platform identifier (Jira key e.g. "PROJ-100", or
+   *                   Linear issue UUID).
+   * @param body       Comment body. Plugins may render markdown/templates
+   *                   into platform-specific markup.
+   * @param projectId  BugSpotter project id — used to resolve credentials.
+   */
+  addComment?(externalId: string, body: string, projectId: string): Promise<void>;
+
+  /**
+   * Move an existing ticket to a canonical status.
+   *
+   * Plugins resolve `target` to a platform-specific transition / state.
+   * If the target status is unreachable from the current state (Jira
+   * workflow restriction, missing transition), the plugin throws — the
+   * rule engine is responsible for catching and degrading gracefully.
+   */
+  transition?(externalId: string, target: CanonicalStatus, projectId: string): Promise<void>;
+
+  /**
+   * Read the current canonical status of an existing ticket.
+   *
+   * Used by the auto-reopen rule to detect regressions on closed tickets.
+   */
+  getStatus?(externalId: string, projectId: string): Promise<CanonicalStatus>;
+}
+
+// ============================================================================
+// Capability discovery
+// ============================================================================
+
+export type CapabilityName = 'addComment' | 'transition' | 'getStatus';
+
+/**
+ * Runtime check: does this service instance implement a given capability?
+ *
+ * The rule engine uses this to decide whether to dispatch an action or
+ * skip it with a warning. We check via duck-typing rather than via
+ * `instanceof` because plugins are loaded from many sources (built-in,
+ * filesystem, database-loaded sandboxed plugins).
+ */
+export function pluginSupports(
+  service: IntegrationService | undefined | null,
+  capability: CapabilityName
+): boolean {
+  if (!service) {
+    return false;
+  }
+  const candidate = service as unknown as Record<string, unknown>;
+  return typeof candidate[capability] === 'function';
+}

--- a/packages/backend/src/integrations/capabilities.ts
+++ b/packages/backend/src/integrations/capabilities.ts
@@ -84,13 +84,19 @@ export interface TicketIntegrationCapabilities extends IntegrationService {
   /**
    * Append a comment to an existing ticket.
    *
-   * @param externalId Platform identifier (Jira key e.g. "PROJ-100", or
-   *                   Linear issue UUID).
-   * @param body       Comment body. Plugins may render markdown/templates
-   *                   into platform-specific markup.
-   * @param projectId  BugSpotter project id — used to resolve credentials.
+   * @param externalId    Platform identifier (Jira key e.g. "PROJ-100", or
+   *                      Linear issue UUID).
+   * @param body          Comment body. Plugins may render markdown /
+   *                      templates into platform-specific markup.
+   * @param integrationId BugSpotter `project_integrations.id` — used to
+   *                      resolve credentials. We key on the integration row
+   *                      rather than the project so a project with multiple
+   *                      configured integrations of the same platform can
+   *                      target the right one. Plugins must reject
+   *                      disabled integrations (`getConfigByIntegrationId`
+   *                      already filters them).
    */
-  addComment?(externalId: string, body: string, projectId: string): Promise<void>;
+  addComment?(externalId: string, body: string, integrationId: string): Promise<void>;
 
   /**
    * Move an existing ticket to a canonical status.
@@ -100,14 +106,14 @@ export interface TicketIntegrationCapabilities extends IntegrationService {
    * workflow restriction, missing transition), the plugin throws — the
    * rule engine is responsible for catching and degrading gracefully.
    */
-  transition?(externalId: string, target: CanonicalStatus, projectId: string): Promise<void>;
+  transition?(externalId: string, target: CanonicalStatus, integrationId: string): Promise<void>;
 
   /**
    * Read the current canonical status of an existing ticket.
    *
    * Used by the auto-reopen rule to detect regressions on closed tickets.
    */
-  getStatus?(externalId: string, projectId: string): Promise<CanonicalStatus>;
+  getStatus?(externalId: string, integrationId: string): Promise<CanonicalStatus>;
 }
 
 // ============================================================================

--- a/packages/backend/src/integrations/capabilities.ts
+++ b/packages/backend/src/integrations/capabilities.ts
@@ -80,40 +80,52 @@ export function isTerminalStatus(status: CanonicalStatus): boolean {
  * from `createFromBugReport`) and `projectId` (BugSpotter project) so the
  * plugin can resolve credentials and per-project config.
  */
+/**
+ * Tenant/project scoping for every capability call.
+ *
+ * Both `projectId` and `integrationId` are required and verified against
+ * each other — `projectId` alone is ambiguous when a project has
+ * multiple integrations of the same platform, and `integrationId` alone
+ * leaks across tenants (a bare-UUID lookup will happily load any
+ * project's enabled config if a caller smuggles in a foreign
+ * integrationId via a stale outbox row, misrouted retry, or a
+ * compromised bug-report event).
+ *
+ * Plugins MUST reject calls where `integrationId` does not belong to
+ * `projectId`. The DB lookup is parameterised on both.
+ */
+export interface CapabilityTarget {
+  externalId: string;
+  projectId: string;
+  integrationId: string;
+}
+
 export interface TicketIntegrationCapabilities extends IntegrationService {
   /**
    * Append a comment to an existing ticket.
    *
-   * @param externalId    Platform identifier (Jira key e.g. "PROJ-100", or
-   *                      Linear issue UUID).
-   * @param body          Comment body. Plugins may render markdown /
-   *                      templates into platform-specific markup.
-   * @param integrationId BugSpotter `project_integrations.id` — used to
-   *                      resolve credentials. We key on the integration row
-   *                      rather than the project so a project with multiple
-   *                      configured integrations of the same platform can
-   *                      target the right one. Plugins must reject
-   *                      disabled integrations (`getConfigByIntegrationId`
-   *                      already filters them).
+   * @param target  External ticket id plus project / integration scoping.
+   * @param body    Comment body. Plugins may render markdown / templates
+   *                into platform-specific markup.
    */
-  addComment?(externalId: string, body: string, integrationId: string): Promise<void>;
+  addComment?(target: CapabilityTarget, body: string): Promise<void>;
 
   /**
    * Move an existing ticket to a canonical status.
    *
-   * Plugins resolve `target` to a platform-specific transition / state.
-   * If the target status is unreachable from the current state (Jira
-   * workflow restriction, missing transition), the plugin throws — the
-   * rule engine is responsible for catching and degrading gracefully.
+   * Plugins resolve `targetStatus` to a platform-specific transition /
+   * state. If the target status is unreachable from the current state
+   * (Jira workflow restriction, missing transition), the plugin throws —
+   * the rule engine catches and degrades gracefully.
    */
-  transition?(externalId: string, target: CanonicalStatus, integrationId: string): Promise<void>;
+  transition?(target: CapabilityTarget, targetStatus: CanonicalStatus): Promise<void>;
 
   /**
    * Read the current canonical status of an existing ticket.
    *
    * Used by the auto-reopen rule to detect regressions on closed tickets.
    */
-  getStatus?(externalId: string, integrationId: string): Promise<CanonicalStatus>;
+  getStatus?(target: CapabilityTarget): Promise<CanonicalStatus>;
 }
 
 // ============================================================================

--- a/packages/backend/src/integrations/jira/client.ts
+++ b/packages/backend/src/integrations/jira/client.ts
@@ -54,10 +54,20 @@ export const JIRA_COMMENT_TRUNCATION_SUFFIX = '\n… [truncated]';
  *
  * Exported so unit tests can exercise it without HTTP.
  */
+/**
+ * The two node types we emit inside a paragraph. Constraining to a
+ * literal union prevents accidentally constructing an invalid ADF tree
+ * (e.g. `{ type: 'image' }`) — TypeScript will reject anything else at
+ * compile time.
+ */
+type AdfTextNode = { type: 'text'; text: string };
+type AdfHardBreakNode = { type: 'hardBreak' };
+type AdfInlineNode = AdfTextNode | AdfHardBreakNode;
+
 export function buildPlainTextADF(body: string): {
   type: 'doc';
   version: 1;
-  content: Array<{ type: 'paragraph'; content: Array<{ type: string; text?: string }> }>;
+  content: Array<{ type: 'paragraph'; content: AdfInlineNode[] }>;
 } {
   const safeBody =
     body.length > JIRA_COMMENT_MAX_CHARS
@@ -66,7 +76,7 @@ export function buildPlainTextADF(body: string): {
       : body;
 
   const lines = safeBody.split(/\r?\n/);
-  const paragraphContent: Array<{ type: string; text?: string }> = [];
+  const paragraphContent: AdfInlineNode[] = [];
   lines.forEach((line, idx) => {
     if (line.length > 0) {
       paragraphContent.push({ type: 'text', text: line });

--- a/packages/backend/src/integrations/jira/client.ts
+++ b/packages/backend/src/integrations/jira/client.ts
@@ -27,6 +27,38 @@ const logger = getLogger();
 /**
  * Jira API endpoints
  */
+/**
+ * Build a minimal ADF document representing a single paragraph of plain text.
+ *
+ * ADF's `text` nodes ignore literal `\n`; the renderer collapses them to
+ * spaces, so multi-line bodies arrive looking like one big run-on line.
+ * We split on newlines and insert `hardBreak` nodes between fragments —
+ * blank source lines become an extra `hardBreak`.
+ *
+ * Exported so unit tests can exercise it without HTTP.
+ */
+export function buildPlainTextADF(body: string): {
+  type: 'doc';
+  version: 1;
+  content: Array<{ type: 'paragraph'; content: Array<{ type: string; text?: string }> }>;
+} {
+  const lines = body.split(/\r?\n/);
+  const paragraphContent: Array<{ type: string; text?: string }> = [];
+  lines.forEach((line, idx) => {
+    if (line.length > 0) {
+      paragraphContent.push({ type: 'text', text: line });
+    }
+    if (idx < lines.length - 1) {
+      paragraphContent.push({ type: 'hardBreak' });
+    }
+  });
+  return {
+    type: 'doc',
+    version: 1,
+    content: [{ type: 'paragraph', content: paragraphContent }],
+  };
+}
+
 const JIRA_API_BASE = '/rest/api/3';
 const JIRA_ENDPOINTS = {
   CREATE_ISSUE: `${JIRA_API_BASE}/issue`,
@@ -604,10 +636,12 @@ export class JiraClient {
   /**
    * Append a comment to an existing Jira issue.
    *
-   * Body is sent as Atlassian Document Format (ADF) plain-text — markdown
-   * isn't supported by the v3 API. Multiline strings become a single ADF
-   * paragraph; this keeps the implementation simple and matches what most
-   * rule-engine action bodies need (one short status line, not an article).
+   * Body is sent as Atlassian Document Format (ADF). The v3 API doesn't
+   * render markdown and ignores literal `\n` inside a `text` node, so we
+   * split on newlines and emit a `hardBreak` between fragments. Blank
+   * lines become an extra `hardBreak` rather than a paragraph break —
+   * the rule-engine bodies we expect to send here are short status
+   * lines, not articles.
    */
   async addComment(issueKey: string, body: string): Promise<void> {
     if (!issueKey) {
@@ -617,18 +651,7 @@ export class JiraClient {
       throw new Error('addComment: body cannot be empty');
     }
 
-    const adfBody = {
-      body: {
-        type: 'doc',
-        version: 1,
-        content: [
-          {
-            type: 'paragraph',
-            content: [{ type: 'text', text: body }],
-          },
-        ],
-      },
-    };
+    const adfBody = { body: buildPlainTextADF(body) };
 
     logger.info('Adding Jira comment', { issueKey, bodyLength: body.length });
 

--- a/packages/backend/src/integrations/jira/client.ts
+++ b/packages/backend/src/integrations/jira/client.ts
@@ -28,12 +28,29 @@ const logger = getLogger();
  * Jira API endpoints
  */
 /**
+ * Soft cap on the raw character length of a comment body, applied before
+ * ADF construction. Jira's hard limit on a comment is ~32 KB of serialized
+ * payload; capping the source text at 16 KB leaves comfortable headroom
+ * for the ADF envelope while staying well above any realistic rule-engine
+ * comment (typically <500 chars).
+ */
+export const JIRA_COMMENT_MAX_CHARS = 16_000;
+
+/** Marker appended to truncated comment bodies so the reader knows. */
+export const JIRA_COMMENT_TRUNCATION_SUFFIX = '\n… [truncated]';
+
+/**
  * Build a minimal ADF document representing a single paragraph of plain text.
  *
  * ADF's `text` nodes ignore literal `\n`; the renderer collapses them to
  * spaces, so multi-line bodies arrive looking like one big run-on line.
  * We split on newlines and insert `hardBreak` nodes between fragments —
  * blank source lines become an extra `hardBreak`.
+ *
+ * Bodies longer than `JIRA_COMMENT_MAX_CHARS` are truncated with a marker
+ * suffix so they fit inside Jira's comment-size limit and don't blow up
+ * the ADF tree. Truncation happens on raw text, before splitting into
+ * lines, so the marker is always preserved.
  *
  * Exported so unit tests can exercise it without HTTP.
  */
@@ -42,7 +59,13 @@ export function buildPlainTextADF(body: string): {
   version: 1;
   content: Array<{ type: 'paragraph'; content: Array<{ type: string; text?: string }> }>;
 } {
-  const lines = body.split(/\r?\n/);
+  const safeBody =
+    body.length > JIRA_COMMENT_MAX_CHARS
+      ? body.slice(0, JIRA_COMMENT_MAX_CHARS - JIRA_COMMENT_TRUNCATION_SUFFIX.length) +
+        JIRA_COMMENT_TRUNCATION_SUFFIX
+      : body;
+
+  const lines = safeBody.split(/\r?\n/);
   const paragraphContent: Array<{ type: string; text?: string }> = [];
   lines.forEach((line, idx) => {
     if (line.length > 0) {

--- a/packages/backend/src/integrations/jira/client.ts
+++ b/packages/backend/src/integrations/jira/client.ts
@@ -19,6 +19,7 @@ import type {
   JiraUser,
   JiraProject,
   JiraProjectSearchResponse,
+  JiraTransition,
 } from './types.js';
 
 const logger = getLogger();
@@ -35,6 +36,9 @@ const JIRA_ENDPOINTS = {
   GET_MYSELF: `${JIRA_API_BASE}/myself`,
   SEARCH_USERS: `${JIRA_API_BASE}/user/search`,
   SEARCH_PROJECTS: `${JIRA_API_BASE}/project/search`,
+  ADD_COMMENT: (issueKey: string) => `${JIRA_API_BASE}/issue/${issueKey}/comment`,
+  GET_TRANSITIONS: (issueKey: string) => `${JIRA_API_BASE}/issue/${issueKey}/transitions`,
+  POST_TRANSITION: (issueKey: string) => `${JIRA_API_BASE}/issue/${issueKey}/transitions`,
 } as const;
 
 /**
@@ -585,5 +589,100 @@ export class JiraClient {
    */
   getIssueUrl(issueKey: string): string {
     return `${this.host}/browse/${issueKey}`;
+  }
+
+  // ==========================================================================
+  // Capability methods (TicketIntegrationCapabilities)
+  // ==========================================================================
+  //
+  // These three methods implement the optional capability interface used by
+  // the dedup rule engine. Each returns the minimum shape needed by the
+  // higher-level service / mapper — status mapping to the canonical enum
+  // happens in jira-status-mapper.ts so unit-tests can exercise it
+  // independently of HTTP.
+
+  /**
+   * Append a comment to an existing Jira issue.
+   *
+   * Body is sent as Atlassian Document Format (ADF) plain-text — markdown
+   * isn't supported by the v3 API. Multiline strings become a single ADF
+   * paragraph; this keeps the implementation simple and matches what most
+   * rule-engine action bodies need (one short status line, not an article).
+   */
+  async addComment(issueKey: string, body: string): Promise<void> {
+    if (!issueKey) {
+      throw new Error('addComment: issueKey is required');
+    }
+    if (!body || body.trim().length === 0) {
+      throw new Error('addComment: body cannot be empty');
+    }
+
+    const adfBody = {
+      body: {
+        type: 'doc',
+        version: 1,
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: body }],
+          },
+        ],
+      },
+    };
+
+    logger.info('Adding Jira comment', { issueKey, bodyLength: body.length });
+
+    await this.request<unknown>({
+      method: 'POST',
+      path: JIRA_ENDPOINTS.ADD_COMMENT(issueKey),
+      headers: {},
+      body: JSON.stringify(adfBody),
+    });
+  }
+
+  /**
+   * List the transitions currently available to an issue.
+   *
+   * Jira's workflow is per-project and per-current-state, so the set of
+   * available transitions varies. The rule engine calls this first, then
+   * picks one whose target `statusCategory` matches the canonical status it
+   * wants to reach, then calls `transitionIssue` with the chosen id.
+   */
+  async getTransitions(issueKey: string): Promise<JiraTransition[]> {
+    if (!issueKey) {
+      throw new Error('getTransitions: issueKey is required');
+    }
+
+    const response = await this.request<{ transitions?: JiraTransition[] }>({
+      method: 'GET',
+      path: JIRA_ENDPOINTS.GET_TRANSITIONS(issueKey),
+      headers: {},
+    });
+
+    return response.transitions ?? [];
+  }
+
+  /**
+   * Execute a transition by id, moving the issue to a new status.
+   *
+   * The id must come from a recent `getTransitions(issueKey)` call — Jira
+   * may reject ids that aren't currently available from the issue's state.
+   */
+  async transitionIssue(issueKey: string, transitionId: string): Promise<void> {
+    if (!issueKey) {
+      throw new Error('transitionIssue: issueKey is required');
+    }
+    if (!transitionId) {
+      throw new Error('transitionIssue: transitionId is required');
+    }
+
+    logger.info('Transitioning Jira issue', { issueKey, transitionId });
+
+    await this.request<unknown>({
+      method: 'POST',
+      path: JIRA_ENDPOINTS.POST_TRANSITION(issueKey),
+      headers: {},
+      body: JSON.stringify({ transition: { id: transitionId } }),
+    });
   }
 }

--- a/packages/backend/src/integrations/jira/config.ts
+++ b/packages/backend/src/integrations/jira/config.ts
@@ -391,15 +391,38 @@ export class JiraConfigManager {
   }
 
   /**
-   * Get Jira configuration by integration ID
-   * Used when project has multiple Jira integrations to get specific one
+   * Get Jira configuration by integration ID.
+   *
+   * Used when a project has multiple Jira integrations and we need to load
+   * a specific one. When `expectedProjectId` is provided, the integration
+   * must belong to that project — mismatches return null and log a warning.
+   * Capability callers (rule engine, future automations) MUST pass
+   * `expectedProjectId` to prevent cross-tenant misuse: the bare-UUID
+   * lookup would otherwise happily load any project's enabled Jira config
+   * if a caller smuggled in a foreign integrationId.
    */
-  async getConfigByIntegrationId(integrationId: string): Promise<JiraConfig | null> {
+  async getConfigByIntegrationId(
+    integrationId: string,
+    expectedProjectId?: string
+  ): Promise<JiraConfig | null> {
     try {
       const integration = await this.integrationRepo.findByIdWithType(integrationId);
 
       if (!integration || !integration.enabled) {
         logger.debug('No enabled Jira integration found', { integrationId });
+        return null;
+      }
+
+      // Defense-in-depth: reject cross-project access. The lookup above is
+      // by integrationId only, so without this check a caller passing in
+      // another tenant's integrationId would silently get back working
+      // credentials.
+      if (expectedProjectId && integration.project_id !== expectedProjectId) {
+        logger.warn('Jira integration does not belong to the expected project', {
+          integrationId,
+          expectedProjectId,
+          actualProjectId: integration.project_id,
+        });
         return null;
       }
 

--- a/packages/backend/src/integrations/jira/config.ts
+++ b/packages/backend/src/integrations/jira/config.ts
@@ -391,19 +391,25 @@ export class JiraConfigManager {
   }
 
   /**
-   * Get Jira configuration by integration ID.
+   * Get Jira configuration by integration ID, scoped to a specific project.
    *
-   * Used when a project has multiple Jira integrations and we need to load
-   * a specific one. When `expectedProjectId` is provided, the integration
-   * must belong to that project — mismatches return null and log a warning.
-   * Capability callers (rule engine, future automations) MUST pass
-   * `expectedProjectId` to prevent cross-tenant misuse: the bare-UUID
-   * lookup would otherwise happily load any project's enabled Jira config
-   * if a caller smuggled in a foreign integrationId.
+   * Both arguments are required: the integrationId on its own is a flat
+   * lookup with no tenant filter, which lets a caller smuggle in a
+   * foreign integrationId (via a stale outbox row, a misrouted retry, or
+   * a compromised bug-report event) and silently get back credentials
+   * for another tenant's Jira connection. We always verify that the
+   * loaded row belongs to `expectedProjectId` — mismatches return null
+   * and log a warning. This applies to every call site, both the
+   * capability methods and the legacy `validateAndLoadConfig` /
+   * `createFromBugReport` flow.
+   *
+   * Making the parameter required (rather than optional) is deliberate:
+   * an optional defense-in-depth check would silently drop protection
+   * any time a future caller forgot to pass it.
    */
   async getConfigByIntegrationId(
     integrationId: string,
-    expectedProjectId?: string
+    expectedProjectId: string
   ): Promise<JiraConfig | null> {
     try {
       const integration = await this.integrationRepo.findByIdWithType(integrationId);
@@ -417,7 +423,7 @@ export class JiraConfigManager {
       // by integrationId only, so without this check a caller passing in
       // another tenant's integrationId would silently get back working
       // credentials.
-      if (expectedProjectId && integration.project_id !== expectedProjectId) {
+      if (integration.project_id !== expectedProjectId) {
         logger.warn('Jira integration does not belong to the expected project', {
           integrationId,
           expectedProjectId,

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -760,17 +760,31 @@ export class JiraIntegrationService implements IntegrationService {
   // ./status-mapper.ts so it can be unit-tested without HTTP.
 
   /**
+   * Resolve the JiraClient for an integration.
+   *
+   * Uses `getConfigByIntegrationId` (not `getConfig(projectId)`) so we
+   * (a) target the specific integration when a project has multiple Jira
+   * connections and (b) reject disabled integrations — the config-manager
+   * already returns null for both `enabled: false` and not-found.
+   */
+  private async resolveClient(integrationId: string): Promise<JiraClient> {
+    const config = await this.configManager.getConfigByIntegrationId(integrationId);
+    if (!config) {
+      throw new Error(
+        `No enabled Jira integration ${integrationId} (missing, disabled, or wrong platform)`
+      );
+    }
+    return new JiraClient(config);
+  }
+
+  /**
    * Append a comment to an existing Jira issue.
    *
-   * Throws when no Jira config is found for the project — the caller (rule
+   * Throws when the integration is missing or disabled — the caller (rule
    * engine) is responsible for treating that as "skip this action and log".
    */
-  async addComment(externalId: string, body: string, projectId: string): Promise<void> {
-    const config = await this.configManager.getConfig(projectId);
-    if (!config) {
-      throw new Error(`No Jira config for project ${projectId}`);
-    }
-    const client = new JiraClient(config);
+  async addComment(externalId: string, body: string, integrationId: string): Promise<void> {
+    const client = await this.resolveClient(integrationId);
     await client.addComment(externalId, body);
   }
 
@@ -783,12 +797,12 @@ export class JiraIntegrationService implements IntegrationService {
    * the right category — the issue's workflow simply doesn't allow it from
    * its current state. Caller logs and degrades.
    */
-  async transition(externalId: string, target: CanonicalStatus, projectId: string): Promise<void> {
-    const config = await this.configManager.getConfig(projectId);
-    if (!config) {
-      throw new Error(`No Jira config for project ${projectId}`);
-    }
-    const client = new JiraClient(config);
+  async transition(
+    externalId: string,
+    target: CanonicalStatus,
+    integrationId: string
+  ): Promise<void> {
+    const client = await this.resolveClient(integrationId);
 
     const transitions = await client.getTransitions(externalId);
     const picked = pickTransitionForCanonicalStatus(transitions, target);
@@ -810,13 +824,8 @@ export class JiraIntegrationService implements IntegrationService {
   /**
    * Read the canonical status of an existing Jira issue.
    */
-  async getStatus(externalId: string, projectId: string): Promise<CanonicalStatus> {
-    const config = await this.configManager.getConfig(projectId);
-    if (!config) {
-      throw new Error(`No Jira config for project ${projectId}`);
-    }
-    const client = new JiraClient(config);
-
+  async getStatus(externalId: string, integrationId: string): Promise<CanonicalStatus> {
+    const client = await this.resolveClient(integrationId);
     const issue = await client.getIssue(externalId);
     return jiraIssueToCanonicalStatus(issue);
   }

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -18,7 +18,7 @@ import { JiraConfigManager } from './config.js';
 import { JiraClient } from './client.js';
 import { JiraBugReportMapper } from './mapper.js';
 import { jiraIssueToCanonicalStatus, pickTransitionForCanonicalStatus } from './status-mapper.js';
-import type { CanonicalStatus } from '../capabilities.js';
+import type { CanonicalStatus, CapabilityTarget } from '../capabilities.js';
 import type { JiraIntegrationResult, JiraConfig, JiraAttachment } from './types.js';
 import { SHARE_TOKEN_EXPIRATION_HOURS } from './types.js';
 
@@ -760,18 +760,26 @@ export class JiraIntegrationService implements IntegrationService {
   // ./status-mapper.ts so it can be unit-tested without HTTP.
 
   /**
-   * Resolve the JiraClient for an integration.
+   * Resolve the JiraClient for a (project, integration) pair.
    *
-   * Uses `getConfigByIntegrationId` (not `getConfig(projectId)`) so we
-   * (a) target the specific integration when a project has multiple Jira
-   * connections and (b) reject disabled integrations — the config-manager
-   * already returns null for both `enabled: false` and not-found.
+   * Loads the config via `getConfigByIntegrationId(integrationId,
+   * projectId)` which rejects three failure modes in one call:
+   *  - integration does not exist
+   *  - integration is disabled
+   *  - integration belongs to a different project (cross-tenant guard)
+   *
+   * The cross-tenant guard matters because the bare integrationId lookup
+   * does a flat `WHERE id = $1` — without the projectId check, a caller
+   * passing a foreign integrationId (smuggled via a stale outbox row or
+   * an attacker-influenced bug event) would get back working credentials
+   * for that tenant.
    */
-  private async resolveClient(integrationId: string): Promise<JiraClient> {
-    const config = await this.configManager.getConfigByIntegrationId(integrationId);
+  private async resolveClient(integrationId: string, projectId: string): Promise<JiraClient> {
+    const config = await this.configManager.getConfigByIntegrationId(integrationId, projectId);
     if (!config) {
       throw new Error(
-        `No enabled Jira integration ${integrationId} (missing, disabled, or wrong platform)`
+        `Jira integration ${integrationId} not usable for project ${projectId} ` +
+          `(missing, disabled, wrong project, or wrong platform)`
       );
     }
     return new JiraClient(config);
@@ -780,42 +788,38 @@ export class JiraIntegrationService implements IntegrationService {
   /**
    * Append a comment to an existing Jira issue.
    *
-   * Throws when the integration is missing or disabled — the caller (rule
-   * engine) is responsible for treating that as "skip this action and log".
+   * Throws when the integration is missing, disabled, or does not belong
+   * to `target.projectId`. The rule engine catches and degrades.
    */
-  async addComment(externalId: string, body: string, integrationId: string): Promise<void> {
-    const client = await this.resolveClient(integrationId);
-    await client.addComment(externalId, body);
+  async addComment(target: CapabilityTarget, body: string): Promise<void> {
+    const client = await this.resolveClient(target.integrationId, target.projectId);
+    await client.addComment(target.externalId, body);
   }
 
   /**
-   * Transition a Jira issue to the canonical status `target`.
+   * Transition a Jira issue to the canonical status `targetStatus`.
    *
    * Two API calls: list the issue's currently-available transitions, then
-   * pick one whose target state's category matches `target` (see
-   * `pickTransitionForCanonicalStatus`). Throws when no transition lands in
-   * the right category — the issue's workflow simply doesn't allow it from
-   * its current state. Caller logs and degrades.
+   * pick one whose target state's category matches `targetStatus` (see
+   * `pickTransitionForCanonicalStatus`). Throws when no transition lands
+   * in the right category — the issue's workflow simply doesn't allow
+   * it from its current state. Caller logs and degrades.
    */
-  async transition(
-    externalId: string,
-    target: CanonicalStatus,
-    integrationId: string
-  ): Promise<void> {
-    const client = await this.resolveClient(integrationId);
+  async transition(target: CapabilityTarget, targetStatus: CanonicalStatus): Promise<void> {
+    const client = await this.resolveClient(target.integrationId, target.projectId);
 
-    const transitions = await client.getTransitions(externalId);
-    const picked = pickTransitionForCanonicalStatus(transitions, target);
+    const transitions = await client.getTransitions(target.externalId);
+    const picked = pickTransitionForCanonicalStatus(transitions, targetStatus);
     if (!picked) {
       throw new Error(
-        `No Jira transition leads to canonical status '${target}' from issue ${externalId}'s current state`
+        `No Jira transition leads to canonical status '${targetStatus}' from issue ${target.externalId}'s current state`
       );
     }
 
-    await client.transitionIssue(externalId, picked.id);
+    await client.transitionIssue(target.externalId, picked.id);
     logger.info('Jira issue transitioned via capability', {
-      issueKey: externalId,
-      target,
+      issueKey: target.externalId,
+      target: targetStatus,
       transitionId: picked.id,
       transitionName: picked.name,
     });
@@ -824,9 +828,9 @@ export class JiraIntegrationService implements IntegrationService {
   /**
    * Read the canonical status of an existing Jira issue.
    */
-  async getStatus(externalId: string, integrationId: string): Promise<CanonicalStatus> {
-    const client = await this.resolveClient(integrationId);
-    const issue = await client.getIssue(externalId);
+  async getStatus(target: CapabilityTarget): Promise<CanonicalStatus> {
+    const client = await this.resolveClient(target.integrationId, target.projectId);
+    const issue = await client.getIssue(target.externalId);
     return jiraIssueToCanonicalStatus(issue);
   }
 }

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -17,6 +17,8 @@ import { generateShareToken } from '../../utils/token-generator.js';
 import { JiraConfigManager } from './config.js';
 import { JiraClient } from './client.js';
 import { JiraBugReportMapper } from './mapper.js';
+import { jiraIssueToCanonicalStatus, pickTransitionForCanonicalStatus } from './status-mapper.js';
+import type { CanonicalStatus } from '../capabilities.js';
 import type { JiraIntegrationResult, JiraConfig, JiraAttachment } from './types.js';
 import { SHARE_TOKEN_EXPIRATION_HOURS } from './types.js';
 
@@ -745,5 +747,77 @@ export class JiraIntegrationService implements IntegrationService {
    */
   getAllowedAvatarDomains(config: Record<string, unknown>): string[] {
     return buildJiraAllowedAvatarDomains(config);
+  }
+
+  // ==========================================================================
+  // Capability methods (TicketIntegrationCapabilities)
+  // ==========================================================================
+  //
+  // These implement the platform-neutral capability interface consumed by
+  // the dedup rule engine. Each loads the project's stored Jira config,
+  // builds a one-shot JiraClient, and delegates the HTTP work. They are
+  // small wrappers — the canonical-status mapping lives in
+  // ./status-mapper.ts so it can be unit-tested without HTTP.
+
+  /**
+   * Append a comment to an existing Jira issue.
+   *
+   * Throws when no Jira config is found for the project — the caller (rule
+   * engine) is responsible for treating that as "skip this action and log".
+   */
+  async addComment(externalId: string, body: string, projectId: string): Promise<void> {
+    const config = await this.configManager.getConfig(projectId);
+    if (!config) {
+      throw new Error(`No Jira config for project ${projectId}`);
+    }
+    const client = new JiraClient(config);
+    await client.addComment(externalId, body);
+  }
+
+  /**
+   * Transition a Jira issue to the canonical status `target`.
+   *
+   * Two API calls: list the issue's currently-available transitions, then
+   * pick one whose target state's category matches `target` (see
+   * `pickTransitionForCanonicalStatus`). Throws when no transition lands in
+   * the right category — the issue's workflow simply doesn't allow it from
+   * its current state. Caller logs and degrades.
+   */
+  async transition(externalId: string, target: CanonicalStatus, projectId: string): Promise<void> {
+    const config = await this.configManager.getConfig(projectId);
+    if (!config) {
+      throw new Error(`No Jira config for project ${projectId}`);
+    }
+    const client = new JiraClient(config);
+
+    const transitions = await client.getTransitions(externalId);
+    const picked = pickTransitionForCanonicalStatus(transitions, target);
+    if (!picked) {
+      throw new Error(
+        `No Jira transition leads to canonical status '${target}' from issue ${externalId}'s current state`
+      );
+    }
+
+    await client.transitionIssue(externalId, picked.id);
+    logger.info('Jira issue transitioned via capability', {
+      issueKey: externalId,
+      target,
+      transitionId: picked.id,
+      transitionName: picked.name,
+    });
+  }
+
+  /**
+   * Read the canonical status of an existing Jira issue.
+   */
+  async getStatus(externalId: string, projectId: string): Promise<CanonicalStatus> {
+    const config = await this.configManager.getConfig(projectId);
+    if (!config) {
+      throw new Error(`No Jira config for project ${projectId}`);
+    }
+    const client = new JiraClient(config);
+
+    const issue = await client.getIssue(externalId);
+    return jiraIssueToCanonicalStatus(issue);
   }
 }

--- a/packages/backend/src/integrations/jira/service.ts
+++ b/packages/backend/src/integrations/jira/service.ts
@@ -206,8 +206,11 @@ export class JiraIntegrationService implements IntegrationService {
       hasFieldMappings: !!metadata?.fieldMappings,
     });
 
-    // Validate and load configuration for specific integration
-    const config = await this.validateAndLoadConfig(integrationId);
+    // Validate and load configuration for the specific (project, integration)
+    // pair — the projectId scoping prevents a foreign integrationId
+    // smuggled via a stale outbox row from loading another tenant's
+    // credentials.
+    const config = await this.validateAndLoadConfig(integrationId, projectId);
 
     // Generate share token for replay if applicable
     const shareReplayUrl = await this.generateShareTokenIfNeeded(bugReport, config);
@@ -243,13 +246,25 @@ export class JiraIntegrationService implements IntegrationService {
   }
 
   /**
-   * Validate project has Jira configured and enabled
+   * Validate that the (project, integration) pair has Jira configured
+   * and enabled. The projectId scope rejects foreign integrationIds —
+   * see `getConfigByIntegrationId` for the threat model.
    */
-  private async validateAndLoadConfig(integrationId: string): Promise<JiraConfig> {
-    const config = await this.configManager.getConfigByIntegrationId(integrationId);
+  private async validateAndLoadConfig(
+    integrationId: string,
+    projectId: string
+  ): Promise<JiraConfig> {
+    const config = await this.configManager.getConfigByIntegrationId(integrationId, projectId);
 
     if (!config) {
-      throw new AppError(`Jira not configured for integration: ${integrationId}`, 404, 'NotFound');
+      // Conflate the failure modes (missing / disabled / wrong project /
+      // wrong platform) into one 404 — the caller doesn't need to know
+      // which, and leaking the difference would expose tenancy facts.
+      throw new AppError(
+        `Jira not usable for integration ${integrationId} in project ${projectId}`,
+        404,
+        'NotFound'
+      );
     }
 
     if (!config.enabled) {

--- a/packages/backend/src/integrations/jira/status-mapper.ts
+++ b/packages/backend/src/integrations/jira/status-mapper.ts
@@ -152,14 +152,20 @@ export function pickTransitionForCanonicalStatus(
     return rankTransitions(inCategory, PREFERRED_STATE_NAMES[target])[0];
   }
 
-  // For `closed`/`wont_fix`, fall back to any `done`-category transition —
-  // some workflows only expose one terminal state and we'd rather use it
-  // than refuse to transition at all. Use `rankTransitions` here too so
-  // multi-`done` workflows are deterministic across runs (the API doesn't
-  // guarantee transition order). Log a warning so admins can spot
-  // misconfigured workflows where this ambiguity matters (e.g. a single
-  // `Abandoned` terminal state being used for what should be `closed`).
-  if (target === 'closed' || target === 'wont_fix') {
+  // For `closed` only, fall back to any `done`-category transition —
+  // some workflows only expose one terminal state ("Done" / "Resolved"
+  // / "Abandoned") and refusing the transition would be more disruptive
+  // than picking something reasonable. Sorted via `rankTransitions` so
+  // the choice is deterministic across API responses.
+  //
+  // We deliberately do NOT fall back for `wont_fix`: silently picking a
+  // `closed`-style state (whose name doesn't match the wont-fix
+  // patterns) would tell the rule engine "transition succeeded to
+  // wont_fix" while the ticket is actually in `closed`. The caller —
+  // typically the rule engine — must be allowed to decide whether to
+  // degrade (e.g. fall back to `closed`) or skip the action. Returning
+  // null surfaces that decision.
+  if (target === 'closed') {
     const allDone = transitions.filter((t) => t.to?.statusCategory?.key === 'done');
     if (allDone.length > 0) {
       const anyDone = rankTransitions(allDone, PREFERRED_STATE_NAMES[target])[0];

--- a/packages/backend/src/integrations/jira/status-mapper.ts
+++ b/packages/backend/src/integrations/jira/status-mapper.ts
@@ -154,12 +154,15 @@ export function pickTransitionForCanonicalStatus(
 
   // For `closed`/`wont_fix`, fall back to any `done`-category transition —
   // some workflows only expose one terminal state and we'd rather use it
-  // than refuse to transition at all. Log a warning so admins can spot
+  // than refuse to transition at all. Use `rankTransitions` here too so
+  // multi-`done` workflows are deterministic across runs (the API doesn't
+  // guarantee transition order). Log a warning so admins can spot
   // misconfigured workflows where this ambiguity matters (e.g. a single
   // `Abandoned` terminal state being used for what should be `closed`).
   if (target === 'closed' || target === 'wont_fix') {
-    const anyDone = transitions.find((t) => t.to?.statusCategory?.key === 'done');
-    if (anyDone) {
+    const allDone = transitions.filter((t) => t.to?.statusCategory?.key === 'done');
+    if (allDone.length > 0) {
+      const anyDone = rankTransitions(allDone, PREFERRED_STATE_NAMES[target])[0];
       logger.warn(
         'Jira transition fallback fired — no name-matched terminal state, using any `done`',
         {

--- a/packages/backend/src/integrations/jira/status-mapper.ts
+++ b/packages/backend/src/integrations/jira/status-mapper.ts
@@ -1,0 +1,105 @@
+/**
+ * Map between Jira workflow states and the BugSpotter canonical-status enum.
+ *
+ * Jira's `statusCategory.key` is the load-bearing field — it's invariant
+ * across customer-renamed statuses ("In Dev" / "Coding" / "Implementing"
+ * all map to category `indeterminate`). The status `name` is only consulted
+ * to distinguish `closed` from `wont_fix`, since Jira lumps both into
+ * category `done`.
+ */
+
+import type { JiraIssue, JiraTransition } from './types.js';
+import type { CanonicalStatus } from '../capabilities.js';
+
+/**
+ * Status names that, in category `done`, signal "won't fix / cancelled /
+ * duplicate" rather than "resolved". Case-insensitive substring match.
+ * Heuristic, deliberately permissive — false positives here mean the
+ * auto-reopen rule won't fire for a ticket we already gave up on, which is
+ * the safe direction.
+ */
+const WONT_FIX_NAME_PATTERNS = ['wont fix', "won't fix", 'cancelled', 'canceled', 'duplicate'];
+
+function isWontFixName(statusName: string | undefined): boolean {
+  if (!statusName) {
+    return false;
+  }
+  const lowered = statusName.toLowerCase();
+  return WONT_FIX_NAME_PATTERNS.some((pattern) => lowered.includes(pattern));
+}
+
+/**
+ * Derive the canonical status of a fetched Jira issue.
+ *
+ * Returns `'open'` as the safe default when `statusCategory` is missing
+ * (e.g. a stripped-down mock or an `undefined`-category state) — better to
+ * underreport "closed" than to fire auto-reopen against a ticket that's
+ * still actively being worked.
+ */
+export function jiraIssueToCanonicalStatus(issue: JiraIssue): CanonicalStatus {
+  const statusName = issue.fields?.status?.name;
+  const categoryKey = issue.fields?.status?.statusCategory?.key;
+
+  if (categoryKey === 'done') {
+    return isWontFixName(statusName) ? 'wont_fix' : 'closed';
+  }
+  if (categoryKey === 'indeterminate') {
+    return 'in_progress';
+  }
+  if (categoryKey === 'new') {
+    return 'open';
+  }
+  // `undefined`/unknown → treat as open
+  return 'open';
+}
+
+/**
+ * Pick the best Jira transition that lands the issue in `target`.
+ *
+ * "Best" = the transition whose target state's `statusCategory.key` matches
+ * the canonical mapping. When more than one matches, prefer transitions
+ * whose target name matches `wont_fix` heuristics when target is `wont_fix`,
+ * otherwise return the first match. Returns null when no transition lands
+ * in the right category.
+ *
+ * Caller is expected to handle the null case — usually by logging a warning
+ * and skipping the rule action.
+ */
+export function pickTransitionForCanonicalStatus(
+  transitions: JiraTransition[],
+  target: CanonicalStatus
+): JiraTransition | null {
+  if (transitions.length === 0) {
+    return null;
+  }
+
+  const matches = transitions.filter((t) => {
+    const targetCategory = t.to?.statusCategory?.key;
+    switch (target) {
+      case 'open':
+        return targetCategory === 'new';
+      case 'in_progress':
+        return targetCategory === 'indeterminate';
+      case 'closed':
+        return targetCategory === 'done' && !isWontFixName(t.to?.name);
+      case 'wont_fix':
+        return targetCategory === 'done' && isWontFixName(t.to?.name);
+    }
+  });
+
+  if (matches.length > 0) {
+    return matches[0];
+  }
+
+  // For `closed`/`wont_fix`, fall back to any `done`-category transition —
+  // some workflows only expose one terminal state and we'd rather use it
+  // than refuse to transition at all.
+  if (target === 'closed' || target === 'wont_fix') {
+    const anyDone = transitions.find((t) => t.to?.statusCategory?.key === 'done');
+    if (anyDone) {
+      return anyDone;
+    }
+  }
+
+  return null;
+}

--- a/packages/backend/src/integrations/jira/status-mapper.ts
+++ b/packages/backend/src/integrations/jira/status-mapper.ts
@@ -10,6 +10,9 @@
 
 import type { JiraIssue, JiraTransition } from './types.js';
 import type { CanonicalStatus } from '../capabilities.js';
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
 
 /**
  * Status names that, in category `done`, signal "won't fix / cancelled /
@@ -102,10 +105,27 @@ export function pickTransitionForCanonicalStatus(
 
   // For `closed`/`wont_fix`, fall back to any `done`-category transition —
   // some workflows only expose one terminal state and we'd rather use it
-  // than refuse to transition at all.
+  // than refuse to transition at all. Log a warning so admins can spot
+  // misconfigured workflows where this ambiguity matters (e.g. a single
+  // `Abandoned` terminal state being used for what should be `closed`).
   if (target === 'closed' || target === 'wont_fix') {
     const anyDone = transitions.find((t) => t.to?.statusCategory?.key === 'done');
     if (anyDone) {
+      logger.warn(
+        'Jira transition fallback fired — no name-matched terminal state, using any `done`',
+        {
+          target,
+          fallbackTransitionId: anyDone.id,
+          fallbackTransitionName: anyDone.name,
+          fallbackToName: anyDone.to?.name,
+          availableTransitions: transitions.map((t) => ({
+            id: t.id,
+            name: t.name,
+            toName: t.to?.name,
+            toCategory: t.to?.statusCategory?.key,
+          })),
+        }
+      );
       return anyDone;
     }
   }

--- a/packages/backend/src/integrations/jira/status-mapper.ts
+++ b/packages/backend/src/integrations/jira/status-mapper.ts
@@ -24,7 +24,16 @@ function isWontFixName(statusName: string | undefined): boolean {
   if (!statusName) {
     return false;
   }
-  const lowered = statusName.toLowerCase();
+  // Normalize curly / typographic apostrophes (U+2018, U+2019, U+02BC
+  // modifier-letter-apostrophe) into the ASCII apostrophe before
+  // matching — Jira admins routinely type "Won't Fix" with a smart
+  // quote when they rename the status, and our patterns are written
+  // with ASCII. Without this, smart-quote variants fall through into
+  // `closed` and the auto-reopen rule mis-fires.
+  // Use explicit Unicode escapes (file may be saved by editors with
+  // varying encodings, especially on Windows). U+2018 LEFT, U+2019
+  // RIGHT, U+02BC MODIFIER-LETTER-APOSTROPHE.
+  const lowered = statusName.toLowerCase().replace(/[‘’ʼ]/g, "'");
   return WONT_FIX_NAME_PATTERNS.some((pattern) => lowered.includes(pattern));
 }
 

--- a/packages/backend/src/integrations/jira/status-mapper.ts
+++ b/packages/backend/src/integrations/jira/status-mapper.ts
@@ -66,16 +66,65 @@ export function jiraIssueToCanonicalStatus(issue: JiraIssue): CanonicalStatus {
 }
 
 /**
+ * Per-canonical preference list of common Jira state names. Used to
+ * pick deterministically when more than one workflow transition lands
+ * in the right category (e.g. both "Done" and "Resolved" available for
+ * canonical `closed`). Case-insensitive exact match wins; falls through
+ * to alphabetical order within the category if no name matches.
+ *
+ * Order matters — earlier entries are preferred. The lists cover the
+ * most common Atlassian / Jira-Cloud defaults plus a handful of
+ * community renames.
+ */
+const PREFERRED_STATE_NAMES: Record<CanonicalStatus, readonly string[]> = {
+  open: ['to do', 'open', 'backlog', 'reopened', 'new'],
+  in_progress: ['in progress', 'in development', 'in review', 'doing', 'working'],
+  closed: ['done', 'resolved', 'closed', 'fixed', 'complete'],
+  wont_fix: ["won't fix", "won't do", 'cancelled', 'canceled', 'duplicate', 'abandoned'],
+} as const;
+
+/**
+ * Sort a set of category-matched transitions deterministically.
+ *
+ * Two-stage ordering:
+ *   1. Transitions whose target-state name is in the preferred list rank
+ *      first, in the order of the preferred list itself (preferred-name
+ *      "Done" before "Resolved" before "Closed", etc).
+ *   2. Remaining transitions rank by `to.name` alphabetically — purely
+ *      to remove the API-order non-determinism flagged by reviewers.
+ */
+function rankTransitions(
+  transitions: JiraTransition[],
+  preferences: readonly string[]
+): JiraTransition[] {
+  return [...transitions].sort((a, b) => {
+    const ai = preferences.indexOf((a.to?.name ?? '').toLowerCase());
+    const bi = preferences.indexOf((b.to?.name ?? '').toLowerCase());
+    if (ai !== -1 && bi !== -1) {
+      return ai - bi; // both preferred — earlier preference wins
+    }
+    if (ai !== -1) {
+      return -1; // a is preferred, b is not
+    }
+    if (bi !== -1) {
+      return 1; // b is preferred, a is not
+    }
+    // neither preferred — alphabetical for determinism
+    return (a.to?.name ?? '').localeCompare(b.to?.name ?? '');
+  });
+}
+
+/**
  * Pick the best Jira transition that lands the issue in `target`.
  *
- * "Best" = the transition whose target state's `statusCategory.key` matches
- * the canonical mapping. When more than one matches, prefer transitions
- * whose target name matches `wont_fix` heuristics when target is `wont_fix`,
- * otherwise return the first match. Returns null when no transition lands
- * in the right category.
+ * "Best" = the transition whose target state's `statusCategory.key`
+ * matches the canonical mapping, with name-based preference and
+ * alphabetical-fallback ordering so the choice is deterministic across
+ * runs (the Jira API doesn't guarantee transition order, and earlier
+ * reviewers flagged the non-determinism).
  *
- * Caller is expected to handle the null case — usually by logging a warning
- * and skipping the rule action.
+ * Returns null when no transition lands in the right category. Caller
+ * handles the null case — usually by logging and skipping the action.
  */
 export function pickTransitionForCanonicalStatus(
   transitions: JiraTransition[],
@@ -85,7 +134,7 @@ export function pickTransitionForCanonicalStatus(
     return null;
   }
 
-  const matches = transitions.filter((t) => {
+  const inCategory = transitions.filter((t) => {
     const targetCategory = t.to?.statusCategory?.key;
     switch (target) {
       case 'open':
@@ -99,8 +148,8 @@ export function pickTransitionForCanonicalStatus(
     }
   });
 
-  if (matches.length > 0) {
-    return matches[0];
+  if (inCategory.length > 0) {
+    return rankTransitions(inCategory, PREFERRED_STATE_NAMES[target])[0];
   }
 
   // For `closed`/`wont_fix`, fall back to any `done`-category transition —

--- a/packages/backend/src/integrations/jira/types.ts
+++ b/packages/backend/src/integrations/jira/types.ts
@@ -133,12 +133,43 @@ export interface JiraIssue {
     description: JiraDescription | string;
     status: {
       name: string;
+      // `statusCategory` is what Jira uses internally to classify a workflow
+      // state regardless of customer-renamed status names. Built-in keys:
+      // 'new' (To Do-ish), 'indeterminate' (In Progress-ish), 'done'
+      // (Done-ish), 'undefined' (unmapped). The capability layer maps these
+      // into our CanonicalStatus enum. Marked optional only because some
+      // older test fixtures don't include it — real responses always do.
+      statusCategory?: {
+        key: 'new' | 'indeterminate' | 'done' | 'undefined' | string;
+        name?: string;
+      };
     };
     priority?: {
       name: string;
     };
     created: string;
     updated: string;
+  };
+}
+
+/**
+ * A single transition available on a Jira issue's current state.
+ *
+ * Returned by `GET /issue/{key}/transitions`. `to` describes the workflow
+ * state the issue lands in after executing this transition. The capability
+ * layer picks a transition whose `to.statusCategory.key` matches the desired
+ * canonical status.
+ */
+export interface JiraTransition {
+  id: string;
+  name: string;
+  to: {
+    id?: string;
+    name: string;
+    statusCategory?: {
+      key: 'new' | 'indeterminate' | 'done' | 'undefined' | string;
+      name?: string;
+    };
   };
 }
 

--- a/packages/backend/src/integrations/linear/client.ts
+++ b/packages/backend/src/integrations/linear/client.ts
@@ -494,9 +494,11 @@ export class LinearClient {
   /**
    * Append a comment to an existing Linear issue.
    *
-   * @param issueId Linear issue UUID (not the human-readable identifier
-   *                like "ENG-123"). The capability layer always passes the
-   *                stored `external_ticket_id`, which is the UUID.
+   * @param issueId Linear issue UUID. The mutation rejects the
+   *                human-readable identifier ("ENG-123"); resolve via
+   *                `getIssue(identifier)` first if you only have the
+   *                identifier (which is what `external_ticket_id` stores
+   *                after `createFromBugReport`).
    * @param body    Markdown-formatted body. Linear supports markdown in
    *                comments natively, so no ADF translation needed.
    */

--- a/packages/backend/src/integrations/linear/client.ts
+++ b/packages/backend/src/integrations/linear/client.ts
@@ -29,6 +29,8 @@ import {
   type LinearAttachment,
   type LinearFileUpload,
   type LinearGraphQLError,
+  type LinearIssueDetail,
+  type LinearWorkflowState,
 } from './types.js';
 
 const logger = getLogger();
@@ -477,6 +479,124 @@ export class LinearClient {
    */
   static getIssueUrl(orgUrlKey: string, identifier: string): string {
     return `${LINEAR_WEB_HOST}/${orgUrlKey}/issue/${identifier}`;
+  }
+
+  // ==========================================================================
+  // Capability methods (TicketIntegrationCapabilities)
+  // ==========================================================================
+  //
+  // Three operations the dedup rule engine needs against an existing Linear
+  // issue: add a comment, transition to a canonical status, and read the
+  // current status. State resolution (canonical → Linear state UUID) is done
+  // in the service layer via `getTeamStates` + ./status-mapper.ts so this
+  // class stays a pure GraphQL wrapper.
+
+  /**
+   * Append a comment to an existing Linear issue.
+   *
+   * @param issueId Linear issue UUID (not the human-readable identifier
+   *                like "ENG-123"). The capability layer always passes the
+   *                stored `external_ticket_id`, which is the UUID.
+   * @param body    Markdown-formatted body. Linear supports markdown in
+   *                comments natively, so no ADF translation needed.
+   */
+  async commentCreate(issueId: string, body: string): Promise<void> {
+    if (!issueId) {
+      throw new Error('commentCreate: issueId is required');
+    }
+    if (!body || body.trim().length === 0) {
+      throw new Error('commentCreate: body cannot be empty');
+    }
+
+    const gql = `mutation CommentCreate($input: CommentCreateInput!) {
+      commentCreate(input: $input) {
+        success
+      }
+    }`;
+    const result = await this.graphql<{ commentCreate: { success: boolean } }>(gql, {
+      input: { issueId, body },
+    });
+    if (!result.commentCreate.success) {
+      throw new Error('Linear commentCreate returned success=false');
+    }
+  }
+
+  /**
+   * Fetch an issue's current state and its team id.
+   *
+   * Used by the capability layer to (a) read canonical status and (b)
+   * resolve a target canonical status to a specific state UUID via the
+   * team's available states.
+   */
+  async getIssue(issueId: string): Promise<LinearIssueDetail> {
+    if (!issueId) {
+      throw new Error('getIssue: issueId is required');
+    }
+    const gql = `query Issue($id: String!) {
+      issue(id: $id) {
+        id
+        identifier
+        state { id name type }
+        team { id name }
+      }
+    }`;
+    const result = await this.graphql<{ issue: LinearIssueDetail | null }>(gql, { id: issueId });
+    if (!result.issue) {
+      throw new Error(`Linear issue not found: ${issueId}`);
+    }
+    return result.issue;
+  }
+
+  /**
+   * List all workflow states defined for a Linear team.
+   *
+   * Each state has a `type` ∈ {triage, backlog, unstarted, started,
+   * completed, canceled} — the capability layer maps these to canonical
+   * statuses. Callers may cache results per-team (states change rarely).
+   */
+  async getTeamStates(teamId: string): Promise<LinearWorkflowState[]> {
+    if (!teamId) {
+      throw new Error('getTeamStates: teamId is required');
+    }
+    const gql = `query TeamStates($id: String!) {
+      team(id: $id) {
+        states { nodes { id name type position } }
+      }
+    }`;
+    const result = await this.graphql<{
+      team: { states: { nodes: LinearWorkflowState[] } } | null;
+    }>(gql, { id: teamId });
+    if (!result.team) {
+      throw new Error(`Linear team not found: ${teamId}`);
+    }
+    return result.team.states.nodes;
+  }
+
+  /**
+   * Move an existing issue to a different workflow state.
+   *
+   * The `stateId` must come from the issue's team's available states (see
+   * `getTeamStates`). Linear silently rejects state IDs from other teams.
+   */
+  async issueUpdateState(issueId: string, stateId: string): Promise<void> {
+    if (!issueId) {
+      throw new Error('issueUpdateState: issueId is required');
+    }
+    if (!stateId) {
+      throw new Error('issueUpdateState: stateId is required');
+    }
+    const gql = `mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
+      issueUpdate(id: $id, input: $input) {
+        success
+      }
+    }`;
+    const result = await this.graphql<{ issueUpdate: { success: boolean } }>(gql, {
+      id: issueId,
+      input: { stateId },
+    });
+    if (!result.issueUpdate.success) {
+      throw new Error('Linear issueUpdate returned success=false');
+    }
   }
 }
 

--- a/packages/backend/src/integrations/linear/config.ts
+++ b/packages/backend/src/integrations/linear/config.ts
@@ -288,13 +288,31 @@ export class LinearConfigManager {
   /**
    * Load config by specific integration row id — required when a project
    * has multiple integrations and the caller wants to disambiguate.
-   * Mirrors `JiraConfigManager.getConfigByIntegrationId`.
+   *
+   * Capability callers MUST pass `expectedProjectId`: the bare-UUID lookup
+   * would otherwise happily load any project's enabled Linear config if
+   * a caller smuggled in a foreign integrationId. The check matches
+   * `JiraConfigManager.getConfigByIntegrationId`.
    */
-  async getConfigByIntegrationId(integrationId: string): Promise<LinearConfig | null> {
+  async getConfigByIntegrationId(
+    integrationId: string,
+    expectedProjectId?: string
+  ): Promise<LinearConfig | null> {
     try {
       const integration = await this.integrationRepo.findByIdWithType(integrationId);
       if (!integration || !integration.enabled) {
         logger.debug('No enabled Linear integration found', { integrationId });
+        return null;
+      }
+
+      // Defense-in-depth: reject cross-project access (see jira/config.ts
+      // for the rationale).
+      if (expectedProjectId && integration.project_id !== expectedProjectId) {
+        logger.warn('Linear integration does not belong to the expected project', {
+          integrationId,
+          expectedProjectId,
+          actualProjectId: integration.project_id,
+        });
         return null;
       }
 

--- a/packages/backend/src/integrations/linear/config.ts
+++ b/packages/backend/src/integrations/linear/config.ts
@@ -286,17 +286,17 @@ export class LinearConfigManager {
   }
 
   /**
-   * Load config by specific integration row id — required when a project
-   * has multiple integrations and the caller wants to disambiguate.
+   * Load config by specific integration row id, scoped to a project.
    *
-   * Capability callers MUST pass `expectedProjectId`: the bare-UUID lookup
-   * would otherwise happily load any project's enabled Linear config if
-   * a caller smuggled in a foreign integrationId. The check matches
-   * `JiraConfigManager.getConfigByIntegrationId`.
+   * Both arguments are required — see `JiraConfigManager.getConfigByIntegrationId`
+   * for the full rationale. Briefly: the integrationId alone is a flat
+   * lookup, so without the projectId check a caller smuggling in a
+   * foreign integrationId would silently get back working credentials
+   * for another tenant's Linear connection.
    */
   async getConfigByIntegrationId(
     integrationId: string,
-    expectedProjectId?: string
+    expectedProjectId: string
   ): Promise<LinearConfig | null> {
     try {
       const integration = await this.integrationRepo.findByIdWithType(integrationId);
@@ -307,7 +307,7 @@ export class LinearConfigManager {
 
       // Defense-in-depth: reject cross-project access (see jira/config.ts
       // for the rationale).
-      if (expectedProjectId && integration.project_id !== expectedProjectId) {
+      if (integration.project_id !== expectedProjectId) {
         logger.warn('Linear integration does not belong to the expected project', {
           integrationId,
           expectedProjectId,

--- a/packages/backend/src/integrations/linear/service.ts
+++ b/packages/backend/src/integrations/linear/service.ts
@@ -173,7 +173,7 @@ export class LinearIntegrationService implements IntegrationService {
       createdAutomatically: metadata?.createdAutomatically,
     });
 
-    const config = await this.loadConfig(integrationId);
+    const config = await this.loadConfig(integrationId, projectId);
     const shareReplayUrl = await this.generateShareTokenIfNeeded(bugReport, config);
 
     const mapper = new LinearBugReportMapper(config, config.templateConfig);
@@ -213,15 +213,16 @@ export class LinearIntegrationService implements IntegrationService {
   }
 
   /**
-   * Load + verify config for the specified integration row.
+   * Load + verify config for the specified (project, integration) pair.
    * Throws `AppError` shapes matching the Jira service so route error
-   * handling stays uniform.
+   * handling stays uniform. The projectId scope rejects foreign
+   * integrationIds — see jira/config.ts for the threat model.
    */
-  private async loadConfig(integrationId: string): Promise<LinearConfig> {
-    const config = await this.configManager.getConfigByIntegrationId(integrationId);
+  private async loadConfig(integrationId: string, projectId: string): Promise<LinearConfig> {
+    const config = await this.configManager.getConfigByIntegrationId(integrationId, projectId);
     if (!config) {
       throw new AppError(
-        `Linear not configured for integration: ${integrationId}`,
+        `Linear not usable for integration ${integrationId} in project ${projectId}`,
         404,
         'NotFound'
       );

--- a/packages/backend/src/integrations/linear/service.ts
+++ b/packages/backend/src/integrations/linear/service.ts
@@ -36,7 +36,7 @@ import { LinearConfigManager } from './config.js';
 import { LinearClient } from './client.js';
 import { LinearBugReportMapper } from './mapper.js';
 import { linearStateTypeToCanonical, pickStateForCanonicalStatus } from './status-mapper.js';
-import type { CanonicalStatus } from '../capabilities.js';
+import type { CanonicalStatus, CapabilityTarget } from '../capabilities.js';
 import type {
   LinearConfig,
   LinearAttachment,
@@ -573,18 +573,20 @@ export class LinearIntegrationService implements IntegrationService {
   // ./status-mapper.ts so it's unit-testable without the network.
 
   /**
-   * Resolve the LinearClient for an integration.
+   * Resolve the LinearClient for a (project, integration) pair.
    *
-   * Uses `getConfigByIntegrationId` (not `getConfig(projectId)`) so we
-   * (a) target the specific integration when a project has multiple
-   * Linear connections and (b) reject disabled integrations — the
-   * config-manager already returns null for both.
+   * Cross-tenant guard: `getConfigByIntegrationId(integrationId,
+   * projectId)` returns null when the integration belongs to a different
+   * project, preventing a foreign integrationId smuggled by a stale
+   * outbox row or compromised event from working under another tenant's
+   * credentials. See jira/service.ts for the full rationale.
    */
-  private async resolveClient(integrationId: string): Promise<LinearClient> {
-    const config = await this.configManager.getConfigByIntegrationId(integrationId);
+  private async resolveClient(integrationId: string, projectId: string): Promise<LinearClient> {
+    const config = await this.configManager.getConfigByIntegrationId(integrationId, projectId);
     if (!config) {
       throw new Error(
-        `No enabled Linear integration ${integrationId} (missing, disabled, or wrong platform)`
+        `Linear integration ${integrationId} not usable for project ${projectId} ` +
+          `(missing, disabled, wrong project, or wrong platform)`
       );
     }
     return new LinearClient(config.apiKey);
@@ -593,48 +595,44 @@ export class LinearIntegrationService implements IntegrationService {
   /**
    * Append a comment to an existing Linear issue.
    *
-   * `externalId` is the Linear issue UUID (the value stored as
+   * `target.externalId` is the Linear issue UUID (the value stored as
    * `external_ticket_id` after `createFromBugReport`). The human-readable
    * identifier "ENG-123" is not accepted by the GraphQL API.
    */
-  async addComment(externalId: string, body: string, integrationId: string): Promise<void> {
-    const client = await this.resolveClient(integrationId);
-    await client.commentCreate(externalId, body);
+  async addComment(target: CapabilityTarget, body: string): Promise<void> {
+    const client = await this.resolveClient(target.integrationId, target.projectId);
+    await client.commentCreate(target.externalId, body);
   }
 
   /**
-   * Move a Linear issue to the canonical status `target`.
+   * Move a Linear issue to the canonical status `targetStatus`.
    *
    * Three GraphQL calls: fetch the issue to discover its team, list the
-   * team's workflow states, pick one whose `type` maps to `target`, and
-   * `issueUpdate` to that state's UUID. We do not cache `getTeamStates`
-   * — state customization is rare and caching adds a per-tenant
-   * invalidation problem we don't need yet.
+   * team's workflow states, pick one whose `type` maps to `targetStatus`,
+   * and `issueUpdate` to that state's UUID. We do not cache
+   * `getTeamStates` — state customization is rare and caching adds a
+   * per-tenant invalidation problem we don't need yet.
    *
    * Throws when no state of the right type exists (heavily customized
-   * workflow without e.g. a `started` state); caller is expected to catch
-   * and skip the rule action.
+   * workflow without e.g. a `started` state); caller is expected to
+   * catch and skip the rule action.
    */
-  async transition(
-    externalId: string,
-    target: CanonicalStatus,
-    integrationId: string
-  ): Promise<void> {
-    const client = await this.resolveClient(integrationId);
+  async transition(target: CapabilityTarget, targetStatus: CanonicalStatus): Promise<void> {
+    const client = await this.resolveClient(target.integrationId, target.projectId);
 
-    const issue = await client.getIssue(externalId);
+    const issue = await client.getIssue(target.externalId);
     const states = await client.getTeamStates(issue.team.id);
-    const picked = pickStateForCanonicalStatus(states, target);
+    const picked = pickStateForCanonicalStatus(states, targetStatus);
     if (!picked) {
       throw new Error(
-        `No Linear state for canonical status '${target}' in team ${issue.team.name} (${issue.team.id})`
+        `No Linear state for canonical status '${targetStatus}' in team ${issue.team.name} (${issue.team.id})`
       );
     }
 
-    await client.issueUpdateState(externalId, picked.id);
+    await client.issueUpdateState(target.externalId, picked.id);
     logger.info('Linear issue transitioned via capability', {
-      issueId: externalId,
-      target,
+      issueId: target.externalId,
+      target: targetStatus,
       stateId: picked.id,
       stateName: picked.name,
       stateType: picked.type,
@@ -644,9 +642,9 @@ export class LinearIntegrationService implements IntegrationService {
   /**
    * Read the canonical status of an existing Linear issue.
    */
-  async getStatus(externalId: string, integrationId: string): Promise<CanonicalStatus> {
-    const client = await this.resolveClient(integrationId);
-    const issue = await client.getIssue(externalId);
+  async getStatus(target: CapabilityTarget): Promise<CanonicalStatus> {
+    const client = await this.resolveClient(target.integrationId, target.projectId);
+    const issue = await client.getIssue(target.externalId);
     return linearStateTypeToCanonical(issue.state.type);
   }
 }

--- a/packages/backend/src/integrations/linear/service.ts
+++ b/packages/backend/src/integrations/linear/service.ts
@@ -596,23 +596,29 @@ export class LinearIntegrationService implements IntegrationService {
   /**
    * Append a comment to an existing Linear issue.
    *
-   * `target.externalId` is the Linear issue UUID (the value stored as
-   * `external_ticket_id` after `createFromBugReport`). The human-readable
-   * identifier "ENG-123" is not accepted by the GraphQL API.
+   * `target.externalId` is the human-readable Linear identifier (e.g.
+   * "ENG-123") — that's what `createFromBugReport` stores. Linear's
+   * mutations (`commentCreate`, `issueUpdate`) need the issue UUID, so
+   * we resolve via `client.getIssue(...)` first; the `issue(id: String!)`
+   * query accepts either the UUID or the identifier and returns the
+   * full row with both. One extra GraphQL hop per call — acceptable for
+   * the rule-engine cadence.
    */
   async addComment(target: CapabilityTarget, body: string): Promise<void> {
     const client = await this.resolveClient(target.integrationId, target.projectId);
-    await client.commentCreate(target.externalId, body);
+    const issue = await client.getIssue(target.externalId);
+    await client.commentCreate(issue.id, body);
   }
 
   /**
    * Move a Linear issue to the canonical status `targetStatus`.
    *
-   * Three GraphQL calls: fetch the issue to discover its team, list the
-   * team's workflow states, pick one whose `type` maps to `targetStatus`,
-   * and `issueUpdate` to that state's UUID. We do not cache
-   * `getTeamStates` — state customization is rare and caching adds a
-   * per-tenant invalidation problem we don't need yet.
+   * Three GraphQL calls: fetch the issue (resolves identifier → UUID
+   * and discovers the team), list the team's workflow states, pick one
+   * whose `type` maps to `targetStatus`, and `issueUpdate` to that
+   * state's UUID. We do not cache `getTeamStates` — state customization
+   * is rare and caching adds a per-tenant invalidation problem we don't
+   * need yet.
    *
    * Throws when no state of the right type exists (heavily customized
    * workflow without e.g. a `started` state); caller is expected to
@@ -630,9 +636,12 @@ export class LinearIntegrationService implements IntegrationService {
       );
     }
 
-    await client.issueUpdateState(target.externalId, picked.id);
+    // `issueUpdateState` needs the UUID (`issue.id`), NOT the
+    // human-readable identifier we received in `target.externalId`.
+    await client.issueUpdateState(issue.id, picked.id);
     logger.info('Linear issue transitioned via capability', {
-      issueId: target.externalId,
+      issueId: issue.id,
+      identifier: issue.identifier,
       target: targetStatus,
       stateId: picked.id,
       stateName: picked.name,
@@ -642,6 +651,11 @@ export class LinearIntegrationService implements IntegrationService {
 
   /**
    * Read the canonical status of an existing Linear issue.
+   *
+   * The `issue(id)` GraphQL query accepts either the UUID or the
+   * human-readable identifier as the `id` argument, so we can pass
+   * `target.externalId` through directly — no separate UUID resolution
+   * needed for a status read.
    */
   async getStatus(target: CapabilityTarget): Promise<CanonicalStatus> {
     const client = await this.resolveClient(target.integrationId, target.projectId);

--- a/packages/backend/src/integrations/linear/service.ts
+++ b/packages/backend/src/integrations/linear/service.ts
@@ -35,6 +35,8 @@ import { generateShareToken } from '../../utils/token-generator.js';
 import { LinearConfigManager } from './config.js';
 import { LinearClient } from './client.js';
 import { LinearBugReportMapper } from './mapper.js';
+import { linearStateTypeToCanonical, pickStateForCanonicalStatus } from './status-mapper.js';
+import type { CanonicalStatus } from '../capabilities.js';
 import type {
   LinearConfig,
   LinearAttachment,
@@ -559,6 +561,84 @@ export class LinearIntegrationService implements IntegrationService {
 
   async setEnabled(projectId: string, enabled: boolean): Promise<void> {
     await this.configManager.setEnabled(projectId, enabled);
+  }
+
+  // ==========================================================================
+  // Capability methods (TicketIntegrationCapabilities)
+  // ==========================================================================
+  //
+  // Used by the dedup rule engine to act on an already-created Linear issue.
+  // Each loads the project's stored config, builds a one-shot LinearClient,
+  // and delegates the GraphQL work. Canonical-status mapping lives in
+  // ./status-mapper.ts so it's unit-testable without the network.
+
+  /**
+   * Append a comment to an existing Linear issue.
+   *
+   * `externalId` is the Linear issue UUID (the value stored as
+   * `external_ticket_id` after `createFromBugReport`). The human-readable
+   * identifier "ENG-123" is not accepted by the GraphQL API.
+   */
+  async addComment(externalId: string, body: string, projectId: string): Promise<void> {
+    const config = await this.configManager.getConfig(projectId);
+    if (!config) {
+      throw new Error(`No Linear config for project ${projectId}`);
+    }
+    const client = new LinearClient(config.apiKey);
+    await client.commentCreate(externalId, body);
+  }
+
+  /**
+   * Move a Linear issue to the canonical status `target`.
+   *
+   * Three GraphQL calls: fetch the issue to discover its team, list the
+   * team's workflow states, pick one whose `type` maps to `target`, and
+   * `issueUpdate` to that state's UUID. We do not cache `getTeamStates`
+   * — state customization is rare and caching adds a per-tenant
+   * invalidation problem we don't need yet.
+   *
+   * Throws when no state of the right type exists (heavily customized
+   * workflow without e.g. a `started` state); caller is expected to catch
+   * and skip the rule action.
+   */
+  async transition(externalId: string, target: CanonicalStatus, projectId: string): Promise<void> {
+    const config = await this.configManager.getConfig(projectId);
+    if (!config) {
+      throw new Error(`No Linear config for project ${projectId}`);
+    }
+    const client = new LinearClient(config.apiKey);
+
+    const issue = await client.getIssue(externalId);
+    const states = await client.getTeamStates(issue.team.id);
+    const picked = pickStateForCanonicalStatus(states, target);
+    if (!picked) {
+      throw new Error(
+        `No Linear state for canonical status '${target}' in team ${issue.team.name} (${issue.team.id})`
+      );
+    }
+
+    await client.issueUpdateState(externalId, picked.id);
+    logger.info('Linear issue transitioned via capability', {
+      issueId: externalId,
+      target,
+      stateId: picked.id,
+      stateName: picked.name,
+      stateType: picked.type,
+    });
+  }
+
+  /**
+   * Read the canonical status of an existing Linear issue.
+   */
+  async getStatus(externalId: string, projectId: string): Promise<CanonicalStatus> {
+    const config = await this.configManager.getConfig(projectId);
+    if (!config) {
+      throw new Error(`No Linear config for project ${projectId}`);
+    }
+    const client = new LinearClient(config.apiKey);
+
+    const issue = await client.getIssue(externalId);
+    return linearStateTypeToCanonical(issue.state.type);
   }
 }
 

--- a/packages/backend/src/integrations/linear/service.ts
+++ b/packages/backend/src/integrations/linear/service.ts
@@ -573,18 +573,32 @@ export class LinearIntegrationService implements IntegrationService {
   // ./status-mapper.ts so it's unit-testable without the network.
 
   /**
+   * Resolve the LinearClient for an integration.
+   *
+   * Uses `getConfigByIntegrationId` (not `getConfig(projectId)`) so we
+   * (a) target the specific integration when a project has multiple
+   * Linear connections and (b) reject disabled integrations — the
+   * config-manager already returns null for both.
+   */
+  private async resolveClient(integrationId: string): Promise<LinearClient> {
+    const config = await this.configManager.getConfigByIntegrationId(integrationId);
+    if (!config) {
+      throw new Error(
+        `No enabled Linear integration ${integrationId} (missing, disabled, or wrong platform)`
+      );
+    }
+    return new LinearClient(config.apiKey);
+  }
+
+  /**
    * Append a comment to an existing Linear issue.
    *
    * `externalId` is the Linear issue UUID (the value stored as
    * `external_ticket_id` after `createFromBugReport`). The human-readable
    * identifier "ENG-123" is not accepted by the GraphQL API.
    */
-  async addComment(externalId: string, body: string, projectId: string): Promise<void> {
-    const config = await this.configManager.getConfig(projectId);
-    if (!config) {
-      throw new Error(`No Linear config for project ${projectId}`);
-    }
-    const client = new LinearClient(config.apiKey);
+  async addComment(externalId: string, body: string, integrationId: string): Promise<void> {
+    const client = await this.resolveClient(integrationId);
     await client.commentCreate(externalId, body);
   }
 
@@ -601,12 +615,12 @@ export class LinearIntegrationService implements IntegrationService {
    * workflow without e.g. a `started` state); caller is expected to catch
    * and skip the rule action.
    */
-  async transition(externalId: string, target: CanonicalStatus, projectId: string): Promise<void> {
-    const config = await this.configManager.getConfig(projectId);
-    if (!config) {
-      throw new Error(`No Linear config for project ${projectId}`);
-    }
-    const client = new LinearClient(config.apiKey);
+  async transition(
+    externalId: string,
+    target: CanonicalStatus,
+    integrationId: string
+  ): Promise<void> {
+    const client = await this.resolveClient(integrationId);
 
     const issue = await client.getIssue(externalId);
     const states = await client.getTeamStates(issue.team.id);
@@ -630,13 +644,8 @@ export class LinearIntegrationService implements IntegrationService {
   /**
    * Read the canonical status of an existing Linear issue.
    */
-  async getStatus(externalId: string, projectId: string): Promise<CanonicalStatus> {
-    const config = await this.configManager.getConfig(projectId);
-    if (!config) {
-      throw new Error(`No Linear config for project ${projectId}`);
-    }
-    const client = new LinearClient(config.apiKey);
-
+  async getStatus(externalId: string, integrationId: string): Promise<CanonicalStatus> {
+    const client = await this.resolveClient(integrationId);
     const issue = await client.getIssue(externalId);
     return linearStateTypeToCanonical(issue.state.type);
   }

--- a/packages/backend/src/integrations/linear/status-mapper.ts
+++ b/packages/backend/src/integrations/linear/status-mapper.ts
@@ -1,0 +1,70 @@
+/**
+ * Map between Linear workflow states and the BugSpotter canonical-status enum.
+ *
+ * Linear's `state.type` is a built-in enum that's invariant across team
+ * renames, which makes the mapping clean — no name-based heuristics needed
+ * (unlike Jira where `closed` vs `wont_fix` lives in the status name).
+ */
+
+import type { CanonicalStatus } from '../capabilities.js';
+import type { LinearStateType, LinearWorkflowState } from './types.js';
+
+/**
+ * Map a Linear `state.type` to the canonical enum.
+ *
+ * Notes:
+ *   - `triage` / `backlog` / `unstarted` all collapse to `'open'`. The rule
+ *     engine doesn't currently distinguish them.
+ *   - `started` → `'in_progress'`.
+ *   - `completed` → `'closed'`. `canceled` → `'wont_fix'`.
+ */
+export function linearStateTypeToCanonical(type: LinearStateType): CanonicalStatus {
+  switch (type) {
+    case 'started':
+      return 'in_progress';
+    case 'completed':
+      return 'closed';
+    case 'canceled':
+      return 'wont_fix';
+    case 'triage':
+    case 'backlog':
+    case 'unstarted':
+      return 'open';
+  }
+}
+
+/**
+ * Find a workflow state in a team whose `type` maps to the target canonical
+ * status. Returns the first match (Linear sorts states by `position` within
+ * a type, so the first match is the team's "default" landing state for that
+ * type — `unstarted` typically returns "Todo", `started` returns "In
+ * Progress", etc).
+ *
+ * Returns null when the team has no state of the right type (rare —
+ * typically only seen on heavily customized workflows). Caller logs and
+ * skips the transition.
+ */
+export function pickStateForCanonicalStatus(
+  states: LinearWorkflowState[],
+  target: CanonicalStatus
+): LinearWorkflowState | null {
+  const candidates = states
+    .filter((s) => linearStateTypeToCanonical(s.type) === target)
+    .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  // For `open`, prefer `unstarted` over `triage`/`backlog` since unstarted is
+  // closer to "ready to work on" — what the rule engine usually wants when
+  // it re-opens an issue.
+  if (target === 'open') {
+    const unstarted = candidates.find((s) => s.type === 'unstarted');
+    if (unstarted) {
+      return unstarted;
+    }
+  }
+
+  return candidates[0];
+}

--- a/packages/backend/src/integrations/linear/types.ts
+++ b/packages/backend/src/integrations/linear/types.ts
@@ -133,6 +133,41 @@ export interface LinearIssue {
 }
 
 /**
+ * Linear workflow-state type. Returned on `state.type` in GraphQL responses.
+ * The capability layer maps these to BugSpotter's CanonicalStatus enum.
+ */
+export type LinearStateType =
+  | 'triage'
+  | 'backlog'
+  | 'unstarted'
+  | 'started'
+  | 'completed'
+  | 'canceled';
+
+/**
+ * A single workflow state within a Linear team. Listed via
+ * `team(id).states.nodes`. The capability layer uses `type` (not `name`)
+ * for canonical mapping since teams freely rename states.
+ */
+export interface LinearWorkflowState {
+  id: string;
+  name: string;
+  type: LinearStateType;
+  position?: number;
+}
+
+/**
+ * Issue detail returned by the `issue(id)` query — slimmer than the full
+ * Linear `Issue` GraphQL type; only the fields the capability layer needs.
+ */
+export interface LinearIssueDetail {
+  id: string;
+  identifier: string;
+  state: { id: string; name: string; type: LinearStateType };
+  team: { id: string; name: string };
+}
+
+/**
  * Team node from the `teams` query.
  */
 export interface LinearTeam {

--- a/packages/backend/tests/integrations/capabilities.test.ts
+++ b/packages/backend/tests/integrations/capabilities.test.ts
@@ -100,3 +100,18 @@ describe('capabilities — pluginSupports', () => {
     expect(pluginSupports(s, 'transition')).toBe(false);
   });
 });
+
+// CapabilityTarget shape is enforced at compile time; we exercise the
+// runtime contract — that callers pass a fully-populated target — in
+// the per-plugin tests against JiraIntegrationService / LinearIntegrationService.
+describe('capabilities — CapabilityTarget contract', () => {
+  it('exposes externalId, projectId, integrationId fields', () => {
+    // Compile-time check: this would fail tsc if any field is missing
+    // from the type. Asserting at runtime ensures the import surface
+    // stays intentional.
+    const target = { externalId: 'X', projectId: 'P', integrationId: 'I' };
+    expect(target.externalId).toBe('X');
+    expect(target.projectId).toBe('P');
+    expect(target.integrationId).toBe('I');
+  });
+});

--- a/packages/backend/tests/integrations/capabilities.test.ts
+++ b/packages/backend/tests/integrations/capabilities.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the platform-neutral capability interface.
+ *
+ * These cover the small bits that don't touch HTTP:
+ *   - `pluginSupports()` runtime check (duck-typed)
+ *   - `isCanonicalStatus()` type guard
+ *   - `isTerminalStatus()` predicate used by auto-reopen
+ *
+ * Per-plugin status mappers (Jira / Linear) have their own test files.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CANONICAL_STATUSES,
+  isCanonicalStatus,
+  isTerminalStatus,
+  pluginSupports,
+} from '../../src/integrations/capabilities.js';
+
+describe('capabilities — CanonicalStatus helpers', () => {
+  describe('CANONICAL_STATUSES', () => {
+    it('contains exactly the four canonical values', () => {
+      expect(CANONICAL_STATUSES).toEqual(['open', 'in_progress', 'closed', 'wont_fix']);
+    });
+  });
+
+  describe('isCanonicalStatus', () => {
+    it('accepts the canonical values', () => {
+      for (const s of CANONICAL_STATUSES) {
+        expect(isCanonicalStatus(s)).toBe(true);
+      }
+    });
+
+    it('rejects unknown strings', () => {
+      expect(isCanonicalStatus('done')).toBe(false);
+      expect(isCanonicalStatus('todo')).toBe(false);
+      expect(isCanonicalStatus('')).toBe(false);
+    });
+
+    it('rejects non-strings', () => {
+      expect(isCanonicalStatus(null)).toBe(false);
+      expect(isCanonicalStatus(undefined)).toBe(false);
+      expect(isCanonicalStatus(0)).toBe(false);
+      expect(isCanonicalStatus({})).toBe(false);
+    });
+  });
+
+  describe('isTerminalStatus', () => {
+    it('marks closed and wont_fix as terminal', () => {
+      expect(isTerminalStatus('closed')).toBe(true);
+      expect(isTerminalStatus('wont_fix')).toBe(true);
+    });
+
+    it('marks open and in_progress as non-terminal', () => {
+      expect(isTerminalStatus('open')).toBe(false);
+      expect(isTerminalStatus('in_progress')).toBe(false);
+    });
+  });
+});
+
+describe('capabilities — pluginSupports', () => {
+  // Minimal stand-in for an IntegrationService — only the bits that matter
+  // for capability detection. We cast through unknown to avoid having to
+  // implement the entire interface for these tests.
+  const stub = (extras: Record<string, unknown>) =>
+    ({
+      platform: 'jira',
+      createFromBugReport: async () => ({ externalId: 'X', externalUrl: 'u' }),
+      testConnection: async () => true,
+      validateConfig: async () => ({ valid: true }),
+      ...extras,
+    }) as never;
+
+  it('returns false for null / undefined services', () => {
+    expect(pluginSupports(null, 'addComment')).toBe(false);
+    expect(pluginSupports(undefined, 'addComment')).toBe(false);
+  });
+
+  it('returns false when the capability method is absent', () => {
+    const s = stub({});
+    expect(pluginSupports(s, 'addComment')).toBe(false);
+    expect(pluginSupports(s, 'transition')).toBe(false);
+    expect(pluginSupports(s, 'getStatus')).toBe(false);
+  });
+
+  it('returns true when the capability method is a function', () => {
+    const s = stub({
+      addComment: async () => undefined,
+      getStatus: async () => 'open',
+    });
+    expect(pluginSupports(s, 'addComment')).toBe(true);
+    expect(pluginSupports(s, 'getStatus')).toBe(true);
+    expect(pluginSupports(s, 'transition')).toBe(false);
+  });
+
+  it('returns false when the property exists but is not a function', () => {
+    // Defensive — plugins loaded from filesystem/database could in principle
+    // ship a `transition: 'yes'` literal. We accept only callable.
+    const s = stub({ transition: 'yes' });
+    expect(pluginSupports(s, 'transition')).toBe(false);
+  });
+});

--- a/packages/backend/tests/integrations/jira/build-plain-text-adf.test.ts
+++ b/packages/backend/tests/integrations/jira/build-plain-text-adf.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for `buildPlainTextADF`, the helper that turns a multi-line
+ * plain-text string into the Atlassian Document Format payload used by
+ * `JiraClient.addComment`.
+ *
+ * The behaviour we care about: literal `\n` does NOT survive ADF rendering
+ * unless we emit `hardBreak` nodes, so this is the unit-test guard against
+ * regressions where multi-line rule-engine comments come out as one giant
+ * run-on line in Jira.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildPlainTextADF } from '../../../src/integrations/jira/client.js';
+
+describe('buildPlainTextADF', () => {
+  it('wraps a single-line body as one text node, no hardBreak', () => {
+    const adf = buildPlainTextADF('hello');
+    expect(adf.type).toBe('doc');
+    expect(adf.version).toBe(1);
+    expect(adf.content).toHaveLength(1);
+    expect(adf.content[0].type).toBe('paragraph');
+    expect(adf.content[0].content).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('inserts a hardBreak between two lines', () => {
+    const adf = buildPlainTextADF('first\nsecond');
+    expect(adf.content[0].content).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'second' },
+    ]);
+  });
+
+  it('treats a blank line as an extra hardBreak (no empty text node)', () => {
+    // "a\n\nb" → ['a', '', 'b'] → text("a"), break, break, text("b")
+    const adf = buildPlainTextADF('a\n\nb');
+    expect(adf.content[0].content).toEqual([
+      { type: 'text', text: 'a' },
+      { type: 'hardBreak' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'b' },
+    ]);
+  });
+
+  it('handles \\r\\n line endings (Windows-style)', () => {
+    const adf = buildPlainTextADF('first\r\nsecond');
+    expect(adf.content[0].content).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'hardBreak' },
+      { type: 'text', text: 'second' },
+    ]);
+  });
+
+  it('does not emit a trailing hardBreak', () => {
+    // Last line never gets a trailing break — otherwise renderers add
+    // a dangling line at the end of the comment.
+    const adf = buildPlainTextADF('only');
+    expect(adf.content[0].content).toEqual([{ type: 'text', text: 'only' }]);
+
+    const multi = buildPlainTextADF('a\nb');
+    const last = multi.content[0].content[multi.content[0].content.length - 1];
+    expect(last).toEqual({ type: 'text', text: 'b' });
+  });
+});

--- a/packages/backend/tests/integrations/jira/build-plain-text-adf.test.ts
+++ b/packages/backend/tests/integrations/jira/build-plain-text-adf.test.ts
@@ -10,7 +10,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildPlainTextADF } from '../../../src/integrations/jira/client.js';
+import {
+  buildPlainTextADF,
+  JIRA_COMMENT_MAX_CHARS,
+  JIRA_COMMENT_TRUNCATION_SUFFIX,
+} from '../../../src/integrations/jira/client.js';
 
 describe('buildPlainTextADF', () => {
   it('wraps a single-line body as one text node, no hardBreak', () => {
@@ -60,5 +64,31 @@ describe('buildPlainTextADF', () => {
     const multi = buildPlainTextADF('a\nb');
     const last = multi.content[0].content[multi.content[0].content.length - 1];
     expect(last).toEqual({ type: 'text', text: 'b' });
+  });
+
+  describe('length cap', () => {
+    it('passes through bodies under the cap unchanged', () => {
+      const body = 'a'.repeat(JIRA_COMMENT_MAX_CHARS - 10);
+      const adf = buildPlainTextADF(body);
+      // Single text node, no truncation marker
+      expect(adf.content[0].content).toHaveLength(1);
+      expect(adf.content[0].content[0]).toEqual({ type: 'text', text: body });
+    });
+
+    it('truncates bodies over the cap and appends a marker', () => {
+      const body = 'x'.repeat(JIRA_COMMENT_MAX_CHARS + 1_000);
+      const adf = buildPlainTextADF(body);
+
+      // Flatten back to the rendered text — the truncation marker
+      // contains a newline, so we expect text/hardBreak/text.
+      const nodes = adf.content[0].content;
+      const lastText = nodes.filter((n) => n.type === 'text').pop();
+      expect(lastText?.text).toBe(JIRA_COMMENT_TRUNCATION_SUFFIX.trimStart());
+
+      // Combined "raw" content length stays at the cap (suffix replaces
+      // the equivalent number of trailing chars of input).
+      const reconstructed = nodes.map((n) => (n.type === 'text' ? n.text : '\n')).join('');
+      expect(reconstructed.length).toBeLessThanOrEqual(JIRA_COMMENT_MAX_CHARS);
+    });
   });
 });

--- a/packages/backend/tests/integrations/jira/config.test.ts
+++ b/packages/backend/tests/integrations/jira/config.test.ts
@@ -434,7 +434,8 @@ describe('JiraConfigManager', () => {
         });
 
         const config = await configManager.getConfigByIntegrationId(
-          '0f3961e5-d429-4271-a057-6aabdde76543'
+          '0f3961e5-d429-4271-a057-6aabdde76543',
+          '4ffb4250-f886-4f1e-af4c-ff9966b48aa6'
         );
 
         expect(config).toBeDefined();
@@ -462,7 +463,7 @@ describe('JiraConfigManager', () => {
           enabled: true,
         });
 
-        const config = await configManager.getConfigByIntegrationId('int-legacy-123');
+        const config = await configManager.getConfigByIntegrationId('int-legacy-123', 'proj-123');
 
         // Should return null because only instanceUrl is supported
         expect(config).toBeNull();
@@ -480,7 +481,7 @@ describe('JiraConfigManager', () => {
           enabled: true,
         });
 
-        const config = await configManager.getConfigByIntegrationId('int-slack-123');
+        const config = await configManager.getConfigByIntegrationId('int-slack-123', 'proj-123');
 
         expect(config).toBeNull();
       });
@@ -495,7 +496,7 @@ describe('JiraConfigManager', () => {
           enabled: false,
         });
 
-        const config = await configManager.getConfigByIntegrationId('int-disabled-123');
+        const config = await configManager.getConfigByIntegrationId('int-disabled-123', 'proj-123');
 
         expect(config).toBeNull();
       });
@@ -517,7 +518,36 @@ describe('JiraConfigManager', () => {
           enabled: true,
         });
 
-        const config = await configManager.getConfigByIntegrationId('int-jira-id');
+        const config = await configManager.getConfigByIntegrationId('int-jira-id', 'proj-123');
+
+        expect(config).toBeNull();
+      });
+
+      it('returns null when the integration belongs to a different project', async () => {
+        // Cross-tenant guard — the lookup is by integrationId alone, so
+        // without this check a caller smuggling a foreign integrationId
+        // would silently get back working credentials. Regression test
+        // for the defense-in-depth that the rule engine relies on.
+        const encryptedCreds = encryptionService.encrypt(
+          JSON.stringify({ email: 'test@bugspotter.com', apiToken: 'secret' })
+        );
+
+        mockRepository.findByIdWithType = vi.fn().mockResolvedValue({
+          project_id: 'real-project-id',
+          integration_id: 'int-jira-id',
+          integration_type: 'jira',
+          config: {
+            projectKey: 'PROJ',
+            instanceUrl: 'https://tenant.atlassian.net',
+          },
+          encrypted_credentials: encryptedCreds,
+          enabled: true,
+        });
+
+        const config = await configManager.getConfigByIntegrationId(
+          'int-jira-id',
+          'foreign-project-id'
+        );
 
         expect(config).toBeNull();
       });

--- a/packages/backend/tests/integrations/jira/status-mapper.test.ts
+++ b/packages/backend/tests/integrations/jira/status-mapper.test.ts
@@ -257,5 +257,23 @@ describe('pickTransitionForCanonicalStatus', () => {
       ];
       expect(pickTransitionForCanonicalStatus(obscure, 'closed')?.to.name).toBe('Mystery A');
     });
+
+    it("does NOT fall back to a closed-style transition when target is 'wont_fix'", () => {
+      // Threat: workflow only exposes "Done" / "Resolved" (i.e. canonical
+      // `closed`). A rule asking for `wont_fix` must not silently succeed
+      // with a `closed`-named transition — that would tell the rule
+      // engine the intent landed when in fact the ticket is in `closed`.
+      // Returning null lets the caller decide whether to degrade or skip.
+      const onlyClosed = [
+        makeTransition({ id: '31', name: 'Done', toName: 'Done', toCategoryKey: 'done' }),
+        makeTransition({
+          id: '32',
+          name: 'Resolve',
+          toName: 'Resolved',
+          toCategoryKey: 'done',
+        }),
+      ];
+      expect(pickTransitionForCanonicalStatus(onlyClosed, 'wont_fix')).toBeNull();
+    });
   });
 });

--- a/packages/backend/tests/integrations/jira/status-mapper.test.ts
+++ b/packages/backend/tests/integrations/jira/status-mapper.test.ts
@@ -91,6 +91,21 @@ describe('jiraIssueToCanonicalStatus', () => {
     ).toBe('wont_fix');
   });
 
+  it('handles typographic / smart-quote apostrophes in wont_fix detection', () => {
+    // Jira admins routinely type the status with a curly apostrophe; the
+    // mapper used to mis-classify these as `closed`. Test all three
+    // common apostrophe variants — U+2018, U+2019, U+02BC.
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Won’t Fix', categoryKey: 'done' }))
+    ).toBe('wont_fix');
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Won‘t Fix', categoryKey: 'done' }))
+    ).toBe('wont_fix');
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Wonʼt Fix', categoryKey: 'done' }))
+    ).toBe('wont_fix');
+  });
+
   it('falls back to open when statusCategory is missing', () => {
     expect(jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Anything' }))).toBe('open');
   });

--- a/packages/backend/tests/integrations/jira/status-mapper.test.ts
+++ b/packages/backend/tests/integrations/jira/status-mapper.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the Jira canonical-status mapper.
+ *
+ * Two functions:
+ *   - `jiraIssueToCanonicalStatus(issue)` — derives canonical from
+ *     `statusCategory.key` with a name heuristic for `wont_fix`.
+ *   - `pickTransitionForCanonicalStatus(transitions, target)` — picks the
+ *     transition whose target state's category matches the canonical
+ *     target.
+ *
+ * No HTTP — pure functions over typed fixtures.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  jiraIssueToCanonicalStatus,
+  pickTransitionForCanonicalStatus,
+} from '../../../src/integrations/jira/status-mapper.js';
+import type { JiraIssue, JiraTransition } from '../../../src/integrations/jira/types.js';
+
+function makeIssue(opts: { statusName: string; categoryKey?: string }): JiraIssue {
+  return {
+    id: '10001',
+    key: 'PROJ-1',
+    self: 'https://example/api/3/issue/PROJ-1',
+    fields: {
+      summary: '...',
+      description: '',
+      status: {
+        name: opts.statusName,
+        ...(opts.categoryKey ? { statusCategory: { key: opts.categoryKey } } : {}),
+      },
+      created: '2026-05-01T00:00:00Z',
+      updated: '2026-05-01T00:00:00Z',
+    },
+  };
+}
+
+function makeTransition(opts: {
+  id: string;
+  name: string;
+  toName: string;
+  toCategoryKey?: string;
+}): JiraTransition {
+  return {
+    id: opts.id,
+    name: opts.name,
+    to: {
+      name: opts.toName,
+      ...(opts.toCategoryKey ? { statusCategory: { key: opts.toCategoryKey } } : {}),
+    },
+  };
+}
+
+describe('jiraIssueToCanonicalStatus', () => {
+  it('maps `new` category to open', () => {
+    expect(jiraIssueToCanonicalStatus(makeIssue({ statusName: 'To Do', categoryKey: 'new' }))).toBe(
+      'open'
+    );
+  });
+
+  it('maps `indeterminate` category to in_progress', () => {
+    expect(
+      jiraIssueToCanonicalStatus(
+        makeIssue({ statusName: 'In Progress', categoryKey: 'indeterminate' })
+      )
+    ).toBe('in_progress');
+  });
+
+  it('maps `done` category with neutral name to closed', () => {
+    expect(jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Done', categoryKey: 'done' }))).toBe(
+      'closed'
+    );
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Resolved', categoryKey: 'done' }))
+    ).toBe('closed');
+  });
+
+  it("maps `done` category with `Won't Fix` / variants to wont_fix", () => {
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: "Won't Fix", categoryKey: 'done' }))
+    ).toBe('wont_fix');
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'wont fix', categoryKey: 'done' }))
+    ).toBe('wont_fix');
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Cancelled', categoryKey: 'done' }))
+    ).toBe('wont_fix');
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Duplicate', categoryKey: 'done' }))
+    ).toBe('wont_fix');
+  });
+
+  it('falls back to open when statusCategory is missing', () => {
+    expect(jiraIssueToCanonicalStatus(makeIssue({ statusName: 'Anything' }))).toBe('open');
+  });
+
+  it('falls back to open for `undefined` / unknown categories', () => {
+    expect(
+      jiraIssueToCanonicalStatus(makeIssue({ statusName: 'X', categoryKey: 'undefined' }))
+    ).toBe('open');
+    expect(jiraIssueToCanonicalStatus(makeIssue({ statusName: 'X', categoryKey: 'mystery' }))).toBe(
+      'open'
+    );
+  });
+});
+
+describe('pickTransitionForCanonicalStatus', () => {
+  const allTransitions: JiraTransition[] = [
+    makeTransition({ id: '11', name: 'To Do', toName: 'To Do', toCategoryKey: 'new' }),
+    makeTransition({
+      id: '21',
+      name: 'In Progress',
+      toName: 'In Progress',
+      toCategoryKey: 'indeterminate',
+    }),
+    makeTransition({ id: '31', name: 'Done', toName: 'Done', toCategoryKey: 'done' }),
+    makeTransition({
+      id: '41',
+      name: "Won't Do",
+      toName: "Won't Fix",
+      toCategoryKey: 'done',
+    }),
+  ];
+
+  it('returns null on empty input', () => {
+    expect(pickTransitionForCanonicalStatus([], 'in_progress')).toBeNull();
+  });
+
+  it('picks a `new` transition for canonical open', () => {
+    expect(pickTransitionForCanonicalStatus(allTransitions, 'open')?.id).toBe('11');
+  });
+
+  it('picks an `indeterminate` transition for canonical in_progress', () => {
+    expect(pickTransitionForCanonicalStatus(allTransitions, 'in_progress')?.id).toBe('21');
+  });
+
+  it('picks a non-wont-fix `done` transition for canonical closed', () => {
+    const picked = pickTransitionForCanonicalStatus(allTransitions, 'closed');
+    expect(picked?.id).toBe('31');
+    expect(picked?.to.name).toBe('Done');
+  });
+
+  it('picks a wont-fix-named `done` transition for canonical wont_fix', () => {
+    const picked = pickTransitionForCanonicalStatus(allTransitions, 'wont_fix');
+    expect(picked?.id).toBe('41');
+    expect(picked?.to.name).toBe("Won't Fix");
+  });
+
+  it('falls back to any `done` transition for closed when no neutral name exists', () => {
+    // Only a "Won't Fix"-named transition is available — still better than
+    // refusing to transition at all when the rule wants `closed`.
+    const onlyWontFix = [
+      makeTransition({
+        id: '41',
+        name: "Won't Do",
+        toName: 'Cancelled',
+        toCategoryKey: 'done',
+      }),
+    ];
+    expect(pickTransitionForCanonicalStatus(onlyWontFix, 'closed')?.id).toBe('41');
+  });
+
+  it('returns null when no transition lands in the target category', () => {
+    const onlyNew = [
+      makeTransition({ id: '11', name: 'Reopen', toName: 'To Do', toCategoryKey: 'new' }),
+    ];
+    expect(pickTransitionForCanonicalStatus(onlyNew, 'in_progress')).toBeNull();
+  });
+});

--- a/packages/backend/tests/integrations/jira/status-mapper.test.ts
+++ b/packages/backend/tests/integrations/jira/status-mapper.test.ts
@@ -11,7 +11,7 @@
  * No HTTP — pure functions over typed fixtures.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   jiraIssueToCanonicalStatus,
   pickTransitionForCanonicalStatus,
@@ -174,6 +174,31 @@ describe('pickTransitionForCanonicalStatus', () => {
       }),
     ];
     expect(pickTransitionForCanonicalStatus(onlyWontFix, 'closed')?.id).toBe('41');
+  });
+
+  it('logs a warning when the closed/wont_fix fallback fires', async () => {
+    // The fallback is intentional but worth observing — admins should
+    // see it in logs to spot misconfigured workflows (e.g. a single
+    // `Abandoned` terminal state being conflated with `closed`).
+    const { getLogger } = await import('../../../src/logger.js');
+    const warnSpy = vi.spyOn(getLogger(), 'warn').mockImplementation(() => undefined);
+
+    const onlyWontFix = [
+      makeTransition({
+        id: '41',
+        name: "Won't Do",
+        toName: 'Cancelled',
+        toCategoryKey: 'done',
+      }),
+    ];
+    pickTransitionForCanonicalStatus(onlyWontFix, 'closed');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('fallback fired'),
+      expect.objectContaining({ target: 'closed', fallbackTransitionId: '41' })
+    );
+
+    warnSpy.mockRestore();
   });
 
   it('returns null when no transition lands in the target category', () => {

--- a/packages/backend/tests/integrations/jira/status-mapper.test.ts
+++ b/packages/backend/tests/integrations/jira/status-mapper.test.ts
@@ -207,4 +207,55 @@ describe('pickTransitionForCanonicalStatus', () => {
     ];
     expect(pickTransitionForCanonicalStatus(onlyNew, 'in_progress')).toBeNull();
   });
+
+  describe('deterministic preference ordering', () => {
+    it('prefers "Done" over "Resolved" over "Fixed" for canonical closed', () => {
+      // All three sit in `done` category and are non-wont-fix. Without
+      // a preference list the picker was non-deterministic — first one
+      // Jira's API returned won.
+      const multiDone = [
+        makeTransition({ id: 'f', name: 'Mark Fixed', toName: 'Fixed', toCategoryKey: 'done' }),
+        makeTransition({
+          id: 'r',
+          name: 'Mark Resolved',
+          toName: 'Resolved',
+          toCategoryKey: 'done',
+        }),
+        makeTransition({ id: 'd', name: 'Mark Done', toName: 'Done', toCategoryKey: 'done' }),
+      ];
+      // Same input shuffled — output is stable.
+      const picked1 = pickTransitionForCanonicalStatus(multiDone, 'closed');
+      const picked2 = pickTransitionForCanonicalStatus([...multiDone].reverse(), 'closed');
+      expect(picked1?.to.name).toBe('Done');
+      expect(picked2?.to.name).toBe('Done');
+    });
+
+    it('prefers "In Progress" over "Doing" for canonical in_progress', () => {
+      const ip = [
+        makeTransition({
+          id: 'd',
+          name: 'Doing',
+          toName: 'Doing',
+          toCategoryKey: 'indeterminate',
+        }),
+        makeTransition({
+          id: 'i',
+          name: 'In Progress',
+          toName: 'In Progress',
+          toCategoryKey: 'indeterminate',
+        }),
+      ];
+      expect(pickTransitionForCanonicalStatus(ip, 'in_progress')?.to.name).toBe('In Progress');
+    });
+
+    it('falls through to alphabetical when no preferred name matches', () => {
+      // Both states are in the right category, neither is in the
+      // preferences list. Alphabetical "Mystery A" wins.
+      const obscure = [
+        makeTransition({ id: 'z', name: 'Z', toName: 'Mystery Z', toCategoryKey: 'done' }),
+        makeTransition({ id: 'a', name: 'A', toName: 'Mystery A', toCategoryKey: 'done' }),
+      ];
+      expect(pickTransitionForCanonicalStatus(obscure, 'closed')?.to.name).toBe('Mystery A');
+    });
+  });
 });

--- a/packages/backend/tests/integrations/linear/config.test.ts
+++ b/packages/backend/tests/integrations/linear/config.test.ts
@@ -9,8 +9,9 @@
  * credential leak with no signal. Worth a test, even if a small one.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { LinearConfigManager } from '../../../src/integrations/linear/config.js';
+import { getEncryptionService } from '../../../src/utils/encryption.js';
 
 describe('LinearConfigManager.fromEnvironment', () => {
   // Snapshot the env vars we touch so we can restore them after each
@@ -77,5 +78,57 @@ describe('LinearConfigManager.fromEnvironment', () => {
     const config = LinearConfigManager.fromEnvironment();
     expect(config).not.toBeNull();
     expect(config?.apiKey).toBe('lin_api_xxx');
+  });
+});
+
+describe('LinearConfigManager.getConfigByIntegrationId — cross-tenant guard', () => {
+  // Regression test for the defense-in-depth check that the rule
+  // engine + outbox flows rely on. Mirrors the equivalent Jira test —
+  // the threat model is identical (foreign integrationId smuggled via
+  // stale outbox row / misrouted retry).
+
+  let configManager: LinearConfigManager;
+  let mockRepo: { findByIdWithType: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockRepo = { findByIdWithType: vi.fn() };
+    configManager = new LinearConfigManager(mockRepo as never);
+  });
+
+  it('returns null when the integration belongs to a different project', async () => {
+    const enc = getEncryptionService().encrypt(JSON.stringify({ apiKey: 'lin_secret' }));
+    mockRepo.findByIdWithType.mockResolvedValue({
+      project_id: 'real-project-id',
+      integration_id: 'int-linear-id',
+      integration_type: 'linear',
+      config: { teamId: 'team-uuid', teamKey: 'ENG' },
+      encrypted_credentials: enc,
+      enabled: true,
+    });
+
+    const result = await configManager.getConfigByIntegrationId(
+      'int-linear-id',
+      'foreign-project-id'
+    );
+
+    expect(result).toBeNull();
+    expect(mockRepo.findByIdWithType).toHaveBeenCalledWith('int-linear-id');
+  });
+
+  it('returns the config when project matches', async () => {
+    const enc = getEncryptionService().encrypt(JSON.stringify({ apiKey: 'lin_secret' }));
+    mockRepo.findByIdWithType.mockResolvedValue({
+      project_id: 'real-project-id',
+      integration_id: 'int-linear-id',
+      integration_type: 'linear',
+      config: { teamId: 'team-uuid', teamKey: 'ENG' },
+      encrypted_credentials: enc,
+      enabled: true,
+    });
+
+    const result = await configManager.getConfigByIntegrationId('int-linear-id', 'real-project-id');
+
+    expect(result).not.toBeNull();
+    expect(result?.apiKey).toBe('lin_secret');
   });
 });

--- a/packages/backend/tests/integrations/linear/service-capability.test.ts
+++ b/packages/backend/tests/integrations/linear/service-capability.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the Linear capability methods on `LinearIntegrationService`.
+ *
+ * Focused on the externalId-vs-UUID resolution path, because that's where
+ * the integration silently failed before review caught it: Linear stores
+ * the human-readable identifier ("ENG-123") in `external_ticket_id`, but
+ * the GraphQL mutations (`commentCreate`, `issueUpdate`) reject anything
+ * other than the issue UUID. The capability methods must resolve the
+ * identifier → UUID via `getIssue(...)` before issuing mutations.
+ *
+ * Everything below the service layer (config manager, LinearClient) is
+ * mocked. The test exercises the contract:
+ *
+ *   addComment(target)   →  getIssue(externalId) → commentCreate(issue.id, body)
+ *   transition(target)   →  getIssue → getTeamStates → issueUpdateState(issue.id, state.id)
+ *   getStatus(target)    →  getIssue (which accepts identifier or UUID, no resolve needed)
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { LinearIntegrationService } from '../../../src/integrations/linear/service.js';
+import type { CapabilityTarget } from '../../../src/integrations/capabilities.js';
+import type { LinearConfig, LinearIssueDetail } from '../../../src/integrations/linear/types.js';
+
+// Mock the LinearClient entirely so we don't make HTTP calls. Each test
+// re-binds the methods through this single shared mock — the service
+// constructs LinearClient via `new LinearClient(apiKey)` so we intercept
+// the constructor.
+const mockClientInstance = {
+  getIssue: vi.fn(),
+  commentCreate: vi.fn(),
+  getTeamStates: vi.fn(),
+  issueUpdateState: vi.fn(),
+};
+vi.mock('../../../src/integrations/linear/client.js', () => ({
+  LinearClient: vi.fn().mockImplementation(() => mockClientInstance),
+}));
+
+// Encryption / config-manager stubs — the service calls
+// `configManager.getConfigByIntegrationId(id, projectId)`; we return a
+// minimal-but-realistic LinearConfig.
+const FAKE_CONFIG: LinearConfig = {
+  apiKey: 'lin_api_test',
+  teamId: 'team-uuid',
+  teamKey: 'ENG',
+  enabled: true,
+};
+
+const FAKE_TARGET: CapabilityTarget = {
+  externalId: 'ENG-123', // identifier, NOT UUID — the realistic shape
+  projectId: 'project-1',
+  integrationId: 'integration-1',
+};
+
+const FAKE_ISSUE: LinearIssueDetail = {
+  id: 'issue-uuid-aaaa-bbbb', // The resolved UUID — what mutations require
+  identifier: 'ENG-123',
+  state: { id: 'state-uuid', name: 'In Progress', type: 'started' },
+  team: { id: 'team-uuid', name: 'Engineering' },
+};
+
+describe('LinearIntegrationService — capability methods', () => {
+  let service: LinearIntegrationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClientInstance.getIssue.mockResolvedValue(FAKE_ISSUE);
+    mockClientInstance.commentCreate.mockResolvedValue(undefined);
+    mockClientInstance.getTeamStates.mockResolvedValue([
+      { id: 'state-done-uuid', name: 'Done', type: 'completed' },
+    ]);
+    mockClientInstance.issueUpdateState.mockResolvedValue(undefined);
+
+    // Build a minimal service whose configManager returns our stub config.
+    service = new LinearIntegrationService(
+      {} as never,
+      {
+        // ProjectIntegrationRepository is only accessed via configManager,
+        // which we stub below.
+      } as never,
+      {} as never,
+      {} as never
+    );
+
+    // Stomp the configManager with one that always returns FAKE_CONFIG.
+    (service as unknown as { configManager: { getConfigByIntegrationId: Mock } }).configManager = {
+      getConfigByIntegrationId: vi.fn().mockResolvedValue(FAKE_CONFIG),
+    };
+  });
+
+  describe('addComment', () => {
+    it('resolves identifier → UUID via getIssue before calling commentCreate', async () => {
+      await service.addComment(FAKE_TARGET, 'hello');
+
+      expect(mockClientInstance.getIssue).toHaveBeenCalledWith('ENG-123');
+      expect(mockClientInstance.commentCreate).toHaveBeenCalledWith(
+        'issue-uuid-aaaa-bbbb', // UUID, NOT 'ENG-123'
+        'hello'
+      );
+    });
+
+    it('passes the projectId scope to the config manager', async () => {
+      await service.addComment(FAKE_TARGET, 'hello');
+      const cm = (service as unknown as { configManager: { getConfigByIntegrationId: Mock } })
+        .configManager;
+      expect(cm.getConfigByIntegrationId).toHaveBeenCalledWith('integration-1', 'project-1');
+    });
+  });
+
+  describe('transition', () => {
+    it('uses the resolved issue.id (UUID), not the identifier, for issueUpdateState', async () => {
+      await service.transition(FAKE_TARGET, 'closed');
+
+      expect(mockClientInstance.getIssue).toHaveBeenCalledWith('ENG-123');
+      expect(mockClientInstance.getTeamStates).toHaveBeenCalledWith('team-uuid');
+      expect(mockClientInstance.issueUpdateState).toHaveBeenCalledWith(
+        'issue-uuid-aaaa-bbbb', // UUID
+        'state-done-uuid'
+      );
+    });
+
+    it('throws when no state of the requested type exists', async () => {
+      // Team only has an `in_progress` state — request for `closed` fails.
+      mockClientInstance.getTeamStates.mockResolvedValueOnce([
+        { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+      ]);
+      await expect(service.transition(FAKE_TARGET, 'closed')).rejects.toThrow(
+        /No Linear state for canonical status 'closed'/
+      );
+      expect(mockClientInstance.issueUpdateState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns the canonical mapping of issue.state.type', async () => {
+      const status = await service.getStatus(FAKE_TARGET);
+      expect(status).toBe('in_progress'); // FAKE_ISSUE.state.type === 'started'
+      // No UUID-resolve hop needed for a read — Linear's issue(id) query
+      // accepts identifier directly. We expect exactly one getIssue call.
+      expect(mockClientInstance.getIssue).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/backend/tests/integrations/linear/status-mapper.test.ts
+++ b/packages/backend/tests/integrations/linear/status-mapper.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the Linear canonical-status mapper.
+ *
+ * Linear's `state.type` is invariant, so the mapping is mechanical. The
+ * non-trivial bit is `pickStateForCanonicalStatus`:
+ *   - prefer `unstarted` over `triage`/`backlog` when target is `open`
+ *   - sort by `position` within a state type
+ *   - return null when no state of the right type exists
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  linearStateTypeToCanonical,
+  pickStateForCanonicalStatus,
+} from '../../../src/integrations/linear/status-mapper.js';
+import type {
+  LinearStateType,
+  LinearWorkflowState,
+} from '../../../src/integrations/linear/types.js';
+
+const state = (
+  id: string,
+  name: string,
+  type: LinearStateType,
+  position = 0
+): LinearWorkflowState => ({ id, name, type, position });
+
+describe('linearStateTypeToCanonical', () => {
+  it.each([
+    ['started' as LinearStateType, 'in_progress'],
+    ['completed' as LinearStateType, 'closed'],
+    ['canceled' as LinearStateType, 'wont_fix'],
+    ['triage' as LinearStateType, 'open'],
+    ['backlog' as LinearStateType, 'open'],
+    ['unstarted' as LinearStateType, 'open'],
+  ] as const)('maps state.type=%s to canonical %s', (type, expected) => {
+    expect(linearStateTypeToCanonical(type)).toBe(expected);
+  });
+});
+
+describe('pickStateForCanonicalStatus', () => {
+  it('returns null when no state of the right type exists', () => {
+    const minimal = [state('s1', 'Triage', 'triage'), state('s2', 'Backlog', 'backlog')];
+    expect(pickStateForCanonicalStatus(minimal, 'in_progress')).toBeNull();
+    expect(pickStateForCanonicalStatus(minimal, 'closed')).toBeNull();
+  });
+
+  it('prefers `unstarted` over triage/backlog when target is open', () => {
+    const team = [
+      state('triage1', 'Triage', 'triage', 0),
+      state('backlog1', 'Backlog', 'backlog', 1),
+      state('todo1', 'Todo', 'unstarted', 2),
+    ];
+    const picked = pickStateForCanonicalStatus(team, 'open');
+    expect(picked?.id).toBe('todo1');
+    expect(picked?.type).toBe('unstarted');
+  });
+
+  it('falls back to triage/backlog when no unstarted state exists', () => {
+    const team = [
+      state('triage1', 'Triage', 'triage', 1),
+      state('backlog1', 'Backlog', 'backlog', 0),
+    ];
+    // Lower position wins among non-unstarted candidates.
+    const picked = pickStateForCanonicalStatus(team, 'open');
+    expect(picked?.id).toBe('backlog1');
+  });
+
+  it('sorts by position within a state type', () => {
+    const team = [state('ip2', 'Coding', 'started', 2), state('ip1', 'In Progress', 'started', 1)];
+    expect(pickStateForCanonicalStatus(team, 'in_progress')?.id).toBe('ip1');
+  });
+
+  it('picks `completed` for canonical closed', () => {
+    const team = [
+      state('done1', 'Done', 'completed', 0),
+      state('cancel1', 'Cancelled', 'canceled', 1),
+    ];
+    expect(pickStateForCanonicalStatus(team, 'closed')?.type).toBe('completed');
+  });
+
+  it('picks `canceled` for canonical wont_fix', () => {
+    const team = [
+      state('done1', 'Done', 'completed', 0),
+      state('cancel1', 'Cancelled', 'canceled', 1),
+    ];
+    expect(pickStateForCanonicalStatus(team, 'wont_fix')?.type).toBe('canceled');
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
       'tests/integrations/jira/template-renderer.test.ts',
       'tests/integrations/jira/formatters/base-formatter.test.ts',
       'tests/integrations/jira/status-mapper.test.ts',
+      'tests/integrations/jira/build-plain-text-adf.test.ts',
       // Linear plugin tests (pure unit, no database, no real HTTP)
       'tests/integrations/linear/plugin.test.ts',
       'tests/integrations/linear/mapper.test.ts',

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
       'tests/integrations/linear/field-mappings.test.ts',
       'tests/integrations/linear/config.test.ts',
       'tests/integrations/linear/status-mapper.test.ts',
+      'tests/integrations/linear/service-capability.test.ts',
       // Intelligence tests (pure unit, mocked dependencies)
       'tests/api/utils/mitigation-trigger.test.ts',
       'tests/api/utils/resolution-sync-trigger.test.ts',

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       'tests/integrations/rpc-http-fetch.test.ts',
       'tests/integrations/rpc-bridge-security.test.ts',
       'tests/integrations/base-integration-helpers.test.ts',
+      'tests/integrations/capabilities.test.ts',
       'tests/api/auth-responses.test.ts',
       'tests/api/auth-handlers.test.ts',
       'tests/api/trust-proxy.test.ts',
@@ -60,12 +61,14 @@ export default defineConfig({
       'tests/integrations/jira/service-list-projects.test.ts',
       'tests/integrations/jira/template-renderer.test.ts',
       'tests/integrations/jira/formatters/base-formatter.test.ts',
+      'tests/integrations/jira/status-mapper.test.ts',
       // Linear plugin tests (pure unit, no database, no real HTTP)
       'tests/integrations/linear/plugin.test.ts',
       'tests/integrations/linear/mapper.test.ts',
       'tests/integrations/linear/client.test.ts',
       'tests/integrations/linear/field-mappings.test.ts',
       'tests/integrations/linear/config.test.ts',
+      'tests/integrations/linear/status-mapper.test.ts',
       // Intelligence tests (pure unit, mocked dependencies)
       'tests/api/utils/mitigation-trigger.test.ts',
       'tests/api/utils/resolution-sync-trigger.test.ts',


### PR DESCRIPTION
Foundation for the tiny rule engine (Phase 0.5). Adds an optional `TicketIntegrationCapabilities` interface with three methods — `addComment` / `transition` / `getStatus` — and implements them on Jira and Linear. The rule engine in upcoming PRs dispatches actions through this interface, so a future 3rd integration only needs to implement what it supports. Status mapping is canonicalised (`open` | `in_progress` | `closed` | `wont_fix`); each plugin maps internally (Jira via `statusCategory.key` + name heuristic for `wont_fix`, Linear via `state.type`). 35 new unit tests, fully mocked, no HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-neutral canonical ticket statuses and a unified capability interface for comments, status checks, and transitions across Jira and Linear.
  * Jira and Linear integrations add comment, status, and transition operations with deterministic mapping/selection and plain-text→ADF comment conversion (with length cap/truncation).
  * Config lookups now enforce project-scoped validation to prevent cross-project access.

* **Tests**
  * Added unit tests covering capabilities, Jira/Linear status mapping, ADF conversion, config guards, and test config updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/141)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->