### PR TITLE
fix(rules): gate notify.email 'reporter' on org-member identity (SaaS)

### DIFF
--- a/packages/backend/src/saas/repositories/organization-member.repository.ts
+++ b/packages/backend/src/saas/repositories/organization-member.repository.ts
@@ -54,9 +54,11 @@ export class OrganizationMemberRepository extends BaseRepository<
    *
    * Case-insensitive on email to match `users.findByEmail`'s pattern;
    * the data the SDK posts can come from any client and shouldn't be
-   * required to round-trip exact casing. Returns `false` on any error
-   * the caller can't recover from — the dedup engine treats that the
-   * same as "not verified" and skips the send.
+   * required to round-trip exact casing.
+   *
+   * DB errors propagate (matches the rest of this repo). The dedup
+   * dispatcher catches and treats a throw as "not verified" — see the
+   * verifier-threw branch in `DefaultActionDispatcher.dispatchEmail`.
    */
   async existsByOrganizationAndEmail(organizationId: string, email: string): Promise<boolean> {
     const query = `

--- a/packages/backend/src/saas/repositories/organization-member.repository.ts
+++ b/packages/backend/src/saas/repositories/organization-member.repository.ts
@@ -47,6 +47,30 @@ export class OrganizationMemberRepository extends BaseRepository<
   }
 
   /**
+   * Cheap existence probe — does `email` map to an active member of
+   * `organizationId`? Used by the dedup-rule engine to gate the
+   * `notify.email` action when the rule targets the SDK-supplied
+   * `reporter` field (which is otherwise attacker-controllable).
+   *
+   * Case-insensitive on email to match `users.findByEmail`'s pattern;
+   * the data the SDK posts can come from any client and shouldn't be
+   * required to round-trip exact casing. Returns `false` on any error
+   * the caller can't recover from — the dedup engine treats that the
+   * same as "not verified" and skips the send.
+   */
+  async existsByOrganizationAndEmail(organizationId: string, email: string): Promise<boolean> {
+    const query = `
+      SELECT 1
+      FROM ${this.schema}.${this.tableName} om
+      INNER JOIN application.users u ON u.id = om.user_id
+      WHERE om.organization_id = $1 AND LOWER(u.email) = LOWER($2)
+      LIMIT 1
+    `;
+    const result = await this.pool.query(query, [organizationId, email]);
+    return result.rows.length > 0;
+  }
+
+  /**
    * Find a specific membership (user + org combination)
    */
   async findMembership(organizationId: string, userId: string): Promise<OrganizationMember | null> {

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -21,7 +21,7 @@ import type {
 import { pluginSupports } from '../../integrations/capabilities.js';
 import type { ActionSpec } from '../../integrations/dedup-rule.schema.js';
 import { getLogger } from '../../logger.js';
-import type { EmailSender } from './email-sender.js';
+import type { EmailSender, ReporterVerifier } from './email-sender.js';
 import { resolveEmailRecipient } from './email-sender.js';
 import type { ActionDispatcher, RuleEvalContext } from './types.js';
 
@@ -71,7 +71,17 @@ export class DefaultActionDispatcher implements ActionDispatcher {
      * actions are skipped if no sender is wired, avoiding the
      * throttle-budget burn.
      */
-    private readonly emailSender?: EmailSender
+    private readonly emailSender?: EmailSender,
+    /**
+     * Optional. Required in SaaS mode (where `bugReport.organization_id`
+     * is non-null) to gate the `reporter` recipient token against
+     * org-member identity. Without it, a SaaS rule with
+     * `notify.email { to: 'reporter' }` fails closed — the bug filer
+     * controls the email field they put in `metadata.user.email`, so
+     * we can't honour it unverified. Selfhosted bugs have
+     * `organization_id === null` and never reach the verifier.
+     */
+    private readonly verifyReporter?: ReporterVerifier
   ) {}
 
   /**
@@ -209,6 +219,45 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       // resolveEmailRecipient logs the reason (unknown token, missing
       // reporter email, etc).
       return false;
+    }
+    // Auth-bound `reporter` gate. The `reporter` field comes from the
+    // SDK payload — a bug filer chooses any string for
+    // `metadata.user.email`. SaaS mode requires it to match an
+    // org-member identity before we'll relay bug data to it; without
+    // a verifier wired we fail closed rather than silently regress to
+    // the spammable shape. Selfhosted bugs have `organization_id ===
+    // null` and skip the check entirely.
+    if (to === 'reporter' && context.bugReport.organization_id !== null) {
+      if (!this.verifyReporter) {
+        logger.warn('Skipping notify.email: SaaS mode without reporter verifier', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+        });
+        return false;
+      }
+      let verified: boolean;
+      try {
+        verified = await this.verifyReporter(context.bugReport.organization_id, recipient);
+      } catch (error) {
+        // Treat a verifier failure the same as "not verified" — the
+        // worst-case alternative is leaking bug data on a transient
+        // DB blip. The executor relies on this being non-throwing.
+        logger.warn('Skipping notify.email: reporter verifier threw', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return false;
+      }
+      if (!verified) {
+        // Email value itself is intentionally not logged — it's PII
+        // and the boolean outcome is enough for ops.
+        logger.info('Skipping notify.email: reporter not in org membership', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+        });
+        return false;
+      }
     }
     return this.emailSender.send({
       projectId: context.projectId,

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -242,10 +242,14 @@ export class DefaultActionDispatcher implements ActionDispatcher {
         // Treat a verifier failure the same as "not verified" — the
         // worst-case alternative is leaking bug data on a transient
         // DB blip. The executor relies on this being non-throwing.
+        // Log the error type/name, not `error.message`. A verifier
+        // implementation could embed user-controlled strings (an email,
+        // an org-name fragment from a SQL error) in the message;
+        // sticking to the class name keeps logs PII-free.
         logger.warn('Skipping notify.email: reporter verifier threw', {
           bugReportId: context.bugReport.id,
           organizationId: context.bugReport.organization_id,
-          error: error instanceof Error ? error.message : String(error),
+          errorType: error instanceof Error ? error.name : 'NonErrorThrown',
         });
         return false;
       }

--- a/packages/backend/src/services/rules/email-sender.ts
+++ b/packages/backend/src/services/rules/email-sender.ts
@@ -8,24 +8,22 @@
  * machinery.
  *
  * The recipient resolution rules mirror the schema's `EMAIL_TARGET_PATTERN`:
- *   - `reporter` -> `bugReport.metadata.metadata.user.email`. **This is
- *     SDK-controlled with no verification** — the bug filer chooses
- *     any string. A malicious bug filer can therefore make the engine
- *     send a "your bug was matched" email to any address (e.g.
- *     `victim@example.com`). The per-(rule, canonical) rate limit
- *     caps spam at one email per canonical per window, but the
- *     attacker can fabricate duplicates of many canonicals, so the
- *     bound is ≈ number-of-canonicals × rules-with-B1 / window.
- *     **Mitigation lands in PR-D**: either require reporter emails
- *     to match an authenticated org-member identity (SaaS) or add a
- *     per-recipient rate limit. Until then, operators should enable
- *     B1 only when their ingest path requires authenticated SDK
- *     submissions.
+ *   - `reporter` -> `bugReport.metadata.metadata.user.email`. The
+ *     value is SDK-controlled, so the dispatcher gates the send on a
+ *     `ReporterVerifier` callback (see `dispatcher.ts`) that confirms
+ *     the email maps to a member of the bug's organisation. In SaaS
+ *     mode without a verifier wired, the send is skipped fail-closed.
+ *     In selfhosted mode (`organization_id === null`) the verifier
+ *     never runs — there's no org-membership concept, so the historical
+ *     "trust the SDK" behaviour stays.
  *   - `closer` and `all_reporters` are recognised by the schema but
  *     not yet resolvable — they need the closer-identity / cluster-
  *     reporters wiring that the persona analysis flagged but didn't
  *     scope into Phase 0.5. Log and skip.
- *   - A literal email passes through.
+ *   - A literal email passes through. The per-org allowlist /
+ *     confirmation flow that protects against `notify.email.to =
+ *     'attacker@evil.com'` rules lands in a follow-up; until then,
+ *     admin-gated rule creation remains the only gate on this branch.
  */
 
 import type { NotificationChannelRepository } from '../../db/repositories/notification-channel.repository.js';
@@ -57,6 +55,21 @@ export interface EmailSendRequest {
 export interface EmailSender {
   send(req: EmailSendRequest): Promise<boolean>;
 }
+
+/**
+ * Auth gate for the `reporter` recipient token. The dispatcher calls
+ * this before sending a `notify.email` whose `to` resolved from the
+ * SDK-supplied reporter field. Returns `true` iff `email` matches an
+ * org-member identity in `organizationId`. Throws and rejects are
+ * surfaced; the dispatcher treats both as "not verified" and skips.
+ *
+ * Production wires this to
+ * `db.organizationMembers.existsByOrganizationAndEmail`. Tests inject
+ * a stub. Selfhosted deployments leave it unset — `bugReport.organization_id`
+ * is null there, so the dispatcher never calls the verifier and the
+ * historical pre-Phase-0.5 trust-the-SDK behaviour is preserved.
+ */
+export type ReporterVerifier = (organizationId: string, email: string) => Promise<boolean>;
 
 /**
  * Production sender — looks up the project's first active email

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -113,7 +113,13 @@ export function buildDedupRuleExecutor(
     db.notificationChannels,
     new EmailChannelHandler()
   );
-  const dispatcher = new DefaultActionDispatcher(resolver, lookup, emailSender);
+  // Reporter verifier — gates the `notify.email { to: 'reporter' }`
+  // path against the bug's organisation membership. Without it the
+  // dispatcher fails closed in SaaS mode (bugs with non-null
+  // organization_id), so wiring this here is load-bearing.
+  const verifyReporter = (orgId: string, email: string): Promise<boolean> =>
+    db.organizationMembers.existsByOrganizationAndEmail(orgId, email);
+  const dispatcher = new DefaultActionDispatcher(resolver, lookup, emailSender, verifyReporter);
   const rateLimiter = new ThrottleBackedRateLimiter(throttle);
   const contextProvider = new DatabaseRuleContextProvider(db);
   return new DedupRuleExecutor(repo, dispatcher, rateLimiter, contextProvider);

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -362,4 +362,130 @@ describe('DefaultActionDispatcher', () => {
       expect(send.mock.calls[0][0].to).toBe('ops@example.com');
     });
   });
+
+  describe('notify.email — auth-bound reporter (SaaS)', () => {
+    function buildVerifierDispatcher(verifyReporter: Mock) {
+      const send: Mock = vi.fn().mockResolvedValue(true);
+      const emailSender = { send };
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        emailSender,
+        verifyReporter as unknown as (orgId: string, email: string) => Promise<boolean>
+      );
+      return { dispatcher: d, send, verifyReporter };
+    }
+
+    const SAAS_CTX = (): RuleEvalContext =>
+      makeContext({
+        bugReport: makeBug({
+          organization_id: 'org-1',
+          metadata: { metadata: { user: { email: 'reporter@example.com' } } },
+        }),
+      });
+
+    it('sends when verifier confirms the reporter is an org member', async () => {
+      const verify = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d, send } = buildVerifierDispatcher(verify);
+
+      const ok = await d.dispatch(SAAS_CTX(), {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(verify).toHaveBeenCalledWith('org-1', 'reporter@example.com');
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips when verifier returns false (reporter not in org)', async () => {
+      const verify = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d, send } = buildVerifierDispatcher(verify);
+
+      const ok = await d.dispatch(SAAS_CTX(), {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(false);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when verifier throws (does not propagate)', async () => {
+      const verify = vi.fn().mockRejectedValue(new Error('db unreachable'));
+      const { dispatcher: d, send } = buildVerifierDispatcher(verify);
+
+      const ok = await d.dispatch(SAAS_CTX(), {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(false);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('fails closed in SaaS mode when no verifier is wired', async () => {
+      const send: Mock = vi.fn().mockResolvedValue(true);
+      const emailSender = { send };
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        emailSender
+        // verifyReporter intentionally omitted
+      );
+
+      const ok = await d.dispatch(SAAS_CTX(), {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(false);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('skips verifier entirely for selfhosted (organization_id is null)', async () => {
+      const verify = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d, send } = buildVerifierDispatcher(verify);
+      const ctx = makeContext({
+        bugReport: makeBug({
+          organization_id: null,
+          metadata: { metadata: { user: { email: 'reporter@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(verify).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not invoke verifier for literal recipients', async () => {
+      const verify = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d, send } = buildVerifierDispatcher(verify);
+      const ctx = makeContext({
+        bugReport: makeBug({ organization_id: 'org-1', metadata: {} }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'ops@example.com',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(verify).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send.mock.calls[0][0].to).toBe('ops@example.com');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The `notify.email { to: 'reporter' }` action reads the email straight from `bug_reports.metadata.metadata.user.email` — an SDK-controlled field. A bug filer can plant `victim@target.com` there and trigger the dedup engine to relay bug data (subject + canonical title via the `dedup_ack` template) to an arbitrary address. The per-(rule, canonical) throttle caps spam at one mail per canonical, but an attacker can fabricate duplicates of many canonicals, so the bound is ≈ N-canonicals × rules-with-B1 / window.

First of four C2 carry-overs from Phase 0.5. This PR closes the SaaS branch.

## What lands

- New `db.organizationMembers.existsByOrganizationAndEmail(orgId, email)` — case-insensitive on email, single-row probe.
- New `ReporterVerifier` callback on `DefaultActionDispatcher`. When the action's `to === 'reporter'` AND `bugReport.organization_id` is non-null, the dispatcher requires a verifier and calls it with the resolved email. Fails closed on:
  - missing verifier in SaaS mode (wiring mistake — log a warn)
  - verifier returns false (log info, no PII in the log line)
  - verifier throws (log warn with error message, swallow)
- Selfhosted (`organization_id === null`) never reaches the verifier; existing single-tenant trust-the-SDK behaviour preserved.
- `buildDedupRuleExecutor` wires the verifier to the new repo method.
- 6 new dispatcher tests covering: verifier-passes, verifier-rejects, verifier-throws, no-verifier-in-SaaS, selfhosted-skips, literal-recipient-skips-verifier.

## Out of scope (remaining C2 carry-overs)

- Per-recipient rate limit (caps fan-out across canonicals)
- Literal-email allowlist / per-org confirmation flow
- `notify.slack` / `notify.webhook` dispatchers

## Test plan

- [x] Backend src typecheck clean
- [x] Backend unit 2782/2782 (+6 new tests)
- [x] Admin lint clean (no admin changes)
- [ ] Backend integration (CI handles testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization membership verification for reporter email notifications in SaaS environments. Reporter notifications are now gated by organization membership—only verified members receive email dispatch, while notifications fail gracefully if verification is unavailable or returns false. Self-hosted deployments preserve existing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->