### PR TITLE
feat(rules): DedupRule schema + dedup_rules storage (PR-B of tiny RE)

### DIFF
--- a/packages/backend/src/db/dedup-rule.repository.ts
+++ b/packages/backend/src/db/dedup-rule.repository.ts
@@ -1,0 +1,86 @@
+/**
+ * Dedup Rule Repository
+ *
+ * Storage for the tiny dedup-rule engine (Phase 0.5). Each row is one
+ * `DedupRule` (see ../integrations/dedup-rule.schema.ts) keyed by
+ * project. The repository deals only in storage — Zod validation
+ * happens at the call sites (admin API on write, executor on read)
+ * so the DB layer can stay agnostic about which fields are
+ * discriminator-required.
+ */
+
+import type { Pool, PoolClient } from 'pg';
+import { BaseRepository } from './repositories/base-repository.js';
+
+/**
+ * Row shape as it lives in the DB. `rule_json` is the raw blob;
+ * the executor parses it through `parseDedupRule` (which validates).
+ */
+export interface DedupRuleRow {
+  id: string;
+  project_id: string;
+  name: string;
+  rule_json: unknown;
+  enabled: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface DedupRuleInsert {
+  id?: string;
+  project_id: string;
+  name: string;
+  rule_json: unknown;
+  enabled?: boolean;
+}
+
+export interface DedupRuleUpdate {
+  name?: string;
+  rule_json?: unknown;
+  enabled?: boolean;
+}
+
+export class DedupRuleRepository extends BaseRepository<
+  DedupRuleRow,
+  DedupRuleInsert,
+  DedupRuleUpdate
+> {
+  constructor(pool: Pool | PoolClient) {
+    super(pool, 'application', 'dedup_rules', ['rule_json']);
+  }
+
+  /**
+   * Find all rules for a project. The executor's hot path uses
+   * `includeDisabled=false` (the partial index on
+   * `dedup_rules(project_id) WHERE enabled = true` is sized for this);
+   * the admin UI uses `includeDisabled=true` to render disabled rows
+   * with a toggle.
+   */
+  async findByProject(projectId: string, includeDisabled = false): Promise<DedupRuleRow[]> {
+    const query = `
+      SELECT id, project_id, name, rule_json, enabled, created_at, updated_at
+      FROM dedup_rules
+      WHERE project_id = $1
+        ${includeDisabled ? '' : 'AND enabled = true'}
+      ORDER BY name ASC
+    `;
+    const result = await this.pool.query<DedupRuleRow>(query, [projectId]);
+    return result.rows;
+  }
+
+  /**
+   * Look up a rule by (project, name). Used by the admin UI to detect
+   * name collisions before INSERT, and by the seed helpers to upsert
+   * the B1 / B2 / B3 preset rules without duplicating them on repeat
+   * deploys.
+   */
+  async findByProjectAndName(projectId: string, name: string): Promise<DedupRuleRow | null> {
+    const query = `
+      SELECT id, project_id, name, rule_json, enabled, created_at, updated_at
+      FROM dedup_rules
+      WHERE project_id = $1 AND name = $2
+    `;
+    const result = await this.pool.query<DedupRuleRow>(query, [projectId, name]);
+    return result.rows[0] ?? null;
+  }
+}

--- a/packages/backend/src/db/dedup-rule.repository.ts
+++ b/packages/backend/src/db/dedup-rule.repository.ts
@@ -59,28 +59,32 @@ export class DedupRuleRepository extends BaseRepository<
   async findByProject(projectId: string, includeDisabled = false): Promise<DedupRuleRow[]> {
     const query = `
       SELECT id, project_id, name, rule_json, enabled, created_at, updated_at
-      FROM dedup_rules
+      FROM ${this.schema}.${this.tableName}
       WHERE project_id = $1
         ${includeDisabled ? '' : 'AND enabled = true'}
       ORDER BY name ASC
     `;
-    const result = await this.pool.query<DedupRuleRow>(query, [projectId]);
-    return result.rows;
+    const result = await this.getClient().query(query, [projectId]);
+    return this.deserializeMany(result.rows);
   }
 
   /**
    * Look up a rule by (project, name). Used by the admin UI to detect
    * name collisions before INSERT, and by the seed helpers to upsert
    * the B1 / B2 / B3 preset rules without duplicating them on repeat
-   * deploys.
+   * deploys. The `unique_dedup_rule_name_per_project` constraint is the
+   * authoritative guard — this lookup is for nicer error UX, not safety.
    */
   async findByProjectAndName(projectId: string, name: string): Promise<DedupRuleRow | null> {
     const query = `
       SELECT id, project_id, name, rule_json, enabled, created_at, updated_at
-      FROM dedup_rules
+      FROM ${this.schema}.${this.tableName}
       WHERE project_id = $1 AND name = $2
     `;
-    const result = await this.pool.query<DedupRuleRow>(query, [projectId, name]);
-    return result.rows[0] ?? null;
+    const result = await this.getClient().query(query, [projectId, name]);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return this.deserialize(result.rows[0]);
   }
 }

--- a/packages/backend/src/db/migrations/022_dedup_rules.sql
+++ b/packages/backend/src/db/migrations/022_dedup_rules.sql
@@ -1,0 +1,49 @@
+SET search_path TO application;
+
+-- Storage for the tiny dedup-rule engine (Phase 0.5).
+--
+-- Each row is one trigger → conditions → actions automation. The rule
+-- body lives in `rule_json` as a JSONB blob; the canonical shape is
+-- defined by the `DedupRule` Pydantic model in bugspotter-intelligence
+-- and mirrored in TypeScript via Zod (see src/integrations/dedup-rule.schema.ts).
+-- Keeping the full rule as JSONB rather than relational columns is
+-- deliberate: the discriminated unions on triggers / actions would
+-- explode into a dozen columns most of which are NULL for any given
+-- row, and the executor parses the whole thing per fire anyway.
+--
+-- Scope is per-project, mirroring `integration_rules` and
+-- `project_integrations`: selfhosted mode has projects but no orgs,
+-- and a single project may have its own ack / counter / reopen
+-- automations independent of other projects in the same org.
+
+CREATE TABLE IF NOT EXISTS dedup_rules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name VARCHAR(120) NOT NULL,
+  rule_json JSONB NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT unique_dedup_rule_name_per_project UNIQUE(project_id, name)
+);
+
+-- The executor hot-path queries `WHERE project_id = $1 AND enabled = true`
+-- for every dedup event, so index that exact predicate. Partial index
+-- keeps the index small in projects with a long tail of historical /
+-- disabled rules.
+CREATE INDEX IF NOT EXISTS idx_dedup_rules_enabled_lookup
+  ON dedup_rules(project_id)
+  WHERE enabled = true;
+
+CREATE TRIGGER update_dedup_rules_updated_at
+  BEFORE UPDATE ON dedup_rules
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE dedup_rules IS
+  'Per-project automation rules for the dedup pipeline. Each row is one trigger -> conditions -> actions DedupRule; canonical shape lives in bugspotter-intelligence Pydantic + src/integrations/dedup-rule.schema.ts (Zod).';
+COMMENT ON COLUMN dedup_rules.rule_json IS
+  'Full DedupRule blob. Validated against the Zod schema on write and on read (so manual SQL edits do not corrupt the executor).';
+COMMENT ON COLUMN dedup_rules.name IS
+  'Human-readable label. Unique per project so the admin UI can address rules by name in URLs / logs.';

--- a/packages/backend/src/integrations/dedup-rule.schema.ts
+++ b/packages/backend/src/integrations/dedup-rule.schema.ts
@@ -1,0 +1,255 @@
+/**
+ * DedupRule schema — TypeScript mirror of the Python Pydantic model in
+ * bugspotter-intelligence (`models/dedup_rule.py`). The intelligence
+ * service produces these via the NL parser; the rule engine in this
+ * package consumes them.
+ *
+ * Two sources of truth is one too many — when you change a constraint
+ * here (a new field, a new action type, a new trigger), change the
+ * Python model in lockstep. The shape, regex patterns, and validation
+ * semantics must match exactly or the rule the LLM emits in bs-intel
+ * will fail to round-trip through this validator.
+ *
+ * Zod is used to validate JSONB blobs at the trust boundary (DB read,
+ * admin write). The repository stores the raw blob; the schema is what
+ * the executor and the API layer parse it through.
+ */
+
+import { z } from 'zod';
+
+// `<digits><unit>` duration strings used by trigger / condition / rate_limit
+// windows. Leading [1-9] forbids zero-duration ("0h") windows that would
+// silently make conditions meaningless. Must match `_WINDOW_PATTERN` in
+// bugspotter-intelligence/src/bugspotter_intelligence/models/dedup_rule.py.
+const WINDOW_PATTERN = /^[1-9]\d*[smhdw]$/;
+
+// Standard 5-field cron. Deliberately loose — catches prose like
+// "every monday" but doesn't validate semantics. Matches `_CRON_PATTERN`
+// in the Python model.
+const CRON_PATTERN = /^(\S+\s+){4}\S+$/;
+
+// Recipients for notify.email.to: three special tokens (resolved at
+// execution time) or a literal email. Loose email regex — strict
+// RFC-5322 validation lives in the executor.
+const EMAIL_TARGET_PATTERN = /^(reporter|closer|all_reporters|[^@\s]+@[^@\s]+\.[^@\s]+)$/;
+
+// ============================================================================
+// Triggers — pick exactly one
+// ============================================================================
+
+const triggerDuplicateDetectedSchema = z.object({
+  type: z.literal('duplicate_detected'),
+});
+
+const triggerOutboxAboutToSkipSchema = z.object({
+  type: z.literal('outbox_about_to_skip'),
+});
+
+const triggerClusterGrowingSchema = z.object({
+  type: z.literal('cluster_growing'),
+  threshold: z.number().int().min(2),
+  window: z.string().regex(WINDOW_PATTERN),
+});
+
+const triggerScheduleSchema = z.object({
+  type: z.literal('schedule'),
+  cron: z.string().regex(CRON_PATTERN),
+});
+
+export const triggerSpecSchema = z.discriminatedUnion('type', [
+  triggerDuplicateDetectedSchema,
+  triggerOutboxAboutToSkipSchema,
+  triggerClusterGrowingSchema,
+  triggerScheduleSchema,
+]);
+
+export type TriggerSpec = z.infer<typeof triggerSpecSchema>;
+
+// ============================================================================
+// Conditions — zero or more, ANDed together
+// ============================================================================
+
+export const CONDITION_FIELDS = [
+  'canonical.status',
+  'canonical.closed_days_ago',
+  'hits_in_window',
+  'reporter.customer.tier',
+  'severity',
+] as const;
+
+export const CONDITION_OPS = ['eq', 'in', 'not_in', 'gte', 'lte'] as const;
+
+// Closed `field` literal so an LLM-emitted rule can't reference unknown
+// paths the executor wouldn't recognize. The Python model gates the
+// op/value coherence (e.g. `gte` requires a number, `in` requires a list)
+// via a `model_validator(mode='after')`. We mirror that with a
+// `superRefine` so the same coercions / rejections happen on the TS side.
+export const conditionSpecSchema = z
+  .object({
+    field: z.enum(CONDITION_FIELDS),
+    op: z.enum(CONDITION_OPS),
+    value: z.unknown(),
+    window: z.string().regex(WINDOW_PATTERN).optional(),
+  })
+  .transform((c) => {
+    // Coerce scalar -> singleton list for in/not_in (LLMs commonly emit
+    // `"value": "closed"` instead of `["closed"]`).
+    if (
+      (c.op === 'in' || c.op === 'not_in') &&
+      !Array.isArray(c.value) &&
+      (typeof c.value === 'string' || typeof c.value === 'number' || typeof c.value === 'boolean')
+    ) {
+      return { ...c, value: [c.value] };
+    }
+    // Coerce string-number -> number for gte/lte ("3" -> 3).
+    if ((c.op === 'gte' || c.op === 'lte') && typeof c.value === 'string') {
+      const n = Number(c.value);
+      if (!Number.isNaN(n)) {
+        return { ...c, value: n };
+      }
+    }
+    return c;
+  })
+  .superRefine((c, ctx) => {
+    if (c.op === 'in' || c.op === 'not_in') {
+      if (!Array.isArray(c.value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `op '${c.op}' on field '${c.field}' requires a list value`,
+          path: ['value'],
+        });
+      }
+    }
+    if (c.op === 'gte' || c.op === 'lte') {
+      // `typeof true === 'number'` is false in JS, but `true > 5`
+      // evaluates — reject explicitly so a smuggled bool doesn't pass.
+      if (typeof c.value !== 'number' || typeof c.value === 'boolean') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `op '${c.op}' on field '${c.field}' requires a numeric value`,
+          path: ['value'],
+        });
+      }
+    }
+    if (c.field === 'hits_in_window' && !c.window) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "field 'hits_in_window' requires a 'window' parameter, e.g. '24h'",
+        path: ['window'],
+      });
+    }
+  });
+
+export type ConditionSpec = z.infer<typeof conditionSpecSchema>;
+
+// ============================================================================
+// Actions — at least one
+// ============================================================================
+
+export const CANONICAL_STATUSES = ['open', 'in_progress', 'closed', 'wont_fix'] as const;
+
+const actionAddCommentSchema = z.object({
+  type: z.literal('ticket.add_comment'),
+  target: z.literal('canonical'),
+  body: z.string().min(1),
+});
+
+const actionTransitionSchema = z.object({
+  type: z.literal('ticket.transition'),
+  target: z.literal('canonical'),
+  to: z.enum(CANONICAL_STATUSES),
+});
+
+const actionEmailSchema = z.object({
+  type: z.literal('notify.email'),
+  to: z.string().regex(EMAIL_TARGET_PATTERN),
+  template: z.string().min(1),
+});
+
+// Slack action must have exactly one of `channel` / `user` set —
+// matches `ActionSlack._exactly_one_target` in the Python model.
+const actionSlackSchema = z
+  .object({
+    type: z.literal('notify.slack'),
+    channel: z.string().nullable().optional(),
+    user: z.string().nullable().optional(),
+    message: z.string().min(1),
+  })
+  .superRefine((a, ctx) => {
+    const hasChannel = !!(a.channel && a.channel.trim() !== '');
+    const hasUser = !!(a.user && a.user.trim() !== '');
+    if (hasChannel === hasUser) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'ActionSlack requires exactly one of `channel` or `user` to be set',
+      });
+    }
+  });
+
+const actionWebhookSchema = z.object({
+  type: z.literal('notify.webhook'),
+  url: z.string().url(),
+  payload: z.record(z.unknown()).nullable().optional(),
+});
+
+// Plain `z.union` instead of `discriminatedUnion`: the latter requires
+// every variant to be a `ZodObject`, but `actionSlackSchema` is a
+// `ZodEffects` (wraps `.superRefine` for the XOR check). The union
+// version produces slightly less targeted error messages on a
+// type-mismatch but otherwise behaves identically.
+export const actionSpecSchema = z.union([
+  actionAddCommentSchema,
+  actionTransitionSchema,
+  actionEmailSchema,
+  actionSlackSchema,
+  actionWebhookSchema,
+]);
+
+export type ActionSpec = z.infer<typeof actionSpecSchema>;
+
+// ============================================================================
+// Rule
+// ============================================================================
+
+export const rateLimitSchema = z.object({
+  count: z.number().int().min(1),
+  window: z.string().regex(WINDOW_PATTERN),
+});
+
+export type RateLimit = z.infer<typeof rateLimitSchema>;
+
+// `if` is a reserved word in JS, so the wire shape (`if`) is normalized
+// to a `conditions` property. The Python model uses `if_` for the same
+// reason and accepts both via `populate_by_name=True`. We accept either
+// `if` or `conditions` on the input and produce `conditions` on the
+// output type, so consumers don't have to bracket-access a reserved
+// keyword.
+export const dedupRuleSchema = z
+  .object({
+    name: z.string().min(1).max(120),
+    when: triggerSpecSchema,
+    if: z.array(conditionSpecSchema).optional(),
+    conditions: z.array(conditionSpecSchema).optional(),
+    then: z.array(actionSpecSchema).min(1),
+    rate_limit: rateLimitSchema.nullable().optional(),
+    enabled: z.boolean().default(true),
+  })
+  .transform((r) => {
+    const { if: ifField, conditions: condField, ...rest } = r;
+    return {
+      ...rest,
+      conditions: condField ?? ifField ?? [],
+    };
+  });
+
+export type DedupRule = z.infer<typeof dedupRuleSchema>;
+
+/**
+ * Parse a stored / submitted DedupRule blob and return a typed value.
+ * Throws a ZodError on validation failure — callers at the API
+ * boundary should catch and surface the issues; the executor should
+ * skip the rule and log.
+ */
+export function parseDedupRule(input: unknown): DedupRule {
+  return dedupRuleSchema.parse(input);
+}

--- a/packages/backend/src/integrations/dedup-rule.schema.ts
+++ b/packages/backend/src/integrations/dedup-rule.schema.ts
@@ -130,9 +130,12 @@ export const conditionSpecSchema = z
       }
     }
     if (c.op === 'gte' || c.op === 'lte') {
-      // `typeof true === 'number'` is false in JS, but `true > 5`
-      // evaluates — reject explicitly so a smuggled bool doesn't pass.
-      if (typeof c.value !== 'number' || typeof c.value === 'boolean') {
+      // `Number.isFinite` is the right check: rejects non-numbers,
+      // booleans (typeof `true` is `'boolean'`, not `'number'`), and
+      // — crucially — NaN / Infinity which would pass a naive
+      // `typeof === 'number'` test but evaluate to `false` for every
+      // comparison downstream, producing rules that silently never fire.
+      if (!Number.isFinite(c.value)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `op '${c.op}' on field '${c.field}' requires a numeric value`,

--- a/packages/backend/src/integrations/dedup-rule.schema.ts
+++ b/packages/backend/src/integrations/dedup-rule.schema.ts
@@ -17,6 +17,8 @@
 
 import { z } from 'zod';
 
+import { validateSSRFProtection } from './security/ssrf-validator.js';
+
 // `<digits><unit>` duration strings used by trigger / condition / rate_limit
 // windows. Leading [1-9] forbids zero-duration ("0h") windows that would
 // silently make conditions meaningless. Must match `_WINDOW_PATTERN` in
@@ -101,11 +103,18 @@ export const conditionSpecSchema = z
     ) {
       return { ...c, value: [c.value] };
     }
-    // Coerce string-number -> number for gte/lte ("3" -> 3).
+    // Coerce string-number -> number for gte/lte ("3" -> 3). Guard the
+    // empty / whitespace-only case explicitly: `Number("")` is 0 in JS
+    // (not NaN), which would silently treat a blank value as zero —
+    // diverging from the Pydantic model where `int("")` raises. Trim
+    // and require non-empty before delegating to Number().
     if ((c.op === 'gte' || c.op === 'lte') && typeof c.value === 'string') {
-      const n = Number(c.value);
-      if (!Number.isNaN(n)) {
-        return { ...c, value: n };
+      const trimmed = c.value.trim();
+      if (trimmed !== '') {
+        const n = Number(trimmed);
+        if (!Number.isNaN(n)) {
+          return { ...c, value: n };
+        }
       }
     }
     return c;
@@ -186,9 +195,30 @@ const actionSlackSchema = z
     }
   });
 
+// `z.string().url()` only checks syntax. Without an SSRF guard, an admin
+// could persist a rule that makes the executor POST to internal services
+// (127.*, 10.*, 169.254.* cloud metadata, etc). Reject at parse time so
+// bad URLs never make it past write; the executor runs the same check
+// again as defense-in-depth.
 const actionWebhookSchema = z.object({
   type: z.literal('notify.webhook'),
-  url: z.string().url(),
+  url: z
+    .string()
+    .url()
+    .refine(
+      (u) => {
+        try {
+          validateSSRFProtection(u);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      {
+        message:
+          'Webhook URL must be a public HTTPS/HTTP endpoint (no localhost, private, or metadata IPs)',
+      }
+    ),
   payload: z.record(z.unknown()).nullable().optional(),
 });
 

--- a/packages/backend/tests/integrations/dedup-rule.schema.test.ts
+++ b/packages/backend/tests/integrations/dedup-rule.schema.test.ts
@@ -173,6 +173,23 @@ describe('conditionSpecSchema', () => {
     ).toThrow();
   });
 
+  it.each([NaN, Infinity, -Infinity])(
+    'rejects non-finite number %s for `gte` (passes typeof check, breaks every comparison)',
+    (bad) => {
+      // `NaN >= 3` is always `false`, so a rule with NaN/Infinity would
+      // silently never fire — worst case for a rule engine. Catch at
+      // parse time via Number.isFinite.
+      expect(() =>
+        conditionSpecSchema.parse({
+          field: 'hits_in_window',
+          op: 'gte',
+          value: bad,
+          window: '24h',
+        })
+      ).toThrow();
+    }
+  );
+
   it('requires `window` when field is `hits_in_window`', () => {
     expect(() =>
       conditionSpecSchema.parse({ field: 'hits_in_window', op: 'gte', value: 3 })

--- a/packages/backend/tests/integrations/dedup-rule.schema.test.ts
+++ b/packages/backend/tests/integrations/dedup-rule.schema.test.ts
@@ -144,6 +144,24 @@ describe('conditionSpecSchema', () => {
     ).toThrow();
   });
 
+  it.each(['', '   ', '\t\n'])(
+    'rejects empty / whitespace-only string for `gte` (Number("") is 0 in JS, not NaN)',
+    (bad) => {
+      // Regression test: `Number("")` evaluates to 0, so an unguarded
+      // coercion would silently treat a blank value as zero — diverging
+      // from the Pydantic model where `int("")` raises a ValueError.
+      // Guard with a trim + non-empty check before delegating to Number().
+      expect(() =>
+        conditionSpecSchema.parse({
+          field: 'hits_in_window',
+          op: 'gte',
+          value: bad,
+          window: '24h',
+        })
+      ).toThrow();
+    }
+  );
+
   it('rejects bool for `gte` (JS coerces `true > 5` silently)', () => {
     expect(() =>
       conditionSpecSchema.parse({
@@ -275,6 +293,27 @@ describe('dedupRuleSchema — actions', () => {
       dedupRuleSchema.parse({
         ...baseRule,
         then: [{ type: 'notify.webhook', url: 'not-a-url' }],
+      })
+    ).toThrow();
+  });
+
+  it.each([
+    'http://127.0.0.1:6379',
+    'http://localhost:3000',
+    'http://10.0.0.1/hook',
+    'http://192.168.1.1/hook',
+    'http://172.16.0.1/hook',
+    'http://169.254.169.254/latest/meta-data/', // AWS metadata
+    'http://[::1]/hook',
+  ])('notify.webhook rejects internal / private host %s (SSRF)', (bad) => {
+    // `z.string().url()` only validates syntax — without the SSRF refine
+    // an admin could persist a rule that makes the executor POST to
+    // internal services. Reject at parse time. The executor re-validates
+    // as defense-in-depth.
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.webhook', url: bad }],
       })
     ).toThrow();
   });

--- a/packages/backend/tests/integrations/dedup-rule.schema.test.ts
+++ b/packages/backend/tests/integrations/dedup-rule.schema.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Schema-level tests for `DedupRule` (Zod) — TypeScript mirror of
+ * `bugspotter-intelligence/tests/models/test_dedup_rule.py`. The two
+ * suites should stay aligned: if the Python model accepts a shape, the
+ * TS schema should accept it too (and vice-versa for rejections).
+ *
+ * The non-obvious checks worth pinning down:
+ *  - ActionSlack requires exactly one of `channel` / `user`
+ *  - Window pattern rejects zero-duration and non-`<n><unit>` shapes
+ *  - Cron pattern catches prose like "every monday"
+ *  - ConditionSpec coerces (scalar -> list for in/not_in, string -> number
+ *    for gte/lte) and rejects bool for gte/lte
+ *  - `hits_in_window` requires a `window` parameter
+ *  - The `if` (wire) / `conditions` (TS) alias both produce the same shape
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  conditionSpecSchema,
+  dedupRuleSchema,
+  parseDedupRule,
+  rateLimitSchema,
+  triggerSpecSchema,
+} from '../../src/integrations/dedup-rule.schema.js';
+
+describe('triggerSpecSchema', () => {
+  it('accepts duplicate_detected with no extra fields', () => {
+    expect(() => triggerSpecSchema.parse({ type: 'duplicate_detected' })).not.toThrow();
+  });
+
+  it('accepts cluster_growing with threshold + window', () => {
+    expect(() =>
+      triggerSpecSchema.parse({ type: 'cluster_growing', threshold: 5, window: '24h' })
+    ).not.toThrow();
+  });
+
+  it('rejects threshold < 2 on cluster_growing', () => {
+    expect(() =>
+      triggerSpecSchema.parse({ type: 'cluster_growing', threshold: 1, window: '24h' })
+    ).toThrow();
+  });
+
+  it.each(['1s', '30s', '1h', '24h', '7d', '1w', '100h'])(
+    'accepts well-formed window %s',
+    (good) => {
+      expect(() =>
+        triggerSpecSchema.parse({ type: 'cluster_growing', threshold: 5, window: good })
+      ).not.toThrow();
+    }
+  );
+
+  it.each(['', '1', '1 h', '1hr', 'one hour', '1m30s', 'h1'])(
+    'rejects malformed window %s',
+    (bad) => {
+      expect(() =>
+        triggerSpecSchema.parse({ type: 'cluster_growing', threshold: 5, window: bad })
+      ).toThrow();
+    }
+  );
+
+  it.each(['0s', '0h', '0d', '00h'])('rejects zero-duration window %s', (bad) => {
+    // Zero-duration windows would make conditions meaningless. The
+    // Python model rejects these via the leading `[1-9]` in the regex;
+    // mirror that here.
+    expect(() =>
+      triggerSpecSchema.parse({ type: 'cluster_growing', threshold: 5, window: bad })
+    ).toThrow();
+  });
+
+  it.each(['0 9 * * 1', '*/5 * * * *', '0 0 1 1 *', '30 9 * * 1-5'])(
+    'accepts well-formed cron %s',
+    (good) => {
+      expect(() => triggerSpecSchema.parse({ type: 'schedule', cron: good })).not.toThrow();
+    }
+  );
+
+  it.each(['every monday', '0 9 * *', '0 9 * * 1 0', '', 'monday at 9'])(
+    'rejects malformed cron %s',
+    (bad) => {
+      expect(() => triggerSpecSchema.parse({ type: 'schedule', cron: bad })).toThrow();
+    }
+  );
+
+  it('rejects unknown trigger type via the discriminator', () => {
+    expect(() => triggerSpecSchema.parse({ type: 'made_up' })).toThrow();
+  });
+});
+
+describe('conditionSpecSchema', () => {
+  it('accepts a known field with a list value for `in`', () => {
+    expect(() =>
+      conditionSpecSchema.parse({ field: 'canonical.status', op: 'in', value: ['closed'] })
+    ).not.toThrow();
+  });
+
+  it('rejects unknown fields', () => {
+    expect(() =>
+      conditionSpecSchema.parse({ field: 'canonical.priority', op: 'eq', value: 'high' })
+    ).toThrow();
+  });
+
+  it('coerces scalar -> singleton list for `in`', () => {
+    const parsed = conditionSpecSchema.parse({
+      field: 'canonical.status',
+      op: 'in',
+      value: 'closed',
+    });
+    expect(parsed.value).toEqual(['closed']);
+  });
+
+  it('coerces scalar -> singleton list for `not_in`', () => {
+    const parsed = conditionSpecSchema.parse({
+      field: 'severity',
+      op: 'not_in',
+      value: 'low',
+    });
+    expect(parsed.value).toEqual(['low']);
+  });
+
+  it('rejects non-coercible value for `in` (object)', () => {
+    expect(() =>
+      conditionSpecSchema.parse({ field: 'canonical.status', op: 'in', value: { bad: true } })
+    ).toThrow();
+  });
+
+  it('coerces numeric-string -> number for `gte`', () => {
+    const parsed = conditionSpecSchema.parse({
+      field: 'hits_in_window',
+      op: 'gte',
+      value: '3',
+      window: '24h',
+    });
+    expect(parsed.value).toBe(3);
+  });
+
+  it('rejects non-numeric string for `gte`', () => {
+    expect(() =>
+      conditionSpecSchema.parse({
+        field: 'hits_in_window',
+        op: 'gte',
+        value: 'lots',
+        window: '24h',
+      })
+    ).toThrow();
+  });
+
+  it('rejects bool for `gte` (JS coerces `true > 5` silently)', () => {
+    expect(() =>
+      conditionSpecSchema.parse({
+        field: 'hits_in_window',
+        op: 'gte',
+        value: true,
+        window: '24h',
+      })
+    ).toThrow();
+  });
+
+  it('requires `window` when field is `hits_in_window`', () => {
+    expect(() =>
+      conditionSpecSchema.parse({ field: 'hits_in_window', op: 'gte', value: 3 })
+    ).toThrow();
+  });
+
+  it('does not require window for non-windowed fields', () => {
+    expect(() =>
+      conditionSpecSchema.parse({ field: 'severity', op: 'eq', value: 'high' })
+    ).not.toThrow();
+  });
+});
+
+describe('dedupRuleSchema — actions', () => {
+  const baseRule = {
+    name: 'test',
+    when: { type: 'duplicate_detected' },
+    then: [{ type: 'notify.email', to: 'reporter', template: 'ack' }],
+  };
+
+  it('accepts a minimal rule with one notify.email action', () => {
+    expect(() => dedupRuleSchema.parse(baseRule)).not.toThrow();
+  });
+
+  it('rejects empty `then` array', () => {
+    expect(() => dedupRuleSchema.parse({ ...baseRule, then: [] })).toThrow();
+  });
+
+  it('rejects unknown action type via the discriminator', () => {
+    expect(() =>
+      dedupRuleSchema.parse({ ...baseRule, then: [{ type: 'ticket.delete' }] })
+    ).toThrow();
+  });
+
+  it.each([
+    'reporter',
+    'closer',
+    'all_reporters',
+    'team@example.com',
+    'alice+ops@sub.example.co.uk',
+  ])('notify.email accepts valid target %s', (good) => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.email', to: good, template: 'ack' }],
+      })
+    ).not.toThrow();
+  });
+
+  it.each(['Reporter', 'everyone', 'not-an-email', '@example.com', 'alice@', 'alice@nodot'])(
+    'notify.email rejects invalid target %s',
+    (bad) => {
+      expect(() =>
+        dedupRuleSchema.parse({
+          ...baseRule,
+          then: [{ type: 'notify.email', to: bad, template: 'ack' }],
+        })
+      ).toThrow();
+    }
+  );
+
+  it('notify.slack accepts channel-only', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.slack', channel: '#regressions', message: 'hi' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('notify.slack accepts user-only', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.slack', user: 'closer', message: 'hi' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('notify.slack rejects both channel and user set', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.slack', channel: '#x', user: 'alice', message: 'hi' }],
+      })
+    ).toThrow();
+  });
+
+  it('notify.slack rejects neither channel nor user set', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.slack', message: 'hi' }],
+      })
+    ).toThrow();
+  });
+
+  it('notify.slack rejects whitespace-only channel + empty user (would smuggle past a naive XOR)', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.slack', channel: '   ', user: '', message: 'hi' }],
+      })
+    ).toThrow();
+  });
+
+  it('notify.webhook accepts a valid https URL', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.webhook', url: 'https://example.com/hook' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('notify.webhook rejects non-URL strings', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.webhook', url: 'not-a-url' }],
+      })
+    ).toThrow();
+  });
+});
+
+describe('dedupRuleSchema — top-level', () => {
+  const baseRule = {
+    name: 'test',
+    when: { type: 'duplicate_detected' },
+    then: [{ type: 'notify.email', to: 'reporter', template: 'ack' }],
+  };
+
+  it('normalizes `if` (wire) and `conditions` (TS) to the same shape', () => {
+    const fromWire = dedupRuleSchema.parse({
+      ...baseRule,
+      if: [{ field: 'severity', op: 'eq', value: 'high' }],
+    });
+    const fromTs = dedupRuleSchema.parse({
+      ...baseRule,
+      conditions: [{ field: 'severity', op: 'eq', value: 'high' }],
+    });
+    expect(fromWire.conditions).toHaveLength(1);
+    expect(fromTs.conditions).toHaveLength(1);
+    expect(fromWire.conditions).toEqual(fromTs.conditions);
+  });
+
+  it('defaults `conditions` to an empty array when neither `if` nor `conditions` is set', () => {
+    const parsed = dedupRuleSchema.parse(baseRule);
+    expect(parsed.conditions).toEqual([]);
+  });
+
+  it('defaults `enabled` to true', () => {
+    const parsed = dedupRuleSchema.parse(baseRule);
+    expect(parsed.enabled).toBe(true);
+  });
+
+  it('rejects name longer than 120 chars', () => {
+    expect(() => dedupRuleSchema.parse({ ...baseRule, name: 'x'.repeat(121) })).toThrow();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => dedupRuleSchema.parse({ ...baseRule, name: '' })).toThrow();
+  });
+});
+
+describe('rateLimitSchema', () => {
+  it('accepts count + window', () => {
+    expect(() => rateLimitSchema.parse({ count: 1, window: '1h' })).not.toThrow();
+  });
+
+  it('rejects malformed window', () => {
+    expect(() => rateLimitSchema.parse({ count: 1, window: 'every hour' })).toThrow();
+  });
+
+  it('rejects count < 1', () => {
+    expect(() => rateLimitSchema.parse({ count: 0, window: '1h' })).toThrow();
+  });
+});
+
+describe('parseDedupRule', () => {
+  it('parses a fully-loaded realistic rule end-to-end', () => {
+    // Mirrors the B3 "auto-reopen on regression" preset from the
+    // Phase 0.5 plan — this is the shape the executor will load.
+    const wire = {
+      name: 'Auto-reopen on regression',
+      when: { type: 'outbox_about_to_skip' },
+      if: [
+        { field: 'canonical.status', op: 'in', value: ['closed', 'wont_fix'] },
+        { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' },
+      ],
+      then: [
+        { type: 'ticket.transition', target: 'canonical', to: 'in_progress' },
+        {
+          type: 'ticket.add_comment',
+          target: 'canonical',
+          body: 'Auto-reopened: {hits_24h} new hits in 24h.',
+        },
+      ],
+      rate_limit: { count: 1, window: '24h' },
+      enabled: true,
+    };
+    const parsed = parseDedupRule(wire);
+    expect(parsed.name).toBe('Auto-reopen on regression');
+    expect(parsed.when.type).toBe('outbox_about_to_skip');
+    expect(parsed.conditions).toHaveLength(2);
+    expect(parsed.then).toHaveLength(2);
+    expect(parsed.rate_limit?.window).toBe('24h');
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'tests/integrations/rpc-bridge-security.test.ts',
       'tests/integrations/base-integration-helpers.test.ts',
       'tests/integrations/capabilities.test.ts',
+      'tests/integrations/dedup-rule.schema.test.ts',
       'tests/api/auth-responses.test.ts',
       'tests/api/auth-handlers.test.ts',
       'tests/api/trust-proxy.test.ts',


### PR DESCRIPTION
## Summary
- PR-B of the tiny dedup-rule engine (Phase 0.5). **Storage + types only** — no runtime behaviour change.
- `application.dedup_rules` table (per-project), partial index on `(project_id) WHERE enabled = true` for the executor's hot-path lookup.
- Zod schema mirroring the Pydantic `DedupRule` in [bugspotter-intelligence#32](https://github.com/apex-bridge/bugspotter-intelligence/pull/32), including the scalar→list / string→number coercions and the slack XOR `channel`/`user` check.
- Minimal `DedupRuleRepository` — `findByProject` / `findByProjectAndName` cover the executor and seed-helper paths.

## Test plan
- [x] 71 schema tests aligned with `tests/models/test_dedup_rule.py` in bs-intelligence
- [x] Full backend unit suite (2620 tests) passes
- [x] Typecheck clean for the new files
- [ ] Migration applied locally
- [ ] PR-C (executor) wired to the repository

## Dependency note
The Python Pydantic model is the canonical source of truth — when constraints change here, change `models/dedup_rule.py` in lockstep. The schema doc comment calls this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent, project-scoped dedup automation rules with validated triggers (cron/window), rich condition operators, actions (email/Slack/webhook), optional rate limits, and efficient retrieval of enabled rules.

* **Tests**
  * Added comprehensive schema tests covering parsing, validation, action/trigger constraints, rate limits, SSRF-safe webhook checks, and end-to-end parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/143)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->