### PR TITLE
feat(rules): dedup rule executor + outbox_about_to_skip hook (PR-C)

### DIFF
--- a/packages/backend/src/db/migrations/023_notification_throttle_polymorphic_rule.sql
+++ b/packages/backend/src/db/migrations/023_notification_throttle_polymorphic_rule.sql
@@ -17,11 +17,15 @@ SET search_path TO application;
 --      one. Duplicates ~30 lines of schema and indexes for no
 --      functional benefit.
 --   2. Drop the FK and make `rule_id` polymorphic.
--- Going with (2). The CASCADE on rule deletion is replaced by:
---   - existing `cleanup_old_notification_history` cron drops rows
---     whose `window_end` has passed (so stale rows time out naturally);
---   - callers that delete a rule should explicitly DELETE matching
---     throttle rows when stronger guarantees matter.
+-- Going with (2). The original FK had `ON DELETE CASCADE` so deleting
+-- a notification_rules row also wiped its throttle rows. After this
+-- migration that cascade is gone — migration 024 restores it with an
+-- AFTER DELETE trigger on `notification_rules` (and adds the parallel
+-- trigger on `dedup_rules` once the engine's deletion path lands).
+-- The DB function `cleanup_expired_throttle_windows()` (migration 001
+-- line 994) drops stale rows by `window_end` if scheduled, but it is
+-- not currently wired to a scheduler — so the per-delete trigger is
+-- the load-bearing cleanup mechanism.
 --
 -- The unique constraint on (rule_id, group_key, window_start) is
 -- unchanged — `rule_id` is just a UUID identifying the owning rule,
@@ -31,4 +35,4 @@ ALTER TABLE notification_throttle
   DROP CONSTRAINT IF EXISTS notification_throttle_rule_id_fkey;
 
 COMMENT ON COLUMN notification_throttle.rule_id IS
-  'Owning rule UUID. Polymorphic: may reference notification_rules(id) or dedup_rules(id) depending on caller. The FK constraint was dropped in migration 023 so the dedup-rule engine can share this table; rows are cleaned up by `cleanup_old_notification_history` once window_end passes.';
+  'Owning rule UUID. Polymorphic: may reference notification_rules(id) or dedup_rules(id) depending on caller. The FK constraint was dropped in migration 023 so the dedup-rule engine can share this table. CASCADE-on-delete is restored via per-source AFTER DELETE triggers (see migration 024); cleanup_expired_throttle_windows() additionally drops stale rows by window_end if scheduled.';

--- a/packages/backend/src/db/migrations/023_notification_throttle_polymorphic_rule.sql
+++ b/packages/backend/src/db/migrations/023_notification_throttle_polymorphic_rule.sql
@@ -1,0 +1,34 @@
+SET search_path TO application;
+
+-- Drop the FK constraint on `notification_throttle.rule_id`.
+--
+-- Migration 001 declared:
+--     rule_id UUID NOT NULL REFERENCES notification_rules(id) ON DELETE CASCADE
+--
+-- assuming this table was notification-only. The dedup-rule engine
+-- (PR-C, src/services/rules/) reuses the same throttle infrastructure
+-- to enforce per-rule, per-canonical fire counts — but its rule ids
+-- live in `dedup_rules` (migration 022), not `notification_rules`. The
+-- FK rejected every insert from the new code path, breaking every rule
+-- that configures `rate_limit`.
+--
+-- Two options were on the table:
+--   1. Create a separate `dedup_rule_throttle` table mirroring this
+--      one. Duplicates ~30 lines of schema and indexes for no
+--      functional benefit.
+--   2. Drop the FK and make `rule_id` polymorphic.
+-- Going with (2). The CASCADE on rule deletion is replaced by:
+--   - existing `cleanup_old_notification_history` cron drops rows
+--     whose `window_end` has passed (so stale rows time out naturally);
+--   - callers that delete a rule should explicitly DELETE matching
+--     throttle rows when stronger guarantees matter.
+--
+-- The unique constraint on (rule_id, group_key, window_start) is
+-- unchanged — `rule_id` is just a UUID identifying the owning rule,
+-- regardless of which table it lives in.
+
+ALTER TABLE notification_throttle
+  DROP CONSTRAINT IF EXISTS notification_throttle_rule_id_fkey;
+
+COMMENT ON COLUMN notification_throttle.rule_id IS
+  'Owning rule UUID. Polymorphic: may reference notification_rules(id) or dedup_rules(id) depending on caller. The FK constraint was dropped in migration 023 so the dedup-rule engine can share this table; rows are cleaned up by `cleanup_old_notification_history` once window_end passes.';

--- a/packages/backend/src/db/migrations/024_notification_throttle_cascade_trigger.sql
+++ b/packages/backend/src/db/migrations/024_notification_throttle_cascade_trigger.sql
@@ -1,0 +1,39 @@
+SET search_path TO application;
+
+-- Restore CASCADE semantics on `notification_throttle.rule_id` after
+-- migration 023 made the column polymorphic (dropped the FK that
+-- carried `ON DELETE CASCADE`). Without this, deleting a row from
+-- `notification_rules` leaves orphan throttle rows behind forever —
+-- the unique `(rule_id, group_key, window_start)` index gives them
+-- no natural collision so they never get reclaimed, and
+-- `cleanup_expired_throttle_windows()` is not currently wired to a
+-- scheduler.
+--
+-- Use AFTER DELETE triggers instead of restoring the FK because the
+-- column is now polymorphic — a single FK can only reference one
+-- parent table. Each source table gets its own trigger that DELETEs
+-- matching rows. Same row-level cascade behaviour as the original
+-- FK, scoped per source.
+--
+-- The trigger on `dedup_rules` is intentionally omitted here: the
+-- dedup-rule deletion path doesn't exist yet (the engine reads
+-- rules; the admin UI in PR-D will introduce the DELETE handler).
+-- The parallel trigger lands alongside that work to keep this
+-- migration narrowly scoped to the regression it fixes.
+
+CREATE OR REPLACE FUNCTION cascade_delete_notification_rule_throttle()
+RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM notification_throttle WHERE rule_id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS cascade_delete_throttle ON notification_rules;
+CREATE TRIGGER cascade_delete_throttle
+  AFTER DELETE ON notification_rules
+  FOR EACH ROW
+  EXECUTE FUNCTION cascade_delete_notification_rule_throttle();
+
+COMMENT ON FUNCTION cascade_delete_notification_rule_throttle() IS
+  'Restores the CASCADE-on-delete behaviour the polymorphic rule_id lost in migration 023. Fires AFTER DELETE on notification_rules. A parallel trigger on dedup_rules will be added when the dedup-rule deletion path lands.';

--- a/packages/backend/src/db/repositories/notification-throttle.repository.ts
+++ b/packages/backend/src/db/repositories/notification-throttle.repository.ts
@@ -108,4 +108,65 @@ export class NotificationThrottleRepository {
 
     return false;
   }
+
+  /**
+   * Atomic check-and-reserve: increments the window's counter if and
+   * only if it's currently below `maxNotifications`, in a single SQL
+   * statement. Returns `true` when the slot was reserved (caller may
+   * proceed), `false` when the window is already at or over the limit.
+   *
+   * Unlike `isThrottled` (which does a separate read + write and is
+   * thus racy under concurrent callers for the same key), this method
+   * enforces the max-count contract even when two workers hit the
+   * same `(ruleId, groupKey)` simultaneously. Used by the dedup-rule
+   * engine where concurrent outbox workers processing duplicates of
+   * the same canonical can race for the same slot.
+   *
+   * The existing `isThrottled` callers (notification rules) keep
+   * their behaviour — they don't need strict max-count enforcement.
+   */
+  async tryReserveSlot(
+    ruleId: string,
+    groupKey: string,
+    maxNotifications: number,
+    windowMinutes: number
+  ): Promise<boolean> {
+    const now = new Date();
+    const windowDuration = windowMinutes * 60 * 1000;
+    const windowStart = new Date(Math.floor(now.getTime() / windowDuration) * windowDuration);
+    const windowEnd = new Date(windowStart.getTime() + windowDuration);
+
+    // Single statement, atomic under READ COMMITTED isolation. The
+    // INSERT path covers the first call in a window (count becomes 1).
+    // The DO UPDATE path runs when a row already exists; the WHERE
+    // clause refuses the update if the existing count has already
+    // hit the limit. In either case, RETURNING gives us the post-
+    // operation count — if no row comes back, the limit was exceeded
+    // and we report throttled.
+    const result = await this.pool.query<{ count: number }>(
+      `INSERT INTO notification_throttle
+         (rule_id, group_key, count, window_start, window_end)
+       VALUES ($1, $2, 1, $3, $4)
+       ON CONFLICT (rule_id, group_key, window_start)
+       DO UPDATE SET
+         count = notification_throttle.count + 1,
+         updated_at = CURRENT_TIMESTAMP
+       WHERE notification_throttle.count < $5
+       RETURNING count`,
+      [ruleId, groupKey, windowStart.toISOString(), windowEnd.toISOString(), maxNotifications]
+    );
+
+    const reserved = result.rows.length > 0;
+    if (!reserved) {
+      logger.warn('Throttle slot refused (atomic)', {
+        ruleId,
+        groupKey,
+        maxNotifications,
+        windowMinutes,
+        windowStart,
+        windowEnd,
+      });
+    }
+    return reserved;
+  }
 }

--- a/packages/backend/src/db/repositories/notification-throttle.repository.ts
+++ b/packages/backend/src/db/repositories/notification-throttle.repository.ts
@@ -165,6 +165,15 @@ export class NotificationThrottleRepository {
     // hit the limit. In either case, RETURNING gives us the post-
     // operation count — if no row comes back, the limit was exceeded
     // and we report throttled.
+    //
+    // Subtle but important: `notification_throttle.count < $5` in the
+    // WHERE refers to the EXISTING row's count (pre-UPDATE), per
+    // Postgres semantics for `ON CONFLICT DO UPDATE` — `<table>.<col>`
+    // is the conflicting row's pre-update value, `EXCLUDED.<col>` is
+    // the proposed-insert value. So a row already at the limit sees
+    // its WHERE evaluate to false, the UPDATE is skipped, no row is
+    // returned. The integration test (12 parallel callers with max=3
+    // → exactly 3 trues) pins this empirically.
     const result = await this.pool.query<{ count: number }>(
       `INSERT INTO notification_throttle
          (rule_id, group_key, count, window_start, window_end)

--- a/packages/backend/src/db/repositories/notification-throttle.repository.ts
+++ b/packages/backend/src/db/repositories/notification-throttle.repository.ts
@@ -138,6 +138,21 @@ export class NotificationThrottleRepository {
     maxNotifications: number,
     windowMinutes: number
   ): Promise<boolean> {
+    // Fail closed on invalid parameters. `windowMinutes < 1` would
+    // produce `Math.floor(now/0) * 0 = NaN`, which `new Date(NaN)`
+    // accepts and `.toISOString()` then throws on. Production callers
+    // go through `windowStringToMinutes` (which clamps to ≥1), but
+    // direct callers have no such guard.
+    if (maxNotifications < 1 || windowMinutes < 1) {
+      logger.warn('Throttle slot refused: invalid parameters', {
+        ruleId,
+        groupKey,
+        maxNotifications,
+        windowMinutes,
+      });
+      return false;
+    }
+
     const now = new Date();
     const windowDuration = windowMinutes * 60 * 1000;
     const windowStart = new Date(Math.floor(now.getTime() / windowDuration) * windowDuration);

--- a/packages/backend/src/db/repositories/notification-throttle.repository.ts
+++ b/packages/backend/src/db/repositories/notification-throttle.repository.ts
@@ -122,6 +122,13 @@ export class NotificationThrottleRepository {
    * engine where concurrent outbox workers processing duplicates of
    * the same canonical can race for the same slot.
    *
+   * `ruleId` here may reference EITHER `notification_rules.id` OR
+   * `dedup_rules.id`. The FK constraint on
+   * `notification_throttle.rule_id` was dropped in migration 023 to
+   * make this column polymorphic — without that, inserts from the
+   * dedup-rule engine were rejected at runtime. See the migration
+   * comment for the deletion / cleanup semantics.
+   *
    * The existing `isThrottled` callers (notification rules) keep
    * their behaviour — they don't need strict max-count enforcement.
    */

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -46,13 +46,19 @@ export class TicketCreationOutboxProcessor {
   // pluginRegistry / db don't have to also stub the rule engine. The
   // first outbox_about_to_skip event in any process pays the (cheap)
   // construction cost; subsequent events reuse the same executor.
-  private ruleExecutor: DedupRuleExecutor | null = null;
+  // Tests can also inject a pre-built executor via the constructor
+  // (4th arg) to bypass the build helper entirely — required for
+  // coverage of the hook path without spinning up the plugin registry.
+  private ruleExecutor: DedupRuleExecutor | null;
 
   constructor(
     private readonly db: DatabaseClient,
     private readonly pluginRegistry: PluginRegistry,
-    private readonly queue?: Queue<OutboxProcessorJobData>
-  ) {}
+    private readonly queue?: Queue<OutboxProcessorJobData>,
+    injectedRuleExecutor?: DedupRuleExecutor
+  ) {
+    this.ruleExecutor = injectedRuleExecutor ?? null;
+  }
 
   private getRuleExecutor(): DedupRuleExecutor {
     if (!this.ruleExecutor) {
@@ -125,13 +131,21 @@ export class TicketCreationOutboxProcessor {
           bugReportId: entry.bug_report_id,
           duplicateOf: bugReport.duplicate_of,
         });
-        // Fire the outbox_about_to_skip rule trigger BEFORE the
-        // markSkipped call so rules can react to the suppression (e.g.
-        // add a "+1 occurrence" comment to the canonical ticket, or
-        // auto-reopen a closed canonical). Awaiting is safe — the
-        // executor swallows action failures internally and only
-        // returns telemetry, so a slow Jira call cannot fail the
-        // outbox row's terminal state transition.
+        // Order matters: `markSkipped` (terminal state) FIRST, then
+        // fire the rule. The reverse order would mean a `markSkipped`
+        // failure (DB blip, pool exhaustion) bubbles up and BullMQ
+        // retries the job — the worker re-fetches the bug, sees
+        // `duplicate_of` still set, and fires the trigger again,
+        // replaying every action. Rules without a `rate_limit`
+        // (allowed by the schema) would spam the canonical ticket.
+        //
+        // After `markSkipped` succeeds the row is in a terminal state;
+        // any retry hits the `markProcessing` early-out and never re-
+        // fires the rule. The trade-off: a one-shot `markSkipped`
+        // success followed by a process crash before `fire` runs means
+        // the rule misses this event. We accept that — "rule skipped
+        // on a rare blip" is far better than "rule fires twice".
+        await this.db.ticketOutbox.markSkipped(outboxEntryId, 'duplicate_of_set');
         try {
           const results = await this.getRuleExecutor().fire('outbox_about_to_skip', bugReport);
           if (results.length > 0) {
@@ -144,15 +158,15 @@ export class TicketCreationOutboxProcessor {
           }
         } catch (error) {
           // Defensive: the executor wraps its own errors, but if a
-          // bug in the engine itself escapes, log and continue. Outbox
-          // suppression must not be blocked by the rule engine.
+          // bug in the engine itself escapes, log and continue. The
+          // entry is already in `skipped`, so the worker simply
+          // returns.
           logger.error('Dedup rule executor crashed for outbox_about_to_skip', {
             outboxEntryId,
             bugReportId: entry.bug_report_id,
             error: error instanceof Error ? error.message : String(error),
           });
         }
-        await this.db.ticketOutbox.markSkipped(outboxEntryId, 'duplicate_of_set');
         return;
       }
 

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -25,6 +25,8 @@ import { getLogger } from '../../../logger.js';
 import type { DatabaseClient } from '../../../db/client.js';
 import type { BugReport } from '../../../db/types.js';
 import type { PluginRegistry } from '../../../integrations/plugin-registry.js';
+import { DedupRuleExecutor } from '../../../services/rules/executor.js';
+import { buildDedupRuleExecutor } from '../../../services/rules/wiring.js';
 import type { TicketCreationOutboxEntry } from '../../../db/repositories/ticket-creation-outbox.repository.js';
 
 const logger = getLogger();
@@ -40,11 +42,24 @@ export interface OutboxProcessorJobData {
  * Worker to process ticket creation outbox entries
  */
 export class TicketCreationOutboxProcessor {
+  // Lazy-built so tests that construct this processor with stub
+  // pluginRegistry / db don't have to also stub the rule engine. The
+  // first outbox_about_to_skip event in any process pays the (cheap)
+  // construction cost; subsequent events reuse the same executor.
+  private ruleExecutor: DedupRuleExecutor | null = null;
+
   constructor(
     private readonly db: DatabaseClient,
     private readonly pluginRegistry: PluginRegistry,
     private readonly queue?: Queue<OutboxProcessorJobData>
   ) {}
+
+  private getRuleExecutor(): DedupRuleExecutor {
+    if (!this.ruleExecutor) {
+      this.ruleExecutor = buildDedupRuleExecutor(this.db, this.pluginRegistry);
+    }
+    return this.ruleExecutor;
+  }
 
   /**
    * Process a single outbox entry (called by Bull queue)
@@ -110,6 +125,33 @@ export class TicketCreationOutboxProcessor {
           bugReportId: entry.bug_report_id,
           duplicateOf: bugReport.duplicate_of,
         });
+        // Fire the outbox_about_to_skip rule trigger BEFORE the
+        // markSkipped call so rules can react to the suppression (e.g.
+        // add a "+1 occurrence" comment to the canonical ticket, or
+        // auto-reopen a closed canonical). Awaiting is safe — the
+        // executor swallows action failures internally and only
+        // returns telemetry, so a slow Jira call cannot fail the
+        // outbox row's terminal state transition.
+        try {
+          const results = await this.getRuleExecutor().fire('outbox_about_to_skip', bugReport);
+          if (results.length > 0) {
+            logger.info('Dedup rules evaluated for outbox_about_to_skip', {
+              outboxEntryId,
+              bugReportId: entry.bug_report_id,
+              fired: results.filter((r) => r.fired).length,
+              total: results.length,
+            });
+          }
+        } catch (error) {
+          // Defensive: the executor wraps its own errors, but if a
+          // bug in the engine itself escapes, log and continue. Outbox
+          // suppression must not be blocked by the rule engine.
+          logger.error('Dedup rule executor crashed for outbox_about_to_skip', {
+            outboxEntryId,
+            bugReportId: entry.bug_report_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
         await this.db.ticketOutbox.markSkipped(outboxEntryId, 'duplicate_of_set');
         return;
       }

--- a/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
+++ b/packages/backend/src/queue/workers/outbox/ticket-creation-outbox.worker.ts
@@ -165,6 +165,11 @@ export class TicketCreationOutboxProcessor {
             outboxEntryId,
             bugReportId: entry.bug_report_id,
             error: error instanceof Error ? error.message : String(error),
+            // Stack trace mirrors the surrounding error-log pattern in
+            // this file — the executor wraps its own errors, so a
+            // throw reaching us means a genuine engine bug worth
+            // debugging from the trace.
+            stack: error instanceof Error ? error.stack : undefined,
           });
         }
         return;

--- a/packages/backend/src/services/rules/context-provider.ts
+++ b/packages/backend/src/services/rules/context-provider.ts
@@ -17,11 +17,26 @@ const logger = getLogger();
 export class DatabaseRuleContextProvider implements RuleContextProvider {
   constructor(private readonly db: DatabaseClient) {}
 
-  async loadCanonical(canonicalBugId: string): Promise<BugReport | null> {
-    return this.db.bugReports.findById(canonicalBugId);
+  async loadCanonical(canonicalBugId: string, projectId: string): Promise<BugReport | null> {
+    // Enforce the project scope in SQL — a stale `duplicate_of`
+    // referencing a foreign bug must return null rather than leak
+    // the foreign canonical into the rule context. `findById` alone
+    // would not do this; the SQL adds the AND project_id check.
+    const result = await this.db.getPool().query<BugReport>(
+      `SELECT * FROM application.bug_reports
+       WHERE id = $1
+         AND project_id = $2
+         AND deleted_at IS NULL`,
+      [canonicalBugId, projectId]
+    );
+    return result.rows[0] ?? null;
   }
 
-  async countHitsInWindow(canonicalBugId: string, window: string): Promise<number> {
+  async countHitsInWindow(
+    canonicalBugId: string,
+    projectId: string,
+    window: string
+  ): Promise<number> {
     const minutes = windowStringToMinutes(window);
     try {
       // Filter `deleted_at IS NULL` to match how the rest of the
@@ -30,13 +45,17 @@ export class DatabaseRuleContextProvider implements RuleContextProvider {
       // rule like `hits_in_window >= 10` can fire on a cluster whose
       // raw rows have been cleaned up — misfiring the loud-bug
       // suppression / auto-reopen actions.
+      //
+      // The `project_id = $3` clause scopes the count to the firing
+      // rule's tenant. Same defense-in-depth as loadCanonical.
       const result = await this.db.getPool().query<{ count: string }>(
         `SELECT COUNT(*)::text AS count
          FROM application.bug_reports
          WHERE duplicate_of = $1
+           AND project_id = $3
            AND deleted_at IS NULL
            AND created_at >= NOW() - ($2::int * INTERVAL '1 minute')`,
-        [canonicalBugId, minutes]
+        [canonicalBugId, minutes, projectId]
       );
       // pg returns COUNT(*) as a string to avoid precision loss on
       // very large counts — cast back to a number for the rule
@@ -45,6 +64,7 @@ export class DatabaseRuleContextProvider implements RuleContextProvider {
     } catch (error) {
       logger.warn('Failed to count hits in window, defaulting to 0', {
         canonicalBugId,
+        projectId,
         window,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/packages/backend/src/services/rules/context-provider.ts
+++ b/packages/backend/src/services/rules/context-provider.ts
@@ -32,6 +32,35 @@ export class DatabaseRuleContextProvider implements RuleContextProvider {
     return result.rows[0] ?? null;
   }
 
+  async loadReporterTier(organizationId: string | null): Promise<string | null> {
+    if (!organizationId) {
+      // Legacy bug reports without organization_id (pre-SaaS data) and
+      // selfhosted deployments (no `subscriptions` rows at all) both
+      // resolve to null. A condition like `reporter.customer.tier eq
+      // 'enterprise'` will fail closed.
+      return null;
+    }
+    try {
+      const result = await this.db.getPool().query<{ plan_name: string }>(
+        `SELECT plan_name
+         FROM saas.subscriptions
+         WHERE organization_id = $1
+         LIMIT 1`,
+        [organizationId]
+      );
+      return result.rows[0]?.plan_name ?? null;
+    } catch (error) {
+      // Common case in selfhosted: the `saas.subscriptions` table
+      // doesn't exist. Log at debug and fall through to null —
+      // tier-based rules simply never match in that mode.
+      logger.debug('Failed to load reporter tier, defaulting to null', {
+        organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
   async countHitsInWindow(
     canonicalBugId: string,
     projectId: string,

--- a/packages/backend/src/services/rules/context-provider.ts
+++ b/packages/backend/src/services/rules/context-provider.ts
@@ -41,10 +41,21 @@ export class DatabaseRuleContextProvider implements RuleContextProvider {
       return null;
     }
     try {
+      // Filter by live statuses only. `subscriptions` keeps rows
+      // around after cancellation (status values include 'canceled',
+      // 'past_due', 'paused', 'incomplete_expired' — see
+      // BILLING_STATUS in db/types.ts). Without this filter, a rule
+      // conditioned on `reporter.customer.tier eq 'enterprise'`
+      // would continue to fire for orgs that have cancelled or
+      // whose billing has lapsed, driving external API calls on
+      // behalf of non-paying tenants. Other readers in the codebase
+      // (e.g. saas/jobs/invoice-scheduler.job.ts) follow the same
+      // pattern with `BILLING_STATUS.ACTIVE`.
       const result = await this.db.getPool().query<{ plan_name: string }>(
         `SELECT plan_name
          FROM saas.subscriptions
          WHERE organization_id = $1
+           AND status IN ('active', 'trial')
          LIMIT 1`,
         [organizationId]
       );

--- a/packages/backend/src/services/rules/context-provider.ts
+++ b/packages/backend/src/services/rules/context-provider.ts
@@ -51,11 +51,20 @@ export class DatabaseRuleContextProvider implements RuleContextProvider {
       // behalf of non-paying tenants. Other readers in the codebase
       // (e.g. saas/jobs/invoice-scheduler.job.ts) follow the same
       // pattern with `BILLING_STATUS.ACTIVE`.
+      // `subscriptions.organization_id` has a UNIQUE constraint
+      // (migration 001), so at most one row matches per org and the
+      // LIMIT 1 is theoretically redundant. The explicit
+      // `ORDER BY created_at DESC` is defense-in-depth against a
+      // future schema change that drops the UNIQUE — if multiple
+      // matching rows ever appear, we deterministically pick the
+      // most recent one rather than getting whichever Postgres
+      // happens to return.
       const result = await this.db.getPool().query<{ plan_name: string }>(
         `SELECT plan_name
          FROM saas.subscriptions
          WHERE organization_id = $1
            AND status IN ('active', 'trial')
+         ORDER BY created_at DESC
          LIMIT 1`,
         [organizationId]
       );

--- a/packages/backend/src/services/rules/context-provider.ts
+++ b/packages/backend/src/services/rules/context-provider.ts
@@ -1,0 +1,47 @@
+/**
+ * Production `RuleContextProvider` — looks up the canonical bug and
+ * computes windowed hit counts directly from `application.bug_reports`.
+ *
+ * Kept separate from the executor so unit tests can swap a stub
+ * provider in without touching the DB.
+ */
+
+import type { DatabaseClient } from '../../db/client.js';
+import type { BugReport } from '../../db/types.js';
+import { getLogger } from '../../logger.js';
+import type { RuleContextProvider } from './executor.js';
+import { windowStringToMinutes } from './rate-limiter.js';
+
+const logger = getLogger();
+
+export class DatabaseRuleContextProvider implements RuleContextProvider {
+  constructor(private readonly db: DatabaseClient) {}
+
+  async loadCanonical(canonicalBugId: string): Promise<BugReport | null> {
+    return this.db.bugReports.findById(canonicalBugId);
+  }
+
+  async countHitsInWindow(canonicalBugId: string, window: string): Promise<number> {
+    const minutes = windowStringToMinutes(window);
+    try {
+      const result = await this.db.getPool().query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count
+         FROM application.bug_reports
+         WHERE duplicate_of = $1
+           AND created_at >= NOW() - ($2::int * INTERVAL '1 minute')`,
+        [canonicalBugId, minutes]
+      );
+      // pg returns COUNT(*) as a string to avoid precision loss on
+      // very large counts — cast back to a number for the rule
+      // engine's numeric comparisons.
+      return Number.parseInt(result.rows[0]?.count ?? '0', 10);
+    } catch (error) {
+      logger.warn('Failed to count hits in window, defaulting to 0', {
+        canonicalBugId,
+        window,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return 0;
+    }
+  }
+}

--- a/packages/backend/src/services/rules/context-provider.ts
+++ b/packages/backend/src/services/rules/context-provider.ts
@@ -24,10 +24,17 @@ export class DatabaseRuleContextProvider implements RuleContextProvider {
   async countHitsInWindow(canonicalBugId: string, window: string): Promise<number> {
     const minutes = windowStringToMinutes(window);
     try {
+      // Filter `deleted_at IS NULL` to match how the rest of the
+      // codebase reads `bug_reports` (see bug-report.repository.ts).
+      // Without this, soft-deleted duplicates inflate the count, so a
+      // rule like `hits_in_window >= 10` can fire on a cluster whose
+      // raw rows have been cleaned up — misfiring the loud-bug
+      // suppression / auto-reopen actions.
       const result = await this.db.getPool().query<{ count: string }>(
         `SELECT COUNT(*)::text AS count
          FROM application.bug_reports
          WHERE duplicate_of = $1
+           AND deleted_at IS NULL
            AND created_at >= NOW() - ($2::int * INTERVAL '1 minute')`,
         [canonicalBugId, minutes]
       );

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -221,11 +221,20 @@ export class TicketsTableResolver implements CanonicalTicketResolver {
       project_id: string;
       integration_id: string | null;
     }>(
+      // Filter `br.deleted_at IS NULL` — without it, the resolver
+      // bypasses the soft-delete guard that `loadCanonical` applies in
+      // the context provider. When `context.canonical` is null because
+      // the canonical was soft-deleted, the dispatcher's fallback to
+      // `bugReport.duplicate_of` would otherwise reach this SQL and
+      // happily resolve the soft-deleted canonical's external ticket,
+      // letting the engine post comments / transitions to a ticket an
+      // admin has just retired.
       `SELECT t.external_id, br.project_id, t.integration_id
        FROM application.tickets t
        JOIN application.bug_reports br ON br.id = t.bug_report_id
        WHERE t.bug_report_id = $1
          AND br.project_id = $2
+         AND br.deleted_at IS NULL
          AND t.integration_id IS NOT NULL
        ORDER BY t.created_at DESC
        LIMIT 1`,

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -1,0 +1,203 @@
+/**
+ * Action dispatcher for the dedup-rule engine (PR-C slice).
+ *
+ * Routes `ticket.add_comment` and `ticket.transition` actions to the
+ * platform-neutral capability interface introduced in PR #142.
+ * `notify.email` / `notify.slack` / `notify.webhook` log a one-shot
+ * info message and skip — those land in PR-C2 (email), PR-D (slack /
+ * webhook), so they're recognised by the schema but no-op at runtime.
+ *
+ * The dispatcher takes its dependencies via constructor so the
+ * executor stays unit-testable: tests inject a stub
+ * `TicketIntegrationCapabilities` instance instead of the real
+ * Jira/Linear service.
+ */
+
+import type { DatabaseClient } from '../../db/client.js';
+import type {
+  TicketIntegrationCapabilities,
+  CapabilityTarget,
+} from '../../integrations/capabilities.js';
+import { pluginSupports } from '../../integrations/capabilities.js';
+import type { ActionSpec } from '../../integrations/dedup-rule.schema.js';
+import { getLogger } from '../../logger.js';
+import type { ActionDispatcher, RuleEvalContext } from './types.js';
+
+const logger = getLogger();
+
+/**
+ * Resolves the canonical bug's external ticket coordinates so a
+ * ticket.* action knows what to address. The minimal lookup the
+ * dispatcher needs: (externalId, projectId, integrationId) — see
+ * `CapabilityTarget`.
+ */
+export interface CanonicalTicketResolver {
+  resolve(canonicalBugId: string): Promise<CapabilityTarget | null>;
+}
+
+/**
+ * Factory that returns a ticket-capability service for the given
+ * (project, integration) pair, or null if the integration is not
+ * usable (disabled / missing / wrong project — all reasons live in
+ * the underlying `IntegrationPluginRegistry`). The dispatcher uses
+ * this rather than reaching into the plugin registry directly so the
+ * tests can stub a single function.
+ */
+export type CapabilityServiceLookup = (
+  integrationId: string,
+  projectId: string
+) => Promise<TicketIntegrationCapabilities | null>;
+
+export class DefaultActionDispatcher implements ActionDispatcher {
+  constructor(
+    private readonly resolver: CanonicalTicketResolver,
+    private readonly lookupService: CapabilityServiceLookup
+  ) {}
+
+  async dispatch(context: RuleEvalContext, action: ActionSpec): Promise<boolean> {
+    switch (action.type) {
+      case 'ticket.add_comment':
+        return this.dispatchTicketAddComment(context, action.body);
+      case 'ticket.transition':
+        return this.dispatchTicketTransition(context, action.to);
+      case 'notify.email':
+      case 'notify.slack':
+      case 'notify.webhook':
+        // Recognised but not yet wired — log once at info so deploys
+        // running with a seeded rule of this shape don't look broken,
+        // but we don't spam the error stream.
+        logger.info('Rule action type not yet implemented, skipping', {
+          actionType: action.type,
+          bugReportId: context.bugReport.id,
+        });
+        return false;
+      default: {
+        // Exhaustiveness check — if a new ActionSpec variant is added
+        // to the schema and not handled here, the assignment fails to
+        // typecheck.
+        const _exhaustive: never = action;
+        void _exhaustive;
+        return false;
+      }
+    }
+  }
+
+  private async dispatchTicketAddComment(context: RuleEvalContext, body: string): Promise<boolean> {
+    const target = await this.resolveTarget(context);
+    if (!target) {
+      return false;
+    }
+    const service = await this.lookupService(target.integrationId, target.projectId);
+    if (!pluginSupports(service, 'addComment')) {
+      logger.info('Skipping ticket.add_comment: integration does not support addComment', {
+        integrationId: target.integrationId,
+        bugReportId: context.bugReport.id,
+      });
+      return false;
+    }
+    try {
+      // `pluginSupports` proved the method exists; the cast is the
+      // narrowest way to satisfy the optional-method signature.
+      await service!.addComment!(target, body);
+      return true;
+    } catch (error) {
+      logger.error('ticket.add_comment dispatch failed', {
+        integrationId: target.integrationId,
+        bugReportId: context.bugReport.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
+  private async dispatchTicketTransition(
+    context: RuleEvalContext,
+    to: 'open' | 'in_progress' | 'closed' | 'wont_fix'
+  ): Promise<boolean> {
+    const target = await this.resolveTarget(context);
+    if (!target) {
+      return false;
+    }
+    const service = await this.lookupService(target.integrationId, target.projectId);
+    if (!pluginSupports(service, 'transition')) {
+      logger.info('Skipping ticket.transition: integration does not support transition', {
+        integrationId: target.integrationId,
+        bugReportId: context.bugReport.id,
+      });
+      return false;
+    }
+    try {
+      await service!.transition!(target, to);
+      return true;
+    } catch (error) {
+      logger.error('ticket.transition dispatch failed', {
+        integrationId: target.integrationId,
+        bugReportId: context.bugReport.id,
+        targetStatus: to,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
+  private async resolveTarget(context: RuleEvalContext): Promise<CapabilityTarget | null> {
+    const canonicalId = context.canonical?.id ?? context.bugReport.duplicate_of;
+    if (!canonicalId) {
+      // No canonical -> no external ticket to act on. Common for
+      // duplicate_detected events where the canonical was hard-deleted
+      // between the dedup decision and our handler firing.
+      logger.debug('Skipping ticket action: no canonical to resolve', {
+        bugReportId: context.bugReport.id,
+      });
+      return null;
+    }
+    const target = await this.resolver.resolve(canonicalId);
+    if (!target) {
+      // Canonical exists but has no external ticket on file — likely
+      // dedup-suppressed its own outbox row before any ticket was
+      // filed. Log at debug; not an error.
+      logger.debug('Skipping ticket action: canonical has no external ticket', {
+        canonicalId,
+        bugReportId: context.bugReport.id,
+      });
+      return null;
+    }
+    return target;
+  }
+}
+
+/**
+ * Production `CanonicalTicketResolver` backed by the `tickets` table.
+ * Picks the most-recent ticket if the canonical has more than one
+ * (rare but possible: two integrations file in parallel before the
+ * pre-file dedup grace lands).
+ */
+export class TicketsTableResolver implements CanonicalTicketResolver {
+  constructor(private readonly db: DatabaseClient) {}
+
+  async resolve(canonicalBugId: string): Promise<CapabilityTarget | null> {
+    const result = await this.db.getPool().query<{
+      external_id: string;
+      project_id: string;
+      integration_id: string | null;
+    }>(
+      `SELECT t.external_id, br.project_id, t.integration_id
+       FROM application.tickets t
+       JOIN application.bug_reports br ON br.id = t.bug_report_id
+       WHERE t.bug_report_id = $1
+         AND t.integration_id IS NOT NULL
+       ORDER BY t.created_at DESC
+       LIMIT 1`,
+      [canonicalBugId]
+    );
+    const row = result.rows[0];
+    if (!row || !row.integration_id) {
+      return null;
+    }
+    return {
+      externalId: row.external_id,
+      projectId: row.project_id,
+      integrationId: row.integration_id,
+    };
+  }
+}

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -62,6 +62,30 @@ export class DefaultActionDispatcher implements ActionDispatcher {
     private readonly lookupService: CapabilityServiceLookup
   ) {}
 
+  /**
+   * Synchronous capability probe — used by the executor to skip
+   * rules whose actions can't run yet, so the rate-limit slot
+   * isn't consumed for zero work. Keep in sync with `dispatch` below.
+   */
+  canDispatch(action: ActionSpec): boolean {
+    switch (action.type) {
+      case 'ticket.add_comment':
+      case 'ticket.transition':
+        return true;
+      case 'notify.email':
+      case 'notify.slack':
+      case 'notify.webhook':
+        // PR-C2 (email) + PR-D (slack / webhook) flip these to true
+        // as the wiring lands.
+        return false;
+      default: {
+        const _exhaustive: never = action;
+        void _exhaustive;
+        return false;
+      }
+    }
+  }
+
   async dispatch(context: RuleEvalContext, action: ActionSpec): Promise<boolean> {
     switch (action.type) {
       case 'ticket.add_comment':

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -30,9 +30,17 @@ const logger = getLogger();
  * ticket.* action knows what to address. The minimal lookup the
  * dispatcher needs: (externalId, projectId, integrationId) — see
  * `CapabilityTarget`.
+ *
+ * Takes `expectedProjectId` and is responsible for verifying that the
+ * resolved ticket belongs to it. `bug_reports.id` is a globally-unique
+ * UUID, so a cross-project collision shouldn't happen in normal
+ * operation; the scope check is defense-in-depth against a stale rule
+ * pointing at a bug that was moved/recreated under another project.
+ * Returning `null` on mismatch is the safe behaviour — the dispatcher
+ * skips the action rather than acting on the wrong tenant's ticket.
  */
 export interface CanonicalTicketResolver {
-  resolve(canonicalBugId: string): Promise<CapabilityTarget | null>;
+  resolve(canonicalBugId: string, expectedProjectId: string): Promise<CapabilityTarget | null>;
 }
 
 /**
@@ -151,7 +159,10 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       });
       return null;
     }
-    const target = await this.resolver.resolve(canonicalId);
+    // Scope the resolution to the firing rule's project. The resolver
+    // returns null if the canonical's project doesn't match — a stale
+    // rule must never act on another tenant's ticket.
+    const target = await this.resolver.resolve(canonicalId, context.projectId);
     if (!target) {
       // Canonical exists but has no external ticket on file — likely
       // dedup-suppressed its own outbox row before any ticket was
@@ -170,12 +181,17 @@ export class DefaultActionDispatcher implements ActionDispatcher {
  * Production `CanonicalTicketResolver` backed by the `tickets` table.
  * Picks the most-recent ticket if the canonical has more than one
  * (rare but possible: two integrations file in parallel before the
- * pre-file dedup grace lands).
+ * pre-file dedup grace lands). The `expectedProjectId` is enforced in
+ * the SQL `WHERE` so a cross-project hit returns zero rows rather
+ * than leaking a ticket into the wrong tenant's action.
  */
 export class TicketsTableResolver implements CanonicalTicketResolver {
   constructor(private readonly db: DatabaseClient) {}
 
-  async resolve(canonicalBugId: string): Promise<CapabilityTarget | null> {
+  async resolve(
+    canonicalBugId: string,
+    expectedProjectId: string
+  ): Promise<CapabilityTarget | null> {
     const result = await this.db.getPool().query<{
       external_id: string;
       project_id: string;
@@ -185,10 +201,11 @@ export class TicketsTableResolver implements CanonicalTicketResolver {
        FROM application.tickets t
        JOIN application.bug_reports br ON br.id = t.bug_report_id
        WHERE t.bug_report_id = $1
+         AND br.project_id = $2
          AND t.integration_id IS NOT NULL
        ORDER BY t.created_at DESC
        LIMIT 1`,
-      [canonicalBugId]
+      [canonicalBugId, expectedProjectId]
     );
     const row = result.rows[0];
     if (!row || !row.integration_id) {

--- a/packages/backend/src/services/rules/evaluator.ts
+++ b/packages/backend/src/services/rules/evaluator.ts
@@ -20,6 +20,21 @@ import type { ConditionSpec } from '../../integrations/dedup-rule.schema.js';
 import type { RuleEvalContext } from './types.js';
 
 /**
+ * Build the key under which a condition's resolved value lives in
+ * `RuleEvalContext.resolved`. For `hits_in_window` the key includes
+ * the window so two conditions on the same field with different
+ * windows ("1h" vs "24h") get independent values. All other fields
+ * use the raw field name. Exported so the executor uses identical
+ * keying on the resolve side.
+ */
+export function resolutionKey(field: string, window: string | null | undefined): string {
+  if (field === 'hits_in_window') {
+    return `hits_in_window:${window ?? '24h'}`;
+  }
+  return field;
+}
+
+/**
  * Returns true iff every condition is satisfied. Empty conditions
  * array means "no conditions" → always true. Order doesn't matter
  * for AND.
@@ -34,13 +49,19 @@ export function evaluateConditions(context: RuleEvalContext, conditions: Conditi
 }
 
 function evaluateOne(context: RuleEvalContext, condition: ConditionSpec): boolean {
+  // `hits_in_window` is parameterised by the window, so two conditions
+  // on the same field with different windows must NOT collide in the
+  // cache. The executor uses the same composite key when populating
+  // the map; keep these in lockstep.
+  const cacheKey = resolutionKey(condition.field, condition.window);
+
   // Field was never resolved -> bug in the executor. Fail closed (treat
   // as unsatisfied) rather than throw, so one malformed rule can't
   // cascade and break the trigger handler for the other rules.
-  if (!context.resolved.has(condition.field)) {
+  if (!context.resolved.has(cacheKey)) {
     return false;
   }
-  const actual = context.resolved.get(condition.field);
+  const actual = context.resolved.get(cacheKey);
 
   // `null` resolved means "this field is absent in this context"
   // (e.g. `canonical.status` when canonical was hard-deleted). For

--- a/packages/backend/src/services/rules/evaluator.ts
+++ b/packages/backend/src/services/rules/evaluator.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure condition evaluator for the dedup-rule engine.
+ *
+ * Takes a parsed DedupRule's `conditions` array and a RuleEvalContext
+ * with already-resolved field values, and decides whether all
+ * conditions are satisfied (AND semantics). No DB, no I/O — keeping
+ * this pure lets the bulk of rule-engine logic stay covered by unit
+ * tests without testcontainers.
+ *
+ * Field resolution (looking up `canonical.status`, `hits_in_window`,
+ * etc.) happens in the executor BEFORE calling this. The map of
+ * resolved values is passed in via `context.resolved`. A missing key
+ * means the executor hasn't asked for that field — should never
+ * happen if `resolveContextFields` is called first; we treat it as a
+ * false condition rather than crash, so a buggy executor doesn't take
+ * down the entire dedup pipeline.
+ */
+
+import type { ConditionSpec } from '../../integrations/dedup-rule.schema.js';
+import type { RuleEvalContext } from './types.js';
+
+/**
+ * Returns true iff every condition is satisfied. Empty conditions
+ * array means "no conditions" → always true. Order doesn't matter
+ * for AND.
+ */
+export function evaluateConditions(context: RuleEvalContext, conditions: ConditionSpec[]): boolean {
+  for (const c of conditions) {
+    if (!evaluateOne(context, c)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function evaluateOne(context: RuleEvalContext, condition: ConditionSpec): boolean {
+  // Field was never resolved -> bug in the executor. Fail closed (treat
+  // as unsatisfied) rather than throw, so one malformed rule can't
+  // cascade and break the trigger handler for the other rules.
+  if (!context.resolved.has(condition.field)) {
+    return false;
+  }
+  const actual = context.resolved.get(condition.field);
+
+  // `null` resolved means "this field is absent in this context"
+  // (e.g. `canonical.status` when canonical was hard-deleted). For
+  // every op, treat absent as not-matching — conservative but
+  // predictable.
+  if (actual === null || actual === undefined) {
+    return false;
+  }
+
+  switch (condition.op) {
+    case 'eq':
+      return actual === condition.value;
+    case 'in':
+      return Array.isArray(condition.value) && condition.value.includes(actual);
+    case 'not_in':
+      return Array.isArray(condition.value) && !condition.value.includes(actual);
+    case 'gte':
+      return (
+        typeof actual === 'number' &&
+        typeof condition.value === 'number' &&
+        actual >= condition.value
+      );
+    case 'lte':
+      return (
+        typeof actual === 'number' &&
+        typeof condition.value === 'number' &&
+        actual <= condition.value
+      );
+    default: {
+      // Exhaustiveness check — if a new op is added to the schema and
+      // not handled here, TypeScript will flag the assignment below.
+      const _exhaustive: never = condition.op;
+      void _exhaustive;
+      return false;
+    }
+  }
+}

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -56,10 +56,20 @@ const logger = getLogger();
  * interface so tests can stub the DB-touching parts.
  */
 export interface RuleContextProvider {
-  /** Fetch the canonical bug (the one `duplicate_of` points at), or null. */
-  loadCanonical(canonicalBugId: string): Promise<BugReport | null>;
-  /** Count bugs whose `duplicate_of` is `canonicalBugId` within the window. */
-  countHitsInWindow(canonicalBugId: string, window: string): Promise<number>;
+  /**
+   * Fetch the canonical bug (the one `duplicate_of` points at), or null.
+   * Scoped by `projectId` — defense-in-depth so a stale `duplicate_of`
+   * pointing at a bug in a different project (shouldn't happen for
+   * globally-unique UUIDs, but a tampered row could) returns null
+   * rather than leaking the foreign canonical.
+   */
+  loadCanonical(canonicalBugId: string, projectId: string): Promise<BugReport | null>;
+  /**
+   * Count bugs whose `duplicate_of` is `canonicalBugId` within the
+   * window. Scoped by `projectId` for the same reason as
+   * `loadCanonical`.
+   */
+  countHitsInWindow(canonicalBugId: string, projectId: string, window: string): Promise<number>;
 }
 
 export class DedupRuleExecutor {
@@ -140,7 +150,10 @@ export class DedupRuleExecutor {
       if (!canonicalLoaded && this.needsCanonical(rule)) {
         if (bugReport.duplicate_of) {
           try {
-            evalContext.canonical = await this.context.loadCanonical(bugReport.duplicate_of);
+            evalContext.canonical = await this.context.loadCanonical(
+              bugReport.duplicate_of,
+              bugReport.project_id
+            );
           } catch (error) {
             logger.warn('Rule executor: canonical lookup failed', {
               ruleId: row.id,
@@ -296,7 +309,7 @@ export class DedupRuleExecutor {
             const w = cond.window ?? '24h';
             context.resolved.set(
               key,
-              await this.context.countHitsInWindow(context.canonical.id, w)
+              await this.context.countHitsInWindow(context.canonical.id, context.projectId, w)
             );
           } else {
             context.resolved.set(key, null);

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -180,10 +180,14 @@ export class DedupRuleExecutor {
         continue;
       }
 
-      // Rate limit applies per (rule, canonical) pair. When there's no
-      // canonical we fall back to the bug report's own id so the limit
-      // still has a stable key.
-      const limitKey = evalContext.canonical?.id ?? bugReport.id;
+      // Rate limit applies per (rule, canonical) pair. Prefer
+      // `canonical.id`; fall back to `bugReport.duplicate_of` (the same
+      // cluster identifier the dedup pipeline used to set
+      // `duplicate_of`), and only last to `bugReport.id`. Using the
+      // bug's own id as the primary fallback would make every retry /
+      // every new duplicate get a fresh throttle key — disabling the
+      // rate limit exactly when defense-in-depth matters most.
+      const limitKey = evalContext.canonical?.id ?? bugReport.duplicate_of ?? bugReport.id;
       const allowed = await this.rateLimiter.shouldFire(row.id, limitKey, rule);
       if (!allowed) {
         results.push({

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -6,11 +6,16 @@
  * limit, then dispatches each action through the injected
  * `ActionDispatcher`. Returns telemetry for the caller to log.
  *
- * Fire-and-forget at the call site: callers (the dedup service, the
- * outbox worker) invoke `fire(...)` without awaiting on the
- * dispatch — we don't want a slow Jira call to back up the dedup
- * pipeline. Errors inside the executor are caught and logged; nothing
- * propagates back to the trigger handler.
+ * **Error containment, not fire-and-forget.** Callers (the outbox
+ * worker, eventually the dedup service) DO await `fire(...)` — the
+ * trigger handler runs at a point where awaiting is safe (already
+ * inside a BullMQ job, no user request blocked on it). The executor's
+ * job is to make sure nothing it does propagates back: rule load
+ * errors return `[]`, individual action dispatch failures are caught
+ * inside the dispatcher and logged, malformed `rule_json` is reported
+ * as `evaluation_error` and other rules continue. The caller can
+ * safely await without writing its own try/catch (though the outbox
+ * worker wraps one anyway as defense-in-depth).
  *
  * Architectural choices worth flagging:
  *  - The executor talks to `DedupRuleRepository` (rule storage from
@@ -21,12 +26,12 @@
  *  - Rule blobs are validated through `parseDedupRule` (Zod). Validation
  *    errors get logged and the rule is skipped — one malformed rule
  *    must not poison the others on the same trigger.
- *  - Only `duplicate_detected` and `outbox_about_to_skip` are wired in
- *    this PR. Schedule-based and cluster-growing triggers are valid at
- *    the schema level but require a cron worker / aggregator — they
- *    fire from different entry points (a BullMQ job, a counter
- *    flush). The executor's design accommodates them; the wiring lands
- *    in a follow-up.
+ *  - Only `outbox_about_to_skip` is wired in this PR (`duplicate_detected`
+ *    lands with the email handler in PR-C2). Schedule-based and
+ *    cluster-growing triggers are valid at the schema level but require
+ *    a cron worker / aggregator — they fire from different entry points
+ *    (a BullMQ job, a counter flush). The executor's design accommodates
+ *    them; the wiring lands in follow-ups.
  */
 
 import type { DedupRuleRepository } from '../../db/dedup-rule.repository.js';
@@ -34,7 +39,7 @@ import type { BugReport } from '../../db/types.js';
 import type { DedupRule } from '../../integrations/dedup-rule.schema.js';
 import { parseDedupRule } from '../../integrations/dedup-rule.schema.js';
 import { getLogger } from '../../logger.js';
-import { evaluateConditions } from './evaluator.js';
+import { evaluateConditions, resolutionKey } from './evaluator.js';
 import type {
   ActionDispatcher,
   RuleEvalContext,
@@ -232,15 +237,21 @@ export class DedupRuleExecutor {
 
   private async resolveFields(context: RuleEvalContext, rule: DedupRule): Promise<void> {
     for (const cond of rule.conditions) {
-      if (context.resolved.has(cond.field)) {
+      // Composite key for `hits_in_window` (field + window) so a rule
+      // with two conditions on different windows resolves both. All
+      // other fields key on the field name alone. `resolutionKey`
+      // owns the keying logic so the evaluator's lookup stays
+      // consistent.
+      const key = resolutionKey(cond.field, cond.window);
+      if (context.resolved.has(key)) {
         continue;
       }
       switch (cond.field) {
         case 'canonical.status':
-          context.resolved.set('canonical.status', mapStatusToCanonical(context.canonical));
+          context.resolved.set(key, mapStatusToCanonical(context.canonical));
           break;
         case 'canonical.closed_days_ago':
-          context.resolved.set('canonical.closed_days_ago', daysSinceUpdate(context.canonical));
+          context.resolved.set(key, daysSinceUpdate(context.canonical));
           break;
         case 'hits_in_window':
           // `cond.window` is guaranteed non-empty by the schema's
@@ -250,16 +261,16 @@ export class DedupRuleExecutor {
           if (context.canonical) {
             const w = cond.window ?? '24h';
             context.resolved.set(
-              'hits_in_window',
+              key,
               await this.context.countHitsInWindow(context.canonical.id, w)
             );
           } else {
-            context.resolved.set('hits_in_window', null);
+            context.resolved.set(key, null);
           }
           break;
         case 'reporter.customer.tier': {
           const tier = readPath(context.bugReport.metadata, ['user', 'tier']);
-          context.resolved.set('reporter.customer.tier', tier);
+          context.resolved.set(key, tier);
           break;
         }
         case 'severity':
@@ -267,13 +278,13 @@ export class DedupRuleExecutor {
           // same axis from the dedup rule's perspective. Mapping kept
           // simple (1:1) until product introduces a separate severity
           // field.
-          context.resolved.set('severity', context.bugReport.priority);
+          context.resolved.set(key, context.bugReport.priority);
           break;
         default: {
           // Exhaustiveness check on the closed field literal.
           const _exhaustive: never = cond.field;
           void _exhaustive;
-          context.resolved.set(cond.field, null);
+          context.resolved.set(key, null);
         }
       }
     }

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -70,6 +70,15 @@ export interface RuleContextProvider {
    * `loadCanonical`.
    */
   countHitsInWindow(canonicalBugId: string, projectId: string, window: string): Promise<number>;
+  /**
+   * Resolve the customer tier for the bug report's owning
+   * organization. Sourced from `subscriptions.plan_name` — NOT from
+   * SDK-supplied `bug_reports.metadata`, which would let any reporter
+   * spoof "enterprise". Returns null when the bug has no
+   * organization_id (legacy / selfhosted) or there's no subscription
+   * row.
+   */
+  loadReporterTier(organizationId: string | null): Promise<string | null>;
 }
 
 export class DedupRuleExecutor {
@@ -198,6 +207,24 @@ export class DedupRuleExecutor {
         continue;
       }
 
+      // Pre-flight: skip the rule entirely if the dispatcher can't
+      // handle ANY of its actions. This avoids consuming a rate-limit
+      // slot for a rule whose only actions are not-yet-wired (e.g. an
+      // all-`notify.slack` rule before PR-D lands). Without this, the
+      // throttle window burns out for zero actual work and future
+      // legitimate fires get blocked.
+      const dispatchableActions = rule.then.filter((a) => this.dispatcher.canDispatch(a));
+      if (dispatchableActions.length === 0) {
+        results.push({
+          ruleId: row.id,
+          fired: false,
+          skipReason: 'no_supported_actions',
+          actionsDispatched: 0,
+          actionsSkipped: rule.then.length,
+        });
+        continue;
+      }
+
       // Rate limit applies per (rule, canonical) pair. Prefer
       // `canonical.id`; fall back to `bugReport.duplicate_of` (the same
       // cluster identifier the dedup pipeline used to set
@@ -298,7 +325,7 @@ export class DedupRuleExecutor {
           context.resolved.set(key, mapStatusToCanonical(context.canonical));
           break;
         case 'canonical.closed_days_ago':
-          context.resolved.set(key, daysSinceUpdate(context.canonical));
+          context.resolved.set(key, daysSinceClose(context.canonical));
           break;
         case 'hits_in_window':
           // `cond.window` is guaranteed non-empty by the schema's
@@ -316,7 +343,15 @@ export class DedupRuleExecutor {
           }
           break;
         case 'reporter.customer.tier': {
-          const tier = readPath(context.bugReport.metadata, ['user', 'tier']);
+          // Source from `subscriptions.plan_name` via the provider —
+          // NOT from `bug_reports.metadata`, which is SDK-supplied
+          // and would let any reporter set tier='enterprise'. The
+          // bug's owning org may be null in selfhosted / legacy
+          // data, in which case the tier resolves to null and the
+          // condition fails closed.
+          const tier = await this.context.loadReporterTier(
+            context.bugReport.organization_id ?? null
+          );
           context.resolved.set(key, tier);
           break;
         }
@@ -370,9 +405,25 @@ function mapStatusToCanonical(canonical: BugReport | null): string | null {
   }
 }
 
-/** Whole days since the canonical's `updated_at` (proxy for "closed at"). */
-function daysSinceUpdate(canonical: BugReport | null): number | null {
+/**
+ * Whole days since the canonical was last touched, but ONLY if the
+ * canonical is in a closed-ish status. Returns null for open / in-
+ * progress canonicals so a rule like `canonical.closed_days_ago >= 7`
+ * doesn't misfire on an open ticket that's simply been quiet for a
+ * week. The evaluator treats null as "fail closed".
+ *
+ * `updated_at` is the closest proxy for "closed at" we have today —
+ * `bug_reports` doesn't carry a dedicated closure timestamp. The
+ * status gate makes this approximation safe: an ascended-then-closed
+ * canonical's updated_at refers to the closure, and any subsequent
+ * activity that bumps updated_at (e.g. an admin re-opening) also
+ * moves the canonical out of `closed`, which falls back to null.
+ */
+function daysSinceClose(canonical: BugReport | null): number | null {
   if (!canonical) {
+    return null;
+  }
+  if (canonical.status !== 'closed' && canonical.status !== 'resolved') {
     return null;
   }
   const updated =
@@ -382,16 +433,4 @@ function daysSinceUpdate(canonical: BugReport | null): number | null {
   // gte/lte comparisons. Treat "future" timestamps as "just now".
   const elapsedMs = Math.max(0, Date.now() - updated.getTime());
   return Math.floor(elapsedMs / (1000 * 60 * 60 * 24));
-}
-
-/** Safe traversal of an unknown object by a dotted-path-equivalent array. */
-function readPath(obj: unknown, path: string[]): unknown {
-  let cur: unknown = obj;
-  for (const key of path) {
-    if (cur === null || cur === undefined || typeof cur !== 'object') {
-      return null;
-    }
-    cur = (cur as Record<string, unknown>)[key];
-  }
-  return cur ?? null;
 }

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -79,7 +79,12 @@ export class DedupRuleExecutor {
   async fire(trigger: TriggerType, bugReport: BugReport): Promise<RuleFireResult[]> {
     let candidateRules;
     try {
-      candidateRules = await this.repo.findByProject(bugReport.project_id, false);
+      // The second arg is `includeDisabled` — `false` means the
+      // repository's SQL filters with `AND enabled = true` and only
+      // enabled rows come back. The naming is easy to misread as
+      // "skip enabled rules"; spelling out the intent here.
+      const includeDisabled = false;
+      candidateRules = await this.repo.findByProject(bugReport.project_id, includeDisabled);
     } catch (error) {
       logger.error('Rule executor: failed to load rules', {
         projectId: bugReport.project_id,

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -359,7 +359,10 @@ function daysSinceUpdate(canonical: BugReport | null): number | null {
   }
   const updated =
     canonical.updated_at instanceof Date ? canonical.updated_at : new Date(canonical.updated_at);
-  const elapsedMs = Date.now() - updated.getTime();
+  // Clamp to 0 — if the DB clock is slightly ahead of the app clock,
+  // `Date.now() - updated.getTime()` can be negative and would flip
+  // gte/lte comparisons. Treat "future" timestamps as "just now".
+  const elapsedMs = Math.max(0, Date.now() - updated.getTime());
   return Math.floor(elapsedMs / (1000 * 60 * 60 * 24));
 }
 

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -188,29 +188,54 @@ export class DedupRuleExecutor {
       // every new duplicate get a fresh throttle key — disabling the
       // rate limit exactly when defense-in-depth matters most.
       const limitKey = evalContext.canonical?.id ?? bugReport.duplicate_of ?? bugReport.id;
-      const allowed = await this.rateLimiter.shouldFire(row.id, limitKey, rule);
-      if (!allowed) {
+
+      // Wrap the rate-limit + dispatch path in a per-rule try/catch.
+      // The dispatcher already swallows its own action failures, and
+      // ThrottleBackedRateLimiter shouldn't throw — but a custom
+      // implementation (or a DB hiccup the limiter doesn't catch)
+      // would otherwise propagate up and abort every remaining rule
+      // in this fire. The documented error-containment contract says
+      // that must not happen.
+      let dispatched = 0;
+      let skipped = 0;
+      try {
+        const allowed = await this.rateLimiter.shouldFire(row.id, limitKey, rule);
+        if (!allowed) {
+          results.push({
+            ruleId: row.id,
+            fired: false,
+            skipReason: 'rate_limited',
+            actionsDispatched: 0,
+            actionsSkipped: 0,
+          });
+          continue;
+        }
+
+        for (const action of rule.then) {
+          const ok = await this.dispatcher.dispatch(evalContext, action);
+          if (ok) {
+            dispatched += 1;
+          } else {
+            skipped += 1;
+          }
+        }
+        await this.rateLimiter.recordFire(row.id, limitKey, rule);
+      } catch (error) {
+        logger.error('Rule executor: rate-limit/dispatch path crashed for rule', {
+          ruleId: row.id,
+          projectId: bugReport.project_id,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        });
         results.push({
           ruleId: row.id,
           fired: false,
-          skipReason: 'rate_limited',
-          actionsDispatched: 0,
-          actionsSkipped: 0,
+          skipReason: 'dispatch_error',
+          actionsDispatched: dispatched,
+          actionsSkipped: skipped,
         });
         continue;
       }
-
-      let dispatched = 0;
-      let skipped = 0;
-      for (const action of rule.then) {
-        const ok = await this.dispatcher.dispatch(evalContext, action);
-        if (ok) {
-          dispatched += 1;
-        } else {
-          skipped += 1;
-        }
-      }
-      await this.rateLimiter.recordFire(row.id, limitKey, rule);
 
       results.push({
         ruleId: row.id,

--- a/packages/backend/src/services/rules/executor.ts
+++ b/packages/backend/src/services/rules/executor.ts
@@ -1,0 +1,336 @@
+/**
+ * Dedup-rule executor.
+ *
+ * Loads enabled rules for the firing project, filters by trigger type,
+ * builds an evaluation context, evaluates conditions, checks rate
+ * limit, then dispatches each action through the injected
+ * `ActionDispatcher`. Returns telemetry for the caller to log.
+ *
+ * Fire-and-forget at the call site: callers (the dedup service, the
+ * outbox worker) invoke `fire(...)` without awaiting on the
+ * dispatch — we don't want a slow Jira call to back up the dedup
+ * pipeline. Errors inside the executor are caught and logged; nothing
+ * propagates back to the trigger handler.
+ *
+ * Architectural choices worth flagging:
+ *  - The executor talks to `DedupRuleRepository` (rule storage from
+ *    PR-B) and to the injected `ActionDispatcher` / `RuleRateLimiter`.
+ *    No direct DB access for tickets / integrations / bug reports —
+ *    those go through the dispatcher's `CanonicalTicketResolver` and
+ *    the trigger context.
+ *  - Rule blobs are validated through `parseDedupRule` (Zod). Validation
+ *    errors get logged and the rule is skipped — one malformed rule
+ *    must not poison the others on the same trigger.
+ *  - Only `duplicate_detected` and `outbox_about_to_skip` are wired in
+ *    this PR. Schedule-based and cluster-growing triggers are valid at
+ *    the schema level but require a cron worker / aggregator — they
+ *    fire from different entry points (a BullMQ job, a counter
+ *    flush). The executor's design accommodates them; the wiring lands
+ *    in a follow-up.
+ */
+
+import type { DedupRuleRepository } from '../../db/dedup-rule.repository.js';
+import type { BugReport } from '../../db/types.js';
+import type { DedupRule } from '../../integrations/dedup-rule.schema.js';
+import { parseDedupRule } from '../../integrations/dedup-rule.schema.js';
+import { getLogger } from '../../logger.js';
+import { evaluateConditions } from './evaluator.js';
+import type {
+  ActionDispatcher,
+  RuleEvalContext,
+  RuleFireResult,
+  RuleRateLimiter,
+  TriggerType,
+} from './types.js';
+
+const logger = getLogger();
+
+/**
+ * Resolves contextual data the conditions might reference: the
+ * canonical bug, the count of hits in a window, etc. Kept as an
+ * interface so tests can stub the DB-touching parts.
+ */
+export interface RuleContextProvider {
+  /** Fetch the canonical bug (the one `duplicate_of` points at), or null. */
+  loadCanonical(canonicalBugId: string): Promise<BugReport | null>;
+  /** Count bugs whose `duplicate_of` is `canonicalBugId` within the window. */
+  countHitsInWindow(canonicalBugId: string, window: string): Promise<number>;
+}
+
+export class DedupRuleExecutor {
+  constructor(
+    private readonly repo: DedupRuleRepository,
+    private readonly dispatcher: ActionDispatcher,
+    private readonly rateLimiter: RuleRateLimiter,
+    private readonly context: RuleContextProvider
+  ) {}
+
+  /**
+   * Entry point. Loads enabled rules for `bugReport.project_id`,
+   * filters those whose `when.type` matches `trigger`, and runs each
+   * through the full pipeline. Returns one result per rule it
+   * attempted (skipped rules are included with their reason).
+   */
+  async fire(trigger: TriggerType, bugReport: BugReport): Promise<RuleFireResult[]> {
+    let candidateRules;
+    try {
+      candidateRules = await this.repo.findByProject(bugReport.project_id, false);
+    } catch (error) {
+      logger.error('Rule executor: failed to load rules', {
+        projectId: bugReport.project_id,
+        bugReportId: bugReport.id,
+        trigger,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+    if (candidateRules.length === 0) {
+      return [];
+    }
+
+    const evalContext: RuleEvalContext = {
+      bugReport,
+      canonical: null,
+      projectId: bugReport.project_id,
+      resolved: new Map<string, unknown>(),
+    };
+
+    // Hydrate canonical lazily — only if at least one rule references
+    // `canonical.*` OR `hits_in_window`. Saves a round-trip for rules
+    // that only test on the new bug's fields.
+    let canonicalLoaded = false;
+
+    const results: RuleFireResult[] = [];
+
+    for (const row of candidateRules) {
+      let rule: DedupRule;
+      try {
+        rule = parseDedupRule(row.rule_json);
+      } catch (error) {
+        logger.warn('Rule executor: invalid rule_json, skipping', {
+          ruleId: row.id,
+          projectId: bugReport.project_id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        results.push({
+          ruleId: row.id,
+          fired: false,
+          skipReason: 'evaluation_error',
+          actionsDispatched: 0,
+          actionsSkipped: 0,
+        });
+        continue;
+      }
+
+      if (rule.when.type !== trigger) {
+        continue; // Trigger mismatch — not a "fire" attempt, don't record.
+      }
+
+      // Lazy canonical hydration.
+      if (!canonicalLoaded && this.needsCanonical(rule)) {
+        if (bugReport.duplicate_of) {
+          try {
+            evalContext.canonical = await this.context.loadCanonical(bugReport.duplicate_of);
+          } catch (error) {
+            logger.warn('Rule executor: canonical lookup failed', {
+              ruleId: row.id,
+              canonicalId: bugReport.duplicate_of,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            evalContext.canonical = null;
+          }
+        }
+        canonicalLoaded = true;
+      }
+
+      // Resolve the fields this rule's conditions reference. Cache hits
+      // across rules in the same fire so two rules touching
+      // `canonical.status` only resolve once.
+      try {
+        await this.resolveFields(evalContext, rule);
+      } catch (error) {
+        logger.warn('Rule executor: field resolution failed', {
+          ruleId: row.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        results.push({
+          ruleId: row.id,
+          fired: false,
+          skipReason: 'evaluation_error',
+          actionsDispatched: 0,
+          actionsSkipped: 0,
+        });
+        continue;
+      }
+
+      const conditionsMet = evaluateConditions(evalContext, rule.conditions);
+      if (!conditionsMet) {
+        results.push({
+          ruleId: row.id,
+          fired: false,
+          skipReason: 'conditions_unmet',
+          actionsDispatched: 0,
+          actionsSkipped: 0,
+        });
+        continue;
+      }
+
+      // Rate limit applies per (rule, canonical) pair. When there's no
+      // canonical we fall back to the bug report's own id so the limit
+      // still has a stable key.
+      const limitKey = evalContext.canonical?.id ?? bugReport.id;
+      const allowed = await this.rateLimiter.shouldFire(row.id, limitKey, rule);
+      if (!allowed) {
+        results.push({
+          ruleId: row.id,
+          fired: false,
+          skipReason: 'rate_limited',
+          actionsDispatched: 0,
+          actionsSkipped: 0,
+        });
+        continue;
+      }
+
+      let dispatched = 0;
+      let skipped = 0;
+      for (const action of rule.then) {
+        const ok = await this.dispatcher.dispatch(evalContext, action);
+        if (ok) {
+          dispatched += 1;
+        } else {
+          skipped += 1;
+        }
+      }
+      await this.rateLimiter.recordFire(row.id, limitKey, rule);
+
+      results.push({
+        ruleId: row.id,
+        fired: true,
+        skipReason: null,
+        actionsDispatched: dispatched,
+        actionsSkipped: skipped,
+      });
+    }
+
+    return results;
+  }
+
+  private needsCanonical(rule: DedupRule): boolean {
+    for (const cond of rule.conditions) {
+      if (cond.field.startsWith('canonical.') || cond.field === 'hits_in_window') {
+        return true;
+      }
+    }
+    // Ticket actions also need a canonical — see `DefaultActionDispatcher.resolveTarget`.
+    for (const action of rule.then) {
+      if (action.type === 'ticket.add_comment' || action.type === 'ticket.transition') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private async resolveFields(context: RuleEvalContext, rule: DedupRule): Promise<void> {
+    for (const cond of rule.conditions) {
+      if (context.resolved.has(cond.field)) {
+        continue;
+      }
+      switch (cond.field) {
+        case 'canonical.status':
+          context.resolved.set('canonical.status', mapStatusToCanonical(context.canonical));
+          break;
+        case 'canonical.closed_days_ago':
+          context.resolved.set('canonical.closed_days_ago', daysSinceUpdate(context.canonical));
+          break;
+        case 'hits_in_window':
+          // `cond.window` is guaranteed non-empty by the schema's
+          // hits_in_window validator, but TypeScript can't see that —
+          // fall back to a 24h window if it's missing rather than
+          // throwing.
+          if (context.canonical) {
+            const w = cond.window ?? '24h';
+            context.resolved.set(
+              'hits_in_window',
+              await this.context.countHitsInWindow(context.canonical.id, w)
+            );
+          } else {
+            context.resolved.set('hits_in_window', null);
+          }
+          break;
+        case 'reporter.customer.tier': {
+          const tier = readPath(context.bugReport.metadata, ['user', 'tier']);
+          context.resolved.set('reporter.customer.tier', tier);
+          break;
+        }
+        case 'severity':
+          // `severity` mirrors `bug_reports.priority` — both express the
+          // same axis from the dedup rule's perspective. Mapping kept
+          // simple (1:1) until product introduces a separate severity
+          // field.
+          context.resolved.set('severity', context.bugReport.priority);
+          break;
+        default: {
+          // Exhaustiveness check on the closed field literal.
+          const _exhaustive: never = cond.field;
+          void _exhaustive;
+          context.resolved.set(cond.field, null);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Map `bug_reports.status` (the BugSpotter internal `BugStatus` —
+ * `'open' | 'in-progress' | 'resolved' | 'closed'`) onto the DedupRule
+ * schema's `CanonicalStatus` (`'open' | 'in_progress' | 'closed' |
+ * 'wont_fix'`).
+ *
+ * The two enums diverge in two places:
+ *   - `'in-progress'` (kebab) vs `'in_progress'` (snake)
+ *   - `'resolved'` collapses into `'closed'` (rule authors think in
+ *     terms of "closed or not"; the dedup engine doesn't care about
+ *     the distinction)
+ * `'wont_fix'` has no source counterpart yet — a rule comparing
+ * `canonical.status in ['wont_fix']` will simply never match until
+ * `BugStatus` gains a corresponding state.
+ */
+function mapStatusToCanonical(canonical: BugReport | null): string | null {
+  if (!canonical) {
+    return null;
+  }
+  switch (canonical.status) {
+    case 'open':
+      return 'open';
+    case 'in-progress':
+      return 'in_progress';
+    case 'resolved':
+    case 'closed':
+      return 'closed';
+    default:
+      return null;
+  }
+}
+
+/** Whole days since the canonical's `updated_at` (proxy for "closed at"). */
+function daysSinceUpdate(canonical: BugReport | null): number | null {
+  if (!canonical) {
+    return null;
+  }
+  const updated =
+    canonical.updated_at instanceof Date ? canonical.updated_at : new Date(canonical.updated_at);
+  const elapsedMs = Date.now() - updated.getTime();
+  return Math.floor(elapsedMs / (1000 * 60 * 60 * 24));
+}
+
+/** Safe traversal of an unknown object by a dotted-path-equivalent array. */
+function readPath(obj: unknown, path: string[]): unknown {
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (cur === null || cur === undefined || typeof cur !== 'object') {
+      return null;
+    }
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur ?? null;
+}

--- a/packages/backend/src/services/rules/index.ts
+++ b/packages/backend/src/services/rules/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Public surface of the dedup-rule engine. Trigger handlers (the dedup
+ * service, the outbox worker) only need `DedupRuleExecutor` and the
+ * `TriggerType` enum; the rest is exported for the small wiring helper
+ * that constructs the executor from `DatabaseClient` + the plugin
+ * registry.
+ */
+
+export { DedupRuleExecutor } from './executor.js';
+export type { RuleContextProvider } from './executor.js';
+export { DatabaseRuleContextProvider } from './context-provider.js';
+export { DefaultActionDispatcher, TicketsTableResolver } from './dispatcher.js';
+export type { CanonicalTicketResolver, CapabilityServiceLookup } from './dispatcher.js';
+export { ThrottleBackedRateLimiter, windowStringToMinutes } from './rate-limiter.js';
+export { evaluateConditions } from './evaluator.js';
+export type {
+  ActionDispatcher,
+  RuleEvalContext,
+  RuleFireResult,
+  RuleRateLimiter,
+  TriggerType,
+} from './types.js';

--- a/packages/backend/src/services/rules/rate-limiter.ts
+++ b/packages/backend/src/services/rules/rate-limiter.ts
@@ -1,22 +1,17 @@
 /**
  * Rate-limit adapter for the dedup-rule engine.
  *
- * Routes through the existing `notification_throttle` table /
- * `NotificationThrottleRepository.isThrottled` so we don't introduce a
- * second store. The group key is `<canonicalId>` — rate limits in
- * DedupRule are per-canonical-bug, mirroring the persona-driven design
- * ("at most one auto-reopen comment per cluster per day").
+ * Routes through the existing `notification_throttle` table via
+ * `NotificationThrottleRepository.tryReserveSlot` — a single
+ * `INSERT ... ON CONFLICT DO UPDATE WHERE count < $max RETURNING`
+ * statement that performs the check and the reservation atomically.
+ * Concurrent fires for the same canonical (e.g. several outbox
+ * workers processing duplicates of the same cluster in parallel)
+ * no longer race past the configured `rate_limit.count`.
  *
- * **Concurrency caveat.** `isThrottled` is two statements
- * (`getWindowCount` then a conditional `incrementWindowCount`), NOT a
- * single atomic check-and-increment. Concurrent fires for the same
- * canonical (e.g. several outbox workers processing duplicates of the
- * same cluster in parallel) can both observe `currentCount < max` and
- * both increment, exceeding the configured limit. At MVP rule
- * density / cluster ingest rate this is a theoretical edge; the
- * tighter fix is a single `INSERT ... ON CONFLICT DO UPDATE WHERE
- * count < $max RETURNING` statement and lands in a follow-up that
- * also touches the existing notification callers of this repository.
+ * The group key is `<canonicalId>` — rate limits in DedupRule are
+ * per-canonical-bug, mirroring the persona-driven design ("at most
+ * one auto-reopen comment per cluster per day").
  *
  * `recordFire` is a no-op (the increment already happened inside
  * `shouldFire`). If a rule's actions all fail after `shouldFire`
@@ -61,7 +56,11 @@ export function windowStringToMinutes(window: string): number {
     d: 60 * 24,
     w: 60 * 24 * 7,
   };
-  return Math.max(1, Math.floor(n * (multipliers[unit] ?? 60)));
+  // Round UP, not down: a "61s" window collapses to 1 minute under
+  // Math.floor (less restrictive — slot resets sooner than the rule
+  // author asked for). Math.ceil makes the limiter strictly more
+  // conservative, matching the doc above.
+  return Math.max(1, Math.ceil(n * (multipliers[unit] ?? 60)));
 }
 
 export class ThrottleBackedRateLimiter implements RuleRateLimiter {
@@ -73,13 +72,7 @@ export class ThrottleBackedRateLimiter implements RuleRateLimiter {
       return true;
     }
     const minutes = windowStringToMinutes(rule.rate_limit.window);
-    const throttled = await this.throttle.isThrottled(
-      ruleId,
-      canonicalId,
-      rule.rate_limit.count,
-      minutes
-    );
-    return !throttled;
+    return this.throttle.tryReserveSlot(ruleId, canonicalId, rule.rate_limit.count, minutes);
   }
 
   /**

--- a/packages/backend/src/services/rules/rate-limiter.ts
+++ b/packages/backend/src/services/rules/rate-limiter.ts
@@ -1,0 +1,84 @@
+/**
+ * Rate-limit adapter for the dedup-rule engine.
+ *
+ * Routes through the existing `notification_throttle` table /
+ * `NotificationThrottleRepository.isThrottled` so we don't introduce a
+ * second store. The group key is `<canonicalId>` — rate limits in
+ * DedupRule are per-canonical-bug, mirroring the persona-driven design
+ * ("at most one auto-reopen comment per cluster per day").
+ *
+ * `isThrottled` performs check-and-increment atomically; we surface
+ * the inverse via `shouldFire` for caller-side readability and treat
+ * `recordFire` as a no-op (the increment already happened inside
+ * `shouldFire`). If a rule's actions all fail after `shouldFire` returns
+ * true, the slot is still burned for the window — acceptable for the
+ * MVP, matches the existing notification-throttle behaviour.
+ */
+
+import type { NotificationThrottleRepository } from '../../db/repositories/notification-throttle.repository.js';
+import type { DedupRule } from '../../integrations/dedup-rule.schema.js';
+import { getLogger } from '../../logger.js';
+import type { RuleRateLimiter } from './types.js';
+
+const logger = getLogger();
+
+/**
+ * Convert a `<digits><s|m|h|d|w>` window string into whole minutes.
+ * The notification_throttle infra has minute granularity; sub-minute
+ * windows would otherwise round to zero and disable the limit
+ * entirely. Clamp to a minimum of 1 — a rule author writing "30s" gets
+ * 1 minute, which is the conservative direction (more limiting, not
+ * less). Anything that the schema rejected (zero / malformed) won't
+ * reach this code path.
+ */
+export function windowStringToMinutes(window: string): number {
+  const match = /^(\d+)([smhdw])$/.exec(window);
+  if (!match) {
+    // Schema-level validation should make this unreachable, but if a
+    // hand-edited row sneaks in we don't want to silently disable the
+    // limit. Default to 1 hour — a safe-ish conservative bound.
+    logger.warn('Malformed window string in rate limiter, defaulting to 60 minutes', {
+      window,
+    });
+    return 60;
+  }
+  const n = Number.parseInt(match[1], 10);
+  const unit = match[2];
+  const multipliers: Record<string, number> = {
+    s: 1 / 60,
+    m: 1,
+    h: 60,
+    d: 60 * 24,
+    w: 60 * 24 * 7,
+  };
+  return Math.max(1, Math.floor(n * (multipliers[unit] ?? 60)));
+}
+
+export class ThrottleBackedRateLimiter implements RuleRateLimiter {
+  constructor(private readonly throttle: NotificationThrottleRepository) {}
+
+  async shouldFire(ruleId: string, canonicalId: string, rule: DedupRule): Promise<boolean> {
+    if (!rule.rate_limit) {
+      // No rate limit configured -> always allow.
+      return true;
+    }
+    const minutes = windowStringToMinutes(rule.rate_limit.window);
+    const throttled = await this.throttle.isThrottled(
+      ruleId,
+      canonicalId,
+      rule.rate_limit.count,
+      minutes
+    );
+    return !throttled;
+  }
+
+  /**
+   * No-op: `isThrottled` already incremented the counter on the
+   * allow path. Kept on the interface so a future limiter
+   * implementation (one that separates check from record) can be
+   * swapped in without touching the executor.
+   */
+  async recordFire(_ruleId: string, _canonicalId: string, _rule: DedupRule): Promise<void> {
+    return;
+  }
+}

--- a/packages/backend/src/services/rules/rate-limiter.ts
+++ b/packages/backend/src/services/rules/rate-limiter.ts
@@ -7,12 +7,22 @@
  * DedupRule are per-canonical-bug, mirroring the persona-driven design
  * ("at most one auto-reopen comment per cluster per day").
  *
- * `isThrottled` performs check-and-increment atomically; we surface
- * the inverse via `shouldFire` for caller-side readability and treat
- * `recordFire` as a no-op (the increment already happened inside
- * `shouldFire`). If a rule's actions all fail after `shouldFire` returns
- * true, the slot is still burned for the window — acceptable for the
- * MVP, matches the existing notification-throttle behaviour.
+ * **Concurrency caveat.** `isThrottled` is two statements
+ * (`getWindowCount` then a conditional `incrementWindowCount`), NOT a
+ * single atomic check-and-increment. Concurrent fires for the same
+ * canonical (e.g. several outbox workers processing duplicates of the
+ * same cluster in parallel) can both observe `currentCount < max` and
+ * both increment, exceeding the configured limit. At MVP rule
+ * density / cluster ingest rate this is a theoretical edge; the
+ * tighter fix is a single `INSERT ... ON CONFLICT DO UPDATE WHERE
+ * count < $max RETURNING` statement and lands in a follow-up that
+ * also touches the existing notification callers of this repository.
+ *
+ * `recordFire` is a no-op (the increment already happened inside
+ * `shouldFire`). If a rule's actions all fail after `shouldFire`
+ * returns true, the slot is still burned for the window — acceptable
+ * for the MVP and matches the existing notification-throttle
+ * behaviour.
  */
 
 import type { NotificationThrottleRepository } from '../../db/repositories/notification-throttle.repository.js';

--- a/packages/backend/src/services/rules/types.ts
+++ b/packages/backend/src/services/rules/types.ts
@@ -64,6 +64,20 @@ export interface RuleEvalContext {
  */
 export interface ActionDispatcher {
   dispatch(context: RuleEvalContext, action: ActionSpec): Promise<boolean>;
+  /**
+   * Synchronous capability probe — does this dispatcher have any
+   * wiring for the given action type?
+   *
+   * The executor calls this BEFORE consuming the rate-limit slot:
+   * a rule whose actions are all unsupported (e.g. notify.slack
+   * before its dispatcher lands) would otherwise burn the throttle
+   * budget for zero work, blocking future legitimate fires within
+   * the window.
+   *
+   * Implementations should return `false` for actions they log-and-
+   * skip in `dispatch` and `true` for actions they actually wire.
+   */
+  canDispatch(action: ActionSpec): boolean;
 }
 
 /**
@@ -86,7 +100,13 @@ export interface RuleFireResult {
   ruleId: string;
   fired: boolean;
   /** When fired=false, the reason. `null` when fired=true. */
-  skipReason: 'conditions_unmet' | 'rate_limited' | 'dispatch_error' | 'evaluation_error' | null;
+  skipReason:
+    | 'conditions_unmet'
+    | 'rate_limited'
+    | 'dispatch_error'
+    | 'evaluation_error'
+    | 'no_supported_actions'
+    | null;
   /** Count of actions that ran successfully (vs were skipped). */
   actionsDispatched: number;
   actionsSkipped: number;

--- a/packages/backend/src/services/rules/types.ts
+++ b/packages/backend/src/services/rules/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Types for the tiny dedup-rule engine.
+ *
+ * The executor takes a (TriggerType, BugReport) pair, loads the
+ * matching rules from `application.dedup_rules`, builds an evaluation
+ * context for each one, evaluates its conditions, and dispatches its
+ * actions via the injected ActionDispatcher. The split here is so the
+ * evaluator stays a pure function (easy to test without a DB) and the
+ * executor only orchestrates.
+ */
+
+import type { BugReport } from '../../db/types.js';
+import type { ActionSpec, DedupRule } from '../../integrations/dedup-rule.schema.js';
+
+/**
+ * Triggers the engine knows how to fire on in this slice (PR-C).
+ *
+ * Other DedupRule trigger types (`cluster_growing`, `schedule`) are valid
+ * at the schema level but not wired here yet — they need an aggregator
+ * and a cron worker respectively, both deferred to follow-up PRs.
+ */
+export type TriggerType = 'duplicate_detected' | 'outbox_about_to_skip';
+
+/**
+ * Evaluation context shared between condition matching and action
+ * dispatch. Built once per (trigger, bugReport) and reused across
+ * every rule that fires for the same event.
+ *
+ * `canonical` may be null when the trigger fires before a canonical is
+ * known — e.g. a `duplicate_detected` event for a bug whose
+ * `duplicate_of` field was just set but the canonical row has since
+ * been hard-deleted. Rules with conditions on `canonical.*` skip when
+ * canonical is null; rules with no canonical conditions still fire.
+ */
+export interface RuleEvalContext {
+  /** The bug that triggered the event. */
+  bugReport: BugReport;
+  /** The canonical (the bug `bugReport.duplicate_of` points at), if any. */
+  canonical: BugReport | null;
+  /** Project id, mirrored for action dispatch (no rule will cross projects). */
+  projectId: string;
+  /**
+   * Map from condition field literal -> resolved value, populated lazily
+   * by the executor before evaluation. Lazy because `hits_in_window`
+   * requires a DB count, and most rules won't reference it.
+   *
+   * `null` means "the field was looked up and resolved to absent" (e.g.
+   * `hits_in_window` when canonical is null), which distinguishes from
+   * "not yet resolved" (key missing).
+   */
+  resolved: Map<string, unknown>;
+}
+
+/**
+ * Pluggable side-effect handler. The executor stays free of HTTP /
+ * SMTP / Slack concerns; the route or worker that invokes it provides
+ * a concrete dispatcher. PR-C ships an implementation for
+ * `ticket.add_comment` and `ticket.transition`; the other action
+ * types log and skip until their follow-up PRs land.
+ *
+ * Returns whether the action ran (true) or was skipped/failed (false).
+ * Failures must be logged inside the dispatcher; the executor does not
+ * inspect the return except to record telemetry.
+ */
+export interface ActionDispatcher {
+  dispatch(context: RuleEvalContext, action: ActionSpec): Promise<boolean>;
+}
+
+/**
+ * Optional rate-limit gate. The executor calls `shouldFire` BEFORE
+ * dispatching any actions, and `recordFire` AFTER all actions for one
+ * rule have been dispatched. Implementation routes through the
+ * existing `notification_throttle` table so we don't introduce a
+ * second throttle store.
+ */
+export interface RuleRateLimiter {
+  shouldFire(ruleId: string, canonicalId: string, rule: DedupRule): Promise<boolean>;
+  recordFire(ruleId: string, canonicalId: string, rule: DedupRule): Promise<void>;
+}
+
+/**
+ * What the executor returns for telemetry / debugging. Not surfaced to
+ * end users — the engine fires fire-and-forget from the trigger hooks.
+ */
+export interface RuleFireResult {
+  ruleId: string;
+  fired: boolean;
+  /** When fired=false, the reason. `null` when fired=true. */
+  skipReason: 'conditions_unmet' | 'rate_limited' | 'dispatch_error' | 'evaluation_error' | null;
+  /** Count of actions that ran successfully (vs were skipped). */
+  actionsDispatched: number;
+  actionsSkipped: number;
+}

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -43,15 +43,24 @@ export function buildCapabilityServiceLookup(
 ): CapabilityServiceLookup {
   return async (
     integrationId: string,
-    _projectId: string
+    projectId: string
   ): Promise<TicketIntegrationCapabilities | null> => {
     try {
+      // Scope the lookup by both project_integrations.id AND
+      // project_id. The id alone is a UUID and globally unique in
+      // practice, but the join lets an integration from project A
+      // resolve under a request scoped to project B if upstream code
+      // ever swaps the ids by mistake. Adding the project_id check
+      // means a cross-project hit returns zero rows -> null -> the
+      // dispatcher skips the action. Same defense-in-depth pattern
+      // used by TicketsTableResolver.
       const result = await db.getPool().query<{ platform: string; enabled: boolean }>(
         `SELECT i.type AS platform, pi.enabled
          FROM application.project_integrations pi
          JOIN application.integrations i ON i.id = pi.integration_id
-         WHERE pi.id = $1`,
-        [integrationId]
+         WHERE pi.id = $1
+           AND pi.project_id = $2`,
+        [integrationId, projectId]
       );
       const row = result.rows[0];
       if (!row || !row.enabled) {
@@ -65,6 +74,7 @@ export function buildCapabilityServiceLookup(
     } catch (error) {
       logger.warn('CapabilityServiceLookup: integration lookup failed', {
         integrationId,
+        projectId,
         error: error instanceof Error ? error.message : String(error),
       });
       return null;

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -1,0 +1,92 @@
+/**
+ * Wiring helpers — construct a fully-configured `DedupRuleExecutor`
+ * from the dependencies a trigger handler (the outbox worker, the
+ * intelligence worker) already has.
+ *
+ * Kept separate from the executor itself so the executor module stays
+ * a clean "logic only" boundary that can be unit-tested without the
+ * plugin registry. The wiring here does talk to the DB (for the
+ * integration -> platform name lookup) and to the plugin registry,
+ * which is why callers want a single helper instead of constructing
+ * five collaborators inline.
+ */
+
+import type { DatabaseClient } from '../../db/client.js';
+import { DedupRuleRepository } from '../../db/dedup-rule.repository.js';
+import { NotificationThrottleRepository } from '../../db/repositories/notification-throttle.repository.js';
+import type { TicketIntegrationCapabilities } from '../../integrations/capabilities.js';
+import type { PluginRegistry } from '../../integrations/plugin-registry.js';
+import { getLogger } from '../../logger.js';
+import { DatabaseRuleContextProvider } from './context-provider.js';
+import { DefaultActionDispatcher, TicketsTableResolver } from './dispatcher.js';
+import type { CapabilityServiceLookup } from './dispatcher.js';
+import { DedupRuleExecutor } from './executor.js';
+import { ThrottleBackedRateLimiter } from './rate-limiter.js';
+
+const logger = getLogger();
+
+/**
+ * Build the capability-service lookup that the dispatcher needs. Given
+ * an `integrationId` (a `project_integrations.id`), discovers the
+ * platform name by joining `project_integrations -> integrations.type`
+ * and asks the plugin registry for the matching service.
+ *
+ * The registry returns services typed as `IntegrationService` — the
+ * capability methods (`addComment`, `transition`, `getStatus`) live on
+ * the wider `TicketIntegrationCapabilities` interface, so we cast
+ * here. The dispatcher uses `pluginSupports` before calling any
+ * optional method, which is the actual runtime guard.
+ */
+export function buildCapabilityServiceLookup(
+  db: DatabaseClient,
+  pluginRegistry: PluginRegistry
+): CapabilityServiceLookup {
+  return async (
+    integrationId: string,
+    _projectId: string
+  ): Promise<TicketIntegrationCapabilities | null> => {
+    try {
+      const result = await db.getPool().query<{ platform: string; enabled: boolean }>(
+        `SELECT i.type AS platform, pi.enabled
+         FROM application.project_integrations pi
+         JOIN application.integrations i ON i.id = pi.integration_id
+         WHERE pi.id = $1`,
+        [integrationId]
+      );
+      const row = result.rows[0];
+      if (!row || !row.enabled) {
+        return null;
+      }
+      const service = pluginRegistry.get(row.platform);
+      if (!service) {
+        return null;
+      }
+      return service as unknown as TicketIntegrationCapabilities;
+    } catch (error) {
+      logger.warn('CapabilityServiceLookup: integration lookup failed', {
+        integrationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  };
+}
+
+/**
+ * One-shot constructor. Trigger handlers call this once at startup and
+ * reuse the returned executor across firings.
+ */
+export function buildDedupRuleExecutor(
+  db: DatabaseClient,
+  pluginRegistry: PluginRegistry
+): DedupRuleExecutor {
+  const pool = db.getPool();
+  const repo = new DedupRuleRepository(pool);
+  const throttle = new NotificationThrottleRepository(pool);
+  const resolver = new TicketsTableResolver(db);
+  const lookup = buildCapabilityServiceLookup(db, pluginRegistry);
+  const dispatcher = new DefaultActionDispatcher(resolver, lookup);
+  const rateLimiter = new ThrottleBackedRateLimiter(throttle);
+  const contextProvider = new DatabaseRuleContextProvider(db);
+  return new DedupRuleExecutor(repo, dispatcher, rateLimiter, contextProvider);
+}

--- a/packages/backend/tests/integration/notification-throttle.integration.test.ts
+++ b/packages/backend/tests/integration/notification-throttle.integration.test.ts
@@ -419,6 +419,53 @@ describe('NotificationThrottleRepository', () => {
       }
     );
 
+    it('deletes throttle rows when the owning notification_rule is deleted (migration 024 trigger)', async () => {
+      // Migration 023 dropped the FK + CASCADE that originally
+      // wiped throttle rows on rule deletion. Migration 024 restores
+      // the cascade via an AFTER DELETE trigger on notification_rules.
+      // Without it, deleted rules would leak throttle rows forever.
+      await db.notificationThrottle.tryReserveSlot(testRuleId1, 'g1', 5, 60);
+      await db.notificationThrottle.tryReserveSlot(testRuleId1, 'g2', 5, 60);
+
+      // Confirm the rows exist
+      const now = new Date();
+      const windowDuration = 60 * 60 * 1000;
+      const windowStart = new Date(Math.floor(now.getTime() / windowDuration) * windowDuration);
+      const windowEnd = new Date(windowStart.getTime() + windowDuration);
+      const before1 = await db.notificationThrottle.getWindowCount(
+        testRuleId1,
+        'g1',
+        windowStart,
+        windowEnd
+      );
+      const before2 = await db.notificationThrottle.getWindowCount(
+        testRuleId1,
+        'g2',
+        windowStart,
+        windowEnd
+      );
+      expect(before1).toBe(1);
+      expect(before2).toBe(1);
+
+      // Delete the parent rule — trigger should drop both throttle rows.
+      await db.notificationRules.delete(testRuleId1);
+
+      const after1 = await db.notificationThrottle.getWindowCount(
+        testRuleId1,
+        'g1',
+        windowStart,
+        windowEnd
+      );
+      const after2 = await db.notificationThrottle.getWindowCount(
+        testRuleId1,
+        'g2',
+        windowStart,
+        windowEnd
+      );
+      expect(after1).toBe(0);
+      expect(after2).toBe(0);
+    });
+
     it('does not interfere with the legacy isThrottled path on a different rule', async () => {
       // Sanity check that the new atomic path and the old read-then-
       // increment path don't tread on each other's rows when keyed

--- a/packages/backend/tests/integration/notification-throttle.integration.test.ts
+++ b/packages/backend/tests/integration/notification-throttle.integration.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
 import { createTestDatabase } from '../setup.integration.js';
 import type { DatabaseClient } from '../../src/db/client.js';
 
@@ -315,6 +316,101 @@ describe('NotificationThrottleRepository', () => {
         60
       );
 
+      expect(isThrottled).toBe(false);
+    });
+  });
+
+  describe('tryReserveSlot (atomic check-and-reserve)', () => {
+    // Migration 023 dropped the FK from `notification_throttle.rule_id`
+    // -> `notification_rules.id` so the dedup-rule engine can share
+    // this table without its rule ids being rejected by Postgres. The
+    // unit tests for ThrottleBackedRateLimiter mock the repository and
+    // never exercise the real SQL path, so these tests are the actual
+    // guard against the FK reappearing (or `tryReserveSlot`'s
+    // ON CONFLICT clause regressing).
+
+    it('accepts a rule_id UUID that does not exist in notification_rules (FK is dropped)', async () => {
+      // This is the regression test for the production bug Claude
+      // flagged: before migration 023, this insert would fail with
+      // `violates foreign key constraint
+      //  notification_throttle_rule_id_fkey`. After the migration the
+      // column is polymorphic — any UUID is accepted.
+      const dedupRuleId = randomUUID();
+      const reserved = await db.notificationThrottle.tryReserveSlot(
+        dedupRuleId,
+        'canonical-bug-uuid',
+        3,
+        60
+      );
+      expect(reserved).toBe(true);
+    });
+
+    it('returns true up to the limit, then false', async () => {
+      const ruleId = randomUUID();
+      const groupKey = 'canonical-A';
+
+      const r1 = await db.notificationThrottle.tryReserveSlot(ruleId, groupKey, 2, 60);
+      const r2 = await db.notificationThrottle.tryReserveSlot(ruleId, groupKey, 2, 60);
+      const r3 = await db.notificationThrottle.tryReserveSlot(ruleId, groupKey, 2, 60);
+      const r4 = await db.notificationThrottle.tryReserveSlot(ruleId, groupKey, 2, 60);
+
+      expect(r1).toBe(true);
+      expect(r2).toBe(true);
+      expect(r3).toBe(false);
+      expect(r4).toBe(false);
+    });
+
+    it('separates limits across different group_keys', async () => {
+      const ruleId = randomUUID();
+
+      // groupKey A exhausts the limit
+      await db.notificationThrottle.tryReserveSlot(ruleId, 'A', 1, 60);
+      const aSecond = await db.notificationThrottle.tryReserveSlot(ruleId, 'A', 1, 60);
+      // groupKey B is still fresh
+      const bFirst = await db.notificationThrottle.tryReserveSlot(ruleId, 'B', 1, 60);
+
+      expect(aSecond).toBe(false);
+      expect(bFirst).toBe(true);
+    });
+
+    it('enforces max-count atomically under concurrent callers (TOCTOU resistant)', async () => {
+      // This is the property that motivated tryReserveSlot in the
+      // first place: two outbox workers racing on the same canonical
+      // must not both win. With the old read-then-increment path
+      // both could see currentCount < max and both increment. With
+      // INSERT ... ON CONFLICT DO UPDATE WHERE count < $max
+      // RETURNING, exactly `max` callers come back with `true`.
+      const ruleId = randomUUID();
+      const groupKey = 'race-canonical';
+      const max = 3;
+      const concurrent = 12;
+
+      const results = await Promise.all(
+        Array.from({ length: concurrent }, () =>
+          db.notificationThrottle.tryReserveSlot(ruleId, groupKey, max, 60)
+        )
+      );
+
+      const reserved = results.filter((r) => r === true).length;
+      const refused = results.filter((r) => r === false).length;
+
+      expect(reserved).toBe(max);
+      expect(refused).toBe(concurrent - max);
+    });
+
+    it('does not interfere with the legacy isThrottled path on a different rule', async () => {
+      // Sanity check that the new atomic path and the old read-then-
+      // increment path don't tread on each other's rows when keyed
+      // by different rule_ids — i.e. the unique constraint
+      // (rule_id, group_key, window_start) keeps them isolated.
+      const dedupRuleId = randomUUID();
+
+      await db.notificationThrottle.tryReserveSlot(dedupRuleId, 'g', 5, 60);
+      await db.notificationThrottle.tryReserveSlot(dedupRuleId, 'g', 5, 60);
+
+      // testRuleId1 is a real notification_rule from beforeEach.
+      // Its counter for the same group_key should still be 0.
+      const isThrottled = await db.notificationThrottle.isThrottled(testRuleId1, 'g', 5, 60);
       expect(isThrottled).toBe(false);
     });
   });

--- a/packages/backend/tests/integration/notification-throttle.integration.test.ts
+++ b/packages/backend/tests/integration/notification-throttle.integration.test.ts
@@ -398,6 +398,27 @@ describe('NotificationThrottleRepository', () => {
       expect(refused).toBe(concurrent - max);
     });
 
+    it.each([
+      { maxNotifications: 0, windowMinutes: 60 },
+      { maxNotifications: -1, windowMinutes: 60 },
+      { maxNotifications: 5, windowMinutes: 0 },
+      { maxNotifications: 5, windowMinutes: -5 },
+    ])(
+      'returns false (fails closed) on invalid params: %s',
+      async ({ maxNotifications, windowMinutes }) => {
+        // Without the early-return guard, windowMinutes < 1 makes the
+        // window math produce NaN dates that throw on .toISOString().
+        // Verify the guard short-circuits with a clean `false`.
+        const reserved = await db.notificationThrottle.tryReserveSlot(
+          randomUUID(),
+          'g',
+          maxNotifications,
+          windowMinutes
+        );
+        expect(reserved).toBe(false);
+      }
+    );
+
     it('does not interfere with the legacy isThrottled path on a different rule', async () => {
       // Sanity check that the new atomic path and the old read-then-
       // increment path don't tread on each other's rows when keyed

--- a/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
+++ b/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
@@ -180,17 +180,15 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
 
   describe('outbox_about_to_skip rule trigger', () => {
     it('fires the rule executor after markSkipped, with the dedup-suppressed bug', async () => {
-      const fire = vi
-        .fn()
-        .mockResolvedValue([
-          {
-            ruleId: 'rule-x',
-            fired: true,
-            skipReason: null,
-            actionsDispatched: 1,
-            actionsSkipped: 0,
-          },
-        ]);
+      const fire = vi.fn().mockResolvedValue([
+        {
+          ruleId: 'rule-x',
+          fired: true,
+          skipReason: null,
+          actionsDispatched: 1,
+          actionsSkipped: 0,
+        },
+      ]);
       const ruleExecutor = { fire } as never;
       const processorWithExec = new TicketCreationOutboxProcessor(
         db,

--- a/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
+++ b/packages/backend/tests/services/integrations/outbox-worker-dedup.test.ts
@@ -164,4 +164,116 @@ describe('TicketCreationOutboxProcessor — pre-file dedup gate', () => {
     expect(db.ticketOutbox.markCompleted).not.toHaveBeenCalled();
     expect(db.ticketOutbox.markSkipped).not.toHaveBeenCalled();
   });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Rule executor hook (outbox_about_to_skip trigger)
+  //
+  // The hook fires the rule engine on the dedup-suppression branch.
+  // These tests pass an injected stub executor (4th constructor arg)
+  // so we exercise the worker's contract with the engine without
+  // building the real DedupRuleExecutor or its plugin-registry deps.
+  // The earlier dedup-gate test happened to pass even though the
+  // executor was unreachable (the stub `db` lacks `getPool()`, so
+  // the lazy build threw and was swallowed); these tests close that
+  // coverage gap.
+  // ──────────────────────────────────────────────────────────────────
+
+  describe('outbox_about_to_skip rule trigger', () => {
+    it('fires the rule executor after markSkipped, with the dedup-suppressed bug', async () => {
+      const fire = vi
+        .fn()
+        .mockResolvedValue([
+          {
+            ruleId: 'rule-x',
+            fired: true,
+            skipReason: null,
+            actionsDispatched: 1,
+            actionsSkipped: 0,
+          },
+        ]);
+      const ruleExecutor = { fire } as never;
+      const processorWithExec = new TicketCreationOutboxProcessor(
+        db,
+        registry,
+        undefined,
+        ruleExecutor
+      );
+
+      const entry = buildEntry();
+      (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
+        ...entry,
+        status: 'processing',
+      });
+      const bug = { id: 'bug-1', project_id: 'project-1', duplicate_of: 'bug-canonical' };
+      (db.bugReports.findById as Mock).mockResolvedValueOnce(bug);
+
+      await processorWithExec.process(buildJob('outbox-1') as never);
+
+      // Order matters: markSkipped FIRST (terminal state), then fire.
+      // Reversing would mean a markSkipped failure causes BullMQ to
+      // retry and re-fire — actions replay.
+      const markSkippedOrder = (db.ticketOutbox.markSkipped as Mock).mock.invocationCallOrder[0];
+      const fireOrder = fire.mock.invocationCallOrder[0];
+      expect(markSkippedOrder).toBeLessThan(fireOrder);
+
+      expect(fire).toHaveBeenCalledWith('outbox_about_to_skip', bug);
+      expect(db.ticketOutbox.markSkipped).toHaveBeenCalledWith('outbox-1', 'duplicate_of_set');
+    });
+
+    it('still markSkipped runs to completion when the executor throws', async () => {
+      // The executor's contract is "no error propagates", but
+      // defensively the worker also wraps the call. Even if the
+      // executor escapes its own guards, the outbox row must still
+      // land in terminal state.
+      const fire = vi.fn().mockRejectedValue(new Error('executor went sideways'));
+      const ruleExecutor = { fire } as never;
+      const processorWithExec = new TicketCreationOutboxProcessor(
+        db,
+        registry,
+        undefined,
+        ruleExecutor
+      );
+
+      (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
+        ...buildEntry(),
+        status: 'processing',
+      });
+      (db.bugReports.findById as Mock).mockResolvedValueOnce({
+        id: 'bug-1',
+        duplicate_of: 'bug-canonical',
+      });
+
+      await expect(
+        processorWithExec.process(buildJob('outbox-1') as never)
+      ).resolves.toBeUndefined();
+
+      expect(db.ticketOutbox.markSkipped).toHaveBeenCalledWith('outbox-1', 'duplicate_of_set');
+      expect(fire).toHaveBeenCalled();
+    });
+
+    it('does not fire the executor on the happy path (no duplicate_of)', async () => {
+      const fire = vi.fn();
+      const ruleExecutor = { fire } as never;
+      const processorWithExec = new TicketCreationOutboxProcessor(
+        db,
+        registry,
+        undefined,
+        ruleExecutor
+      );
+
+      (db.ticketOutbox.markProcessing as Mock).mockResolvedValueOnce({
+        ...buildEntry(),
+        status: 'processing',
+      });
+      (db.bugReports.findById as Mock).mockResolvedValue({
+        id: 'bug-1',
+        duplicate_of: null,
+      });
+
+      await processorWithExec.process(buildJob('outbox-1') as never);
+
+      expect(fire).not.toHaveBeenCalled();
+      expect(createFromBugReport).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for `DefaultActionDispatcher`.
+ *
+ * Covers the dispatcher's contract:
+ *  - `ticket.add_comment` / `ticket.transition` route through
+ *    the capability service when one is available;
+ *  - missing canonical, missing ticket, unsupported plugin all
+ *    short-circuit with a false return (no throw);
+ *  - capability call failures are caught, logged, and return false —
+ *    the executor relies on this so one bad rule can't abort the loop;
+ *  - `notify.email` / `notify.slack` / `notify.webhook` are recognised
+ *    but no-op in this PR slice (PR-C2 wires email, PR-D wires the rest);
+ *  - `resolveTarget` passes the firing rule's `projectId` to the
+ *    canonical resolver (cross-tenant scoping).
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { DefaultActionDispatcher } from '../../../src/services/rules/dispatcher.js';
+import type {
+  CanonicalTicketResolver,
+  CapabilityServiceLookup,
+} from '../../../src/services/rules/dispatcher.js';
+import type { RuleEvalContext } from '../../../src/services/rules/types.js';
+import type { ActionSpec } from '../../../src/integrations/dedup-rule.schema.js';
+import type {
+  CapabilityTarget,
+  TicketIntegrationCapabilities,
+} from '../../../src/integrations/capabilities.js';
+import type { BugReport } from '../../../src/db/types.js';
+
+const TARGET: CapabilityTarget = {
+  externalId: 'JIRA-123',
+  projectId: 'project-1',
+  integrationId: 'integration-1',
+};
+
+function makeBug(overrides: Partial<BugReport> = {}): BugReport {
+  return {
+    id: 'bug-new',
+    project_id: 'project-1',
+    title: 't',
+    description: null,
+    screenshot_url: null,
+    replay_url: null,
+    metadata: {},
+    status: 'open',
+    priority: 'high',
+    deleted_at: null,
+    deleted_by: null,
+    legal_hold: false,
+    organization_id: null,
+    duplicate_of: 'bug-canonical',
+    created_at: new Date(),
+    updated_at: new Date(),
+    screenshot_key: null,
+    thumbnail_key: null,
+    replay_key: null,
+    upload_status: 'completed',
+    replay_upload_status: 'completed',
+    ...overrides,
+  } as BugReport;
+}
+
+function makeContext(overrides: Partial<RuleEvalContext> = {}): RuleEvalContext {
+  return {
+    bugReport: makeBug(),
+    canonical: makeBug({ id: 'bug-canonical', duplicate_of: null }),
+    projectId: 'project-1',
+    resolved: new Map(),
+    ...overrides,
+  };
+}
+
+describe('DefaultActionDispatcher', () => {
+  let resolver: { resolve: Mock };
+  let lookup: Mock;
+  let capabilityService: { addComment: Mock; transition: Mock; getStatus: Mock };
+  let dispatcher: DefaultActionDispatcher;
+
+  beforeEach(() => {
+    resolver = { resolve: vi.fn().mockResolvedValue(TARGET) };
+    capabilityService = {
+      addComment: vi.fn().mockResolvedValue(undefined),
+      transition: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn().mockResolvedValue('closed'),
+    };
+    lookup = vi
+      .fn()
+      .mockResolvedValue(capabilityService as unknown as TicketIntegrationCapabilities);
+    dispatcher = new DefaultActionDispatcher(
+      resolver as unknown as CanonicalTicketResolver,
+      lookup as CapabilityServiceLookup
+    );
+  });
+
+  describe('ticket.add_comment', () => {
+    it('resolves the canonical target then calls service.addComment', async () => {
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hello',
+      });
+      expect(ok).toBe(true);
+      expect(resolver.resolve).toHaveBeenCalledWith('bug-canonical', 'project-1');
+      expect(capabilityService.addComment).toHaveBeenCalledWith(TARGET, 'hello');
+    });
+
+    it('passes context.projectId to the resolver (cross-tenant scoping)', async () => {
+      // The resolver enforces the project_id scope in SQL; pinning the
+      // arg means a future refactor that drops the scope shows up in
+      // this test.
+      const context = makeContext({ projectId: 'project-XYZ' });
+      await dispatcher.dispatch(context, {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hi',
+      });
+      expect(resolver.resolve).toHaveBeenCalledWith('bug-canonical', 'project-XYZ');
+    });
+
+    it('returns false (without throwing) when no canonical exists', async () => {
+      const context = makeContext({ canonical: null, bugReport: makeBug({ duplicate_of: null }) });
+      const ok = await dispatcher.dispatch(context, {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hi',
+      });
+      expect(ok).toBe(false);
+      expect(resolver.resolve).not.toHaveBeenCalled();
+      expect(capabilityService.addComment).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the resolver finds no external ticket', async () => {
+      resolver.resolve.mockResolvedValueOnce(null);
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hi',
+      });
+      expect(ok).toBe(false);
+      expect(capabilityService.addComment).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the lookup yields no service', async () => {
+      lookup.mockResolvedValueOnce(null);
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hi',
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when the plugin lacks the addComment capability', async () => {
+      // pluginSupports does a duck-type check; a service without
+      // `addComment` is treated as not supporting it.
+      lookup.mockResolvedValueOnce({
+        transition: vi.fn(),
+        getStatus: vi.fn(),
+      } as unknown as TicketIntegrationCapabilities);
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hi',
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('catches addComment failures (executor relies on this to keep the loop alive)', async () => {
+      capabilityService.addComment.mockRejectedValueOnce(new Error('jira 502'));
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hi',
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('falls back to bugReport.duplicate_of when context.canonical is null', async () => {
+      const context = makeContext({ canonical: null }); // duplicate_of still set on bugReport
+      await dispatcher.dispatch(context, {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: 'hi',
+      });
+      expect(resolver.resolve).toHaveBeenCalledWith('bug-canonical', 'project-1');
+    });
+  });
+
+  describe('ticket.transition', () => {
+    it('routes to service.transition with the requested status', async () => {
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.transition',
+        target: 'canonical',
+        to: 'in_progress',
+      });
+      expect(ok).toBe(true);
+      expect(capabilityService.transition).toHaveBeenCalledWith(TARGET, 'in_progress');
+    });
+
+    it('returns false when the plugin lacks the transition capability', async () => {
+      lookup.mockResolvedValueOnce({
+        addComment: vi.fn(),
+      } as unknown as TicketIntegrationCapabilities);
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.transition',
+        target: 'canonical',
+        to: 'closed',
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('catches transition failures', async () => {
+      capabilityService.transition.mockRejectedValueOnce(new Error('no valid transition'));
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'ticket.transition',
+        target: 'canonical',
+        to: 'open',
+      });
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('notify.* (not wired in PR-C)', () => {
+    // The action types parse and dispatch, but the dispatcher
+    // intentionally logs+returns false until PR-C2 (email) / PR-D
+    // (slack, webhook). Pinning false here means a future PR that
+    // adds real wiring also has to update this test, which is the
+    // signal we want.
+
+    it.each<ActionSpec>([
+      { type: 'notify.email', to: 'reporter', template: 'dedup_ack' },
+      { type: 'notify.slack', channel: '#regressions', message: 'hit' },
+      { type: 'notify.webhook', url: 'https://example.com/hook' },
+    ])('returns false for %s without touching the resolver or lookup', async (action) => {
+      const ok = await dispatcher.dispatch(makeContext(), action);
+      expect(ok).toBe(false);
+      expect(resolver.resolve).not.toHaveBeenCalled();
+      expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -221,6 +221,36 @@ describe('DefaultActionDispatcher', () => {
     });
   });
 
+  describe('canDispatch', () => {
+    it('returns true for ticket.* actions', () => {
+      expect(
+        dispatcher.canDispatch({
+          type: 'ticket.add_comment',
+          target: 'canonical',
+          body: 'x',
+        })
+      ).toBe(true);
+      expect(
+        dispatcher.canDispatch({
+          type: 'ticket.transition',
+          target: 'canonical',
+          to: 'closed',
+        })
+      ).toBe(true);
+    });
+
+    it.each<ActionSpec>([
+      { type: 'notify.email', to: 'reporter', template: 'ack' },
+      { type: 'notify.slack', channel: '#x', message: 'hi' },
+      { type: 'notify.webhook', url: 'https://example.com/hook' },
+    ])('returns false for not-yet-wired %s', (action) => {
+      // PR-C2 / PR-D will flip these as the dispatchers land. The
+      // executor relies on this to skip rate-limit-consuming fires
+      // that would do zero work.
+      expect(dispatcher.canDispatch(action)).toBe(false);
+    });
+  });
+
   describe('notify.* (not wired in PR-C)', () => {
     // The action types parse and dispatch, but the dispatcher
     // intentionally logs+returns false until PR-C2 (email) / PR-D

--- a/packages/backend/tests/services/rules/evaluator.test.ts
+++ b/packages/backend/tests/services/rules/evaluator.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure-function tests for the dedup rule condition evaluator.
+ *
+ * The evaluator works against an already-resolved context map — it
+ * doesn't touch the DB — so these tests cover every (op, value-shape)
+ * combination directly. Field resolution is exercised by the executor
+ * tests, which mock the DB-touching providers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateConditions } from '../../../src/services/rules/evaluator.js';
+import type { RuleEvalContext } from '../../../src/services/rules/types.js';
+import type { ConditionSpec } from '../../../src/integrations/dedup-rule.schema.js';
+import type { BugReport } from '../../../src/db/types.js';
+
+// Cheap factory — never actually used as a real BugReport; the evaluator
+// only reads `context.resolved` for condition checks. The fields below
+// satisfy the type but most are inert.
+function makeBugReport(): BugReport {
+  return {
+    id: 'bug-1',
+    project_id: 'project-1',
+    title: 't',
+    description: null,
+    screenshot_url: null,
+    replay_url: null,
+    metadata: {},
+    status: 'open',
+    priority: 'medium',
+    deleted_at: null,
+    deleted_by: null,
+    legal_hold: false,
+    organization_id: null,
+    duplicate_of: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    screenshot_key: null,
+    thumbnail_key: null,
+    replay_key: null,
+    upload_status: 'completed',
+    replay_upload_status: 'completed',
+  } as BugReport;
+}
+
+function makeContext(resolved: Record<string, unknown>): RuleEvalContext {
+  return {
+    bugReport: makeBugReport(),
+    canonical: null,
+    projectId: 'project-1',
+    resolved: new Map(Object.entries(resolved)),
+  };
+}
+
+describe('evaluateConditions', () => {
+  it('returns true for an empty conditions array (no conditions = always pass)', () => {
+    expect(evaluateConditions(makeContext({}), [])).toBe(true);
+  });
+
+  describe('eq', () => {
+    it('passes when resolved value equals condition value', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'severity', op: 'eq', value: 'high' } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ severity: 'high' }), conds)).toBe(true);
+    });
+
+    it('fails when resolved value differs', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'severity', op: 'eq', value: 'high' } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ severity: 'low' }), conds)).toBe(false);
+    });
+
+    it('fails when resolved value is null (absent field)', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'canonical.status', op: 'eq', value: 'closed' } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ 'canonical.status': null }), conds)).toBe(false);
+    });
+  });
+
+  describe('in / not_in', () => {
+    it('in passes when resolved value is in the list', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'canonical.status', op: 'in', value: ['closed', 'wont_fix'] } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ 'canonical.status': 'closed' }), conds)).toBe(true);
+    });
+
+    it('in fails when resolved value is not in the list', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'canonical.status', op: 'in', value: ['closed', 'wont_fix'] } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ 'canonical.status': 'open' }), conds)).toBe(false);
+    });
+
+    it('not_in passes when resolved value is absent from the list', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'severity', op: 'not_in', value: ['low'] } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ severity: 'critical' }), conds)).toBe(true);
+    });
+
+    it('not_in fails when resolved value is in the list', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'severity', op: 'not_in', value: ['low'] } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ severity: 'low' }), conds)).toBe(false);
+    });
+  });
+
+  describe('gte / lte', () => {
+    it('gte passes when resolved value meets the threshold', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ hits_in_window: 5 }), conds)).toBe(true);
+      expect(evaluateConditions(makeContext({ hits_in_window: 3 }), conds)).toBe(true);
+    });
+
+    it('gte fails when resolved value is below the threshold', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ hits_in_window: 2 }), conds)).toBe(false);
+    });
+
+    it('lte mirrors gte', () => {
+      const conds: ConditionSpec[] = [
+        {
+          field: 'canonical.closed_days_ago',
+          op: 'lte',
+          value: 30,
+        } as ConditionSpec,
+      ];
+      expect(evaluateConditions(makeContext({ 'canonical.closed_days_ago': 7 }), conds)).toBe(true);
+      expect(evaluateConditions(makeContext({ 'canonical.closed_days_ago': 60 }), conds)).toBe(
+        false
+      );
+    });
+
+    it('gte fails when resolved value is non-numeric (defense-in-depth)', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
+      ];
+      // Schema rejects this on parse, but the evaluator should still
+      // refuse to compare if a bug let one through.
+      expect(evaluateConditions(makeContext({ hits_in_window: 'lots' }), conds)).toBe(false);
+    });
+  });
+
+  describe('AND semantics', () => {
+    it('all conditions must pass', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'canonical.status', op: 'in', value: ['closed'] } as ConditionSpec,
+        { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
+      ];
+      expect(
+        evaluateConditions(makeContext({ 'canonical.status': 'closed', hits_in_window: 5 }), conds)
+      ).toBe(true);
+    });
+
+    it('one failing condition fails the whole rule', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'canonical.status', op: 'in', value: ['closed'] } as ConditionSpec,
+        { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
+      ];
+      expect(
+        evaluateConditions(makeContext({ 'canonical.status': 'closed', hits_in_window: 1 }), conds)
+      ).toBe(false);
+    });
+  });
+
+  describe('unresolved fields', () => {
+    it('treats missing-from-resolved-map as a failed condition (fail-closed)', () => {
+      const conds: ConditionSpec[] = [
+        { field: 'severity', op: 'eq', value: 'high' } as ConditionSpec,
+      ];
+      // `severity` was never resolved into the map -> the evaluator
+      // returns false rather than throwing, so a bug in the resolver
+      // can't break unrelated rules in the same fire.
+      expect(evaluateConditions(makeContext({}), conds)).toBe(false);
+    });
+  });
+});

--- a/packages/backend/tests/services/rules/evaluator.test.ts
+++ b/packages/backend/tests/services/rules/evaluator.test.ts
@@ -111,18 +111,21 @@ describe('evaluateConditions', () => {
 
   describe('gte / lte', () => {
     it('gte passes when resolved value meets the threshold', () => {
+      // `hits_in_window` keys on `<field>:<window>` so two conditions
+      // with different windows don't alias — the evaluator's lookup
+      // uses the same composite key.
       const conds: ConditionSpec[] = [
         { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
       ];
-      expect(evaluateConditions(makeContext({ hits_in_window: 5 }), conds)).toBe(true);
-      expect(evaluateConditions(makeContext({ hits_in_window: 3 }), conds)).toBe(true);
+      expect(evaluateConditions(makeContext({ 'hits_in_window:24h': 5 }), conds)).toBe(true);
+      expect(evaluateConditions(makeContext({ 'hits_in_window:24h': 3 }), conds)).toBe(true);
     });
 
     it('gte fails when resolved value is below the threshold', () => {
       const conds: ConditionSpec[] = [
         { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
       ];
-      expect(evaluateConditions(makeContext({ hits_in_window: 2 }), conds)).toBe(false);
+      expect(evaluateConditions(makeContext({ 'hits_in_window:24h': 2 }), conds)).toBe(false);
     });
 
     it('lte mirrors gte', () => {
@@ -145,7 +148,7 @@ describe('evaluateConditions', () => {
       ];
       // Schema rejects this on parse, but the evaluator should still
       // refuse to compare if a bug let one through.
-      expect(evaluateConditions(makeContext({ hits_in_window: 'lots' }), conds)).toBe(false);
+      expect(evaluateConditions(makeContext({ 'hits_in_window:24h': 'lots' }), conds)).toBe(false);
     });
   });
 
@@ -156,7 +159,10 @@ describe('evaluateConditions', () => {
         { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
       ];
       expect(
-        evaluateConditions(makeContext({ 'canonical.status': 'closed', hits_in_window: 5 }), conds)
+        evaluateConditions(
+          makeContext({ 'canonical.status': 'closed', 'hits_in_window:24h': 5 }),
+          conds
+        )
       ).toBe(true);
     });
 
@@ -166,7 +172,25 @@ describe('evaluateConditions', () => {
         { field: 'hits_in_window', op: 'gte', value: 3, window: '24h' } as ConditionSpec,
       ];
       expect(
-        evaluateConditions(makeContext({ 'canonical.status': 'closed', hits_in_window: 1 }), conds)
+        evaluateConditions(
+          makeContext({ 'canonical.status': 'closed', 'hits_in_window:24h': 1 }),
+          conds
+        )
+      ).toBe(false);
+    });
+
+    it('two `hits_in_window` conditions on different windows do not alias', () => {
+      // Regression test for the cache-collision bug fixed alongside.
+      const conds: ConditionSpec[] = [
+        { field: 'hits_in_window', op: 'gte', value: 3, window: '1h' } as ConditionSpec,
+        { field: 'hits_in_window', op: 'gte', value: 10, window: '24h' } as ConditionSpec,
+      ];
+      expect(
+        evaluateConditions(makeContext({ 'hits_in_window:1h': 5, 'hits_in_window:24h': 15 }), conds)
+      ).toBe(true);
+      // The 1h check passes (5 >= 3) but the 24h check fails (2 < 10).
+      expect(
+        evaluateConditions(makeContext({ 'hits_in_window:1h': 5, 'hits_in_window:24h': 2 }), conds)
       ).toBe(false);
     });
   });

--- a/packages/backend/tests/services/rules/executor.test.ts
+++ b/packages/backend/tests/services/rules/executor.test.ts
@@ -100,7 +100,9 @@ describe('DedupRuleExecutor.fire', () => {
   beforeEach(() => {
     repo = { findByProject: vi.fn().mockResolvedValue([COMMENT_RULE]) };
     dispatchSpy = vi.fn().mockResolvedValue(true);
-    dispatcher = { dispatch: dispatchSpy };
+    // Default stub: all actions are dispatchable. Specific tests
+    // override canDispatch to exercise the no-supported-actions path.
+    dispatcher = { dispatch: dispatchSpy, canDispatch: vi.fn().mockReturnValue(true) };
     rateLimiter = {
       shouldFire: vi.fn().mockResolvedValue(true),
       recordFire: vi.fn().mockResolvedValue(undefined),
@@ -108,6 +110,7 @@ describe('DedupRuleExecutor.fire', () => {
     context = {
       loadCanonical: vi.fn().mockResolvedValue(makeCanonical()),
       countHitsInWindow: vi.fn().mockResolvedValue(7),
+      loadReporterTier: vi.fn().mockResolvedValue(null),
     };
     executor = new DedupRuleExecutor(
       repo as unknown as DedupRuleRepository,
@@ -353,6 +356,157 @@ describe('DedupRuleExecutor.fire', () => {
     const results = await executor.fire('outbox_about_to_skip', makeBugReport());
     expect(results[0].fired).toBe(false);
     expect(results[0].skipReason).toBe('conditions_unmet');
+  });
+
+  describe('canonical.closed_days_ago gating', () => {
+    it('returns null (condition fails) for an open canonical, even if last touched long ago', async () => {
+      // Regression: previously the resolver returned days-since-
+      // updated regardless of status, so a stale-but-open canonical
+      // matched `closed_days_ago >= 7`. Now the value is null unless
+      // status is closed/resolved.
+      const staleOpen = makeCanonical({
+        status: 'open',
+        updated_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      });
+      (context.loadCanonical as ReturnType<typeof vi.fn>).mockResolvedValueOnce(staleOpen);
+
+      const rule: DedupRuleRow = {
+        ...COMMENT_RULE,
+        id: 'rule-stale-open',
+        rule_json: {
+          name: 'reopen old closed',
+          when: { type: 'outbox_about_to_skip' },
+          if: [{ field: 'canonical.closed_days_ago', op: 'gte', value: 7 }],
+          then: [{ type: 'ticket.add_comment', target: 'canonical', body: 'hi' }],
+        },
+      };
+      repo.findByProject.mockResolvedValueOnce([rule]);
+
+      const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+      expect(results[0].fired).toBe(false);
+      expect(results[0].skipReason).toBe('conditions_unmet');
+    });
+
+    it('returns days-since for a closed canonical', async () => {
+      const closedOld = makeCanonical({
+        status: 'closed',
+        updated_at: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      });
+      (context.loadCanonical as ReturnType<typeof vi.fn>).mockResolvedValueOnce(closedOld);
+
+      const rule: DedupRuleRow = {
+        ...COMMENT_RULE,
+        id: 'rule-closed-7',
+        rule_json: {
+          name: 'reopen old closed',
+          when: { type: 'outbox_about_to_skip' },
+          if: [{ field: 'canonical.closed_days_ago', op: 'gte', value: 7 }],
+          then: [{ type: 'ticket.add_comment', target: 'canonical', body: 'hi' }],
+        },
+      };
+      repo.findByProject.mockResolvedValueOnce([rule]);
+
+      const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+      expect(results[0].fired).toBe(true);
+    });
+  });
+
+  describe('reporter.customer.tier sourcing', () => {
+    it('routes through context.loadReporterTier(organization_id), not through bugReport.metadata', async () => {
+      // The path was previously read from bugReport.metadata.user.tier
+      // — which no writer populates and which an SDK could spoof.
+      // Now it's sourced from subscriptions via the provider.
+      (context.loadReporterTier as ReturnType<typeof vi.fn>).mockResolvedValueOnce('enterprise');
+
+      const bug = makeBugReport({ organization_id: 'org-uuid' });
+      const rule: DedupRuleRow = {
+        ...COMMENT_RULE,
+        id: 'rule-tier',
+        rule_json: {
+          name: 'enterprise only',
+          when: { type: 'outbox_about_to_skip' },
+          if: [{ field: 'reporter.customer.tier', op: 'eq', value: 'enterprise' }],
+          then: [{ type: 'ticket.add_comment', target: 'canonical', body: 'hi' }],
+        },
+      };
+      repo.findByProject.mockResolvedValueOnce([rule]);
+
+      const results = await executor.fire('outbox_about_to_skip', bug);
+
+      expect(context.loadReporterTier).toHaveBeenCalledWith('org-uuid');
+      expect(results[0].fired).toBe(true);
+    });
+
+    it('passes null when bugReport has no organization_id (selfhosted / legacy)', async () => {
+      (context.loadReporterTier as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+      const bug = makeBugReport({ organization_id: null });
+      const rule: DedupRuleRow = {
+        ...COMMENT_RULE,
+        id: 'rule-tier-null',
+        rule_json: {
+          name: 'enterprise only',
+          when: { type: 'outbox_about_to_skip' },
+          if: [{ field: 'reporter.customer.tier', op: 'eq', value: 'enterprise' }],
+          then: [{ type: 'ticket.add_comment', target: 'canonical', body: 'hi' }],
+        },
+      };
+      repo.findByProject.mockResolvedValueOnce([rule]);
+
+      const results = await executor.fire('outbox_about_to_skip', bug);
+
+      expect(context.loadReporterTier).toHaveBeenCalledWith(null);
+      // Tier resolves to null -> condition fails closed
+      expect(results[0].fired).toBe(false);
+      expect(results[0].skipReason).toBe('conditions_unmet');
+    });
+  });
+
+  describe('no_supported_actions', () => {
+    it('skips the rule without consuming the rate-limit slot when no action is dispatchable', async () => {
+      // Regression: a rule whose only actions are not-yet-wired
+      // (e.g. all-notify.slack in PR-C) used to burn the throttle
+      // budget for zero work. Now the executor probes canDispatch
+      // upfront and skips the rule entirely.
+      (dispatcher.canDispatch as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+      const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+
+      expect(results[0].fired).toBe(false);
+      expect(results[0].skipReason).toBe('no_supported_actions');
+      expect(results[0].actionsDispatched).toBe(0);
+      expect(results[0].actionsSkipped).toBe(1); // mirrors rule.then.length
+      // Rate limiter MUST NOT have been touched — that's the whole point.
+      expect(rateLimiter.shouldFire).not.toHaveBeenCalled();
+      expect(rateLimiter.recordFire).not.toHaveBeenCalled();
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+
+    it('still fires when at least one action is dispatchable', async () => {
+      // Mixed dispatchability: as long as one action can run, the
+      // rule fires and consumes the slot normally.
+      (dispatcher.canDispatch as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+      const mixedRule: DedupRuleRow = {
+        ...COMMENT_RULE,
+        id: 'rule-mixed',
+        rule_json: {
+          name: 'mixed-dispatchability',
+          when: { type: 'outbox_about_to_skip' },
+          if: [{ field: 'canonical.status', op: 'eq', value: 'closed' }],
+          then: [
+            { type: 'notify.slack', channel: '#x', message: 'hi' },
+            { type: 'ticket.add_comment', target: 'canonical', body: 'hi' },
+          ],
+        },
+      };
+      repo.findByProject.mockResolvedValueOnce([mixedRule]);
+
+      const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+
+      expect(results[0].fired).toBe(true);
+      expect(rateLimiter.shouldFire).toHaveBeenCalled();
+    });
   });
 
   describe('per-rule error isolation', () => {

--- a/packages/backend/tests/services/rules/executor.test.ts
+++ b/packages/backend/tests/services/rules/executor.test.ts
@@ -129,7 +129,7 @@ describe('DedupRuleExecutor.fire', () => {
 
   it('passes the canonical into the eval context for ticket actions', async () => {
     await executor.fire('outbox_about_to_skip', makeBugReport());
-    expect(context.loadCanonical).toHaveBeenCalledWith('bug-canonical');
+    expect(context.loadCanonical).toHaveBeenCalledWith('bug-canonical', 'project-1');
     const ctxArg = dispatchSpy.mock.calls[0][0] as RuleEvalContext;
     expect(ctxArg.canonical?.id).toBe('bug-canonical');
   });
@@ -317,8 +317,18 @@ describe('DedupRuleExecutor.fire', () => {
     const results = await executor.fire('outbox_about_to_skip', makeBugReport());
     expect(results[0].fired).toBe(true);
     expect(context.countHitsInWindow).toHaveBeenCalledTimes(2);
-    expect(context.countHitsInWindow).toHaveBeenNthCalledWith(1, 'bug-canonical', '1h');
-    expect(context.countHitsInWindow).toHaveBeenNthCalledWith(2, 'bug-canonical', '24h');
+    expect(context.countHitsInWindow).toHaveBeenNthCalledWith(
+      1,
+      'bug-canonical',
+      'project-1',
+      '1h'
+    );
+    expect(context.countHitsInWindow).toHaveBeenNthCalledWith(
+      2,
+      'bug-canonical',
+      'project-1',
+      '24h'
+    );
   });
 
   it('fails the rule when one window passes but the other does not', async () => {

--- a/packages/backend/tests/services/rules/executor.test.ts
+++ b/packages/backend/tests/services/rules/executor.test.ts
@@ -344,4 +344,56 @@ describe('DedupRuleExecutor.fire', () => {
     expect(results[0].fired).toBe(false);
     expect(results[0].skipReason).toBe('conditions_unmet');
   });
+
+  describe('per-rule error isolation', () => {
+    // The executor's documented contract: a single rule throwing
+    // anywhere in the rate-limit / dispatch path must not abort the
+    // remaining rules in the same fire. These regressions catch a
+    // future refactor that drops the inner try/catch.
+
+    it('reports dispatch_error when rateLimiter.shouldFire throws and continues to the next rule', async () => {
+      const otherRule: DedupRuleRow = {
+        ...COMMENT_RULE,
+        id: 'rule-2',
+        rule_json: {
+          ...(COMMENT_RULE.rule_json as object),
+          name: 'B2-copy',
+        },
+      };
+      repo.findByProject.mockResolvedValueOnce([COMMENT_RULE, otherRule]);
+      (rateLimiter.shouldFire as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('throttle table unreachable'))
+        .mockResolvedValueOnce(true);
+
+      const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+      expect(results).toHaveLength(2);
+      const first = results.find((r) => r.ruleId === 'rule-1');
+      const second = results.find((r) => r.ruleId === 'rule-2');
+      expect(first?.fired).toBe(false);
+      expect(first?.skipReason).toBe('dispatch_error');
+      expect(second?.fired).toBe(true);
+    });
+
+    it('reports dispatch_error when an action dispatch throws and continues to the next rule', async () => {
+      const otherRule: DedupRuleRow = {
+        ...COMMENT_RULE,
+        id: 'rule-2',
+        rule_json: {
+          ...(COMMENT_RULE.rule_json as object),
+          name: 'B2-copy',
+        },
+      };
+      repo.findByProject.mockResolvedValueOnce([COMMENT_RULE, otherRule]);
+      // Dispatcher contract is to swallow its own errors and return
+      // false. If a buggy custom dispatcher throws instead, the
+      // executor's outer try/catch must still contain it.
+      dispatchSpy.mockRejectedValueOnce(new Error('dispatch went sideways'));
+
+      const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+      const first = results.find((r) => r.ruleId === 'rule-1');
+      const second = results.find((r) => r.ruleId === 'rule-2');
+      expect(first?.skipReason).toBe('dispatch_error');
+      expect(second?.fired).toBe(true);
+    });
+  });
 });

--- a/packages/backend/tests/services/rules/executor.test.ts
+++ b/packages/backend/tests/services/rules/executor.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for `DedupRuleExecutor.fire(...)` — the orchestrator that
+ * loads rules, filters by trigger, evaluates conditions, applies the
+ * rate limit, and dispatches actions.
+ *
+ * All four collaborators (`DedupRuleRepository`, `ActionDispatcher`,
+ * `RuleRateLimiter`, `RuleContextProvider`) are stubbed so this suite
+ * runs in the unit harness without Postgres. Coverage focus:
+ *   - happy path: rule fires, actions dispatched
+ *   - trigger mismatch -> rule not even attempted
+ *   - conditions fail -> reported as 'conditions_unmet', no actions
+ *   - rate-limited -> reported as 'rate_limited', no actions
+ *   - invalid rule_json -> reported as 'evaluation_error', other rules continue
+ *   - canonical-touching rule with no canonical -> conditions on
+ *     canonical.* return null and fail closed
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DedupRuleExecutor } from '../../../src/services/rules/executor.js';
+import type { RuleContextProvider } from '../../../src/services/rules/executor.js';
+import type {
+  ActionDispatcher,
+  RuleEvalContext,
+  RuleRateLimiter,
+} from '../../../src/services/rules/types.js';
+import type { DedupRuleRepository, DedupRuleRow } from '../../../src/db/dedup-rule.repository.js';
+import type { ActionSpec } from '../../../src/integrations/dedup-rule.schema.js';
+import type { BugReport } from '../../../src/db/types.js';
+
+function makeBugReport(overrides: Partial<BugReport> = {}): BugReport {
+  return {
+    id: 'bug-new',
+    project_id: 'project-1',
+    title: 't',
+    description: null,
+    screenshot_url: null,
+    replay_url: null,
+    metadata: {},
+    status: 'open',
+    priority: 'high',
+    deleted_at: null,
+    deleted_by: null,
+    legal_hold: false,
+    organization_id: null,
+    duplicate_of: 'bug-canonical',
+    created_at: new Date(),
+    updated_at: new Date(),
+    screenshot_key: null,
+    thumbnail_key: null,
+    replay_key: null,
+    upload_status: 'completed',
+    replay_upload_status: 'completed',
+    ...overrides,
+  } as BugReport;
+}
+
+function makeCanonical(overrides: Partial<BugReport> = {}): BugReport {
+  return makeBugReport({
+    id: 'bug-canonical',
+    duplicate_of: null,
+    status: 'closed',
+    updated_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), // 5 days ago
+    ...overrides,
+  });
+}
+
+// COMMENT_RULE: B2-shaped "+1 occurrence" comment. Constrained to
+// `canonical.status === 'closed'` so the conditions_unmet test can
+// flip status to 'open' (which the executor maps to canonical 'open')
+// and observe the mismatch deterministically.
+const COMMENT_RULE: DedupRuleRow = {
+  id: 'rule-1',
+  project_id: 'project-1',
+  name: 'B2 — counter on canonical',
+  enabled: true,
+  rule_json: {
+    name: 'B2 — counter on canonical',
+    when: { type: 'outbox_about_to_skip' },
+    if: [{ field: 'canonical.status', op: 'eq', value: 'closed' }],
+    then: [
+      {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: '+1 occurrence',
+      },
+    ],
+  },
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+describe('DedupRuleExecutor.fire', () => {
+  let repo: { findByProject: ReturnType<typeof vi.fn> };
+  let dispatcher: ActionDispatcher;
+  let rateLimiter: RuleRateLimiter;
+  let context: RuleContextProvider;
+  let executor: DedupRuleExecutor;
+  let dispatchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    repo = { findByProject: vi.fn().mockResolvedValue([COMMENT_RULE]) };
+    dispatchSpy = vi.fn().mockResolvedValue(true);
+    dispatcher = { dispatch: dispatchSpy };
+    rateLimiter = {
+      shouldFire: vi.fn().mockResolvedValue(true),
+      recordFire: vi.fn().mockResolvedValue(undefined),
+    };
+    context = {
+      loadCanonical: vi.fn().mockResolvedValue(makeCanonical()),
+      countHitsInWindow: vi.fn().mockResolvedValue(7),
+    };
+    executor = new DedupRuleExecutor(
+      repo as unknown as DedupRuleRepository,
+      dispatcher,
+      rateLimiter,
+      context
+    );
+  });
+
+  it('fires a rule when trigger matches, conditions pass, and rate limit allows', async () => {
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results).toHaveLength(1);
+    expect(results[0].fired).toBe(true);
+    expect(results[0].skipReason).toBeNull();
+    expect(results[0].actionsDispatched).toBe(1);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(rateLimiter.recordFire as ReturnType<typeof vi.fn>).toHaveBeenCalledOnce();
+  });
+
+  it('passes the canonical into the eval context for ticket actions', async () => {
+    await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(context.loadCanonical).toHaveBeenCalledWith('bug-canonical');
+    const ctxArg = dispatchSpy.mock.calls[0][0] as RuleEvalContext;
+    expect(ctxArg.canonical?.id).toBe('bug-canonical');
+  });
+
+  it('skips rules whose when.type does not match the trigger', async () => {
+    // Rule with `when.type = 'duplicate_detected'` shouldn't be touched
+    // when we fire `outbox_about_to_skip`. Mismatches don't appear in
+    // results (they're not "attempted" — keeps telemetry meaningful).
+    const mismatchRule: DedupRuleRow = {
+      ...COMMENT_RULE,
+      id: 'rule-mismatch',
+      rule_json: {
+        ...(COMMENT_RULE.rule_json as object),
+        when: { type: 'duplicate_detected' },
+      },
+    };
+    repo.findByProject.mockResolvedValueOnce([COMMENT_RULE, mismatchRule]);
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results.map((r) => r.ruleId)).toEqual(['rule-1']);
+  });
+
+  it('reports conditions_unmet when condition fails', async () => {
+    // Canonical is 'open' (maps to canonical 'open'); rule wants 'closed'.
+    (context.loadCanonical as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeCanonical({ status: 'open' })
+    );
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results[0].fired).toBe(false);
+    expect(results[0].skipReason).toBe('conditions_unmet');
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(rateLimiter.recordFire).not.toHaveBeenCalled();
+  });
+
+  it('reports rate_limited and does not dispatch when limiter says no', async () => {
+    (rateLimiter.shouldFire as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results[0].fired).toBe(false);
+    expect(results[0].skipReason).toBe('rate_limited');
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(rateLimiter.recordFire).not.toHaveBeenCalled();
+  });
+
+  it('skips malformed rule_json and continues with other rules', async () => {
+    const malformed: DedupRuleRow = {
+      ...COMMENT_RULE,
+      id: 'rule-malformed',
+      rule_json: { name: 'bad', when: { type: 'made_up' } }, // invalid: unknown trigger, no `then`
+    };
+    repo.findByProject.mockResolvedValueOnce([malformed, COMMENT_RULE]);
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results).toHaveLength(2);
+    const bad = results.find((r) => r.ruleId === 'rule-malformed');
+    const good = results.find((r) => r.ruleId === 'rule-1');
+    expect(bad?.fired).toBe(false);
+    expect(bad?.skipReason).toBe('evaluation_error');
+    expect(good?.fired).toBe(true);
+  });
+
+  it('returns empty array when there are no rules for the project', async () => {
+    repo.findByProject.mockResolvedValueOnce([]);
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results).toEqual([]);
+    expect(context.loadCanonical).not.toHaveBeenCalled();
+  });
+
+  it('does not load the canonical when no rule references canonical.* or ticket actions', async () => {
+    const reporterRule: DedupRuleRow = {
+      ...COMMENT_RULE,
+      id: 'rule-no-canonical',
+      rule_json: {
+        name: 'severity check',
+        when: { type: 'outbox_about_to_skip' },
+        if: [{ field: 'severity', op: 'eq', value: 'high' }],
+        // notify.email is a no-op in PR-C but the dispatcher won't
+        // need a canonical to resolve it — so the executor should
+        // skip the canonical fetch entirely.
+        then: [{ type: 'notify.email', to: 'reporter', template: 'dedup_ack' }],
+      },
+    };
+    repo.findByProject.mockResolvedValueOnce([reporterRule]);
+    // Default dispatcher mock returns true; in production notify.email
+    // would log-and-return-false, but the test focuses on whether
+    // canonical was loaded.
+
+    await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(context.loadCanonical).not.toHaveBeenCalled();
+  });
+
+  it('isolates per-rule errors — DB-level failure on rules lookup returns []', async () => {
+    repo.findByProject.mockRejectedValueOnce(new Error('db unavailable'));
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results).toEqual([]);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it('dispatches multiple actions in order', async () => {
+    const twoActionsRule: DedupRuleRow = {
+      ...COMMENT_RULE,
+      id: 'rule-two-actions',
+      rule_json: {
+        name: 'B3 — auto-reopen',
+        when: { type: 'outbox_about_to_skip' },
+        if: [{ field: 'canonical.status', op: 'in', value: ['closed', 'wont_fix'] }],
+        then: [
+          { type: 'ticket.transition', target: 'canonical', to: 'in_progress' },
+          { type: 'ticket.add_comment', target: 'canonical', body: 'auto-reopened' },
+        ],
+      },
+    };
+    repo.findByProject.mockResolvedValueOnce([twoActionsRule]);
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results[0].fired).toBe(true);
+    expect(results[0].actionsDispatched).toBe(2);
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    // First call should be the transition (order matters — transition
+    // before comment so the comment lands in the new state).
+    const firstAction = dispatchSpy.mock.calls[0][1] as ActionSpec;
+    const secondAction = dispatchSpy.mock.calls[1][1] as ActionSpec;
+    expect(firstAction.type).toBe('ticket.transition');
+    expect(secondAction.type).toBe('ticket.add_comment');
+  });
+
+  it('counts dispatched vs skipped actions correctly', async () => {
+    dispatchSpy.mockReset();
+    dispatchSpy.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const twoActionsRule: DedupRuleRow = {
+      ...COMMENT_RULE,
+      id: 'rule-two',
+      rule_json: {
+        name: 'mixed',
+        when: { type: 'outbox_about_to_skip' },
+        if: [{ field: 'canonical.status', op: 'eq', value: 'closed' }],
+        then: [
+          { type: 'ticket.add_comment', target: 'canonical', body: 'a' },
+          { type: 'ticket.add_comment', target: 'canonical', body: 'b' },
+        ],
+      },
+    };
+    repo.findByProject.mockResolvedValueOnce([twoActionsRule]);
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results[0].fired).toBe(true);
+    expect(results[0].actionsDispatched).toBe(1);
+    expect(results[0].actionsSkipped).toBe(1);
+  });
+
+  it('passes the rate limit key as canonicalId when canonical is loaded', async () => {
+    await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(rateLimiter.shouldFire).toHaveBeenCalledWith(
+      'rule-1',
+      'bug-canonical', // canonical's id, NOT the new bug's id
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/backend/tests/services/rules/executor.test.ts
+++ b/packages/backend/tests/services/rules/executor.test.ts
@@ -290,4 +290,58 @@ describe('DedupRuleExecutor.fire', () => {
       expect.any(Object)
     );
   });
+
+  it('resolves hits_in_window separately per window (multi-window cache key)', async () => {
+    // Regression: a rule with two `hits_in_window` conditions on
+    // different windows used to alias on the same cache key (just
+    // `'hits_in_window'`), so the second condition saw the first
+    // condition's count. Now the key is `hits_in_window:<window>`.
+    const multiWindowRule: DedupRuleRow = {
+      ...COMMENT_RULE,
+      id: 'rule-multi-window',
+      rule_json: {
+        name: 'multi-window',
+        when: { type: 'outbox_about_to_skip' },
+        if: [
+          { field: 'hits_in_window', op: 'gte', value: 3, window: '1h' },
+          { field: 'hits_in_window', op: 'gte', value: 10, window: '24h' },
+        ],
+        then: [{ type: 'ticket.add_comment', target: 'canonical', body: 'noisy' }],
+      },
+    };
+    repo.findByProject.mockResolvedValueOnce([multiWindowRule]);
+    (context.countHitsInWindow as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(5) // 1h window -> meets 3
+      .mockResolvedValueOnce(15); // 24h window -> meets 10
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results[0].fired).toBe(true);
+    expect(context.countHitsInWindow).toHaveBeenCalledTimes(2);
+    expect(context.countHitsInWindow).toHaveBeenNthCalledWith(1, 'bug-canonical', '1h');
+    expect(context.countHitsInWindow).toHaveBeenNthCalledWith(2, 'bug-canonical', '24h');
+  });
+
+  it('fails the rule when one window passes but the other does not', async () => {
+    const multiWindowRule: DedupRuleRow = {
+      ...COMMENT_RULE,
+      id: 'rule-multi-window-fail',
+      rule_json: {
+        name: 'multi-window-fail',
+        when: { type: 'outbox_about_to_skip' },
+        if: [
+          { field: 'hits_in_window', op: 'gte', value: 3, window: '1h' },
+          { field: 'hits_in_window', op: 'gte', value: 10, window: '24h' },
+        ],
+        then: [{ type: 'ticket.add_comment', target: 'canonical', body: 'noisy' }],
+      },
+    };
+    repo.findByProject.mockResolvedValueOnce([multiWindowRule]);
+    (context.countHitsInWindow as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(5) // 1h -> 5 >= 3 OK
+      .mockResolvedValueOnce(2); // 24h -> 2 < 10 FAIL
+
+    const results = await executor.fire('outbox_about_to_skip', makeBugReport());
+    expect(results[0].fired).toBe(false);
+    expect(results[0].skipReason).toBe('conditions_unmet');
+  });
 });

--- a/packages/backend/tests/services/rules/rate-limiter.test.ts
+++ b/packages/backend/tests/services/rules/rate-limiter.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the rate-limiter helper.
+ *
+ * Covers:
+ *  - `windowStringToMinutes` pure conversion (CodeRabbit pinned the
+ *    Math.ceil rounding behaviour after `Math.floor` was found to make
+ *    sub-minute windows like "61s" *less* restrictive than configured)
+ *  - `ThrottleBackedRateLimiter.shouldFire` routes through the
+ *    repository's atomic `tryReserveSlot` and respects the `rate_limit`
+ *    being absent (always allow)
+ *  - `recordFire` is a no-op (kept on the interface for future
+ *    swap-in limiters that separate check from record)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ThrottleBackedRateLimiter,
+  windowStringToMinutes,
+} from '../../../src/services/rules/rate-limiter.js';
+import type { NotificationThrottleRepository } from '../../../src/db/repositories/notification-throttle.repository.js';
+import type { DedupRule } from '../../../src/integrations/dedup-rule.schema.js';
+
+function makeRule(rate_limit: DedupRule['rate_limit']): DedupRule {
+  return {
+    name: 'test',
+    when: { type: 'duplicate_detected' },
+    conditions: [],
+    then: [{ type: 'notify.email', to: 'reporter', template: 'ack' }],
+    rate_limit,
+    enabled: true,
+  } as DedupRule;
+}
+
+describe('windowStringToMinutes', () => {
+  it.each([
+    ['1m', 1],
+    ['5m', 5],
+    ['1h', 60],
+    ['24h', 60 * 24],
+    ['7d', 60 * 24 * 7],
+    ['1w', 60 * 24 * 7],
+    ['2w', 60 * 24 * 14],
+  ])('converts %s → %d minutes', (input, expected) => {
+    expect(windowStringToMinutes(input)).toBe(expected);
+  });
+
+  it('rounds sub-minute windows UP (Math.ceil), never down', () => {
+    // Regression: Math.floor used to make "61s" collapse to 1 minute,
+    // which is LESS restrictive than the rule author asked for. With
+    // Math.ceil it rounds up to 2 minutes — strictly more conservative.
+    expect(windowStringToMinutes('60s')).toBe(1);
+    expect(windowStringToMinutes('61s')).toBe(2);
+    expect(windowStringToMinutes('90s')).toBe(2);
+    expect(windowStringToMinutes('120s')).toBe(2);
+    expect(windowStringToMinutes('121s')).toBe(3);
+  });
+
+  it('clamps below-1-minute windows to 1', () => {
+    // The throttle infra has minute granularity, so anything under
+    // a minute rounds to 1 — but never to 0 (which would disable
+    // the limit entirely).
+    expect(windowStringToMinutes('30s')).toBe(1);
+    expect(windowStringToMinutes('1s')).toBe(1);
+  });
+
+  it('falls back to 60 minutes on malformed input rather than disabling the limit', () => {
+    // Schema validation should make this unreachable, but a manually-
+    // edited row must not silently turn the limit off.
+    expect(windowStringToMinutes('garbage')).toBe(60);
+    expect(windowStringToMinutes('')).toBe(60);
+  });
+});
+
+describe('ThrottleBackedRateLimiter', () => {
+  function buildLimiter() {
+    const tryReserveSlot = vi.fn().mockResolvedValue(true);
+    const throttle = { tryReserveSlot } as unknown as NotificationThrottleRepository;
+    return { limiter: new ThrottleBackedRateLimiter(throttle), tryReserveSlot };
+  }
+
+  describe('shouldFire', () => {
+    it('returns true without touching the throttle when rule has no rate_limit', async () => {
+      const { limiter, tryReserveSlot } = buildLimiter();
+      const rule = makeRule(undefined);
+      const allowed = await limiter.shouldFire('rule-1', 'canonical-1', rule);
+      expect(allowed).toBe(true);
+      expect(tryReserveSlot).not.toHaveBeenCalled();
+    });
+
+    it('delegates to throttle.tryReserveSlot with converted window minutes', async () => {
+      const { limiter, tryReserveSlot } = buildLimiter();
+      const rule = makeRule({ count: 1, window: '24h' });
+      await limiter.shouldFire('rule-1', 'canonical-1', rule);
+      expect(tryReserveSlot).toHaveBeenCalledWith(
+        'rule-1',
+        'canonical-1',
+        1,
+        60 * 24 // 24h converted
+      );
+    });
+
+    it('returns whatever tryReserveSlot returns (false = throttled, no extra logic)', async () => {
+      const { limiter, tryReserveSlot } = buildLimiter();
+      tryReserveSlot.mockResolvedValueOnce(false);
+      const rule = makeRule({ count: 1, window: '1h' });
+      const allowed = await limiter.shouldFire('rule-1', 'canonical-1', rule);
+      expect(allowed).toBe(false);
+    });
+
+    it('does NOT use the racy isThrottled path — atomic tryReserveSlot only', async () => {
+      // Defense-in-depth check: if a future refactor accidentally
+      // reintroduces the read-then-increment `isThrottled` path, the
+      // limiter's max-count contract silently breaks under concurrent
+      // workers. Lock the contract by asserting tryReserveSlot is the
+      // ONLY repository method touched.
+      const tryReserveSlot = vi.fn().mockResolvedValue(true);
+      const isThrottled = vi.fn();
+      const throttle = {
+        tryReserveSlot,
+        isThrottled,
+      } as unknown as NotificationThrottleRepository;
+      const limiter = new ThrottleBackedRateLimiter(throttle);
+      await limiter.shouldFire('rule-1', 'canonical-1', makeRule({ count: 1, window: '1h' }));
+      expect(tryReserveSlot).toHaveBeenCalledOnce();
+      expect(isThrottled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordFire', () => {
+    it('is a no-op — increment already happened inside shouldFire', async () => {
+      const { limiter, tryReserveSlot } = buildLimiter();
+      await limiter.recordFire('rule-1', 'canonical-1', makeRule({ count: 1, window: '1h' }));
+      // No DB calls at all.
+      expect(tryReserveSlot).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -79,6 +79,8 @@ export default defineConfig({
       'tests/api/utils/enrichment-trigger.test.ts',
       'tests/services/intelligence/dedup-service.test.ts',
       'tests/services/intelligence/self-service.test.ts',
+      'tests/services/rules/evaluator.test.ts',
+      'tests/services/rules/executor.test.ts',
       // Pure env-var / config validation test, no DB.
       'tests/config.test.ts',
     ],

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -81,6 +81,8 @@ export default defineConfig({
       'tests/services/intelligence/self-service.test.ts',
       'tests/services/rules/evaluator.test.ts',
       'tests/services/rules/executor.test.ts',
+      'tests/services/rules/dispatcher.test.ts',
+      'tests/services/rules/rate-limiter.test.ts',
       // Pure env-var / config validation test, no DB.
       'tests/config.test.ts',
     ],


### PR DESCRIPTION
## Summary
- **PR-C of the tiny dedup-rule engine** (Phase 0.5). Builds on #142 (capability interface) and #143 (schema + storage). Reopened from #145 to consolidate review history. No user-visible behaviour yet — admin UI lands in PR-D.
- New `src/services/rules/` module: pure evaluator, action dispatcher (routes `ticket.add_comment` / `ticket.transition` through the capability registry), atomic throttle-backed rate limiter, executor with full error containment.
- Outbox worker hook: right after `markSkipped('duplicate_of_set')`, fire the `outbox_about_to_skip` trigger.

## Hardening from prior review rounds (all already applied)

**Correctness / security:**
- Atomic `NotificationThrottleRepository.tryReserveSlot` — single `INSERT ON CONFLICT DO UPDATE WHERE count < $max RETURNING`; max-count contract holds under concurrent workers.
- Migration 023 drops the `notification_throttle.rule_id` FK so dedup-rule UUIDs are accepted; migration 024 restores CASCADE-on-delete via a trigger on `notification_rules` (prevents orphan rows).
- `loadReporterTier` filters `subscriptions.status IN ('active', 'trial')` so canceled / past_due / paused orgs fall through to null.
- `TicketsTableResolver` filters `br.deleted_at IS NULL` so soft-deleted canonicals can't receive engine actions.
- `RuleContextProvider` methods all scoped by `projectId`; `CanonicalTicketResolver` and `CapabilityServiceLookup` ditto — cross-tenant defense-in-depth at every boundary.
- `daysSinceClose` returns null unless canonical is `closed`/`resolved` — stale open tickets no longer match `closed_days_ago >= 7`.
- Multi-window cache key (`hits_in_window:<window>`) so two conditions on different windows don't alias.
- Per-rule try/catch around rate-limit + dispatch path; one bad rule can't abort the loop.
- Order: `markSkipped` FIRST, then fire — retries hit the terminal-state early-out, no double-fire.
- Rate-limit fallback chain: `canonical.id ?? duplicate_of ?? bugReport.id` (cluster-stable).
- `windowStringToMinutes` rounds up (Math.ceil) so sub-minute windows are strictly more conservative.
- `tryReserveSlot` fails closed on `maxNotifications < 1` or `windowMinutes < 1`.

**Throttle-budget protection:**
- New `ActionDispatcher.canDispatch(action)` probe; executor skips rules whose actions are all unwired (`notify.*` in PR-C) so the rate-limit slot isn't burned for zero work.

## Deliberately out of scope
- `duplicate_detected` trigger wiring — lands with PR-C2 alongside the email handler.
- `notify.email` / `notify.slack` / `notify.webhook` action dispatchers — recognised but `canDispatch` returns false.
- `cluster_growing` / `schedule` triggers — need an aggregator / cron worker respectively.
- Trigger on `dedup_rules` deletion → throttle cleanup — lands with the dedup-rule deletion path in PR-D.

## Test plan
- [x] 78 unit tests across 5 files (evaluator, executor, dispatcher, rate-limiter, outbox-worker hook)
- [x] Integration tests for `tryReserveSlot` (FK-drop, atomic TOCTOU, param validation, cascade trigger)
- [x] Full backend unit suite passes locally
- [x] Typecheck clean for new files
- [x] All CI checks green on #145 at the same commit
- [ ] PR-C2 (`duplicate_detected` hook + `notify.email` dispatcher) wires the engine end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notification throttling with atomic slot reservation for improved accuracy and prevention of over-limiting
  * New dedup rule engine enabling automated responses to duplicate bug reports, including ticket comments and status transitions
  * Rate-limited rule execution with configurable time windows to control action frequency

* **Bug Fixes**
  * Restored cascade delete behavior for notification throttle records when rules are removed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->