### PR TITLE
feat(rules): admin CRUD + B1/B2 seeding for dedup-rule engine (PR-D1)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,110 @@
+# BugSpotter Onboarding
+
+For new engineers. Tells you what the system is, what's in flight, and which existing doc to read for each task. **Not a duplicate of the other docs — a map to them.**
+
+## What BugSpotter is
+
+A SaaS bug-reporting platform. Customers embed an SDK in their web app; end users hit a button to file a bug; BugSpotter captures screenshot + console logs + network requests + session replay (rrweb) and routes the report through dedup/enrichment to the customer's Jira/Linear/etc. integration. Two deployment modes share one codebase:
+
+- **`saas`** — multi-tenant on `*.kz.bugspotter.io`, billing, self-service signup, quota enforcement.
+- **`selfhosted`** — single-tenant customer install, no billing, no signup.
+
+Architecture in one sentence: Fastify API + BullMQ workers + Postgres + Redis + S3/MinIO, with a separate Python FastAPI service (`bugspotter-intelligence`) for dedup/enrichment AI.
+
+## First 30 minutes
+
+1. Clone the repo. Read [README.md](README.md) for the product framing.
+2. Bring up the dev stack: `./dev.sh start` then `./dev.sh migrate` then `./dev.sh dev` (tmux). Full procedure in [LOCAL_DEVELOPMENT.md](LOCAL_DEVELOPMENT.md).
+3. Open `http://localhost:5173` (admin UI) and `http://localhost:3000` (API). Confirm both load.
+4. Run `pnpm --filter @bugspotter/backend test:unit`. Should pass with no Docker needed.
+
+If any of those steps fail, the troubleshooting section of [LOCAL_DEVELOPMENT.md](LOCAL_DEVELOPMENT.md) covers the common cases.
+
+## Where to read next
+
+| If you're going to work on...             | Start here                                                                     |
+| ----------------------------------------- | ------------------------------------------------------------------------------ |
+| Anything backend                          | [packages/backend/CLAUDE.md](packages/backend/CLAUDE.md)                       |
+| Backend system architecture               | [packages/backend/docs/architecture.md](packages/backend/docs/architecture.md) |
+| Database schema, migrations, RBAC tables  | [packages/backend/docs/db-schema.md](packages/backend/docs/db-schema.md)       |
+| Auth (JWT / API key / share token / RBAC) | [packages/backend/docs/auth.md](packages/backend/docs/auth.md)                 |
+| Admin UI (React + Vite + i18n)            | [apps/admin/CLAUDE.md](apps/admin/CLAUDE.md)                                   |
+| HTTP API surface                          | [API_DOCUMENTATION.md](API_DOCUMENTATION.md)                                   |
+| Permissions / access control rules        | [ACCESS_CONTROL.md](ACCESS_CONTROL.md)                                         |
+| Docker / production deploy                | [DOCKER.md](DOCKER.md)                                                         |
+| Submitting a PR                           | [CONTRIBUTING.md](CONTRIBUTING.md)                                             |
+
+The two separate repos worth knowing about:
+
+- **`bugspotter-intelligence`** — Python FastAPI service for dedup/enrichment/mitigation. Talks to the backend over HTTP. Has its own schema (Pydantic) for `DedupRule`; the TypeScript Zod mirror in this repo at [packages/backend/src/integrations/dedup-rule.schema.ts](packages/backend/src/integrations/dedup-rule.schema.ts) must stay in lockstep.
+- **`bugspotter-landing`** — Astro site, hosts the self-service signup wizard.
+- **`bugspotter-extension`** — Chrome extension, separate concern from the embedded SDK.
+
+## Repo layout
+
+```text
+packages/
+  backend/          Fastify + pg + BullMQ. Most complex package.
+  sdk/              The browser SDK customers embed.
+  billing/          Region-specific billing plugins (KZ, …).
+  types/            Shared TS types.
+  utils/, message-broker/, payment-service/, backend-mock/
+
+apps/
+  admin/            React/Vite admin panel.
+  demo/             Showcase site.
+
+docker-compose*.yml + dev.sh   Local dev orchestration.
+```
+
+## What's in flight
+
+A few active workstreams worth knowing about so you don't accidentally collide:
+
+- **Phase 0.5 dedup-rule engine** — a tiny per-project rule engine that fires on dedup events to send acknowledgement emails, comment on canonical tickets, etc. Shipped in PRs #142 / #143 / #146 / #148; admin CRUD (PR-D1) currently in review. The full architecture is documented in [packages/backend/docs/architecture.md](packages/backend/docs/architecture.md) under "Dedup-rule engine."
+- **Admin UI for the rule engine (PR-D2)** — frontend on top of the PR-D1 CRUD API. Not started.
+- **C2 security carry-overs** — auth-bound `reporter` recipient, per-recipient rate limit, literal-email allowlist. Block tenant-user rule authoring; rule creation is admin-only until they land.
+
+## Common commands
+
+```bash
+# Whole-monorepo
+pnpm install
+pnpm build
+
+# Backend
+pnpm --filter @bugspotter/backend dev          # API on :3000
+pnpm --filter @bugspotter/backend typecheck    # src-only
+pnpm --filter @bugspotter/backend test:unit    # no Docker
+pnpm --filter @bugspotter/backend test:integration  # needs Docker
+pnpm --filter @bugspotter/backend migrate      # apply DB migrations
+
+# Admin UI
+pnpm --filter @bugspotter/admin dev            # :5173
+
+# Optional Dozzle live log viewer (Docker compose monitoring profile)
+docker compose --profile monitoring up -d dozzle  # then http://localhost:9999
+```
+
+## Conventions that aren't obvious
+
+- **Migrations are append-only.** Never edit a merged migration; add a new one. The runner applies in lexicographic order. See [packages/backend/docs/db-schema.md](packages/backend/docs/db-schema.md) → "Migration ordering invariants" for the load-bearing ones.
+- **JSONB columns are validated by Zod at the API boundary**, not by the DB. Schemas live next to the code that owns the table (`bug_reports.metadata`, `dedup_rules.rule_json`, `integration_rules.filters`, etc).
+- **`request.authProject` is not a legacy field.** It's set for single-project API keys and is the gate the SDK-ingest key relies on. See [packages/backend/CLAUDE.md](packages/backend/CLAUDE.md) for the trio.
+- **The notification pipeline and the dedup-rule engine are separate systems** that happen to share the `notification_throttle` table (made polymorphic in migration 023). Don't conflate them.
+- **External HTTP from a plugin always routes through `security/hardened-http.ts` + `ssrf-validator.ts`.** Plugin code runs sandboxed via `security/plugin-executor.ts`.
+- **The intelligence service may be off.** Treat its absence as expected: `circuit-breaker.ts` short-circuits, and the backend falls back to the no-AI code path.
+
+## When you're stuck
+
+- **Where does X live?** — `grep` first. The repo is 2700+ unit tests' worth of TypeScript; search beats spelunking.
+- **What does this migration do?** — Read its header comment. They're written for humans.
+- **What's the auth model?** — [packages/backend/docs/auth.md](packages/backend/docs/auth.md). The trio + project-access + RBAC layers are non-trivial.
+- **Why does the dedup grace exist?** — See migration 021's header + [packages/backend/docs/db-schema.md](packages/backend/docs/db-schema.md) "Transactional outbox."
+- **Tests pass locally but CI fails?** — The unit suite has occasional flakes in `packages/backend/tests/integrations/rpc-bridge-security.test.ts` (HTTP method/header timeouts). Re-run; if it persists, it's a real issue.
+
+## Getting help
+
+- PR review tools (CodeRabbit, Gemini, Claude) auto-review every PR. They generate a lot of signal; read their threads but use judgment — accept real findings, push back politely on noise.
+- Production logs: Dozzle at `http://localhost:9999` (after enabling the `monitoring` Docker compose profile).
+- Note: there is no team chat channel pointer documented here. Ask your lead.

--- a/packages/backend/CLAUDE.md
+++ b/packages/backend/CLAUDE.md
@@ -2,6 +2,12 @@
 
 Fastify + pg + BullMQ. Most complex package in the monorepo.
 
+## Where to look first
+
+- **System architecture** — [docs/architecture.md](docs/architecture.md). Component map, the major end-to-end flows (SDK ingest, outbox, intelligence dedup, the rule engine, notifications), deployment modes, external boundaries.
+- **DB schema** — [docs/db-schema.md](docs/db-schema.md). Per-table reference for `application.*` and `saas.*`, the cross-cutting patterns (polymorphic throttle, soft-delete, JSONB validation), and the migration ordering invariants.
+- **Auth + RBAC** — [docs/auth.md](docs/auth.md). Header precedence, 3-layer model, effective project role, API-key bypass rules.
+
 ## The auth trio
 
 Every request can carry up to four auth artifacts:
@@ -28,6 +34,7 @@ For the full RBAC reference — header precedence rules, the 3-layer authorizati
 - `application.*` — users, projects, bug_reports, api_keys (used in every mode).
 - `saas.*` — organizations, subscriptions, organization_requests, invitations (SaaS-mode only).
 - Migrations in `src/db/migrations/NNN_description.sql`, run via `pnpm migrate`. Never rewrite a merged migration — add a new one.
+- Per-table reference + cross-cutting patterns: [docs/db-schema.md](docs/db-schema.md).
 
 ## Repositories + transactions
 

--- a/packages/backend/docs/architecture.md
+++ b/packages/backend/docs/architecture.md
@@ -1,0 +1,225 @@
+# Backend Architecture
+
+System overview for `packages/backend`. Pairs with [db-schema.md](db-schema.md) for the persistence layer and [auth.md](auth.md) for the auth model. This doc covers component boundaries, the major end-to-end flows, deployment modes, and external dependencies.
+
+## Topology
+
+```text
+                ┌──────────────┐
+                │   Admin UI   │  React/Vite, talks HTTP/JWT
+                └──────┬───────┘
+                       │
+   SDK ── X-API-Key ──►│             ┌─────────────────────┐
+                       ▼             │ Intelligence service│ FastAPI (Python)
+                ┌──────────────┐ HTTP│  dedup / enrich     │ — separate repo
+                │   Fastify    │◄───►│  / mitigate         │   bugspotter-intelligence
+                │   API server │     └─────────────────────┘
+                └──────┬───────┘
+                       │
+        ┌──────────────┼───────────────┬─────────────┐
+        ▼              ▼               ▼             ▼
+   ┌─────────┐    ┌──────────┐   ┌──────────┐  ┌──────────┐
+   │Postgres │    │ Redis    │   │MinIO / S3│  │ BullMQ   │
+   │ pg pool │    │ cache +  │   │ replays, │  │ workers  │
+   │         │    │ BullMQ   │   │ images   │  │ (same    │
+   │         │    │ backplane│   │          │  │ process  │
+   │         │    │          │   │          │  │ via      │
+   │         │    │          │   │          │  │ worker.ts)│
+   └─────────┘    └──────────┘   └──────────┘  └──────────┘
+                                      ▲              │
+                                      │              ▼
+                                      │       ┌──────────┐
+                                      │       │  SMTP    │
+                                      │       │ + Jira/  │
+                                      │       │ Linear / │
+                                      │       │ Slack /  │
+                                      │       │ Webhook  │
+                                      │       └──────────┘
+                                      │
+                                  data residency
+                                  router selects
+                                  per-org region
+```
+
+The backend runs in two processes that share the same codebase: the API server ([api/server.ts](../src/api/server.ts), bootstrapped from [index.ts](../src/index.ts)) and the worker process ([worker.ts](../src/worker.ts)). Both connect to Postgres, Redis, and S3/MinIO; the worker also opens BullMQ consumers.
+
+## Major components
+
+### API layer — [api/](../src/api/)
+
+- Server bootstrap and route registration: [api/server.ts](../src/api/server.ts).
+- ~40 route modules in [api/routes/](../src/api/routes/) (reports, projects, auth, signup, integrations, integration-rules, dedup-rules, intelligence-\*, notifications/, invoice-billing, share-tokens, admin-\*, deployment).
+- Middleware: [api/middleware/](../src/api/middleware/) — `auth/` (JWT + API key + share token handlers), `project-access.ts`, `org-access.ts`, `audit.ts`, `metrics.ts`, `error.ts` (the centralized `AppError` handler).
+- Authorization policies: [api/authorization/](../src/api/authorization/) (`guard` composer, per-resource policies). Newer routes use `guard(...)`; older ones still compose `requireAuth + requireProjectAccess + requireProjectRole(...)` in preHandler chains.
+
+### Persistence — [db/](../src/db/)
+
+- [client.ts](../src/db/client.ts) — single pg Pool, retry wrapper, the typed repository registry. Repositories are obtained via `db.bugReports`, `db.dedupRules`, etc.
+- [transaction.ts](../src/db/transaction.ts) + `db.transaction(async tx => …)` — tx-scoped repos. `db.queryWithTransaction(async client => …)` exposes the raw `pg.PoolClient` for advisory locks.
+- Raw SQL migrations live in [db/migrations/](../src/db/migrations/) — see [db-schema.md](db-schema.md) for the table map.
+- Repositories under [db/repositories/](../src/db/repositories/) extend `BaseRepository<T, TInsert, TUpdate>`. A few specialized repos (outbox flows, advisory-lock paths) hand-write SQL — that's intentional.
+
+### Queue + workers — [queue/](../src/queue/)
+
+- [queue-manager.ts](../src/queue/queue-manager.ts) + [worker-manager.ts](../src/queue/worker-manager.ts) own the BullMQ lifecycle; [redis-connection-pool.ts](../src/queue/redis-connection-pool.ts) pools the connections.
+- Job types in [queue/jobs/](../src/queue/jobs/): `integration-job.ts`, `intelligence-job.ts`, `notification-job.ts`, `replay-job.ts`, `screenshot-job.ts`.
+- Workers in [queue/workers/](../src/queue/workers/): `integration-worker.ts`, `intelligence-worker.ts`, `notification-worker.ts`, `replay-worker.ts`, `screenshot-worker.ts`, `payment-event-worker.ts`, and the transactional-outbox processor at [outbox/ticket-creation-outbox.worker.ts](../src/queue/workers/outbox/ticket-creation-outbox.worker.ts).
+
+### Integrations — [integrations/](../src/integrations/)
+
+- Plugin core: [plugin-registry.ts](../src/integrations/plugin-registry.ts) (`PluginRegistry`), `plugin-loader.ts`, `base-integration.service.ts`, [capabilities.ts](../src/integrations/capabilities.ts) (`TicketIntegrationCapabilities`, `pluginSupports`).
+- Dedup-rule schema (Zod): [dedup-rule.schema.ts](../src/integrations/dedup-rule.schema.ts). Mirrors the Python Pydantic model in `bugspotter-intelligence`; the two must stay in lockstep.
+- Plugins: `jira/`, `linear/`, `generic-http/` (each with `plugin.ts`, `service.ts`, `client.ts`, `mapper.ts`, `template-renderer.ts`).
+- Sandbox: [security/](../src/integrations/security/) — `plugin-executor.ts`, `code-analyzer.ts`, `hardened-http.ts`, `ssrf-validator.ts`, `rpc-bridge.ts`. Every external HTTP call from a plugin routes through `hardened-http` + `ssrf-validator`.
+
+### Services — [services/](../src/services/)
+
+- **Intelligence** (`intelligence/`): HTTP client for the Python service ([intelligence-client.ts](../src/services/intelligence/intelligence-client.ts)) wrapped by a circuit breaker. [dedup-service.ts](../src/services/intelligence/dedup-service.ts) (`IntelligenceDedupService.applyDedupAction`) decides whether to flag a bug as a duplicate and updates `bug_reports.duplicate_of`. Sibling services: `enrichment-service.ts`, `mitigation-service.ts`, `feedback-service.ts`.
+- **Notifications** (`notifications/`): the rule-driven notification pipeline — `notification-service.ts`, channel handlers (`slack-handler.ts`, [email-handler.ts](../src/services/notifications/email-handler.ts), `discord-handler.ts`, `teams-handler.ts`, `webhook-handler.ts`), and a three-stage pipeline in `pipeline/` (rule match → throttle → deliver → history).
+- **Dedup rules engine** (`rules/`): the Phase 0.5 rule engine. Detailed flow below. Files: [executor.ts](../src/services/rules/executor.ts), [dispatcher.ts](../src/services/rules/dispatcher.ts), [evaluator.ts](../src/services/rules/evaluator.ts), [context-provider.ts](../src/services/rules/context-provider.ts), [rate-limiter.ts](../src/services/rules/rate-limiter.ts), [email-sender.ts](../src/services/rules/email-sender.ts), [email-templates.ts](../src/services/rules/email-templates.ts), [seed.ts](../src/services/rules/seed.ts), [wiring.ts](../src/services/rules/wiring.ts).
+- **Integrations service-layer** (`integrations/`): [auto-ticket-service.ts](../src/services/integrations/auto-ticket-service.ts) (the transactional-outbox writer), `rule-evaluator.ts`, `throttle-checker.ts`, `ticket-template-renderer.ts`.
+- **Auth helpers** (`auth/`, `api-key/`): password reset, lockout, key issuance/verification, per-key rate limits.
+
+### SaaS layer — [saas/](../src/saas/)
+
+Only active when `DEPLOYMENT_MODE=saas`. Holds multi-tenant code that selfhosted deployments never run:
+
+- [config.ts](../src/saas/config.ts) `getDeploymentConfig()` returns the runtime feature flags (`multiTenancy`, `billing`, `usageTracking`, `quotaEnforcement`).
+- Middleware: `tenant.ts` (subdomain resolution), `tenant-match.ts`, `quota.ts`.
+- Services: `signup.service.ts` (self-service onboarding atomic transaction), `organization.service.ts` (quota-checked project creation via advisory lock), `billing.service.ts`, `invitation.service.ts`, `spam-filter.service.ts`, `subdomain.service.ts`.
+- Repositories: subscription, invoice, invoice-line, legal-entity, act, organization-request, usage-record.
+- Scheduled jobs: `dunning.job.ts`, `invoice-scheduler.job.ts`, `trial-expiration.job.ts`, `org-request-expiration.job.ts`.
+
+### Cross-cutting
+
+- **DI**: [container/service-container.ts](../src/container/service-container.ts), `request-context.ts`.
+- **Cache**: [cache/cache-service.ts](../src/cache/cache-service.ts) (Redis or in-memory).
+- **Storage**: [storage/storage-service.ts](../src/storage/storage-service.ts) — local or S3 backend; [data-residency/regional-storage-router.ts](../src/data-residency/regional-storage-router.ts) picks per-org region.
+- **Data residency**: [data-residency/](../src/data-residency/) — audit log + violation tracking + regional routing.
+- **Retention**: [retention/retention-scheduler.ts](../src/retention/retention-scheduler.ts).
+- **Analytics + metrics**: [analytics/](../src/analytics/), [metrics/](../src/metrics/).
+
+## Cross-cutting flows
+
+### 1. SDK bug submission
+
+```text
+SDK ──POST /api/v1/reports── api/routes/reports.ts
+                                │
+                                ├─► db.bugReports.create
+                                ├─► triggerBugReportNotification    (enqueue notification-job)
+                                ├─► triggerBugReportIntegrations    (enqueue integration-job + outbox row via AutoTicketService)
+                                └─► triggerBugReportIntelligence    (enqueue intelligence-job)
+```
+
+The route returns 201 once the row is committed; the three trigger calls dispatch async work via BullMQ. Integration filing is mediated by the transactional outbox (`ticket_creation_outbox`) so a job retry never produces a duplicate ticket — see migration 021's "dedup grace" extension that lets the outbox worker hold off on filing until intelligence has had a chance to mark the bug as a duplicate.
+
+### 2. Outbox worker → external ticket
+
+```text
+ticket_creation_outbox.worker.ts
+   ├─► poll outbox rows in 'pending' state where next_retry_at <= now()
+   ├─► resolve plugin via PluginRegistry
+   ├─► plugin.service.createTicket(...)    (run inside security/plugin-executor sandbox)
+   ├─► on success: write 'tickets' row + mark outbox 'completed'
+   └─► on duplicate-of-set: mark outbox 'skipped' (the dedup-rule engine's
+       'outbox_about_to_skip' trigger fires here)
+```
+
+### 3. Intelligence worker → dedup decision → rule engine
+
+```text
+intelligence-worker.ts
+   ├─► IntelligenceClient.analyze(bugReport)         (HTTP → FastAPI)
+   ├─► IntelligenceDedupService.applyDedupAction
+   │     └─ on duplicate: UPDATE bug_reports SET duplicate_of, status=...
+   └─► on applied: re-fetch the bug (now with duplicate_of set)
+        └─► ruleExecutor.fire('duplicate_detected', updatedBug)
+              (project-match guard runs first; cross-project rejection is logged)
+```
+
+### 4. Dedup-rule engine (PR-C / PR-C2 / PR-D1)
+
+```text
+Trigger source                          (outbox skip path / intelligence dedup path)
+       │
+       ▼
+DedupRuleExecutor.fire(triggerType, bug)
+   ├─► repo.findByProject(projectId, enabled=true)   (partial-indexed query)
+   ├─► RuleContextProvider.build(bug)                (loads canonical, hits-in-window, etc.)
+   ├─► for each rule whose 'when' matches triggerType:
+   │     ├─► evaluator.matches(rule.conditions, ctx)
+   │     ├─► rateLimiter.allow(rule, groupKey)        (notification_throttle row)
+   │     └─► dispatcher.dispatch(ctx, action)
+   │           ├─► ticket.add_comment / ticket.transition
+   │           │   ├─► TicketsTableResolver — find canonical's external ticket
+   │           │   └─► capability service (Jira/Linear plugin) does the call
+   │           └─► notify.email
+   │               ├─► resolveEmailRecipient (reporter / closer / literal)
+   │               ├─► renderEmailTemplate  (subject plain, body HTML-escaped)
+   │               └─► ChannelBackedEmailSender → EmailChannelHandler → SMTP
+   └─► returns RuleFireResult[] for logging
+```
+
+Wiring lives in [services/rules/wiring.ts](../src/services/rules/wiring.ts) (`buildDedupRuleExecutor`). Errors inside dispatch are swallowed — the trigger hooks are wrapped in an outer try so a buggy rule never crashes a queue worker. Rules are admin-only today; tenant-user rule authoring is gated on the C2 security carry-overs (auth-bound reporter, per-recipient rate limit, literal-email allowlist).
+
+### 5. Notification pipeline
+
+```text
+producer
+   │
+   ▼
+NotificationService.dispatch
+   ├─► pipeline/notification-rule-pipeline.ts   (match notification_rules by trigger + filters)
+   ├─► pipeline/notification-delivery-service.ts (throttle via notification_throttle)
+   ├─► handlers/channel-handler-registry.ts     (resolve channel type → handler)
+   │     ├─► slack-handler / email-handler / webhook-handler / discord-handler / teams-handler
+   │     └─► per-handler retry + circuit breaker
+   └─► pipeline/notification-history-service.ts (append notification_history)
+```
+
+This pipeline predates the dedup-rule engine. The two share `notification_throttle` (made polymorphic in migration 023 — see [db-schema.md](db-schema.md)) but are otherwise independent: notifications fire off filter-matched bug events; the rule engine fires off discrete trigger types declared in `DedupRule.when`.
+
+## Deployment modes
+
+`DEPLOYMENT_MODE=saas | selfhosted` toggles behavior at runtime. The switch is read by [saas/config.ts](../src/saas/config.ts) `getDeploymentConfig()` and consumed in:
+
+- `saas/middleware/tenant.ts`, `tenant-match.ts`, `quota.ts` — only run in `saas`.
+- `api/server.ts` — route registration (signup route is skipped in selfhosted).
+- `api/routes/auth.ts`, `api/routes/projects.ts`, `api/routes/deployment.ts` — surface conditional behavior to clients.
+- `analytics/analytics-auth.ts`, `analytics/analytics-scope.ts` — org-scope vs single-tenant.
+- `config/queue.config.ts` — queue partitioning per tenant.
+- [config.ts](../src/config.ts) — `allowRegistration` and `selfServiceSignupEnabled` default to `true` when mode is `saas`.
+
+The `application.*` schema is identical across modes; the `saas.*` schema is unused in selfhosted (the tables exist but stay empty). All FKs from `application.*` to `saas.organizations` are nullable so selfhosted rows can omit them.
+
+## External boundaries
+
+| Boundary              | Code                                                                                                                                                                  | Notes                                                                                                                                  |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Postgres              | [db/client.ts](../src/db/client.ts)                                                                                                                                   | Single pool, retry wrapper, SSL config.                                                                                                |
+| Redis                 | [queue/redis-connection-pool.ts](../src/queue/redis-connection-pool.ts) + [cache/redis-cache.ts](../src/cache/redis-cache.ts)                                         | BullMQ backplane + cache.                                                                                                              |
+| MinIO / S3            | [storage/](../src/storage/)                                                                                                                                           | Local or S3; region selected per-org by [data-residency/regional-storage-router.ts](../src/data-residency/regional-storage-router.ts). |
+| Intelligence FastAPI  | [services/intelligence/intelligence-client.ts](../src/services/intelligence/intelligence-client.ts)                                                                   | HTTP, wrapped by [circuit-breaker.ts](../src/services/intelligence/circuit-breaker.ts). Separate repo: `bugspotter-intelligence`.      |
+| SMTP                  | [services/notifications/email-handler.ts](../src/services/notifications/email-handler.ts) + various `*-email.service.ts`                                              | Nodemailer; per-channel `EmailChannelConfig` row.                                                                                      |
+| Integration platforms | [integrations/jira/](../src/integrations/jira/), [integrations/linear/](../src/integrations/linear/), [integrations/generic-http/](../src/integrations/generic-http/) | All HTTP routed through `security/hardened-http.ts` + `ssrf-validator.ts`.                                                             |
+
+## Auth surface
+
+See [auth.md](auth.md) for the full reference — header precedence, the 3-layer authorization model, effective project role (explicit ∪ inherited), API-key bypass rules, and open policy questions.
+
+Quick map of where things live:
+
+- JWT + API key + share-token handlers: [api/middleware/auth/](../src/api/middleware/auth/) (`handlers.ts`, `assertions.ts`, `authorization.ts`).
+- Project access enforcement: [api/middleware/project-access.ts](../src/api/middleware/project-access.ts).
+- Org access enforcement: [api/middleware/org-access.ts](../src/api/middleware/org-access.ts).
+- Policy composer (newer routes): [api/authorization/](../src/api/authorization/).
+- API-key service: [services/api-key/](../src/services/api-key/).
+- Password reset + lockout: [services/auth/](../src/services/auth/).
+
+## What this doc does not cover
+
+- Per-plugin integration internals (Jira ADF rendering, Linear GraphQL schemas) — see each plugin's `CLAUDE.md` if present.
+- The admin UI routing and i18n — see [apps/admin/CLAUDE.md](../../../apps/admin/CLAUDE.md).
+- The SDK and the landing-page signup wizard — separate repos (`bugspotter-extension`, `bugspotter-landing`).
+- DB-level details — see [db-schema.md](db-schema.md).

--- a/packages/backend/docs/db-schema.md
+++ b/packages/backend/docs/db-schema.md
@@ -1,0 +1,182 @@
+# Database Schema
+
+Reference for the BugSpotter Postgres schema. Pairs with [architecture.md](architecture.md) for how the application uses these tables. Source of truth is the migration files in [../src/db/migrations/](../src/db/migrations/) (001 through 025); this doc is a curated overview, not an exhaustive column listing.
+
+Two top-level schemas:
+
+- **`application.*`** — every BugSpotter deployment. Users, projects, bug reports, integrations, notifications, the dedup-rule engine.
+- **`saas.*`** — multi-tenant deployments only. Organizations, subscriptions, invitations, billing. Tables exist in selfhosted DBs but stay empty.
+
+Schema FKs cross only one direction: `application.*` rows reference `saas.organizations` (always nullable) — never the reverse. The `application` schema is portable; `saas` is the bolt-on layer.
+
+## Conventions
+
+- All timestamps are `TIMESTAMPTZ`. The shared trigger function `application.update_updated_at_column()` (defined in [001_initial_schema.sql](../src/db/migrations/001_initial_schema.sql)) maintains `updated_at` on every UPDATE for any table that wires it.
+- Soft-delete uses `deleted_at TIMESTAMPTZ NULL` + paired partial indexes (`WHERE deleted_at IS NULL` for hot paths, `WHERE deleted_at IS NOT NULL` for purge sweeps). Applied to `bug_reports`, `share_tokens`, `organizations`.
+- JSONB columns that hold service-layer payloads are validated by Zod (or Pydantic on the intelligence side) at the trust boundary. The DB only enforces structural CHECKs (`jsonb_typeof(x) = 'object'`, non-empty arrays). Content validation is the application's job.
+- Migration files are append-only. Re-running a merged migration is unsafe — add a new file (see migration ordering invariants at the bottom).
+
+## `application.*`
+
+### Identity + access
+
+- **`users`** — auth principals. Either `password_hash` OR `(oauth_provider, oauth_id)`, enforced by `check_auth_method` ([001:32](../src/db/migrations/001_initial_schema.sql)). `preferences` JSONB has a GIN index. Migration [015](../src/db/migrations/015_unified_rbac.sql) added a `security` JSONB column for the unified RBAC model (today only `is_platform_admin` is documented). Migration [019](../src/db/migrations/019_email_verification.sql) added `email_verified_at` for self-service signup. The functional index `idx_users_email_lower` ([018](../src/db/migrations/018_users_email_lower_index.sql)) is non-unique by design — historical case-duplicate rows exist.
+
+- **`email_verification_tokens`** — single-use tokens for self-service signup. Partial index on `WHERE consumed_at IS NULL` keeps the hot lookup small. Migration [019](../src/db/migrations/019_email_verification.sql).
+
+- **`api_keys`** — hash-only storage. `permissions` is a JSONB array, `allowed_projects` a `UUID[]`. Multiple CHECKs enforce type/status/scope and non-negative rate-limit fields. A **BEFORE DELETE trigger on `projects`** (`trigger_cleanup_api_keys_on_project_delete`, [001:1273](../src/db/migrations/001_initial_schema.sql)) strips the deleted project's UUID out of every `allowed_projects` array and revokes keys whose array becomes empty. Migration [016](../src/db/migrations/016_backfill_api_key_permissions.sql) backfilled `permissions` from the legacy `permission_scope`.
+
+- **`api_key_usage`**, **`api_key_rate_limits`**, **`api_key_audit_log`** — operational support. The rate-limit table uses composite PK `(api_key_id, window_type, window_start)` and a CHECK enumerating window types.
+
+- **`project_roles`** + **`project_members`** — per-project RBAC. `project_roles` is seeded with `owner`/`admin`/`member`/`viewer` ([001:85](../src/db/migrations/001_initial_schema.sql)). `project_members.role` FKs `project_roles.name` (RESTRICT). Project-level access is independent of the user-level `users.role` / `users.security` columns.
+
+- **`permissions`** (legacy) — role/resource/action tuples seeded at [001:543](../src/db/migrations/001_initial_schema.sql). Coexists with the unified-RBAC `users.security` JSONB; migration 015's comment says `users.role` is slated for deprecation but no migration has done it. Treat it as still load-bearing.
+
+### Tenancy + projects
+
+- **`projects`** — tenant of bug reports. `organization_id` is nullable for selfhosted (and for legacy rows). `data_residency_region` is a CHECK-enumerated string (`kz`/`rf`/`eu`/`us`/`global`) that the storage router reads.
+
+- **`audit_logs`** — append-only audit ledger. `resource_id` is TEXT, not UUID — it can be a UUID, a file path, or an S3 key (documented in the COMMENT). `organization_id` was added and backfilled in [014](../src/db/migrations/014_audit_logs_org_scope.sql); only single-org users get attributed (multi-org users remain NULL by design).
+
+- **`data_residency_audit`** + **`data_residency_violations`** — compliance ledger. CHECK on `violation_type`.
+
+- **`system_config`** — global key/value JSONB store.
+
+### Bug reports + replays
+
+- **`bug_reports`** — the central entity. Soft-delete via `deleted_at` + `deleted_by`, plus `legal_hold` flag (partial indexes on both — [001:149-150](../src/db/migrations/001_initial_schema.sql)). Compound partial indexes `idx_bug_reports_active_project_status_created` and `idx_bug_reports_active_project_priority_created` (both `WHERE deleted_at IS NULL`) drive the dashboard. `metadata` JSONB is the SDK-supplied ingest blob, validated by Zod at the API boundary. Migration [010](../src/db/migrations/010_duplicate_detection.sql) added `duplicate_of` (self-FK) + a CHECK `chk_bug_reports_no_self_duplicate`.
+
+- **`archived_bug_reports`** — cold storage after soft-delete. CHECK `archived_at >= deleted_at`.
+
+- **`sessions`** — rrweb event blobs. `bug_report_id` FK cascades.
+
+- **`share_tokens`** — public-replay grants. CHECK that the token is at least 32 chars and `expires_at > created_at`. Soft-delete via `deleted_at`. The compound index `idx_share_tokens_report_active(bug_report_id, expires_at, deleted_at)` is the access-path the share-token middleware uses.
+
+### Integrations + tickets
+
+- **`integrations`** — plugin catalogue. Jira is seeded in 001; Linear in [020](../src/db/migrations/020_seed_linear_integration.sql). CHECKs enumerate `plugin_source` and `trust_level`.
+
+- **`project_integrations`** — per-project config + encrypted credentials. Circuit-breaker fields (`error_count`, `disabled_at`, `disabled_reason`) have a consistency CHECK ([001:344](../src/db/migrations/001_initial_schema.sql)) — `disabled_at` and `disabled_reason` must agree.
+
+- **`integration_rules`** — per-integration filter/throttle/auto-create rules. `filters` and `throttle` are JSONB. A partial index targets `WHERE auto_create = true AND enabled = true`.
+
+- **`tickets`** — external-system ticket records. UNIQUE `(platform, external_id)`. A partial index on `WHERE sync_status != 'synced'` keeps the sync-retry path fast.
+
+- **`ticket_creation_outbox`** — the transactional-outbox table for filing tickets. UNIQUE `idempotency_key`. The status state machine is `pending → processing → completed | failed | dead_letter | skipped`, with `next_retry_at` for exponential backoff. Migration [021](../src/db/migrations/021_outbox_dedup_grace.sql) extended the enum with `skipped` and added `dedup_grace_until` + `skipped_reason` so the worker can defer filing while async intelligence populates `bug_reports.duplicate_of` (the source of the dedup-rule engine's `outbox_about_to_skip` trigger).
+
+- **`integration_sync_log`**, **`integration_field_mappings`**, **`integration_webhooks`**, **`oauth_tokens`** — operational support. All from 001.
+
+### Notifications
+
+- **`notification_channels`** — channel configs. CHECK enumerates type (`email`/`slack`/`webhook`/`discord`/`teams`). `config` JSONB has a CHECK that it's an object.
+
+- **`notification_rules`** — rule definitions. `triggers` JSONB has a CHECK enforcing non-empty array.
+
+- **`notification_rule_channels`** — many-to-many between rules and channels (composite PK).
+
+- **`notification_templates`** — per-channel templates. Partial UNIQUE `idx_unique_active_template(channel_type, trigger_type) WHERE is_active`. Default email + Slack templates are seeded.
+
+- **`notification_history`** — append-only delivery log. CHECK that `status = 'sent'` implies `delivered_at IS NOT NULL`. GIN index on `recipients` (JSONB array).
+
+- **`notification_throttle`** — rate-limit state. UNIQUE `(rule_id, group_key, window_start)`, CHECK `window_end > window_start`. The **`rule_id` column is polymorphic** since migration 023 — see "Cross-cutting patterns" below.
+
+### Intelligence + dedup-rule engine
+
+- **`intelligence_feedback`** ([008](../src/db/migrations/008_intelligence_feedback.sql)) — user feedback on dedup suggestions. `rating ∈ {-1, 1}`. UNIQUE per `(bug_report_id, suggestion_bug_id, user_id)`.
+
+- **`bug_enrichments`** ([009](../src/db/migrations/009_bug_enrichments.sql)) — five confidence columns each with a `0..1` CHECK. UNIQUE on `bug_report_id` so enrichment is upsert-shaped. `enrichment_version` is the staleness column the worker checks before re-running.
+
+- **`intelligence_deflections`** ([011](../src/db/migrations/011_deflection_tracking.sql)) — ROI counter for the dedup pipeline. UNIQUE `(project_id, matched_bug_id, description_hash)`.
+
+- **`bug_mitigations`** ([013](../src/db/migrations/013_bug_mitigations.sql)) — manual triage actions. UNIQUE on `bug_report_id`. `organization_id` FK to `saas.organizations` with ON DELETE SET NULL.
+
+- **`dedup_rules`** ([022](../src/db/migrations/022_dedup_rules.sql)) — the rule engine's storage. `rule_json` JSONB validated by the Zod schema at [src/integrations/dedup-rule.schema.ts](../src/integrations/dedup-rule.schema.ts) (mirrored to a Python Pydantic model in `bugspotter-intelligence`). UNIQUE `(project_id, name)`. Partial index `idx_dedup_rules_enabled_lookup(project_id) WHERE enabled = true` is the executor's hot-path access. **AFTER DELETE trigger** added in [025](../src/db/migrations/025_dedup_rules_cascade_and_seed.sql) to garbage-collect throttle rows.
+
+## `saas.*`
+
+Active only when `DEPLOYMENT_MODE=saas`. Selfhosted deployments still create these tables (migrations are mode-agnostic) but never write to them.
+
+- **`organizations`** ([001:1431](../src/db/migrations/001_initial_schema.sql)) — `subdomain` UNIQUE. Migration [003](../src/db/migrations/003_organization_soft_delete.sql) added soft-delete columns and the partial index `idx_organizations_active_created … WHERE deleted_at IS NULL`. Migration [006](../src/db/migrations/006_organization_settings.sql) added `settings` JSONB with a GIN index (partial on `WHERE deleted_at IS NULL`). Known `settings` keys are documented in COMMENT only (migrations [006](../src/db/migrations/006_organization_settings.sql), [007](../src/db/migrations/007_intelligence_settings.sql)) — there's no CHECK validating shape; correctness is service-layer. Migration [012](../src/db/migrations/012_invoice_billing.sql) added a `billing_method` CHECK constraint.
+
+- **`organization_members`** — per-org user membership. A **partial UNIQUE** `idx_org_members_one_owner_per_org(organization_id) WHERE role = 'owner'` enforces "at most one owner per org" at the DB level — it prevents multiple owner rows but does not guarantee one exists (the application layer is responsible for ensuring an owner is assigned at org-create time).
+
+- **`organization_invitations`** ([002](../src/db/migrations/002_organization_invitations.sql)) — pending invites. Partial UNIQUE on `(organization_id, email) WHERE status = 'pending'` blocks duplicate pending invites. Migration [004](../src/db/migrations/004_pending_owner.sql) redefined the role CHECK to include `owner` and layered a second partial UNIQUE `WHERE role = 'owner' AND status = 'pending'`. The two indexes compose: one pending invite per email + one pending owner invite per org.
+
+- **`organization_requests`** ([005](../src/db/migrations/005_organization_requests.sql)) — public signup queue (admin-approved). Partial UNIQUE on `lower(contact_email) WHERE status IN ('pending_verification', 'verified')`. Indexes for token lookup, status/created, and IP-based rate-limit. Migration [017](../src/db/migrations/017_org_request_subdomain_index.sql) added a partial index on subdomain.
+
+- **`subscriptions`** — 1:1 with `organizations` (UNIQUE `organization_id`). Partial UNIQUE `(payment_provider, external_subscription_id) WHERE external_subscription_id IS NOT NULL`. CHECKs enumerate plans and billing statuses. `quotas` JSONB.
+
+- **`usage_records`** — periodic metering. UNIQUE `(organization_id, period_start, resource_type)`. CHECK enumerates resource types.
+
+- **`legal_entities`** ([012](../src/db/migrations/012_invoice_billing.sql)) — billing identity. UNIQUE `organization_id` (1:1). `details` JSONB validated by a region-specific billing plugin; the KZ shape includes `bin` + `iik` etc. GIN index on `details->'bin'` accelerates BIN lookup.
+
+- **`invoices`** — invoice records. UNIQUE `invoice_number` (drawn from sequence `saas.invoice_number_seq`). CHECK `amount > 0`. Status CHECK enumerates the lifecycle. Partial index `idx_invoices_due_at WHERE status IN ('sent', 'overdue')` for dunning sweeps.
+
+- **`invoice_lines`** — line items. CASCADE on invoice delete. CHECKs on quantity/amount.
+
+- **`acts`** — Russian/Kazakh act-of-services records. UNIQUE `act_number` (sequence `saas.act_number_seq`). Status CHECK.
+
+## Cross-cutting patterns
+
+### Polymorphic `notification_throttle.rule_id`
+
+The original migration 001 declared `notification_throttle.rule_id` as an FK to `notification_rules` with `ON DELETE CASCADE`. When the dedup-rule engine landed in PR-C, it needed the same throttle infrastructure, but a single FK can only reference one parent table. The three-migration trio handled the transition:
+
+- [023_notification_throttle_polymorphic_rule.sql](../src/db/migrations/023_notification_throttle_polymorphic_rule.sql) — dropped the FK. `rule_id` is now an opaque UUID. The unique `(rule_id, group_key, window_start)` constraint is unchanged. **This migration alone leaves cascade behavior broken** — orphan throttle rows would accumulate forever, since `cleanup_expired_throttle_windows()` is defined but not scheduled.
+- [024_notification_throttle_cascade_trigger.sql](../src/db/migrations/024_notification_throttle_cascade_trigger.sql) — restored cascade for `notification_rules` via an AFTER DELETE trigger that calls `cascade_delete_notification_rule_throttle()`. Explicitly omitted the parallel trigger on `dedup_rules` because the delete path didn't exist yet.
+- [025_dedup_rules_cascade_and_seed.sql](../src/db/migrations/025_dedup_rules_cascade_and_seed.sql) — added the parallel `cascade_delete_dedup_rule_throttle()` trigger on `dedup_rules`, alongside the B1/B2 seed backfill that lands with the admin delete handler in PR-D1.
+
+The 023 → 024 → 025 sequence is the integrity unit; partial application leaves throttle garbage.
+
+### Soft-delete
+
+Applied to `bug_reports`, `share_tokens`, `organizations`. Pattern is `deleted_at TIMESTAMPTZ NULL` + paired partial indexes `WHERE deleted_at IS NULL` for hot paths and `WHERE deleted_at IS NOT NULL` for retention sweeps. `bug_reports` adds `legal_hold` and the cold-storage table `archived_bug_reports` to block retention.
+
+### JSONB validated by Zod at the trust boundary
+
+The DB enforces structural CHECKs (object, array, non-empty); content shape is validated by Zod (or Pydantic on the intelligence side) on every read and write. Examples:
+
+- `bug_reports.metadata` — SDK-supplied; validated by the API ingest schema.
+- `dedup_rules.rule_json` — validated by [src/integrations/dedup-rule.schema.ts](../src/integrations/dedup-rule.schema.ts), mirrored to Pydantic in `bugspotter-intelligence`. Drift between the two would silently break round-trip.
+- `integration_rules.filters` / `throttle` / `attachment_config` — validated by the integration-rule service layer.
+- `notification_rules.triggers` / `filters` / `throttle` — validated by the notification rule pipeline.
+- `legal_entities.details` — validated by the per-region billing plugin.
+- `organizations.settings` — known keys documented in COMMENT only ([006](../src/db/migrations/006_organization_settings.sql), [007](../src/db/migrations/007_intelligence_settings.sql)); no DDL validation. Service-layer correctness only.
+
+### Unified RBAC (migration 015) coexists with legacy `permissions`
+
+Migration [015](../src/db/migrations/015_unified_rbac.sql) added `users.security` JSONB next to the legacy `users.role` column. The 015 comment says `role` will be deprecated in a future migration; that migration has not been written. Today, three RBAC mechanisms coexist:
+
+- `users.security` JSONB (platform admin flag).
+- `users.role` (legacy, still load-bearing — check before assuming it's safe to ignore).
+- `project_members.role` + `project_roles` (per-project, FK-validated).
+
+The `application.permissions` table seeded in 001 holds role/resource/action tuples and is the source of truth for the system-level permission middleware. See [auth.md](auth.md) for the runtime resolution rules.
+
+### Transactional outbox
+
+`ticket_creation_outbox` ([001:457](../src/db/migrations/001_initial_schema.sql)) decouples bug-report creation from external ticket filing. The contract:
+
+- API writes the outbox row in the same transaction as the `bug_reports` insert. Idempotency_key prevents duplicates on retry.
+- The outbox worker polls `pending` rows, attempts plugin call, advances the state machine.
+- Migration 021 added the `skipped` state and `dedup_grace_until` so a row can wait for the async intelligence dedup decision; if `duplicate_of` is set during the grace window, the row transitions to `skipped` (the dedup-rule engine's `outbox_about_to_skip` trigger fires here).
+
+## Migration ordering invariants
+
+A few hard requirements live in the order itself — the migrate runner applies files in lexicographic order, and some files depend on state established earlier:
+
+- **001 must run first.** Declares both schemas, the shared `application.update_updated_at_column()` trigger function (used cross-schema), the BEFORE DELETE trigger on `projects` that cleans up `api_keys.allowed_projects`, and seeds `project_roles`. All later migrations `SET search_path` to a pre-existing schema.
+- **`saas.organizations` must exist before** 003 (soft-delete cols), 006 (settings), 012 (billing_method + legal_entities), 013 (`bug_mitigations.organization_id` FK), 014 (`audit_logs.organization_id` FK), and 002 / 005 / 004 (invitation + request tables FK to it).
+- **004 depends on 002.** It redefines the role CHECK constraint on `organization_invitations` and layers a second partial UNIQUE that composes with 002's index.
+- **023 → 024 → 025 is the throttle-cascade integrity unit.** See the polymorphic-rule_id section.
+- **025's seed depends on 022 + 001.** The seed shape must match the Zod schema at `src/integrations/dedup-rule.schema.ts` — drift here would silently store rules the executor rejects on read.
+- **016 (api_keys permissions backfill) depends on 001's `api_keys`.**
+- **014 backfills `audit_logs.organization_id`** from `saas.organization_members`; only single-org users get attributed, multi-org users remain NULL by design.
+- **The `application` schema search_path is set per-connection** ([001:1408 comment](../src/db/migrations/001_initial_schema.sql)). Migrations that touch `saas` issue `SET search_path TO saas` and reset at the bottom.
+
+## What this doc does not cover
+
+- Per-column types (BIGINT vs INTEGER, VARCHAR limits) — read the migration file.
+- Index storage parameters and reindex strategies — operational concerns, not in scope.
+- The Python intelligence service's tables (lives in a separate repo, separate DB).
+- The retention scheduler's exact sweep cadence — see [retention/](../src/retention/) in the source tree.

--- a/packages/backend/src/api/routes/dedup-rules.ts
+++ b/packages/backend/src/api/routes/dedup-rules.ts
@@ -1,0 +1,419 @@
+/**
+ * Dedup Rules API — admin CRUD for the per-project rule engine.
+ *
+ * The rule executor (PR-C / PR-C2) reads from `application.dedup_rules`
+ * but had no write path. This file is the write path: admin-only routes
+ * for listing, creating, updating, and deleting rules on a project.
+ *
+ * **Auth model**: project-admin gate via `requireProjectRole('admin')`,
+ * mirroring `integration-rules.ts`. Rule creation today is admin-only
+ * because the C2 security carry-overs (auth-bound `reporter` recipient,
+ * per-recipient rate limit, literal-email allowlist) haven't landed —
+ * a non-admin tenant user able to author rules could exfiltrate bug
+ * data via `notify.email.to = 'attacker@evil.com'`. Those mitigations
+ * are tracked separately; when they land, the role gate can relax.
+ *
+ * **API-key surface**: every route rejects API-key auth outright via
+ * `rejectApiKeyAuth`. `requireProjectRole` bypasses for API keys
+ * (machines aren't project members) and `requireApiKeyPermission`
+ * admits full-scope (`['*']`) keys, so the role/permission stack
+ * alone would let any full-scope project key author rules — including
+ * `notify.email.to = 'attacker@evil.com'` — reopening the
+ * exfiltration path the C2 carry-overs are meant to close. Dedup-
+ * rule CRUD is human-admin only until those mitigations ship; machine
+ * automation can land alongside the C2 work or via a separately
+ * scoped API.
+ *
+ * **Validation**: every write goes through `parseDedupRule` (Zod). The
+ * repository stores the raw blob; the schema is what the executor
+ * parses on read, so writing a malformed rule would silently no-op the
+ * executor — fail-closed at the API boundary instead.
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { ZodError } from 'zod';
+import type { DatabaseClient } from '../../db/client.js';
+import { PG_UNIQUE_VIOLATION } from '../../db/pg-error-codes.js';
+import {
+  parseDedupRule,
+  dedupRuleSchema,
+  type DedupRule,
+} from '../../integrations/dedup-rule.schema.js';
+import { getLogger } from '../../logger.js';
+import { requireApiKeyPermission, requireAuth, requireProjectRole } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import { requireProjectAccess } from '../middleware/project-access.js';
+import { getAuditUserId } from '../utils/audit-attribution.js';
+import { sendCreated, sendSuccess } from '../utils/response.js';
+
+const logger = getLogger();
+
+/**
+ * Body shape for POST and PATCH. Matches the wire format of `DedupRule`
+ * but typed loosely here — Zod is the source of truth and runs on every
+ * request. Typing the body as `unknown` would also work; using a
+ * `Record` keeps the route signature documentary without committing to
+ * a TS shape that could drift from Zod.
+ */
+type DedupRuleBody = Record<string, unknown>;
+
+/**
+ * Convert a Zod failure into a 400 with the first issue's path + message.
+ * Returning all issues would leak the schema's internal structure and
+ * also overwhelm the admin UI's error toast; the first issue is what
+ * the user needs to fix first anyway.
+ */
+function rejectIfInvalid(err: unknown): never {
+  if (err instanceof ZodError) {
+    const issue = err.issues[0];
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    throw new AppError(`Invalid dedup rule: ${path}: ${issue.message}`, 400, 'BadRequest');
+  }
+  throw err;
+}
+
+/**
+ * Catches the TOCTOU race where the `findByProjectAndName` pre-check
+ * passes for two concurrent writes and the DB unique constraint trips
+ * for the loser. Map the pg `23505` (unique_violation) to the same
+ * 409 the pre-check produces, so the API contract stays consistent.
+ */
+function isUniqueNameViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: string }).code === PG_UNIQUE_VIOLATION
+  );
+}
+
+/**
+ * Reject API-key auth on every dedup-rule route. `requireProjectRole`
+ * bypasses for API-key requests (machines aren't project members),
+ * and `requireApiKeyPermission` admits full-scope `['*']` keys — so
+ * without this preHandler a full-scope key could still author rules
+ * (including `notify.email.to = 'attacker@evil.com'`) and reopen the
+ * exfiltration path the C2 carry-overs are meant to close.
+ * Dedup-rule CRUD is human-admin only until those land; machine
+ * automation is out of scope for this PR.
+ */
+async function rejectApiKeyAuth(request: FastifyRequest, _reply: FastifyReply): Promise<void> {
+  if (request.apiKey) {
+    throw new AppError(
+      'Dedup rule routes require a human project admin; API keys are not accepted',
+      403,
+      'Forbidden'
+    );
+  }
+}
+
+/**
+ * Look up a rule and verify it belongs to the project in the URL path.
+ * A globally-unique UUID makes cross-project hits unlikely in practice,
+ * but the check closes the rest of the surface (stale link, swapped
+ * id) without an extra query — `findById` already returned project_id.
+ */
+async function loadRuleScopedToProject(ruleId: string, projectId: string, db: DatabaseClient) {
+  const rule = await db.dedupRules.findById(ruleId);
+  if (!rule || rule.project_id !== projectId) {
+    throw new AppError('Dedup rule not found', 404, 'NotFound');
+  }
+  return rule;
+}
+
+export function registerDedupRuleRoutes(fastify: FastifyInstance, db: DatabaseClient): void {
+  /**
+   * GET /api/v1/projects/:projectId/dedup-rules
+   * Lists every rule on the project (enabled and disabled). The admin
+   * UI needs both so it can render the disabled rows with a toggle;
+   * the executor uses `findByProject(_, false)` for its hot path, which
+   * is a different code path.
+   *
+   * Admin-gated because rule bodies contain `notify.email.to` literals
+   * and condition fields that should not be visible to project viewers
+   * until the C2 carry-overs (auth-bound reporter, allowlist) land.
+   */
+  fastify.get<{ Params: { projectId: string } }>(
+    '/api/v1/projects/:projectId/dedup-rules',
+    {
+      preHandler: [
+        requireAuth,
+        rejectApiKeyAuth,
+        requireApiKeyPermission('dedup_rules:read'),
+        requireProjectAccess(db, { paramName: 'projectId' }),
+        requireProjectRole('admin'),
+      ],
+    },
+    async (request, reply) => {
+      const { projectId } = request.params;
+      const rules = await db.dedupRules.findByProject(projectId, true);
+      logger.debug('Listed dedup rules', {
+        projectId,
+        count: rules.length,
+        userId: getAuditUserId(request),
+      });
+      return sendSuccess(reply, { rules });
+    }
+  );
+
+  /**
+   * GET /api/v1/projects/:projectId/dedup-rules/:ruleId
+   * Single rule lookup. Admin-gated for the same reason as list.
+   */
+  fastify.get<{ Params: { projectId: string; ruleId: string } }>(
+    '/api/v1/projects/:projectId/dedup-rules/:ruleId',
+    {
+      preHandler: [
+        requireAuth,
+        rejectApiKeyAuth,
+        requireApiKeyPermission('dedup_rules:read'),
+        requireProjectAccess(db, { paramName: 'projectId' }),
+        requireProjectRole('admin'),
+      ],
+    },
+    async (request, reply) => {
+      const { projectId, ruleId } = request.params;
+      const rule = await loadRuleScopedToProject(ruleId, projectId, db);
+      return sendSuccess(reply, { rule });
+    }
+  );
+
+  /**
+   * POST /api/v1/projects/:projectId/dedup-rules
+   * Body is the full DedupRule blob. Zod validates; the row stores
+   * (name, rule_json, enabled) split out for query convenience.
+   */
+  fastify.post<{ Params: { projectId: string }; Body: DedupRuleBody }>(
+    '/api/v1/projects/:projectId/dedup-rules',
+    {
+      preHandler: [
+        requireAuth,
+        rejectApiKeyAuth,
+        requireApiKeyPermission('dedup_rules:write'),
+        requireProjectAccess(db, { paramName: 'projectId' }),
+        requireProjectRole('admin'),
+      ],
+    },
+    async (request, reply) => {
+      const { projectId } = request.params;
+      let rule: DedupRule;
+      try {
+        rule = parseDedupRule(request.body);
+      } catch (err) {
+        rejectIfInvalid(err);
+      }
+      // Friendlier 409 than the raw uniqueness-constraint error the
+      // DB would emit. The pre-check covers the common case; the
+      // try/catch below catches the TOCTOU race where two concurrent
+      // POSTs both pass this check.
+      const existing = await db.dedupRules.findByProjectAndName(projectId, rule.name);
+      if (existing) {
+        throw new AppError(
+          `Dedup rule '${rule.name}' already exists in this project`,
+          409,
+          'Conflict'
+        );
+      }
+      let created;
+      try {
+        created = await db.dedupRules.create({
+          project_id: projectId,
+          name: rule.name,
+          rule_json: rule,
+          enabled: rule.enabled,
+        });
+      } catch (err) {
+        if (isUniqueNameViolation(err)) {
+          throw new AppError(
+            `Dedup rule '${rule.name}' already exists in this project`,
+            409,
+            'Conflict'
+          );
+        }
+        throw err;
+      }
+      logger.info('Dedup rule created', {
+        projectId,
+        ruleId: created.id,
+        name: rule.name,
+        trigger: rule.when.type,
+        actionCount: rule.then.length,
+        userId: getAuditUserId(request),
+      });
+      return sendCreated(reply, { rule: created });
+    }
+  );
+
+  /**
+   * PATCH /api/v1/projects/:projectId/dedup-rules/:ruleId
+   * Accepts a partial. Two shapes are supported:
+   *  - `{ enabled: boolean }` — toggle only, the common admin-UI op.
+   *  - The full DedupRule blob — replaces name + rule_json + enabled.
+   *
+   * Mixing-and-matching at a sub-field level isn't supported because
+   * the rule body is a discriminated union; rebuilding a half-rule
+   * server-side would either be lossy or surprising. The admin UI
+   * already round-trips full rules.
+   */
+  fastify.patch<{
+    Params: { projectId: string; ruleId: string };
+    Body: DedupRuleBody;
+  }>(
+    '/api/v1/projects/:projectId/dedup-rules/:ruleId',
+    {
+      preHandler: [
+        requireAuth,
+        rejectApiKeyAuth,
+        requireApiKeyPermission('dedup_rules:write'),
+        requireProjectAccess(db, { paramName: 'projectId' }),
+        requireProjectRole('admin'),
+      ],
+    },
+    async (request, reply) => {
+      const { projectId, ruleId } = request.params;
+      const body = request.body ?? {};
+      const existing = await loadRuleScopedToProject(ruleId, projectId, db);
+
+      const keys = Object.keys(body);
+      const enabledOnly = keys.length === 1 && keys[0] === 'enabled';
+
+      if (enabledOnly) {
+        if (typeof body.enabled !== 'boolean') {
+          throw new AppError('enabled must be a boolean', 400, 'BadRequest');
+        }
+        // Keep the `enabled` column and `rule_json.enabled` field in
+        // sync. The executor filters by the column, but the rule
+        // blob also carries an `enabled` field that future code (the
+        // admin UI, an audit log, a re-validation pass) might read.
+        // A drift between the two is technically harmless today but
+        // breaks the implicit contract that `rule_json` is the
+        // canonical rule shape.
+        //
+        // `rule_json` is typed `unknown` at the repo boundary. A
+        // non-object value (null, primitive, array) would TypeError
+        // on spread — fall back to `{ enabled }` only so the toggle
+        // still succeeds and the row gets nudged toward a canonical
+        // shape. The executor would have rejected the malformed blob
+        // anyway via `parseDedupRule`; the toggle path doesn't need
+        // to re-validate the entire body.
+        const isObjectBlob =
+          typeof existing.rule_json === 'object' &&
+          existing.rule_json !== null &&
+          !Array.isArray(existing.rule_json);
+        if (!isObjectBlob) {
+          // Log so corrupted rows surface in dashboards rather than
+          // silently being downgraded to `{ enabled }` by the toggle.
+          // Operator action: full-rule PATCH or DELETE to restore a
+          // valid shape; until then the executor rejects this row on
+          // every fire via parseDedupRule anyway.
+          logger.warn('Dedup rule has malformed rule_json; toggle preserved enabled only', {
+            projectId,
+            ruleId,
+            existingJsonType: existing.rule_json === null ? 'null' : typeof existing.rule_json,
+          });
+        }
+        const existingJson = isObjectBlob ? (existing.rule_json as Record<string, unknown>) : {};
+        const syncedRuleJson = { ...existingJson, enabled: body.enabled };
+        const updated = await db.dedupRules.update(ruleId, {
+          enabled: body.enabled,
+          rule_json: syncedRuleJson,
+        });
+        logger.info('Dedup rule toggled', {
+          projectId,
+          ruleId,
+          enabled: body.enabled,
+          userId: getAuditUserId(request),
+        });
+        return sendSuccess(reply, { rule: updated });
+      }
+
+      // Full-rule replacement path.
+      let rule: DedupRule;
+      try {
+        rule = dedupRuleSchema.parse(body);
+      } catch (err) {
+        rejectIfInvalid(err);
+      }
+      // `dedupRuleSchema.enabled` has `.default(true)`, so a PATCH body
+      // that omits `enabled` would Zod-fill `true` and silently re-enable
+      // a previously-disabled rule. Preserve the existing column value
+      // when the client didn't explicitly set it. Check the raw body
+      // (`body.enabled` is the wire-format flag; Zod's default makes
+      // the parsed `rule.enabled` indistinguishable from a real
+      // request value).
+      const clientSetEnabled = 'enabled' in body;
+      const nextEnabled = clientSetEnabled ? rule.enabled : existing.enabled;
+      // Keep the rule_json blob and the column in sync (same invariant
+      // the toggle path maintains).
+      const nextRuleJson = { ...rule, enabled: nextEnabled };
+      if (rule.name !== existing.name) {
+        const nameClash = await db.dedupRules.findByProjectAndName(projectId, rule.name);
+        if (nameClash && nameClash.id !== ruleId) {
+          throw new AppError(
+            `Dedup rule '${rule.name}' already exists in this project`,
+            409,
+            'Conflict'
+          );
+        }
+      }
+      let updated;
+      try {
+        updated = await db.dedupRules.update(ruleId, {
+          name: rule.name,
+          rule_json: nextRuleJson,
+          enabled: nextEnabled,
+        });
+      } catch (err) {
+        // TOCTOU: a concurrent rename to the same target name slips
+        // past the pre-check above; the unique constraint catches it.
+        if (isUniqueNameViolation(err)) {
+          throw new AppError(
+            `Dedup rule '${rule.name}' already exists in this project`,
+            409,
+            'Conflict'
+          );
+        }
+        throw err;
+      }
+      logger.info('Dedup rule updated', {
+        projectId,
+        ruleId,
+        userId: getAuditUserId(request),
+      });
+      return sendSuccess(reply, { rule: updated });
+    }
+  );
+
+  /**
+   * DELETE /api/v1/projects/:projectId/dedup-rules/:ruleId
+   * The AFTER DELETE trigger added in migration 025 cleans up
+   * `notification_throttle` rows that referenced this rule — without
+   * it, the polymorphic `rule_id` would orphan throttle state forever
+   * (see migration 024's prose).
+   */
+  fastify.delete<{ Params: { projectId: string; ruleId: string } }>(
+    '/api/v1/projects/:projectId/dedup-rules/:ruleId',
+    {
+      preHandler: [
+        requireAuth,
+        rejectApiKeyAuth,
+        requireApiKeyPermission('dedup_rules:write'),
+        requireProjectAccess(db, { paramName: 'projectId' }),
+        requireProjectRole('admin'),
+      ],
+    },
+    async (request, reply) => {
+      const { projectId, ruleId } = request.params;
+      const rule = await loadRuleScopedToProject(ruleId, projectId, db);
+      await db.dedupRules.delete(ruleId);
+      logger.info('Dedup rule deleted', {
+        projectId,
+        ruleId,
+        name: rule.name,
+        userId: getAuditUserId(request),
+      });
+      return sendSuccess(reply, { message: `Dedup rule '${rule.name}' deleted` });
+    }
+  );
+
+  logger.info('Dedup rule routes registered');
+}

--- a/packages/backend/src/api/routes/projects.ts
+++ b/packages/backend/src/api/routes/projects.ts
@@ -18,6 +18,7 @@ import { sendSuccess, sendCreated } from '../utils/response.js';
 import { AppError } from '../middleware/error.js';
 import { OrganizationService } from '../../saas/services/organization.service.js';
 import { getDeploymentConfig, DEPLOYMENT_MODE } from '../../saas/config.js';
+import { seedDefaultDedupRules } from '../../services/rules/seed.js';
 
 interface CreateProjectBody {
   name: string;
@@ -142,6 +143,12 @@ export function projectRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       const project = organizationId
         ? await orgService.createProjectWithQuotaCheck(organizationId, projectInput)
         : await db.projects.create(projectInput);
+
+      // Seed B1 / B2 dedup presets so the rule engine has something
+      // to fire from day one. Failures are logged but not surfaced —
+      // a project without seed rules is still usable, and migration
+      // 025's backfill is the safety net.
+      await seedDefaultDedupRules(db.dedupRules, project.id);
 
       return sendCreated(reply, project);
     }

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -40,6 +40,7 @@ import { BillingRegionRegistry, KzBillingPlugin } from '@bugspotter/billing';
 import { jobRoutes } from './routes/jobs.js';
 import { registerIntegrationRoutes } from './routes/integrations.js';
 import { registerIntegrationRuleRoutes } from './routes/integration-rules.js';
+import { registerDedupRuleRoutes } from './routes/dedup-rules.js';
 import { registerAdminIntegrationRoutes } from './routes/admin-integrations.js';
 import { adminRoutes } from './routes/admin.js';
 import { adminJobsRoutes } from './routes/admin-jobs.js';
@@ -533,6 +534,9 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
 
   // Register integration rules routes
   await registerIntegrationRuleRoutes(fastify, db, options.pluginRegistry);
+
+  // Register dedup rules routes (admin CRUD for the Phase 0.5 rule engine)
+  registerDedupRuleRoutes(fastify, db);
 
   // Register admin integration management routes
   await registerAdminIntegrationRoutes(fastify, db, options.pluginRegistry);

--- a/packages/backend/src/db/client.ts
+++ b/packages/backend/src/db/client.ts
@@ -23,6 +23,7 @@ import type { EmailVerificationTokenRepository } from './repositories/email-veri
 import type { AuditLogRepository } from './repositories/audit-log.repository.js';
 import type { ProjectIntegrationRepository } from './project-integration.repository.js';
 import type { IntegrationRuleRepository } from './integration-rule.repository.js';
+import type { DedupRuleRepository } from './dedup-rule.repository.js';
 import type { IntegrationRepository } from './repositories/integration.repository.js';
 import type { IntegrationSyncLogRepository } from './repositories/integration-sync-log.repository.js';
 import type { FieldMappingRepository } from './repositories/field-mapping.repository.js';
@@ -173,6 +174,7 @@ export class DatabaseClient implements RepositoryRegistry {
   public readonly oauthTokens!: OAuthTokenRepository;
   public readonly apiKeys!: ApiKeyRepository;
   public readonly integrationRules!: IntegrationRuleRepository;
+  public readonly dedupRules!: DedupRuleRepository;
   public readonly ticketOutbox!: TicketCreationOutboxRepository;
   public readonly dataResidency!: DataResidencyRepository;
   // SaaS multi-tenant repositories
@@ -228,6 +230,7 @@ export class DatabaseClient implements RepositoryRegistry {
     this.oauthTokens = this.wrapWithRetry(repositories.oauthTokens);
     this.apiKeys = this.wrapWithRetry(repositories.apiKeys);
     this.integrationRules = this.wrapWithRetry(repositories.integrationRules);
+    this.dedupRules = this.wrapWithRetry(repositories.dedupRules);
     this.ticketOutbox = this.wrapWithRetry(repositories.ticketOutbox);
     // SaaS multi-tenant repositories
     this.organizations = this.wrapWithRetry(repositories.organizations);

--- a/packages/backend/src/db/migrations/025_dedup_rules_cascade_and_seed.sql
+++ b/packages/backend/src/db/migrations/025_dedup_rules_cascade_and_seed.sql
@@ -1,0 +1,97 @@
+SET search_path TO application;
+
+-- Two things land together because they're both consequences of the
+-- dedup-rule write path opening up (PR-D admin CRUD):
+--
+-- 1. AFTER DELETE trigger on `dedup_rules`. Migration 024 made
+--    `notification_throttle.rule_id` polymorphic and added the
+--    cascade trigger on `notification_rules`, but explicitly omitted
+--    the parallel trigger on `dedup_rules` because no delete path
+--    existed yet. PR-D introduces `DELETE /api/v1/projects/:projectId/dedup-rules/:ruleId`,
+--    so the parallel cleanup needs to land in the same migration to
+--    keep the polymorphic guarantee intact.
+--
+-- 2. Idempotent seed of the B1 / B2 preset rules for every existing
+--    project. New projects get them via the service hook in
+--    `project.service.ts`; this migration backfills demo / production
+--    projects that already exist. Re-run safe: the unique constraint
+--    `unique_dedup_rule_name_per_project` lets ON CONFLICT DO NOTHING
+--    handle a project that already has B1 / B2 by hand.
+--
+-- B3 (auto-reopen on regression) is deliberately NOT seeded yet —
+-- the `cluster_growing` trigger and `hits_in_window` condition that
+-- B3 should branch on aren't wired in the executor, so seeding it
+-- disabled-but-broken would be worse than leaving it absent.
+
+-- ---------------------------------------------------------------------------
+-- (1) AFTER DELETE trigger
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION cascade_delete_dedup_rule_throttle()
+RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM notification_throttle WHERE rule_id = OLD.id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS cascade_delete_throttle ON dedup_rules;
+CREATE TRIGGER cascade_delete_throttle
+  AFTER DELETE ON dedup_rules
+  FOR EACH ROW
+  EXECUTE FUNCTION cascade_delete_dedup_rule_throttle();
+
+COMMENT ON FUNCTION cascade_delete_dedup_rule_throttle() IS
+  'Mirrors cascade_delete_notification_rule_throttle (migration 024) for the dedup_rules side of the polymorphic notification_throttle.rule_id reference.';
+
+-- ---------------------------------------------------------------------------
+-- (2) Seed B1 and B2 for every existing project
+-- ---------------------------------------------------------------------------
+--
+-- The blobs below MUST match what `parseDedupRule` (Zod) accepts —
+-- adding a field here without updating the schema would store rules
+-- the executor rejects on read. The schema lives in
+-- src/integrations/dedup-rule.schema.ts.
+
+-- B1 is seeded DISABLED. `to: "reporter"` resolves to the SDK-supplied
+-- `bug_reports.metadata.metadata.user.email`, which has no verification
+-- today — until the C2 mitigations (auth-bound reporter resolver,
+-- per-recipient rate limit, literal-email allowlist) ship, operators
+-- opt B1 on per project explicitly. See `src/services/rules/seed.ts`
+-- for the matching JS preset; the drift test in
+-- `tests/services/rules/seed.test.ts` enforces parity.
+INSERT INTO dedup_rules (project_id, name, rule_json, enabled)
+SELECT
+  p.id,
+  'Notify reporter on dedup',
+  '{
+    "name": "Notify reporter on dedup",
+    "when": {"type": "duplicate_detected"},
+    "conditions": [],
+    "then": [{"type": "notify.email", "to": "reporter", "template": "dedup_ack"}],
+    "rate_limit": {"count": 1, "window": "24h"},
+    "enabled": false
+  }'::jsonb,
+  false
+FROM projects p
+ON CONFLICT (project_id, name) DO NOTHING;
+
+INSERT INTO dedup_rules (project_id, name, rule_json, enabled)
+SELECT
+  p.id,
+  'Counter on canonical',
+  '{
+    "name": "Counter on canonical",
+    "when": {"type": "outbox_about_to_skip"},
+    "conditions": [],
+    "then": [{
+      "type": "ticket.add_comment",
+      "target": "canonical",
+      "body": "+1 occurrence (deduplicated by BugSpotter)."
+    }],
+    "rate_limit": {"count": 1, "window": "60m"},
+    "enabled": true
+  }'::jsonb,
+  true
+FROM projects p
+ON CONFLICT (project_id, name) DO NOTHING;

--- a/packages/backend/src/db/pg-error-codes.ts
+++ b/packages/backend/src/db/pg-error-codes.ts
@@ -1,0 +1,18 @@
+/**
+ * Postgres SQLSTATE codes used by application code to disambiguate
+ * expected error conditions from real failures.
+ *
+ * Reference: https://www.postgresql.org/docs/current/errcodes-appendix.html
+ *
+ * Keep this file small — only add a code when at least two callsites
+ * need to match on it. The single-callsite case is better served by
+ * an inline string with a one-line comment.
+ */
+
+/**
+ * `unique_violation` — a write violated a UNIQUE constraint (or a
+ * UNIQUE partial index). Callers typically catch this to translate
+ * the raw error into a friendlier 409 Conflict instead of letting the
+ * pg driver's generic error surface as a 500.
+ */
+export const PG_UNIQUE_VIOLATION = '23505';

--- a/packages/backend/src/db/repositories/factory.ts
+++ b/packages/backend/src/db/repositories/factory.ts
@@ -15,6 +15,7 @@ import { SystemConfigRepository } from './system-config.repository.js';
 import { AuditLogRepository } from './audit-log.repository.js';
 import { ProjectIntegrationRepository } from '../project-integration.repository.js';
 import { IntegrationRuleRepository } from '../integration-rule.repository.js';
+import { DedupRuleRepository } from '../dedup-rule.repository.js';
 import { NotificationChannelRepository } from './notification-channel.repository.js';
 import { NotificationRuleRepository } from './notification-rule.repository.js';
 import { NotificationTemplateRepository } from './notification-template.repository.js';
@@ -63,6 +64,7 @@ export interface RepositoryRegistry {
   oauthTokens: OAuthTokenRepository;
   apiKeys: ApiKeyRepository;
   integrationRules: IntegrationRuleRepository;
+  dedupRules: DedupRuleRepository;
   ticketOutbox: TicketCreationOutboxRepository;
   dataResidency: DataResidencyRepository;
   // SaaS multi-tenant repositories
@@ -113,6 +115,7 @@ export function createRepositories(pool: Pool | PoolClient): RepositoryRegistry 
     oauthTokens: new OAuthTokenRepository(pool),
     apiKeys: new ApiKeyRepository(pool),
     integrationRules: new IntegrationRuleRepository(pool),
+    dedupRules: new DedupRuleRepository(pool),
     ticketOutbox: new TicketCreationOutboxRepository(pool),
     dataResidency: new DataResidencyRepository(pool),
     // SaaS multi-tenant repositories

--- a/packages/backend/src/saas/services/signup.service.ts
+++ b/packages/backend/src/saas/services/signup.service.ts
@@ -33,6 +33,7 @@ import {
   DATA_RESIDENCY_REGION,
 } from '../../db/types.js';
 import { AppError } from '../../api/middleware/error.js';
+import { seedDefaultDedupRules } from '../../services/rules/seed.js';
 import { PASSWORD } from '../../api/utils/constants.js';
 import { getQuotaForPlan } from '../plans.js';
 import { SubdomainService } from './subdomain.service.js';
@@ -388,6 +389,20 @@ export class SignupService {
       subdomain,
       projectId: result.project.id,
     });
+
+    // Seed B1 / B2 dedup-rule presets POST-commit. The helper catches
+    // per-preset failures, which only works on a non-aborted client;
+    // inside the signup tx, a single failed INSERT would abort it and
+    // every subsequent statement would error with "current transaction
+    // is aborted" — the swallow logic would be a lie. Running here on
+    // `db.dedupRules` gives the helper a fresh, non-tx client.
+    //
+    // A crash between the COMMIT above and this call leaves the
+    // project unseeded; migration 025's idempotent backfill catches
+    // up on the next deploy, and an operator can also POST /dedup-rules
+    // to add presets manually. Acceptable failure mode — the user's
+    // signup itself never fails because of seed trouble.
+    await seedDefaultDedupRules(this.db.dedupRules, result.project.id);
 
     // Fire-and-forget verification email. Non-blocking by design:
     // signup is "Sentry-style" — a transient SMTP outage must never

--- a/packages/backend/src/services/rules/seed.ts
+++ b/packages/backend/src/services/rules/seed.ts
@@ -1,0 +1,130 @@
+/**
+ * Seed default dedup-rule presets on a new project.
+ *
+ * Called from the two project-creation paths (admin `POST /projects`
+ * and the SaaS signup wizard, post-commit). Migration 025 backfills
+ * the same presets for existing projects, so the two layers together
+ * ensure every project the executor reads has B1 / B2 available.
+ *
+ * Idempotent via the `unique_dedup_rule_name_per_project` constraint
+ * — running this twice (e.g. operator manually creates B1 then the
+ * hook fires for a project re-creation) silently skips the existing
+ * row.
+ *
+ * Failures here do NOT roll back project creation. A project without
+ * seed rules is still functional (the engine has no rules to fire
+ * for it; the operator can add rules later via the admin API), so
+ * surfacing a seed failure as a 500 on project-create would be worse
+ * than logging and continuing.
+ *
+ * **NOT safe inside `db.transaction(...)`.** The per-preset try/catch
+ * looks like it tolerates failures, but Postgres aborts the entire
+ * transaction on any failed statement and every subsequent query in
+ * the same tx will fail with "current transaction is aborted" —
+ * `db.transaction` does not use savepoints. Callers running inside a
+ * tx (signup wizard) MUST invoke this AFTER the tx commits, with the
+ * post-commit `db.dedupRules` repo. Crash-between-commit-and-seed is
+ * the accepted failure mode; migration 025's idempotent backfill is
+ * the safety net.
+ */
+
+import type { DedupRuleRepository } from '../../db/dedup-rule.repository.js';
+import { PG_UNIQUE_VIOLATION } from '../../db/pg-error-codes.js';
+import type { DedupRule } from '../../integrations/dedup-rule.schema.js';
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+/**
+ * The hard-coded preset definitions. Keep these in sync with the
+ * INSERT statements in `migrations/025_dedup_rules_cascade_and_seed.sql`
+ * — that migration backfills existing projects, this hook covers new
+ * ones, and divergence between them would leave projects in an
+ * inconsistent default state depending on creation date.
+ *
+ * B3 (auto-reopen on regression) is intentionally omitted: it needs
+ * the `cluster_growing` trigger / `hits_in_window` condition wiring
+ * that lives in a follow-up PR. Seeding it disabled-but-unfireable
+ * would be worse than not seeding it at all.
+ */
+const PRESETS: Array<DedupRule> = [
+  {
+    // Seeded DISABLED. `to: 'reporter'` resolves to the SDK-supplied
+    // `bugReport.metadata.metadata.user.email`, which has no
+    // verification today — a malicious SDK caller can set it to any
+    // address and use BugSpotter as an email relay against a victim.
+    // The per-(rule, canonical) 24h rate limit caps the spam at one
+    // email per canonical, but an attacker fabricating duplicates of
+    // many canonicals scales linearly. The C2 mitigations (auth-bound
+    // reporter resolver, per-recipient rate limit, literal-email
+    // allowlist) close this; until they ship, operators opt in
+    // explicitly by toggling the seeded rule on per project.
+    name: 'Notify reporter on dedup',
+    when: { type: 'duplicate_detected' },
+    conditions: [],
+    then: [{ type: 'notify.email', to: 'reporter', template: 'dedup_ack' }],
+    rate_limit: { count: 1, window: '24h' },
+    enabled: false,
+  },
+  {
+    name: 'Counter on canonical',
+    when: { type: 'outbox_about_to_skip' },
+    conditions: [],
+    then: [
+      {
+        type: 'ticket.add_comment',
+        target: 'canonical',
+        body: '+1 occurrence (deduplicated by BugSpotter).',
+      },
+    ],
+    rate_limit: { count: 1, window: '60m' },
+    enabled: true,
+  },
+];
+
+/**
+ * Insert the default presets for a project. **Call AFTER any
+ * surrounding transaction has committed**, with the post-commit
+ * `db.dedupRules` repo — the per-preset try/catch below can swallow
+ * a JS error but cannot un-abort a Postgres transaction, see the
+ * file-header warning. The admin `POST /projects` path calls this
+ * outside any tx; the signup wizard calls it after `db.transaction`
+ * returns.
+ *
+ * Returns the count of rules actually inserted. A uniqueness
+ * violation on any single preset (operator manually pre-created one
+ * with the same name) is swallowed — partial seeding is still
+ * better than aborting the whole hook.
+ */
+export async function seedDefaultDedupRules(
+  repo: DedupRuleRepository,
+  projectId: string
+): Promise<number> {
+  let inserted = 0;
+  for (const preset of PRESETS) {
+    try {
+      await repo.create({
+        project_id: projectId,
+        name: preset.name,
+        rule_json: preset,
+        enabled: preset.enabled,
+      });
+      inserted++;
+    } catch (error) {
+      // unique_violation is expected if migration 025's backfill
+      // already ran or the operator manually pre-seeded. Anything
+      // else is a real failure; log but don't throw — the project
+      // itself is fine without seeds.
+      const code = (error as { code?: string } | null)?.code;
+      if (code !== PG_UNIQUE_VIOLATION) {
+        logger.warn('Failed to seed dedup-rule preset', {
+          projectId,
+          name: preset.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+  logger.debug('Seeded default dedup rules', { projectId, inserted });
+  return inserted;
+}

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -12,8 +12,6 @@
  */
 
 import type { DatabaseClient } from '../../db/client.js';
-import { DedupRuleRepository } from '../../db/dedup-rule.repository.js';
-import { NotificationThrottleRepository } from '../../db/repositories/notification-throttle.repository.js';
 import type { TicketIntegrationCapabilities } from '../../integrations/capabilities.js';
 import type { PluginRegistry } from '../../integrations/plugin-registry.js';
 import { getLogger } from '../../logger.js';
@@ -103,9 +101,8 @@ export function buildDedupRuleExecutor(
   db: DatabaseClient,
   pluginRegistry: PluginRegistry | null
 ): DedupRuleExecutor {
-  const pool = db.getPool();
-  const repo = new DedupRuleRepository(pool);
-  const throttle = new NotificationThrottleRepository(pool);
+  const repo = db.dedupRules;
+  const throttle = db.notificationThrottle;
   const resolver = new TicketsTableResolver(db);
   const lookup = buildCapabilityServiceLookup(db, pluginRegistry);
   // EmailChannelHandler is stateless (no constructor args) and the

--- a/packages/backend/tests/api/routes/dedup-rules.route.test.ts
+++ b/packages/backend/tests/api/routes/dedup-rules.route.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Dedup Rules API — route-level smoke tests.
+ *
+ * Auth middleware is mocked to no-op (covered by the dedicated
+ * authorization tests). The interesting surface here is:
+ *  - Zod validation on POST / PATCH-full (rejection shape + 400)
+ *  - the (project_id, name) uniqueness pre-check returning 409
+ *  - PATCH toggle-only path vs PATCH full-replace path
+ *  - cross-project guard on ruleId lookup
+ *  - delete cascade-trigger is exercised by the integration migration test,
+ *    not here — this file just verifies the handler returns success
+ *    and the repo's `delete` was called.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { DatabaseClient } from '../../../src/db/client.js';
+import type { DedupRuleRow } from '../../../src/db/dedup-rule.repository.js';
+
+vi.mock('../../../src/api/middleware/auth.js', () => ({
+  requireAuth: vi.fn(async () => undefined),
+  requireProjectRole: () => async () => undefined,
+  requireApiKeyPermission: () => async () => undefined,
+}));
+
+vi.mock('../../../src/api/middleware/project-access.js', () => ({
+  requireProjectAccess: () => async () => undefined,
+}));
+
+vi.mock('../../../src/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Import AFTER mocks so route module resolves to the stubs.
+import { registerDedupRuleRoutes } from '../../../src/api/routes/dedup-rules.js';
+import { errorHandler } from '../../../src/api/middleware/error.js';
+
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const OTHER_PROJECT_ID = '00000000-0000-0000-0000-000000000002';
+const RULE_ID = '11111111-1111-1111-1111-111111111111';
+
+function makeRow(overrides: Partial<DedupRuleRow> = {}): DedupRuleRow {
+  return {
+    id: RULE_ID,
+    project_id: PROJECT_ID,
+    name: 'r',
+    rule_json: {},
+    enabled: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+interface MockDedupRepo {
+  findByProject: Mock;
+  findById: Mock;
+  findByProjectAndName: Mock;
+  create: Mock;
+  update: Mock;
+  delete: Mock;
+}
+
+function makeDb(): { db: DatabaseClient; repo: MockDedupRepo } {
+  const repo: MockDedupRepo = {
+    findByProject: vi.fn(async () => []),
+    findById: vi.fn(async () => null),
+    findByProjectAndName: vi.fn(async () => null),
+    create: vi.fn(async (data) => makeRow({ ...data, id: 'created' })),
+    update: vi.fn(async () => makeRow({ id: 'updated' })),
+    delete: vi.fn(async () => true),
+  };
+  const db = { dedupRules: repo } as unknown as DatabaseClient;
+  return { db, repo };
+}
+
+async function buildServer(db: DatabaseClient): Promise<FastifyInstance> {
+  const server = Fastify();
+  // Test-only hook: simulate API-key auth by setting request.apiKey
+  // when a `x-test-apikey: 1` header is present. The real auth
+  // middleware is mocked to no-op, so we forge the field directly.
+  server.addHook('onRequest', async (request) => {
+    if (request.headers['x-test-apikey'] === '1') {
+      (request as unknown as { apiKey: { id: string } }).apiKey = { id: 'test-key' };
+    }
+  });
+  server.setErrorHandler(errorHandler);
+  registerDedupRuleRoutes(server, db);
+  await server.ready();
+  return server;
+}
+
+const VALID_RULE_BODY = {
+  name: 'Notify reporter on dedup',
+  when: { type: 'duplicate_detected' },
+  conditions: [],
+  then: [{ type: 'notify.email', to: 'reporter', template: 'dedup_ack' }],
+  rate_limit: { count: 1, window: '24h' },
+  enabled: true,
+};
+
+describe('Dedup Rules API', () => {
+  let server: FastifyInstance;
+  let repo: MockDedupRepo;
+
+  beforeEach(() => {
+    const setup = makeDb();
+    repo = setup.repo;
+    return buildServer(setup.db).then((s) => {
+      server = s;
+    });
+  });
+
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  describe('rejectApiKeyAuth gate', () => {
+    // The role/permission stack alone admits full-scope (`['*']`) API
+    // keys via requireApiKeyPermission's wildcard branch — and
+    // requireProjectRole bypasses for API keys entirely. The
+    // rejectApiKeyAuth preHandler closes that path so dedup-rule
+    // routes stay human-admin-only until the C2 mitigations land.
+    it.each([
+      ['GET list', 'GET', `/api/v1/projects/${PROJECT_ID}/dedup-rules`],
+      ['GET one', 'GET', `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`],
+      ['POST', 'POST', `/api/v1/projects/${PROJECT_ID}/dedup-rules`],
+      ['PATCH', 'PATCH', `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`],
+      ['DELETE', 'DELETE', `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`],
+    ])('rejects API-key auth on %s with 403', async (_label, method, url) => {
+      const res = await server.inject({
+        method: method as 'GET',
+        url,
+        headers: { 'x-test-apikey': '1' },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /projects/:projectId/dedup-rules', () => {
+    it('lists rules (including disabled) for the project', async () => {
+      repo.findByProject.mockResolvedValueOnce([
+        makeRow({ name: 'B1' }),
+        makeRow({ name: 'B2', enabled: false }),
+      ]);
+
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.rules).toHaveLength(2);
+      // includeDisabled=true so the admin UI can render disabled rows.
+      expect(repo.findByProject).toHaveBeenCalledWith(PROJECT_ID, true);
+    });
+  });
+
+  describe('GET /projects/:projectId/dedup-rules/:ruleId', () => {
+    it('returns the rule when it belongs to the project', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ name: 'B1' }));
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.rule.name).toBe('B1');
+    });
+
+    it('returns 404 when the rule belongs to a different project', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ project_id: OTHER_PROJECT_ID }));
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('returns 404 when the rule does not exist', async () => {
+      repo.findById.mockResolvedValueOnce(null);
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('POST /projects/:projectId/dedup-rules', () => {
+    it('creates a valid rule and returns 201', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules`,
+        payload: VALID_RULE_BODY,
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(repo.create).toHaveBeenCalledOnce();
+      const arg = repo.create.mock.calls[0][0];
+      expect(arg.project_id).toBe(PROJECT_ID);
+      expect(arg.name).toBe('Notify reporter on dedup');
+      expect(arg.enabled).toBe(true);
+    });
+
+    it('returns 400 with the offending field on Zod failure', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules`,
+        payload: { ...VALID_RULE_BODY, when: { type: 'unknown_trigger' } },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain('Invalid dedup rule');
+      expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when then[] is empty (schema requires min 1 action)', async () => {
+      const res = await server.inject({
+        method: 'POST',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules`,
+        payload: { ...VALID_RULE_BODY, then: [] },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 409 when a rule with the same name already exists', async () => {
+      repo.findByProjectAndName.mockResolvedValueOnce(
+        makeRow({ name: 'Notify reporter on dedup' })
+      );
+
+      const res = await server.inject({
+        method: 'POST',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules`,
+        payload: VALID_RULE_BODY,
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 409 when a concurrent insert wins the TOCTOU race (pg 23505)', async () => {
+      // Pre-check passes (no existing row), then a parallel POST commits
+      // first; our INSERT trips the unique constraint. The handler must
+      // map 23505 to 409, not let it surface as a 500.
+      const uniqueErr = Object.assign(new Error('duplicate key value'), { code: '23505' });
+      repo.create.mockRejectedValueOnce(uniqueErr);
+
+      const res = await server.inject({
+        method: 'POST',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules`,
+        payload: VALID_RULE_BODY,
+      });
+
+      expect(res.statusCode).toBe(409);
+    });
+  });
+
+  describe('PATCH /projects/:projectId/dedup-rules/:ruleId', () => {
+    it('toggles enabled and keeps rule_json.enabled in sync', async () => {
+      repo.findById.mockResolvedValueOnce(
+        makeRow({ rule_json: { name: 'r', enabled: true, foo: 'bar' } })
+      );
+      const res = await server.inject({
+        method: 'PATCH',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+        payload: { enabled: false },
+      });
+      expect(res.statusCode).toBe(200);
+      // Both the column and the blob field must flip together so any
+      // future code reading rule_json.enabled (the admin UI, a
+      // re-validation pass) doesn't see drift.
+      const arg = repo.update.mock.calls[0][1];
+      expect(arg.enabled).toBe(false);
+      expect(arg.rule_json).toMatchObject({ enabled: false, foo: 'bar' });
+    });
+
+    it('rejects non-boolean enabled on the toggle-only path', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow());
+      const res = await server.inject({
+        method: 'PATCH',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+        payload: { enabled: 'no' },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it.each([
+      ['null', null],
+      ['primitive string', 'broken'],
+      ['array', ['a', 'b']],
+    ])(
+      'toggle path falls back to { enabled } on malformed rule_json (%s)',
+      async (_label, malformed) => {
+        // Defensive fallback path: the row's rule_json is unparseable,
+        // so the toggle nudges it toward a canonical shape rather than
+        // TypeError-ing on spread. The executor would have rejected
+        // the malformed blob anyway; migration 025's backfill is the
+        // recovery mechanism for the rule definition itself.
+        repo.findById.mockResolvedValueOnce(makeRow({ rule_json: malformed }));
+        const res = await server.inject({
+          method: 'PATCH',
+          url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+          payload: { enabled: false },
+        });
+        expect(res.statusCode).toBe(200);
+        const arg = repo.update.mock.calls[0][1];
+        expect(arg.enabled).toBe(false);
+        expect(arg.rule_json).toEqual({ enabled: false });
+      }
+    );
+
+    it('replaces the full rule when the body is the complete DedupRule shape', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ name: 'Old name' }));
+      const res = await server.inject({
+        method: 'PATCH',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+        payload: { ...VALID_RULE_BODY, name: 'New name' },
+      });
+      expect(res.statusCode).toBe(200);
+      const arg = repo.update.mock.calls[0][1];
+      expect(arg.name).toBe('New name');
+      expect(arg.rule_json).toMatchObject({ name: 'New name' });
+    });
+
+    it('preserves existing enabled when full-PATCH body omits the field', async () => {
+      // The Zod schema has `enabled: z.boolean().default(true)`. Without
+      // explicit handling, a full-rule PATCH that doesn't carry `enabled`
+      // would Zod-fill `true` and silently re-enable a previously-disabled
+      // rule. The route preserves the existing column value in that case.
+      repo.findById.mockResolvedValueOnce(makeRow({ name: 'Old name', enabled: false }));
+      const { enabled: _drop, ...bodyWithoutEnabled } = VALID_RULE_BODY;
+      const res = await server.inject({
+        method: 'PATCH',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+        payload: { ...bodyWithoutEnabled, name: 'New name' },
+      });
+      expect(res.statusCode).toBe(200);
+      const arg = repo.update.mock.calls[0][1];
+      expect(arg.enabled).toBe(false);
+      expect(arg.rule_json).toMatchObject({ enabled: false });
+    });
+
+    it('returns 409 if the renamed rule collides with another in the project', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ name: 'Old name' }));
+      repo.findByProjectAndName.mockResolvedValueOnce(
+        makeRow({ id: 'other-id', name: 'New name' })
+      );
+
+      const res = await server.inject({
+        method: 'PATCH',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+        payload: { ...VALID_RULE_BODY, name: 'New name' },
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('returns 409 when the rename race trips pg 23505 (TOCTOU)', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ name: 'Old name' }));
+      // Pre-check finds no collision, but a concurrent rename slips
+      // through; the UPDATE trips the unique constraint.
+      const uniqueErr = Object.assign(new Error('duplicate key value'), { code: '23505' });
+      repo.update.mockRejectedValueOnce(uniqueErr);
+
+      const res = await server.inject({
+        method: 'PATCH',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+        payload: { ...VALID_RULE_BODY, name: 'New name' },
+      });
+
+      expect(res.statusCode).toBe(409);
+    });
+
+    it('returns 404 when the rule is scoped to another project', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ project_id: OTHER_PROJECT_ID }));
+      const res = await server.inject({
+        method: 'PATCH',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+        payload: { enabled: false },
+      });
+      expect(res.statusCode).toBe(404);
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE /projects/:projectId/dedup-rules/:ruleId', () => {
+    it('deletes the rule when found', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ name: 'B1' }));
+      const res = await server.inject({
+        method: 'DELETE',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(repo.delete).toHaveBeenCalledWith(RULE_ID);
+    });
+
+    it('returns 404 and skips delete when the rule is not in this project', async () => {
+      repo.findById.mockResolvedValueOnce(makeRow({ project_id: OTHER_PROJECT_ID }));
+      const res = await server.inject({
+        method: 'DELETE',
+        url: `/api/v1/projects/${PROJECT_ID}/dedup-rules/${RULE_ID}`,
+      });
+      expect(res.statusCode).toBe(404);
+      expect(repo.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/tests/services/rules/seed.test.ts
+++ b/packages/backend/tests/services/rules/seed.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for the dedup-rule preset seed helper.
+ *
+ * Covers what the integration-time backfill (migration 025) does NOT —
+ * the per-call hook that runs on `POST /projects` and the signup
+ * wizard's transaction. The helper must be idempotent, must swallow
+ * uniqueness violations on individual presets, and must not throw
+ * past the caller (project creation continues even on seed failure).
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
+import type { DedupRuleRepository } from '../../../src/db/dedup-rule.repository.js';
+import { parseDedupRule } from '../../../src/integrations/dedup-rule.schema.js';
+import { seedDefaultDedupRules } from '../../../src/services/rules/seed.js';
+
+function mockRepo(overrides: Partial<DedupRuleRepository> = {}): DedupRuleRepository {
+  // Cast through unknown — the helper only touches `.create`, so we
+  // don't need to stub the rest of the BaseRepository surface.
+  return overrides as unknown as DedupRuleRepository;
+}
+
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+
+describe('seedDefaultDedupRules', () => {
+  it('inserts both presets (B1 + B2) on a fresh project', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'r' });
+    const repo = mockRepo({ create });
+
+    const count = await seedDefaultDedupRules(repo, PROJECT_ID);
+
+    expect(count).toBe(2);
+    expect(create).toHaveBeenCalledTimes(2);
+    const names = create.mock.calls.map((c) => c[0].name);
+    expect(names).toEqual(['Notify reporter on dedup', 'Counter on canonical']);
+  });
+
+  it('passes through the project_id on each insert', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'r' });
+    const repo = mockRepo({ create });
+
+    await seedDefaultDedupRules(repo, PROJECT_ID);
+
+    for (const call of create.mock.calls) {
+      expect(call[0].project_id).toBe(PROJECT_ID);
+    }
+  });
+
+  it('seeds B1 with the duplicate_detected trigger and notify.email action', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'r' });
+    const repo = mockRepo({ create });
+
+    await seedDefaultDedupRules(repo, PROJECT_ID);
+
+    const b1 = create.mock.calls[0][0];
+    expect(b1.rule_json).toMatchObject({
+      when: { type: 'duplicate_detected' },
+      then: [{ type: 'notify.email', to: 'reporter', template: 'dedup_ack' }],
+      rate_limit: { count: 1, window: '24h' },
+    });
+  });
+
+  it('seeds B2 with outbox_about_to_skip + ticket.add_comment on canonical', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'r' });
+    const repo = mockRepo({ create });
+
+    await seedDefaultDedupRules(repo, PROJECT_ID);
+
+    const b2 = create.mock.calls[1][0];
+    expect(b2.rule_json).toMatchObject({
+      when: { type: 'outbox_about_to_skip' },
+      then: [
+        {
+          type: 'ticket.add_comment',
+          target: 'canonical',
+        },
+      ],
+      rate_limit: { count: 1, window: '60m' },
+    });
+  });
+
+  it('swallows pg unique_violation (23505) on individual presets', async () => {
+    // Simulates the case where migration 025 already backfilled B1 for
+    // an existing project but B2 was missing. Should still seed B2.
+    const uniqueErr = Object.assign(new Error('duplicate key value'), { code: '23505' });
+    const create = vi.fn().mockRejectedValueOnce(uniqueErr).mockResolvedValueOnce({ id: 'r2' });
+    const repo = mockRepo({ create });
+
+    const count = await seedDefaultDedupRules(repo, PROJECT_ID);
+
+    expect(count).toBe(1);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues past non-uniqueness errors but reports them in the count', async () => {
+    // Other errors (a connection drop mid-loop, a schema mismatch) are
+    // logged but never thrown — project creation must not fail because
+    // of a broken seed hook.
+    const create = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ id: 'r2' });
+    const repo = mockRepo({ create });
+
+    const count = await seedDefaultDedupRules(repo, PROJECT_ID);
+
+    expect(count).toBe(1);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 0 and does not throw when every preset fails', async () => {
+    const create = vi.fn().mockRejectedValue(new Error('total outage'));
+    const repo = mockRepo({ create });
+
+    await expect(seedDefaultDedupRules(repo, PROJECT_ID)).resolves.toBe(0);
+  });
+});
+
+/**
+ * The B1 / B2 preset shapes live in three places: the `PRESETS` array
+ * in seed.ts, the INSERT statements in migration 025, and the Zod
+ * `parseDedupRule` schema they must conform to. A drift between any
+ * two of those would silently break the engine on the affected
+ * deployment (the executor parses on read and rejects bad blobs).
+ *
+ * These tests are the canary: they fail the suite when someone
+ * touches one side without the other.
+ */
+describe('preset / migration 025 / Zod schema consistency', () => {
+  const MIGRATION_PATH = join(
+    __dirname,
+    '../../../src/db/migrations/025_dedup_rules_cascade_and_seed.sql'
+  );
+
+  /**
+   * Pull every `'{...}'::jsonb` literal out of the migration. The
+   * naive single-quote split is good enough because the migration
+   * has no embedded apostrophes inside the JSON blobs and no other
+   * `::jsonb` casts in the file.
+   */
+  function extractMigrationBlobs(): unknown[] {
+    const sql = readFileSync(MIGRATION_PATH, 'utf8');
+    const blobs: unknown[] = [];
+    const re = /'(\{[\s\S]*?\})'::jsonb/g;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(sql)) !== null) {
+      blobs.push(JSON.parse(match[1]));
+    }
+    return blobs;
+  }
+
+  it('migration 025 contains exactly two seed inserts (B1 + B2)', () => {
+    const blobs = extractMigrationBlobs();
+    expect(blobs).toHaveLength(2);
+  });
+
+  it('every migration 025 JSON blob round-trips through parseDedupRule', () => {
+    // If this fails, the migration would store rows the executor
+    // silently rejects on read — a deployment-time data corruption
+    // hazard that no other test catches.
+    for (const blob of extractMigrationBlobs()) {
+      expect(() => parseDedupRule(blob)).not.toThrow();
+    }
+  });
+
+  it('migration 025 B1/B2 shapes match the seed.ts PRESETS array', async () => {
+    // Re-derive PRESETS by inspecting what `seedDefaultDedupRules`
+    // tries to insert for a fresh project — keeps this test
+    // resilient to PRESETS being un-exported.
+    const create = vi.fn().mockResolvedValue({ id: 'r' });
+    await seedDefaultDedupRules(mockRepo({ create }), PROJECT_ID);
+    const fromSeed = create.mock.calls.map((c) => c[0].rule_json);
+
+    const fromMigration = extractMigrationBlobs();
+    expect(fromSeed).toHaveLength(fromMigration.length);
+    // Match by name rather than positional, so re-ordering one side
+    // doesn't cause a false drift signal.
+    const byName = (list: unknown[]) =>
+      Object.fromEntries(list.map((r) => [(r as { name: string }).name, r]));
+    expect(byName(fromSeed)).toEqual(byName(fromMigration));
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
       'tests/api/routes/permissions.test.ts',
       'tests/api/routes/rbac-regression.test.ts',
       'tests/api/routes/signup.route.test.ts',
+      'tests/api/routes/dedup-rules.route.test.ts',
       'tests/api/services/**/*.test.ts',
       'tests/cache/**/*.test.ts',
       // Only include pure unit tests from tests/db/ (no database required)


### PR DESCRIPTION
## Summary

PR-D1 — backend foundation for the admin UI to follow. Opens the write path the executor in #146 / #148 has been reading from with no producer, and ships B1/B2 preset seeds.

(Supersedes #151 — same code, squashed into one commit for a clean review.)

## What lands

- **`/api/v1/projects/:projectId/dedup-rules`** — GET list, GET one, POST, PATCH, DELETE. **Human-admin-only on every route** via `rejectApiKeyAuth` + `requireProjectRole('admin')` + `requireApiKeyPermission('dedup_rules:{read,write}')`. The `rejectApiKeyAuth` gate is load-bearing — without it, full-scope (`'*'`) API keys would bypass the role check (machines aren't project members) and reopen the email-exfil path the C2 mitigations are meant to close.
- **TOCTOU 409**: POST + PATCH-rename wrap create/update in try/catch and map pg `23505` to 409. Shared `PG_UNIQUE_VIOLATION` in `db/pg-error-codes.ts`.
- **PATCH** supports two body shapes: `{ enabled }` toggle-only (keeps `rule_json.enabled` in sync with the column, guards against non-object rule_json with a logger.warn) and full DedupRule replacement (preserves `existing.enabled` when the body omits it, so a rename doesn't accidentally re-enable disabled rules via Zod's `.default(true)`).
- **`DedupRuleRepository`** wired into `DatabaseClient.dedupRules`; `services/rules/wiring.ts` also switched to `db.notificationThrottle`.
- **Migration 025** — AFTER DELETE trigger on `dedup_rules` + idempotent backfill of B1/B2 for every existing project.
- **`services/rules/seed.ts`** — per-project seed hook called from `POST /projects` and from the signup wizard's **post-commit** path (NOT inside the tx — Postgres aborts the tx on any failed statement and the JS catch can't undo that). **B1 seeded `enabled: false` on both sides** until C2 ships: `to: 'reporter'` resolves to SDK-supplied unverified email, so defaulting it on would light up the documented email-relay vector on every project.

## Docs bundled

- **`packages/backend/docs/architecture.md`** — backend system overview.
- **`packages/backend/docs/db-schema.md`** — per-schema reference + migration ordering invariants.
- **`ONBOARDING.md`** — synthesis doc for new engineers.

## B3 deliberately not seeded

The `cluster_growing` trigger and `hits_in_window` condition B3 would depend on aren't wired in the executor yet.

## Test plan

- [x] 10 seed-helper unit tests, including a drift test that reads migration 025 SQL, parses each JSON blob through `parseDedupRule`, and cross-checks against PRESETS by name
- [x] 26 route smoke tests (Zod rejection, 409 races, toggle/full PATCH with column+blob sync, full-PATCH `enabled` preservation, cross-project guard, **API-key rejection on all 5 routes**, malformed `rule_json` toggle fallback)
- [x] All 2769 unit tests pass
- [x] Source typecheck clean
- [ ] Integration test for migration 025 + AFTER DELETE trigger — lands with the admin UI PR (PR-D2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)