### PR TITLE
feat(admin): upgrade rrweb-player to 2.x; default skipInactive off

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -53,7 +53,7 @@
     "react-phone-number-input": "^3.4.16",
     "react-router-dom": "^6.30.3",
     "remark-gfm": "^4.0.1",
-    "rrweb-player": "1.0.0-alpha.4",
+    "rrweb-player": "2.0.0-alpha.20",
     "sonner": "^1.4.41",
     "tailwind-merge": "^3.3.1",
     "validator": "^13.15.26"

--- a/apps/admin/src/components/bug-reports/session-replay-player.tsx
+++ b/apps/admin/src/components/bug-reports/session-replay-player.tsx
@@ -107,7 +107,12 @@ export function SessionReplayPlayer({
           replayEvents = [metaEvent, ...events];
         }
 
-        // Create player instance and store reference for cleanup
+        // Create player instance and store reference for cleanup.
+        // skipInactive defaults to false so the displayed timestamps match
+        // wall-clock recording time on first view — otherwise the player
+        // shows confusing "01:25 / 01:21" mismatches because it skips idle
+        // gaps in playback while the totalTime label keeps the full span.
+        // The player exposes its own UI toggle to let the user opt in.
         playerRef.current = new rrwebPlayerDefault({
           target: containerRef.current!,
           props: {
@@ -117,12 +122,8 @@ export function SessionReplayPlayer({
             height: PLAYER_DIMENSIONS.HEIGHT,
             autoPlay: false,
             showController: true,
-            skipInactive: true,
+            skipInactive: false,
             speed: 1,
-            // CRITICAL FIX: Allow iframe to run scripts for replay rendering
-            // Without this, browser sandboxes the iframe and blocks script execution
-            // Error: "Blocked script execution because document's frame is sandboxed"
-            UNSAFE_replayCanvas: true,
           },
         });
       } catch (err) {

--- a/apps/admin/src/components/bug-reports/session-replay-player.tsx
+++ b/apps/admin/src/components/bug-reports/session-replay-player.tsx
@@ -108,11 +108,25 @@ export function SessionReplayPlayer({
         }
 
         // Create player instance and store reference for cleanup.
+        //
         // skipInactive defaults to false so the displayed timestamps match
         // wall-clock recording time on first view — otherwise the player
         // shows confusing "01:25 / 01:21" mismatches because it skips idle
         // gaps in playback while the totalTime label keeps the full span.
         // The player exposes its own UI toggle to let the user opt in.
+        //
+        // Deliberately NOT passing `UNSAFE_replayCanvas`: in rrweb-player
+        // 2.x the prop is removed from the player options. Canvas replay
+        // is enabled on the *recorder* side (the recorder captures
+        // canvas frames as snapshot events; the player just replays
+        // whatever the event stream contains). An older comment on this
+        // file misattributed the flag to iframe-sandbox bypass — the
+        // sandbox attribute is set on the iframe via separate
+        // `iframeSandbox` plumbing inside rrweb-player and isn't
+        // affected by this option in either major version. See the
+        // matching `toBeUndefined()` assertion in
+        // `session-replay-player.test.tsx` for regression coverage if
+        // a merge / auto-update reintroduces it.
         playerRef.current = new rrwebPlayerDefault({
           target: containerRef.current!,
           props: {

--- a/apps/admin/src/tests/components/session-replay-player.test.tsx
+++ b/apps/admin/src/tests/components/session-replay-player.test.tsx
@@ -152,6 +152,12 @@ describe('SessionReplayPlayer', () => {
       // skipInactive defaults to false so initial timestamps match wall-clock.
       // The player exposes its own toggle for users who want to skip idle time.
       expect(playerCall.props.skipInactive).toBe(false);
+      // Regression pin: `UNSAFE_replayCanvas` was removed when upgrading to
+      // rrweb-player 2.x (canvas replay is now a recorder-side concern, not
+      // a player option). If a merge or dependency auto-update reintroduces
+      // it on the player options, this assertion catches it. See the
+      // matching comment in `session-replay-player.tsx`.
+      expect(playerCall.props.UNSAFE_replayCanvas).toBeUndefined();
 
       // Verify container ref is used
       const containerDiv = container.querySelector('div > div');

--- a/apps/admin/src/tests/components/session-replay-player.test.tsx
+++ b/apps/admin/src/tests/components/session-replay-player.test.tsx
@@ -149,7 +149,9 @@ describe('SessionReplayPlayer', () => {
       expect(playerCall.props.events).toHaveLength(mockEvents.length + 1);
       expect(playerCall.props.autoPlay).toBe(false);
       expect(playerCall.props.showController).toBe(true);
-      expect(playerCall.props.UNSAFE_replayCanvas).toBe(true);
+      // skipInactive defaults to false so initial timestamps match wall-clock.
+      // The player exposes its own toggle for users who want to skip idle time.
+      expect(playerCall.props.skipInactive).toBe(false);
 
       // Verify container ref is used
       const containerDiv = container.querySelector('div > div');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       rrweb-player:
-        specifier: 1.0.0-alpha.4
-        version: 1.0.0-alpha.4
+        specifier: 2.0.0-alpha.20
+        version: 2.0.0-alpha.20
       sonner:
         specifier: ^1.4.41
         version: 1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2475,8 +2475,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rrweb/types@2.0.0-alpha.18':
-    resolution: {integrity: sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==}
+  '@rrweb/packer@2.0.0-alpha.20':
+    resolution: {integrity: sha512-GsByg2olGZ2n3To6keFG604QAboipuXZvjYxO2wITSwARBf/sZdy6cbUEjF0RS+QnuTM5GaVXeQapNMLmpKbrA==}
+
+  '@rrweb/replay@2.0.0-alpha.20':
+    resolution: {integrity: sha512-VodsLb+C2bYNNVbb0U14tKLa9ctzUxYIlt9VnxPATWvfyXHLTku8BhRWptuW/iIjVjmG49LBoR1ilxw/HMiJ1w==}
+
+  '@rrweb/types@2.0.0-alpha.20':
+    resolution: {integrity: sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==}
+
+  '@rrweb/utils@2.0.0-alpha.20':
+    resolution: {integrity: sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
@@ -5819,8 +5828,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rrdom@0.1.7:
-    resolution: {integrity: sha512-ZLd8f14z9pUy2Hk9y636cNv5Y2BMnNEY99wxzW9tD2BLDfe1xFxtLjB4q/xCBYo6HRe0wofzKzjm4JojmpBfFw==}
+  rrdom@2.0.0-alpha.20:
+    resolution: {integrity: sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==}
 
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
@@ -5828,14 +5837,14 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rrweb-player@1.0.0-alpha.4:
-    resolution: {integrity: sha512-Wlmn9GZ5Fdqa37vd3TzsYdLl/JWEvXNUrLCrYpnOwEgmY409HwVIvvA5aIo7k582LoKgdRCsB87N+f0oWAR0Kg==}
+  rrweb-player@2.0.0-alpha.20:
+    resolution: {integrity: sha512-3ZCv1ksUxuIOn3Vn/eWrwWs9Xy+4KVjISD+q26ZLfisZ3hZ0CPgYG3iC22pmmycIeMS2svOfvf7gPh7jExwpUA==}
 
-  rrweb-snapshot@2.0.0-alpha.4:
-    resolution: {integrity: sha512-KQ2OtPpXO5jLYqg1OnXS/Hf+EzqnZyP5A+XPqBCjYpj3XIje/Od4gdUwjbFo3cVuWq5Cw5Y1d3/xwgIS7/XpQQ==}
+  rrweb-snapshot@2.0.0-alpha.20:
+    resolution: {integrity: sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==}
 
-  rrweb@2.0.0-alpha.4:
-    resolution: {integrity: sha512-wEHUILbxDPcNwkM3m4qgPgXAiBJyqCbbOHyVoNEVBJzHszWEFYyTbrZqUdeb1EfmTRC2PsumCIkVcomJ/xcOzA==}
+  rrweb@2.0.0-alpha.20:
+    resolution: {integrity: sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -9226,7 +9235,19 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.52.3':
     optional: true
 
-  '@rrweb/types@2.0.0-alpha.18': {}
+  '@rrweb/packer@2.0.0-alpha.20':
+    dependencies:
+      '@rrweb/types': 2.0.0-alpha.20
+      fflate: 0.4.8
+
+  '@rrweb/replay@2.0.0-alpha.20':
+    dependencies:
+      '@rrweb/types': 2.0.0-alpha.20
+      rrweb: 2.0.0-alpha.20
+
+  '@rrweb/types@2.0.0-alpha.20': {}
+
+  '@rrweb/utils@2.0.0-alpha.20': {}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     dependencies:
@@ -10152,7 +10173,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jsdom@27.0.0)(msw@2.11.6(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jsdom@27.0.0)(msw@2.11.6(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13451,31 +13472,34 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.3
       fsevents: 2.3.3
 
-  rrdom@0.1.7:
+  rrdom@2.0.0-alpha.20:
     dependencies:
-      rrweb-snapshot: 2.0.0-alpha.4
+      rrweb-snapshot: 2.0.0-alpha.20
 
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
 
-  rrweb-player@1.0.0-alpha.4:
+  rrweb-player@2.0.0-alpha.20:
     dependencies:
+      '@rrweb/packer': 2.0.0-alpha.20
+      '@rrweb/replay': 2.0.0-alpha.20
       '@tsconfig/svelte': 1.0.13
-      rrweb: 2.0.0-alpha.4
 
-  rrweb-snapshot@2.0.0-alpha.4: {}
-
-  rrweb@2.0.0-alpha.4:
+  rrweb-snapshot@2.0.0-alpha.20:
     dependencies:
-      '@rrweb/types': 2.0.0-alpha.18
+      postcss: 8.5.6
+
+  rrweb@2.0.0-alpha.20:
+    dependencies:
+      '@rrweb/types': 2.0.0-alpha.20
+      '@rrweb/utils': 2.0.0-alpha.20
       '@types/css-font-loading-module': 0.0.7
       '@xstate/fsm': 1.6.5
       base64-arraybuffer: 1.0.2
-      fflate: 0.4.8
       mitt: 3.0.1
-      rrdom: 0.1.7
-      rrweb-snapshot: 2.0.0-alpha.4
+      rrdom: 2.0.0-alpha.20
+      rrweb-snapshot: 2.0.0-alpha.20
 
   run-parallel@1.2.0:
     dependencies:


### PR DESCRIPTION
The extension records with rrweb@2 but the admin viewer shipped rrweb-player@1.0.0-alpha.4 — one major behind. That mismatch is the likely cause of confusing duration labels in the replay UI (e.g. "01:25 / 01:21" showing wall-clock total vs skip-inactive-adjusted current). Bumping to rrweb-player@2.0.0-alpha.20 aligns the majors; there's no proper 1.x stable — both lines are alphas, 2.x is the active one.

Defaults skipInactive to false so the labels match the recording's actual duration on first view. Users can still toggle skip-inactive via the player's built-in control bar.

Also drops the obsolete UNSAFE_replayCanvas prop (not in 2.x typed props).