### PR TITLE
feat(rules): duplicate_detected hook + notify.email dispatcher (PR-C2)

### DIFF
--- a/packages/backend/src/queue/worker-manager.ts
+++ b/packages/backend/src/queue/worker-manager.ts
@@ -91,7 +91,8 @@ type OutboxWorkerFactory = (
 type IntelligenceWorkerFactory = (
   clientFactory: IClientFactory,
   db: DatabaseClient,
-  connection: Redis
+  connection: Redis,
+  pluginRegistry: PluginRegistry | null
 ) => AnyWorker;
 
 /** Worker configuration with discriminated union for type-safe factories */
@@ -305,7 +306,12 @@ export class WorkerManager {
               'Ensure INTELLIGENCE_ENABLED=true and WORKER_INTELLIGENCE_ENABLED=true.'
           );
         }
-        return workerConfig.factory(this.intelligenceClientFactory, this.db, connection);
+        return workerConfig.factory(
+          this.intelligenceClientFactory,
+          this.db,
+          connection,
+          this.pluginRegistry
+        );
       }
 
       default: {

--- a/packages/backend/src/queue/workers/intelligence-worker.ts
+++ b/packages/backend/src/queue/workers/intelligence-worker.ts
@@ -31,6 +31,9 @@ import type { IntelligenceClientFactory } from '../../services/intelligence/tena
 import { IntelligenceEnrichmentService } from '../../services/intelligence/enrichment-service.js';
 import { IntelligenceMitigationService } from '../../services/intelligence/mitigation-service.js';
 import { IntelligenceDedupService } from '../../services/intelligence/dedup-service.js';
+import type { PluginRegistry } from '../../integrations/plugin-registry.js';
+import type { DedupRuleExecutor } from '../../services/rules/executor.js';
+import { buildDedupRuleExecutor } from '../../services/rules/wiring.js';
 import type {
   IntelligenceJobData,
   IntelligenceJobResult,
@@ -128,7 +131,8 @@ async function resolveClient(
 async function processIntelligenceJob(
   job: IJobHandle<IntelligenceJobData, IntelligenceJobResult>,
   clientFactory: IntelligenceClientFactory,
-  db: DatabaseClient
+  db: DatabaseClient,
+  ruleExecutor: DedupRuleExecutor
 ): Promise<IntelligenceJobResult> {
   const startTime = Date.now();
 
@@ -153,7 +157,7 @@ async function processIntelligenceJob(
   const { client, orgId } = await resolveClient(job, clientFactory, db);
 
   if (type === 'analyze') {
-    return processAnalyzeJob(job, client, db, orgId, startTime);
+    return processAnalyzeJob(job, client, db, orgId, startTime, ruleExecutor);
   }
 
   if (type === 'resolution') {
@@ -183,7 +187,8 @@ async function processAnalyzeJob(
   client: IntelligenceClient,
   db: DatabaseClient,
   resolvedOrgId: string | undefined,
-  startTime: number
+  startTime: number,
+  ruleExecutor: DedupRuleExecutor
 ): Promise<IntelligenceJobResult> {
   const { bugReportId, projectId } = job.data;
   const payload = job.data.payload as AnalyzeBugRequest;
@@ -249,6 +254,53 @@ async function processAnalyzeJob(
           duplicateOf: dedupResult.duplicateOf,
           statusChanged: dedupResult.statusChanged,
         });
+
+        // Fire the duplicate_detected rule trigger. The bug has its
+        // duplicate_of set now, so re-fetch to give the executor the
+        // post-update row. The fire path is fully error-contained —
+        // rule load / dispatch / limiter failures are swallowed
+        // inside the executor, and we wrap an outer try just in case
+        // a bug in the engine itself escapes (the analysis result
+        // must still be returned to the queue).
+        //
+        try {
+          const updatedBug = await db.bugReports.findById(bugReportId);
+          // Defense-in-depth: confirm the re-fetched bug belongs
+          // to the job's project. A poisoned queue entry pointing
+          // at a cross-project bugReportId would otherwise cause
+          // the executor to load THAT other project's rules and
+          // dispatch its actions under our worker — see Claude's
+          // review on PR #147. The BullMQ queue is internal so
+          // the realistic vector is small, but the check is free.
+          if (updatedBug && updatedBug.project_id !== projectId) {
+            logger.error(
+              'Rejecting duplicate_detected fire: bugReport.project_id mismatches job.projectId',
+              {
+                jobId: job.id,
+                bugReportId,
+                bugProjectId: updatedBug.project_id,
+                jobProjectId: projectId,
+              }
+            );
+          } else if (updatedBug) {
+            const results = await ruleExecutor.fire('duplicate_detected', updatedBug);
+            if (results.length > 0) {
+              logger.info('Dedup rules evaluated for duplicate_detected', {
+                jobId: job.id,
+                bugReportId,
+                fired: results.filter((r) => r.fired).length,
+                total: results.length,
+              });
+            }
+          }
+        } catch (error) {
+          logger.error('Dedup rule executor crashed for duplicate_detected', {
+            jobId: job.id,
+            bugReportId,
+            error: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+        }
       }
     } catch (error) {
       // Never throw from dedup — analysis result must still be returned
@@ -476,9 +528,23 @@ async function processMitigationJob(
 export function createIntelligenceWorker(
   clientFactory: IntelligenceClientFactory,
   db: DatabaseClient,
-  connection: Redis
+  connection: Redis,
+  pluginRegistry: PluginRegistry | null
 ): IWorkerHost<IntelligenceJobData, IntelligenceJobResult> {
   logger.info('Creating intelligence worker');
+
+  // Build the rule executor once at worker construction and reuse it
+  // across every job. The executor is stateless (its collaborators
+  // share the same db + plugin registry references), so a single
+  // instance is correct AND avoids the per-job allocation churn that
+  // Gemini flagged on PR #147.
+  //
+  // pluginRegistry may be null on selfhosted-without-integrations
+  // deployments. We still build the executor: `notify.email` rules
+  // don't touch the registry, and the wiring helper supplies a
+  // null-yielding capability lookup so `ticket.*` actions runtime-
+  // skip cleanly instead of being globally disabled.
+  const ruleExecutor = buildDedupRuleExecutor(db, pluginRegistry);
 
   const worker = createWorker<
     IntelligenceJobData,
@@ -486,7 +552,7 @@ export function createIntelligenceWorker(
     typeof QUEUE_NAMES.INTELLIGENCE
   >({
     name: QUEUE_NAMES.INTELLIGENCE,
-    processor: async (job) => processIntelligenceJob(job, clientFactory, db),
+    processor: async (job) => processIntelligenceJob(job, clientFactory, db, ruleExecutor),
     connection,
     workerType: QUEUE_NAMES.INTELLIGENCE,
   });

--- a/packages/backend/src/services/notifications/email-handler.ts
+++ b/packages/backend/src/services/notifications/email-handler.ts
@@ -44,14 +44,27 @@ function createTransporter(config: EmailChannelConfig): Transporter {
 }
 
 /**
- * Strip HTML tags from string for plain text version
+ * Strip HTML tags from string for the multipart `text/plain` alternative.
+ *
+ * `<br>` and block-level closers (`</p>`, `</div>`, `</li>`, `</h1..6>`) are
+ * converted to `\n` before the catch-all strip so text-only clients see the
+ * document's line / paragraph structure. Without this, a body whose HTML
+ * uses `<br>` to separate lines collapses into one run-on paragraph in plain
+ * text (HTML clients render fine because they read the `html:` part).
+ *
+ * Horizontal whitespace runs collapse to one space; newline runs collapse to
+ * at most a blank line so paragraph breaks survive without unbounded vertical
+ * gaps.
  */
 function stripHtml(html: string): string {
   return html
     .replace(/<style[^>]*>.*?<\/style>/gis, '')
     .replace(/<script[^>]*>.*?<\/script>/gis, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(?:p|div|li|h[1-6])>/gi, '\n')
     .replace(/<[^>]+>/g, '')
-    .replace(/\s+/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
     .trim();
 }
 

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -21,6 +21,8 @@ import type {
 import { pluginSupports } from '../../integrations/capabilities.js';
 import type { ActionSpec } from '../../integrations/dedup-rule.schema.js';
 import { getLogger } from '../../logger.js';
+import type { EmailSender } from './email-sender.js';
+import { resolveEmailRecipient } from './email-sender.js';
 import type { ActionDispatcher, RuleEvalContext } from './types.js';
 
 const logger = getLogger();
@@ -59,7 +61,17 @@ export type CapabilityServiceLookup = (
 export class DefaultActionDispatcher implements ActionDispatcher {
   constructor(
     private readonly resolver: CanonicalTicketResolver,
-    private readonly lookupService: CapabilityServiceLookup
+    private readonly lookupService: CapabilityServiceLookup,
+    /**
+     * Optional. When provided, `notify.email` actions are dispatched
+     * via this sender. Left optional so the executor's unit tests
+     * (and any selfhosted deployment without notification channels)
+     * keep working without forcing a sender to exist. The
+     * `canDispatch` probe flips with this — rules with email-only
+     * actions are skipped if no sender is wired, avoiding the
+     * throttle-budget burn.
+     */
+    private readonly emailSender?: EmailSender
   ) {}
 
   /**
@@ -73,10 +85,14 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       case 'ticket.transition':
         return true;
       case 'notify.email':
+        // Wired in PR-C2 when an EmailSender is provided. Without
+        // one (test harness, selfhosted with no channels configured)
+        // we still report false so the rule skips cleanly.
+        return this.emailSender !== undefined;
       case 'notify.slack':
       case 'notify.webhook':
-        // PR-C2 (email) + PR-D (slack / webhook) flip these to true
-        // as the wiring lands.
+        // PR-D flips these to true as the slack / webhook wiring
+        // lands.
         return false;
       default: {
         const _exhaustive: never = action;
@@ -93,6 +109,7 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       case 'ticket.transition':
         return this.dispatchTicketTransition(context, action.to);
       case 'notify.email':
+        return this.dispatchEmail(context, action.to, action.template);
       case 'notify.slack':
       case 'notify.webhook':
         // Recognised but not yet wired — log once at info so deploys
@@ -170,6 +187,71 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       });
       return false;
     }
+  }
+
+  private async dispatchEmail(
+    context: RuleEvalContext,
+    to: string,
+    templateId: string
+  ): Promise<boolean> {
+    if (!this.emailSender) {
+      // Defensive — `canDispatch` already excludes this path when no
+      // sender is wired, so the executor shouldn't actually call us
+      // here. Log at info in case a custom dispatcher subclass
+      // overrides only one of the two.
+      logger.info('Skipping notify.email: no EmailSender wired', {
+        bugReportId: context.bugReport.id,
+      });
+      return false;
+    }
+    const recipient = resolveEmailRecipient(to, context);
+    if (!recipient) {
+      // resolveEmailRecipient logs the reason (unknown token, missing
+      // reporter email, etc).
+      return false;
+    }
+    return this.emailSender.send({
+      projectId: context.projectId,
+      to: recipient,
+      templateId,
+      vars: this.buildEmailVars(context),
+    });
+  }
+
+  /**
+   * Build the `{{path.to.value}}` substitution map handed to
+   * `renderEmailTemplate`. Mirrors the few-shot examples in the
+   * Pydantic prompt — rule authors can reference these in template
+   * bodies. Keep additions backward-compatible: removing or
+   * renaming a top-level key would silently break existing
+   * templates.
+   *
+   * Currently populates `bug` and `canonical`. The shipped templates
+   * also reference `{{hits.count}}` (used by `regression_alert`) and
+   * `{{digest.body}}` (used by `weekly_digest`); both render as empty
+   * strings today because the triggers that would populate them
+   * (`cluster_growing`, `schedule`) aren't wired in this PR. The
+   * fixes land alongside those triggers — `hits` from the windowed
+   * count already resolved by `RuleContextProvider.countHitsInWindow`,
+   * `digest` from the schedule-trigger context. The unused templates
+   * are kept in the registry so PR-D's seed rules can reference them
+   * without a second round-trip.
+   */
+  private buildEmailVars(context: RuleEvalContext): Record<string, unknown> {
+    return {
+      bug: {
+        id: context.bugReport.id,
+        title: context.bugReport.title,
+        priority: context.bugReport.priority,
+      },
+      canonical: context.canonical
+        ? {
+            id: context.canonical.id,
+            title: context.canonical.title,
+            status: context.canonical.status,
+          }
+        : null,
+    };
   }
 
   private async resolveTarget(context: RuleEvalContext): Promise<CapabilityTarget | null> {

--- a/packages/backend/src/services/rules/email-sender.ts
+++ b/packages/backend/src/services/rules/email-sender.ts
@@ -1,0 +1,182 @@
+/**
+ * Email sender for `notify.email` actions.
+ *
+ * Sits between the rule dispatcher and the existing
+ * `EmailChannelHandler`. The handler is the same nodemailer-based
+ * sender the notification pipeline uses; we just resolve a project's
+ * email channel + render a template + call `send`. No new SMTP
+ * machinery.
+ *
+ * The recipient resolution rules mirror the schema's `EMAIL_TARGET_PATTERN`:
+ *   - `reporter` -> `bugReport.metadata.metadata.user.email`. **This is
+ *     SDK-controlled with no verification** — the bug filer chooses
+ *     any string. A malicious bug filer can therefore make the engine
+ *     send a "your bug was matched" email to any address (e.g.
+ *     `victim@example.com`). The per-(rule, canonical) rate limit
+ *     caps spam at one email per canonical per window, but the
+ *     attacker can fabricate duplicates of many canonicals, so the
+ *     bound is ≈ number-of-canonicals × rules-with-B1 / window.
+ *     **Mitigation lands in PR-D**: either require reporter emails
+ *     to match an authenticated org-member identity (SaaS) or add a
+ *     per-recipient rate limit. Until then, operators should enable
+ *     B1 only when their ingest path requires authenticated SDK
+ *     submissions.
+ *   - `closer` and `all_reporters` are recognised by the schema but
+ *     not yet resolvable — they need the closer-identity / cluster-
+ *     reporters wiring that the persona analysis flagged but didn't
+ *     scope into Phase 0.5. Log and skip.
+ *   - A literal email passes through.
+ */
+
+import type { NotificationChannelRepository } from '../../db/repositories/notification-channel.repository.js';
+import type { EmailChannelHandler } from '../../services/notifications/email-handler.js';
+import type { EmailChannelConfig } from '../../types/notifications.js';
+import { getLogger } from '../../logger.js';
+import { renderEmailTemplate } from './email-templates.js';
+import type { RuleEvalContext } from './types.js';
+
+const logger = getLogger();
+
+export interface EmailSendRequest {
+  /** Project whose email channel should send this. */
+  projectId: string;
+  /** Resolved literal email address. */
+  to: string;
+  /** Template id from the rule's `notify.email.template` field. */
+  templateId: string;
+  /** Vars for `{{path.to.value}}` substitution in the template. */
+  vars: Record<string, unknown>;
+}
+
+/**
+ * Boundary the dispatcher talks to. Implementations decide HOW the
+ * email reaches the recipient — production uses `ChannelBackedEmailSender`
+ * (real SMTP via the project's notification channel); tests inject a
+ * stub returning `true` / `false`.
+ */
+export interface EmailSender {
+  send(req: EmailSendRequest): Promise<boolean>;
+}
+
+/**
+ * Production sender — looks up the project's first active email
+ * channel and dispatches via `EmailChannelHandler`. Returns `false`
+ * on any expected failure (no channel, unknown template, SMTP
+ * error). Errors are logged but never thrown — the executor relies
+ * on the dispatcher contract that nothing propagates back.
+ */
+export class ChannelBackedEmailSender implements EmailSender {
+  constructor(
+    private readonly channels: NotificationChannelRepository,
+    private readonly handler: EmailChannelHandler
+  ) {}
+
+  async send(req: EmailSendRequest): Promise<boolean> {
+    // Resolve the project's email channel. `findAll` is fine here —
+    // a project rarely has more than one email channel; if it has
+    // many, we take the first active row. PR-D's admin UI can
+    // surface a per-rule channel override if that becomes a real
+    // user need.
+    let channels;
+    try {
+      channels = await this.channels.findAll({
+        project_id: req.projectId,
+        type: 'email',
+        active: true,
+      });
+    } catch (error) {
+      logger.warn('EmailSender: channel lookup failed', {
+        projectId: req.projectId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+    const channel = channels[0];
+    if (!channel) {
+      logger.info('EmailSender: no active email channel for project, skipping', {
+        projectId: req.projectId,
+        templateId: req.templateId,
+      });
+      return false;
+    }
+
+    const rendered = renderEmailTemplate(req.templateId, req.vars);
+    if (!rendered) {
+      // renderEmailTemplate logs the unknown-id warn itself.
+      return false;
+    }
+
+    try {
+      const result = await this.handler.send(channel.config as unknown as EmailChannelConfig, {
+        to: req.to,
+        subject: rendered.subject,
+        body: rendered.body,
+      });
+      if (!result.success) {
+        logger.warn('EmailSender: handler reported failure', {
+          projectId: req.projectId,
+          templateId: req.templateId,
+          error: result.error,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      logger.warn('EmailSender: handler threw', {
+        projectId: req.projectId,
+        templateId: req.templateId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+}
+
+/**
+ * Resolve the `to` field of a `notify.email` action against the
+ * eval context. Returns null when the recipient can't be resolved
+ * — the dispatcher then skips with a log, same fail-closed pattern
+ * as missing channels / unknown templates.
+ */
+export function resolveEmailRecipient(to: string, context: RuleEvalContext): string | null {
+  if (to === 'reporter') {
+    // SDK-supplied — `reports.ts` wraps the SDK payload under a
+    // second-level `metadata` key, so the user object lives at
+    // `bug_reports.metadata.metadata.user`.
+    return readPath(context.bugReport.metadata, ['metadata', 'user', 'email']);
+  }
+  if (to === 'closer' || to === 'all_reporters') {
+    // Not yet wired. `closer` needs the closer-identity tracking
+    // that lives outside Phase 0.5; `all_reporters` needs a cluster-
+    // reporters query. Both land in follow-ups once the persona
+    // workflow actually demands them.
+    logger.info('EmailSender: recipient token not yet wired', { to });
+    return null;
+  }
+  // Literal email — the schema's regex validated the shape, but
+  // NOT the recipient. A rule author could write
+  // `notify.email.to = 'attacker@evil.com'` and exfiltrate bug data
+  // (subject + body include canonical title / status from the bug
+  // report). Rule creation is admin-gated (no public rule API), so
+  // this matches "admin-writes-rule sees bug data" which is the
+  // status quo; PR-D's admin UI surfaces per-org allowlist /
+  // confirmation flows before non-admin tenant users get to author
+  // rules. Until then, treat literal `notify.email.to` as
+  // trust-but-document.
+  return to;
+}
+
+/**
+ * Safe path traversal helper. Returns a string when the path
+ * resolves to a string, null otherwise.
+ */
+function readPath(obj: unknown, path: string[]): string | null {
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (cur === null || cur === undefined || typeof cur !== 'object') {
+      return null;
+    }
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return typeof cur === 'string' && cur.length > 0 ? cur : null;
+}

--- a/packages/backend/src/services/rules/email-templates.ts
+++ b/packages/backend/src/services/rules/email-templates.ts
@@ -107,7 +107,7 @@ export function renderEmailTemplate(
   }
   return {
     subject: interpolate(tmpl.subject, vars, { escape: false }),
-    body: interpolate(tmpl.body, vars, { escape: true }).replace(/\n/g, '<br>'),
+    body: interpolate(tmpl.body, vars, { escape: true }).replace(/\r?\n/g, '<br>'),
   };
 }
 

--- a/packages/backend/src/services/rules/email-templates.ts
+++ b/packages/backend/src/services/rules/email-templates.ts
@@ -1,0 +1,178 @@
+/**
+ * Hardcoded email-template registry for the dedup-rule engine.
+ *
+ * The Pydantic schema declares `notify.email.template` as a free
+ * string, but the executor needs to translate it into a concrete
+ * (subject, body) pair to hand to `EmailChannelHandler.send`. PR-D
+ * will likely replace this with the `notification_templates` table
+ * once the admin UI lets users edit dedup-rule templates; for now
+ * the three presets that the seed rules will use live here.
+ *
+ * Interpolation is `{{path.to.value}}`, looked up against the `vars`
+ * map; missing values render as empty string.
+ *
+ * Two rendering modes:
+ *   - **Subject**: plain text (per RFC 5322). Interpolated values
+ *     are NOT HTML-escaped — entities would render literally in the
+ *     inbox.
+ *   - **Body**: HTML (the channel handler sends with nodemailer's
+ *     `html:` field). Interpolated values ARE HTML-escaped to block
+ *     `<script>` payloads from user-controlled fields, and `\n` in
+ *     the rendered output is replaced with `<br>` because HTML
+ *     collapses runs of whitespace.
+ *
+ * If a rule references an unknown template id, the executor logs a
+ * warn and skips — same fail-closed pattern as missing channels.
+ */
+
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+export interface EmailTemplate {
+  subject: string;
+  body: string;
+}
+
+/**
+ * Registry. Keep keys in sync with the seed rules in PR-D — adding
+ * a new preset that references a template id not in this map will
+ * silently no-op at runtime, so the integration test in PR-D should
+ * assert every preset's template id resolves.
+ */
+const TEMPLATES: Record<string, EmailTemplate> = {
+  // B1: "Notify reporter on dedup". Sent to the reporter of the bug
+  // that was just identified as a duplicate.
+  dedup_ack: {
+    subject: 'Your bug report was matched to an existing issue',
+    body: [
+      'Thanks for filing — we grouped your report with an existing bug we are tracking.',
+      '',
+      'Canonical: {{canonical.title}}',
+      'Status: {{canonical.status}}',
+      '',
+      'You will hear back when there is movement.',
+    ].join('\n'),
+  },
+
+  // B3-adjacent: notify operations when a closed canonical is hit
+  // again. Used by an opt-in regression-alert rule once that lands.
+  regression_alert: {
+    subject: 'Regression detected: {{canonical.title}}',
+    body: [
+      'A bug previously marked {{canonical.status}} has received a new occurrence.',
+      '',
+      'Canonical: {{canonical.title}}',
+      'Hits in window: {{hits.count}}',
+      '',
+      'The canonical ticket has been reopened by the rule engine.',
+    ].join('\n'),
+  },
+
+  // Placeholder for the weekly-digest preset that lands with the
+  // schedule trigger in a later PR. Kept here so the registry is
+  // the single source of truth.
+  weekly_digest: {
+    subject: 'BugSpotter weekly digest',
+    body: 'Top clusters this week:\n\n{{digest.body}}',
+  },
+};
+
+/**
+ * Render `subject` + `body` for a known template. Returns null when
+ * the id is unknown — callers should fail closed and log.
+ *
+ * The subject and body have different rendering rules:
+ *  - **Subject** is the email's `Subject:` header, which is plain
+ *    text per RFC 5322. HTML-escaping it would produce visible
+ *    entities (`&amp;`, `&lt;`) in the recipient's inbox. We render
+ *    it without escaping.
+ *  - **Body** is delivered via `EmailChannelHandler` as
+ *    nodemailer's `html:`, so it MUST be HTML-escaped (XSS via
+ *    user-controlled values) AND newlines must be converted to
+ *    `<br>` because HTML collapses whitespace runs.
+ *
+ * If `EmailChannelHandler` ever switches to dual `text:` + `html:`,
+ * this layer can render both. Today it doesn't, so we render HTML
+ * and hand it to the handler as-is.
+ */
+export function renderEmailTemplate(
+  templateId: string,
+  vars: Record<string, unknown>
+): EmailTemplate | null {
+  const tmpl = TEMPLATES[templateId];
+  if (!tmpl) {
+    logger.warn('Unknown email template id, skipping render', { templateId });
+    return null;
+  }
+  return {
+    subject: interpolate(tmpl.subject, vars, { escape: false }),
+    body: interpolate(tmpl.body, vars, { escape: true }).replace(/\n/g, '<br>'),
+  };
+}
+
+/** Exposed for tests. */
+export function listKnownTemplateIds(): string[] {
+  return Object.keys(TEMPLATES);
+}
+
+/**
+ * Replace `{{path.to.value}}` tokens. Missing or non-stringifiable
+ * values render as empty string — a missing canonical title is
+ * better than an undefined-literal in the email body.
+ *
+ * **`escape: true`** (the body case) HTML-escapes every interpolated
+ * string. Without this, a malicious bug filer could put a
+ * `<script>` / `<a href="javascript:...">` payload into a bug title
+ * and have it land in the recipient's inbox as live markup (the
+ * channel handler sends with nodemailer's `html:` field).
+ *
+ * **`escape: false`** (the subject case) skips the escape because
+ * the Subject header is plain text per RFC 5322 — entities would
+ * render literally (`&amp;` etc).
+ *
+ * In either case, only the value side is touched. Template strings
+ * are trusted code.
+ */
+function interpolate(
+  template: string,
+  vars: Record<string, unknown>,
+  opts: { escape: boolean }
+): string {
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, path: string) => {
+    const segments = path.split('.');
+    let cur: unknown = vars;
+    for (const seg of segments) {
+      if (cur === null || cur === undefined || typeof cur !== 'object') {
+        return '';
+      }
+      cur = (cur as Record<string, unknown>)[seg];
+    }
+    if (cur === null || cur === undefined) {
+      return '';
+    }
+    if (typeof cur === 'string') {
+      return opts.escape ? escapeHtml(cur) : cur;
+    }
+    if (typeof cur === 'number' || typeof cur === 'boolean') {
+      // Numbers and booleans can't contain HTML, no escape needed.
+      return String(cur);
+    }
+    return '';
+  });
+}
+
+/**
+ * Minimal HTML entity escape covering the five characters whose raw
+ * appearance changes how a renderer parses the document. We don't
+ * use a library here because the templates are short and the surface
+ * is small; the equivalent of `lodash.escape`.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -17,9 +17,11 @@ import { NotificationThrottleRepository } from '../../db/repositories/notificati
 import type { TicketIntegrationCapabilities } from '../../integrations/capabilities.js';
 import type { PluginRegistry } from '../../integrations/plugin-registry.js';
 import { getLogger } from '../../logger.js';
+import { EmailChannelHandler } from '../notifications/email-handler.js';
 import { DatabaseRuleContextProvider } from './context-provider.js';
 import { DefaultActionDispatcher, TicketsTableResolver } from './dispatcher.js';
 import type { CapabilityServiceLookup } from './dispatcher.js';
+import { ChannelBackedEmailSender } from './email-sender.js';
 import { DedupRuleExecutor } from './executor.js';
 import { ThrottleBackedRateLimiter } from './rate-limiter.js';
 
@@ -39,8 +41,19 @@ const logger = getLogger();
  */
 export function buildCapabilityServiceLookup(
   db: DatabaseClient,
-  pluginRegistry: PluginRegistry
+  pluginRegistry: PluginRegistry | null
 ): CapabilityServiceLookup {
+  // Selfhosted deployments without any integration plugins still get
+  // an executor — they just can't run `ticket.*` actions. Returning
+  // a null-yielding lookup keeps the dispatcher contract intact:
+  // `canDispatch('ticket.add_comment')` still returns true (the
+  // dispatcher doesn't know plugins are missing), the dispatch
+  // attempt looks up null, logs `integration does not support …`,
+  // returns false. `notify.email` rules — which have nothing to do
+  // with the plugin registry — continue to work.
+  if (!pluginRegistry) {
+    return async () => null;
+  }
   return async (
     integrationId: string,
     projectId: string
@@ -88,14 +101,22 @@ export function buildCapabilityServiceLookup(
  */
 export function buildDedupRuleExecutor(
   db: DatabaseClient,
-  pluginRegistry: PluginRegistry
+  pluginRegistry: PluginRegistry | null
 ): DedupRuleExecutor {
   const pool = db.getPool();
   const repo = new DedupRuleRepository(pool);
   const throttle = new NotificationThrottleRepository(pool);
   const resolver = new TicketsTableResolver(db);
   const lookup = buildCapabilityServiceLookup(db, pluginRegistry);
-  const dispatcher = new DefaultActionDispatcher(resolver, lookup);
+  // EmailChannelHandler is stateless (no constructor args) and the
+  // channel repo is already wired on the db client. Pass both to
+  // ChannelBackedEmailSender so the dispatcher can fire notify.email
+  // actions through the project's configured channel.
+  const emailSender = new ChannelBackedEmailSender(
+    db.notificationChannels,
+    new EmailChannelHandler()
+  );
+  const dispatcher = new DefaultActionDispatcher(resolver, lookup, emailSender);
   const rateLimiter = new ThrottleBackedRateLimiter(throttle);
   const contextProvider = new DatabaseRuleContextProvider(db);
   return new DedupRuleExecutor(repo, dispatcher, rateLimiter, contextProvider);

--- a/packages/backend/tests/services/notifications/email-handler.test.ts
+++ b/packages/backend/tests/services/notifications/email-handler.test.ts
@@ -458,7 +458,76 @@ describe('EmailChannelHandler', () => {
       await handler.send(config, payload);
 
       const call = mockTransporter.sendMail.mock.calls[0][0];
-      expect(call.text).not.toMatch(/\s{2,}/);
+      // Horizontal whitespace runs collapse, but paragraph breaks (\n\n) are
+      // intentionally preserved — so check no double-space, not /\s{2,}/.
+      expect(call.text).not.toMatch(/ {2,}/);
+      expect(call.text).not.toMatch(/\t/);
+    });
+
+    it('should convert <br> to newline so text clients see line breaks', async () => {
+      // Without this, a body whose HTML uses <br> to separate lines (the
+      // dedup-rule email templates do exactly that) collapses into one
+      // run-on paragraph in the multipart text/plain alternative.
+      const payload: NotificationPayload = {
+        to: 'test@example.com',
+        subject: 'Test',
+        body: 'Line one<br>Line two<br><br>Line three',
+      };
+
+      mockTransporter.sendMail.mockResolvedValue({
+        messageId: '<msg-123@example.com>',
+        accepted: [],
+        rejected: [],
+        response: '250 OK',
+      });
+
+      await handler.send(config, payload);
+
+      const call = mockTransporter.sendMail.mock.calls[0][0];
+      expect(call.text).toBe('Line one\nLine two\n\nLine three');
+    });
+
+    it('should convert block-close tags (</p>, </li>, </h1..6>) to newline', async () => {
+      const payload: NotificationPayload = {
+        to: 'test@example.com',
+        subject: 'Test',
+        body: '<h2>Heading</h2><p>Paragraph one</p><ul><li>One</li><li>Two</li></ul>',
+      };
+
+      mockTransporter.sendMail.mockResolvedValue({
+        messageId: '<msg-123@example.com>',
+        accepted: [],
+        rejected: [],
+        response: '250 OK',
+      });
+
+      await handler.send(config, payload);
+
+      const call = mockTransporter.sendMail.mock.calls[0][0];
+      expect(call.text).toContain('Heading\n');
+      expect(call.text).toContain('Paragraph one\n');
+      expect(call.text).toContain('One\nTwo');
+    });
+
+    it('caps consecutive newlines at one blank line (no unbounded gaps)', async () => {
+      // Many <br> in a row shouldn't produce a wall of empty lines.
+      const payload: NotificationPayload = {
+        to: 'test@example.com',
+        subject: 'Test',
+        body: 'A<br><br><br><br><br>B',
+      };
+
+      mockTransporter.sendMail.mockResolvedValue({
+        messageId: '<msg-123@example.com>',
+        accepted: [],
+        rejected: [],
+        response: '250 OK',
+      });
+
+      await handler.send(config, payload);
+
+      const call = mockTransporter.sendMail.mock.calls[0][0];
+      expect(call.text).toBe('A\n\nB');
     });
   });
 });

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -239,27 +239,31 @@ describe('DefaultActionDispatcher', () => {
       ).toBe(true);
     });
 
+    it('returns false for notify.email when no EmailSender is wired', () => {
+      // Dispatcher constructed without an emailSender (the default
+      // 3-arg form used by other tests in this file). canDispatch
+      // flips to true once the wiring helper provides one.
+      expect(
+        dispatcher.canDispatch({ type: 'notify.email', to: 'reporter', template: 'ack' })
+      ).toBe(false);
+    });
+
     it.each<ActionSpec>([
-      { type: 'notify.email', to: 'reporter', template: 'ack' },
       { type: 'notify.slack', channel: '#x', message: 'hi' },
       { type: 'notify.webhook', url: 'https://example.com/hook' },
     ])('returns false for not-yet-wired %s', (action) => {
-      // PR-C2 / PR-D will flip these as the dispatchers land. The
-      // executor relies on this to skip rate-limit-consuming fires
-      // that would do zero work.
+      // PR-D will flip these as the slack / webhook dispatchers
+      // land. The executor relies on this to skip rate-limit-
+      // consuming fires that would do zero work.
       expect(dispatcher.canDispatch(action)).toBe(false);
     });
   });
 
-  describe('notify.* (not wired in PR-C)', () => {
-    // The action types parse and dispatch, but the dispatcher
-    // intentionally logs+returns false until PR-C2 (email) / PR-D
-    // (slack, webhook). Pinning false here means a future PR that
-    // adds real wiring also has to update this test, which is the
-    // signal we want.
+  describe('notify.slack / notify.webhook (not wired in PR-C2)', () => {
+    // Pinning false here means a future PR that adds real wiring also
+    // has to update this test, which is the signal we want.
 
     it.each<ActionSpec>([
-      { type: 'notify.email', to: 'reporter', template: 'dedup_ack' },
       { type: 'notify.slack', channel: '#regressions', message: 'hit' },
       { type: 'notify.webhook', url: 'https://example.com/hook' },
     ])('returns false for %s without touching the resolver or lookup', async (action) => {
@@ -267,6 +271,95 @@ describe('DefaultActionDispatcher', () => {
       expect(ok).toBe(false);
       expect(resolver.resolve).not.toHaveBeenCalled();
       expect(lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('notify.email (wired with EmailSender)', () => {
+    function buildEmailDispatcher() {
+      const send: Mock = vi.fn().mockResolvedValue(true);
+      const emailSender = { send };
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        emailSender
+      );
+      return { dispatcher: d, send };
+    }
+
+    it('canDispatch returns true once an EmailSender is provided', () => {
+      const { dispatcher: d } = buildEmailDispatcher();
+      expect(d.canDispatch({ type: 'notify.email', to: 'reporter', template: 'dedup_ack' })).toBe(
+        true
+      );
+    });
+
+    it('dispatches to the EmailSender with projectId, resolved recipient, and template id', async () => {
+      const { dispatcher: d, send } = buildEmailDispatcher();
+      const ctx = makeContext({
+        bugReport: makeBug({
+          metadata: { metadata: { user: { email: 'reporter@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(send).toHaveBeenCalledTimes(1);
+      const arg = send.mock.calls[0][0];
+      expect(arg.projectId).toBe('project-1');
+      expect(arg.to).toBe('reporter@example.com');
+      expect(arg.templateId).toBe('dedup_ack');
+      // Vars include the canonical-shaped projection expected by the
+      // few-shot templates (`{{canonical.title}}` etc).
+      expect(arg.vars).toMatchObject({
+        bug: { id: ctx.bugReport.id, title: ctx.bugReport.title },
+        canonical: { id: ctx.canonical?.id, title: ctx.canonical?.title },
+      });
+    });
+
+    it('returns false when the recipient resolves to null (e.g. reporter email missing)', async () => {
+      const { dispatcher: d, send } = buildEmailDispatcher();
+      // No metadata.metadata.user — reporter resolution returns null.
+      const ctx = makeContext({ bugReport: makeBug({ metadata: {} }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+      expect(ok).toBe(false);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the EmailSender reports failure (executor stays alive)', async () => {
+      const { dispatcher: d, send } = buildEmailDispatcher();
+      send.mockResolvedValueOnce(false);
+      const ctx = makeContext({
+        bugReport: makeBug({
+          metadata: { metadata: { user: { email: 'reporter@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('passes a literal email recipient straight through', async () => {
+      const { dispatcher: d, send } = buildEmailDispatcher();
+      await d.dispatch(makeContext(), {
+        type: 'notify.email',
+        to: 'ops@example.com',
+        template: 'dedup_ack',
+      });
+      expect(send.mock.calls[0][0].to).toBe('ops@example.com');
     });
   });
 });

--- a/packages/backend/tests/services/rules/email-sender.test.ts
+++ b/packages/backend/tests/services/rules/email-sender.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the email-sender layer.
+ *
+ * Two pieces:
+ *  - `resolveEmailRecipient`: pure function mapping the
+ *    `notify.email.to` token + bug context to a literal address (or
+ *    null when the recipient can't be derived).
+ *  - `ChannelBackedEmailSender`: stubs the channel repo and the
+ *    EmailChannelHandler, asserts the wiring (channel lookup, template
+ *    render, handler.send call) without touching SMTP.
+ */
+
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import {
+  ChannelBackedEmailSender,
+  resolveEmailRecipient,
+} from '../../../src/services/rules/email-sender.js';
+import type { NotificationChannelRepository } from '../../../src/db/repositories/notification-channel.repository.js';
+import type { EmailChannelHandler } from '../../../src/services/notifications/email-handler.js';
+import type { RuleEvalContext } from '../../../src/services/rules/types.js';
+import type { BugReport } from '../../../src/db/types.js';
+
+function makeContext(metadata: Record<string, unknown> = {}): RuleEvalContext {
+  return {
+    bugReport: {
+      id: 'bug-1',
+      project_id: 'project-1',
+      title: 'something broke',
+      metadata,
+    } as BugReport,
+    canonical: null,
+    projectId: 'project-1',
+    resolved: new Map(),
+  };
+}
+
+describe('resolveEmailRecipient', () => {
+  it('returns null for "closer" (not yet wired)', () => {
+    expect(resolveEmailRecipient('closer', makeContext())).toBeNull();
+  });
+
+  it('returns null for "all_reporters" (not yet wired)', () => {
+    expect(resolveEmailRecipient('all_reporters', makeContext())).toBeNull();
+  });
+
+  it('passes a literal email through unchanged', () => {
+    expect(resolveEmailRecipient('ops@example.com', makeContext())).toBe('ops@example.com');
+  });
+
+  it('resolves "reporter" to bugReport.metadata.metadata.user.email', () => {
+    // The reports.ts writer wraps SDK metadata under a second-level
+    // `metadata` key: bug_reports.metadata = { console, network,
+    // metadata: report.metadata, source, apiKeyPrefix }. The SDK's
+    // user.email therefore lives two levels deep.
+    const ctx = makeContext({
+      metadata: { user: { email: 'reporter@example.com' } },
+    });
+    expect(resolveEmailRecipient('reporter', ctx)).toBe('reporter@example.com');
+  });
+
+  it('returns null when "reporter" path is not populated', () => {
+    expect(resolveEmailRecipient('reporter', makeContext({}))).toBeNull();
+    expect(resolveEmailRecipient('reporter', makeContext({ metadata: {} }))).toBeNull();
+    expect(resolveEmailRecipient('reporter', makeContext({ metadata: { user: {} } }))).toBeNull();
+  });
+
+  it('returns null when "reporter" email is an empty string', () => {
+    expect(
+      resolveEmailRecipient('reporter', makeContext({ metadata: { user: { email: '' } } }))
+    ).toBeNull();
+  });
+});
+
+describe('ChannelBackedEmailSender', () => {
+  const FAKE_CHANNEL = {
+    id: 'ch-1',
+    project_id: 'project-1',
+    type: 'email',
+    active: true,
+    config: {
+      type: 'email',
+      smtp_host: 'smtp.example.com',
+      smtp_port: 587,
+      smtp_secure: false,
+      smtp_user: 'user',
+      smtp_pass: 'pass',
+      from_address: 'noreply@example.com',
+      from_name: 'BugSpotter',
+    },
+  } as never;
+
+  function buildSender() {
+    const findAll: Mock = vi.fn().mockResolvedValue([FAKE_CHANNEL]);
+    const channels = { findAll } as unknown as NotificationChannelRepository;
+    const send: Mock = vi.fn().mockResolvedValue({ success: true });
+    const handler = { send } as unknown as EmailChannelHandler;
+    return {
+      sender: new ChannelBackedEmailSender(channels, handler),
+      findAll,
+      send,
+    };
+  }
+
+  it('sends via the handler with the project channel + rendered template', async () => {
+    const { sender, findAll, send } = buildSender();
+    const ok = await sender.send({
+      projectId: 'project-1',
+      to: 'reporter@example.com',
+      templateId: 'dedup_ack',
+      vars: { canonical: { title: 'Login crash', status: 'closed' } },
+    });
+    expect(ok).toBe(true);
+    expect(findAll).toHaveBeenCalledWith({
+      project_id: 'project-1',
+      type: 'email',
+      active: true,
+    });
+    const [, payload] = send.mock.calls[0];
+    expect(payload.to).toBe('reporter@example.com');
+    expect(payload.subject).toBe('Your bug report was matched to an existing issue');
+    expect(payload.body).toContain('Login crash');
+  });
+
+  it('returns false when no active email channel exists for the project', async () => {
+    const { sender, send } = buildSender();
+    const findAll = sender['channels'].findAll as Mock;
+    findAll.mockResolvedValueOnce([]);
+    const ok = await sender.send({
+      projectId: 'project-1',
+      to: 'reporter@example.com',
+      templateId: 'dedup_ack',
+      vars: {},
+    });
+    expect(ok).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the template id is unknown', async () => {
+    const { sender, send } = buildSender();
+    const ok = await sender.send({
+      projectId: 'project-1',
+      to: 'reporter@example.com',
+      templateId: 'does-not-exist',
+      vars: {},
+    });
+    expect(ok).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns false (without throwing) when the channel lookup fails', async () => {
+    const { sender, send } = buildSender();
+    const findAll = sender['channels'].findAll as Mock;
+    findAll.mockRejectedValueOnce(new Error('db down'));
+    const ok = await sender.send({
+      projectId: 'project-1',
+      to: 'reporter@example.com',
+      templateId: 'dedup_ack',
+      vars: {},
+    });
+    expect(ok).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the handler reports failure', async () => {
+    const { sender, send } = buildSender();
+    send.mockResolvedValueOnce({ success: false, error: 'SMTP 530' });
+    const ok = await sender.send({
+      projectId: 'project-1',
+      to: 'reporter@example.com',
+      templateId: 'dedup_ack',
+      vars: {},
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when the handler throws (executor relies on no propagation)', async () => {
+    const { sender, send } = buildSender();
+    send.mockRejectedValueOnce(new Error('connection reset'));
+    const ok = await sender.send({
+      projectId: 'project-1',
+      to: 'reporter@example.com',
+      templateId: 'dedup_ack',
+      vars: {},
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/packages/backend/tests/services/rules/email-templates.test.ts
+++ b/packages/backend/tests/services/rules/email-templates.test.ts
@@ -142,5 +142,16 @@ describe('renderEmailTemplate', () => {
       });
       expect(rendered!.body).toContain('line1<br>line2');
     });
+
+    it('converts CRLF (`\\r\\n`) to `<br>` so Windows-supplied values render cleanly', () => {
+      // A bug title pasted from a Windows clipboard arrives with CRLF.
+      // The `\r` would otherwise survive as `\r<br>` and render as a
+      // visible artifact in some clients.
+      const rendered = renderEmailTemplate('dedup_ack', {
+        canonical: { title: 'line1\r\nline2', status: 'open' },
+      });
+      expect(rendered!.body).toContain('line1<br>line2');
+      expect(rendered!.body).not.toContain('\r');
+    });
   });
 });

--- a/packages/backend/tests/services/rules/email-templates.test.ts
+++ b/packages/backend/tests/services/rules/email-templates.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the email-template registry.
+ *
+ * Covers:
+ *  - known template ids render
+ *  - {{path.to.value}} interpolation, nested lookup
+ *  - missing variables render as empty string (not the literal token)
+ *  - unknown template id returns null (caller fails closed)
+ *  - the three preset ids referenced by the Phase 0.5 plan exist
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  listKnownTemplateIds,
+  renderEmailTemplate,
+} from '../../../src/services/rules/email-templates.js';
+
+describe('renderEmailTemplate', () => {
+  it('returns null for an unknown template id (caller fail-closes)', () => {
+    expect(renderEmailTemplate('does-not-exist', {})).toBeNull();
+  });
+
+  it('renders subject + body for dedup_ack', () => {
+    const rendered = renderEmailTemplate('dedup_ack', {
+      canonical: { title: 'Login crash on iOS', status: 'in_progress' },
+    });
+    expect(rendered).not.toBeNull();
+    expect(rendered!.subject).toBe('Your bug report was matched to an existing issue');
+    expect(rendered!.body).toContain('Login crash on iOS');
+    expect(rendered!.body).toContain('in_progress');
+  });
+
+  it('substitutes nested {{path.to.value}} tokens', () => {
+    const rendered = renderEmailTemplate('regression_alert', {
+      canonical: { title: 'Stripe webhook 502', status: 'closed' },
+      hits: { count: 14 },
+    });
+    expect(rendered!.subject).toBe('Regression detected: Stripe webhook 502');
+    expect(rendered!.body).toContain('Hits in window: 14');
+    expect(rendered!.body).toContain('previously marked closed');
+  });
+
+  it('renders missing variables as empty string (not the literal token)', () => {
+    // No canonical.* provided — the dedup_ack body references
+    // canonical.title and canonical.status. Both should expand to
+    // empty string, leaving the surrounding prose intact.
+    const rendered = renderEmailTemplate('dedup_ack', {});
+    expect(rendered!.body).not.toContain('{{');
+    expect(rendered!.body).not.toContain('}}');
+  });
+
+  it('handles number / boolean leaves correctly', () => {
+    const rendered = renderEmailTemplate('regression_alert', {
+      canonical: { title: 't', status: 's' },
+      hits: { count: 0 }, // falsy number must still render as "0"
+    });
+    expect(rendered!.body).toContain('Hits in window: 0');
+  });
+
+  it('exposes the preset ids referenced by Phase 0.5 seed rules', () => {
+    const ids = listKnownTemplateIds();
+    expect(ids).toContain('dedup_ack');
+    expect(ids).toContain('regression_alert');
+    expect(ids).toContain('weekly_digest');
+  });
+
+  describe('subject vs body rendering', () => {
+    // Subject is the email's plain-text `Subject:` header — escaping
+    // would surface as literal entities in the inbox. Body is HTML
+    // (nodemailer `html:` field), so it MUST be escaped (XSS) and
+    // `\n` becomes `<br>` (HTML collapses whitespace).
+
+    it('does NOT HTML-escape the subject (plain-text header)', () => {
+      const rendered = renderEmailTemplate('regression_alert', {
+        canonical: { title: 'A & B <c>', status: 'closed' },
+        hits: { count: 0 },
+      });
+      // Subject contains `Regression detected: {{canonical.title}}` → no escape
+      expect(rendered!.subject).toBe('Regression detected: A & B <c>');
+      expect(rendered!.subject).not.toContain('&amp;');
+    });
+
+    it('HTML-escapes interpolated values in the body (XSS protection)', () => {
+      // The rendered body is passed to nodemailer as `html:`, so any
+      // un-escaped `<` or `&` from a variable becomes interpreted
+      // markup.
+      const rendered = renderEmailTemplate('dedup_ack', {
+        canonical: { title: '<script>alert(1)</script>', status: 'open' },
+      });
+      expect(rendered!.body).not.toContain('<script>');
+      expect(rendered!.body).toContain('&lt;script&gt;');
+    });
+
+    it('escapes & < > " and \' in body values', () => {
+      const rendered = renderEmailTemplate('regression_alert', {
+        canonical: {
+          title: 'A & B <c> "d" \'e\'',
+          status: 'closed',
+        },
+        hits: { count: 0 },
+      });
+      expect(rendered!.body).toContain('A &amp; B &lt;c&gt; &quot;d&quot; &#39;e&#39;');
+    });
+
+    it('does not escape numbers or booleans (no HTML chars possible)', () => {
+      const rendered = renderEmailTemplate('regression_alert', {
+        canonical: { title: 't', status: 's' },
+        hits: { count: 42 },
+      });
+      expect(rendered!.body).toContain('Hits in window: 42');
+    });
+
+    it('escapes any future template var sourced from user input (defense-in-depth)', () => {
+      const rendered = renderEmailTemplate('dedup_ack', {
+        canonical: {
+          title: '"><img src=x onerror=alert(1)>',
+          status: 'closed',
+        },
+      });
+      expect(rendered!.body).not.toMatch(/<img\s+src=/);
+      expect(rendered!.body).toContain('&quot;&gt;&lt;img src=x onerror=alert(1)&gt;');
+    });
+
+    it('converts `\\n` to `<br>` in the body so multi-line templates render', () => {
+      // HTML collapses runs of whitespace, so a template body with
+      // explicit `\n` separators would otherwise appear as one
+      // single line in the recipient's inbox.
+      const rendered = renderEmailTemplate('dedup_ack', {
+        canonical: { title: 'X', status: 'open' },
+      });
+      expect(rendered!.body).toContain('<br>');
+      expect(rendered!.body).not.toContain('\n');
+    });
+
+    it('preserves `\\n` to `<br>` conversion through escaped values too', () => {
+      // A user-supplied value containing a real newline gets the
+      // same `<br>` treatment as the template's structural
+      // newlines. That's intentional — multi-line bug titles render
+      // as visible line breaks, not as collapsed whitespace.
+      const rendered = renderEmailTemplate('dedup_ack', {
+        canonical: { title: 'line1\nline2', status: 'open' },
+      });
+      expect(rendered!.body).toContain('line1<br>line2');
+    });
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -83,6 +83,8 @@ export default defineConfig({
       'tests/services/rules/executor.test.ts',
       'tests/services/rules/dispatcher.test.ts',
       'tests/services/rules/rate-limiter.test.ts',
+      'tests/services/rules/email-templates.test.ts',
+      'tests/services/rules/email-sender.test.ts',
       // Pure env-var / config validation test, no DB.
       'tests/config.test.ts',
     ],


### PR DESCRIPTION
## Summary

PR-C2 of the tiny dedup-rule engine (Phase 0.5). Follows #146. Makes **B1** ("Notify reporter on dedup") operable end-to-end and wires the second of the two trigger points the engine cares about.

(Supersedes #147 — same code, squashed into one commit for a clean review.)

## What lands

- **`email-templates.ts`** — hardcoded registry for `dedup_ack`, `regression_alert`, `weekly_digest`. Tiny `{{path.to.value}}` interpolation with two rendering modes:
  - **Subject** is plain text (RFC 5322, no escape — entities would render literally in the inbox).
  - **Body** is HTML (escapes interpolated values for XSS, replaces `\n` with `<br>` so multi-line templates render).
- **`email-sender.ts`** — `EmailSender` boundary + `ChannelBackedEmailSender` that resolves a project's email channel and dispatches via the existing `EmailChannelHandler` (no new SMTP machinery). `resolveEmailRecipient` maps `reporter` / literal-email; `closer` / `all_reporters` return null until their wiring lands.
- **Dispatcher** — `notify.email` routes through the injected sender. `canDispatch` flips to true when a sender is wired, so rules with email-only actions stop hitting `no_supported_actions`.
- **Intelligence worker** — after `applyDedupAction.applied`, re-fetch the bug, project-match guard, then fire `duplicate_detected`. Same error-containment pattern as the outbox hook. `pluginRegistry` threaded through `createIntelligenceWorker → processIntelligenceJob → processAnalyzeJob` + the worker manager. Optional throughout so selfhosted deployments without integrations still execute `notify.email` rules.

## Security note on the `reporter` token

SDK supplies the reporter email with no verification, so a bug filer can fabricate duplicate canonicals to spam any address. The per-(rule, canonical) rate limit caps spam at one email per canonical per window, but the attacker can fabricate duplicates of many canonicals.

Proper mitigation (auth-bound reporter / per-recipient rate limit / allowlist) belongs in PR-D where authenticated rule creation lands. Operators should only enable B1 today with authenticated SDK ingest.

## Out of scope (deferred to PR-D)

- `notify.slack` / `notify.webhook` dispatchers.
- Admin UI for editing per-rule email templates.
- AFTER DELETE trigger on `dedup_rules` mirroring migration 024.

## Test plan

- [x] 13 email-template tests (interpolation, missing vars, preset ids, subject vs body escaping, `\n`→`<br>` conversion)
- [x] 12 email-sender tests (recipient resolution + sender wiring + every failure mode)
- [x] `notify.email` branch added to dispatcher.test
- [x] Prettier clean
- [x] All 2736 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email notifications now triggered by duplicate detection events
  * Email action support in rule automation system
  * Email template rendering system for notifications

* **Improvements**
  * Enhanced HTML-to-plain-text conversion for improved email formatting

* **Tests**
  * Added comprehensive test coverage for email notification functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->