### PR TITLE
fix(api-keys): admin usage dialog shows Invalid Date / NaN

### DIFF
--- a/apps/admin/src/lib/api-constants.ts
+++ b/apps/admin/src/lib/api-constants.ts
@@ -191,7 +191,10 @@ export const API_ENDPOINTS = {
     update: (id: string) => `${API_VERSION}/api-keys/${id}`,
     delete: (id: string) => `${API_VERSION}/api-keys/${id}`,
     rotate: (id: string) => `${API_VERSION}/api-keys/${id}/rotate`,
-    usage: (id: string) => `${API_VERSION}/api-keys/${id}/usage`,
+    // Aggregate stats (24h/7d/30d windows + name/created_at/last_used_at)
+    // — distinct from the raw `/usage` log array endpoint. The dashboard
+    // usage dialog renders the aggregate shape.
+    usage: (id: string) => `${API_VERSION}/api-keys/${id}/usage-stats`,
   },
 
   // Admin endpoints

--- a/apps/admin/src/tests/services/api-key-service.test.ts
+++ b/apps/admin/src/tests/services/api-key-service.test.ts
@@ -252,7 +252,7 @@ describe('API Key Service', () => {
 
       const result = await apiKeyService.getUsage('key-1');
 
-      expect(api.get).toHaveBeenCalledWith('/api/v1/api-keys/key-1/usage');
+      expect(api.get).toHaveBeenCalledWith('/api/v1/api-keys/key-1/usage-stats');
       expect(result).toEqual(mockUsage);
       expect(result.total_requests).toBe(1000);
       expect(result.requests_last_24h).toBe(50);

--- a/packages/backend/src/api/routes/api-keys.ts
+++ b/packages/backend/src/api/routes/api-keys.ts
@@ -24,6 +24,7 @@ import {
   revokeApiKeySchema,
   rotateApiKeySchema,
   getApiKeyUsageSchema,
+  getApiKeyUsageStatsSchema,
   getApiKeyAuditSchema,
 } from '../schemas/api-key-schema.js';
 
@@ -528,6 +529,37 @@ export function apiKeyRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       const logs = await apiKeyService.getUsageLogs(id, limit, offset);
 
       return sendSuccess(reply, logs);
+    }
+  );
+
+  // Get rolling-window usage statistics (used by the dashboard usage
+  // dialog). Distinct shape from /usage (raw log array) and from the
+  // /api/v1/api-keys/:id detail's `usage_stats` (calendar buckets).
+  // The dialog wants 24h / 7d / 30d rolling windows next to the key's
+  // name, created_at, and last_used_at.
+  fastify.get(
+    '/api/v1/api-keys/:id/usage-stats',
+    {
+      preHandler: requireUser,
+      schema: getApiKeyUsageStatsSchema,
+    },
+    async (request, reply) => {
+      assertAuthUser(request);
+      const { id } = request.params as { id: string };
+
+      await authorizeApiKeyReadAccess(
+        apiKeyService,
+        id,
+        request.authUser.id,
+        isPlatformAdmin(request),
+        db
+      );
+
+      const stats = await apiKeyService.getUsageStats(id);
+      if (!stats) {
+        throw new AppError('API key not found', 404, 'NotFound');
+      }
+      return sendSuccess(reply, stats);
     }
   );
 

--- a/packages/backend/src/api/schemas/api-key-schema.ts
+++ b/packages/backend/src/api/schemas/api-key-schema.ts
@@ -436,6 +436,55 @@ export const getApiKeyUsageSchema = {
 } as const;
 
 /**
+ * GET /api/v1/api-keys/:id/usage-stats - Aggregate rolling-window stats
+ * (24h / 7d / 30d). Distinct from `/usage` (raw log array) and from the
+ * detail-route `usage_stats` (calendar buckets) — see api-keys.ts.
+ *
+ * Response schema is defined here intentionally (unlike the older
+ * `getApiKeyUsageSchema` / `getApiKeyAuditSchema`): this endpoint was
+ * born from a UI/backend contract mismatch that produced "Invalid Date"
+ * and `NaN` in the dashboard. Validating the response at the boundary
+ * makes the next regression of that shape fail fast in tests instead
+ * of silently rendering bad values.
+ */
+export const getApiKeyUsageStatsSchema = {
+  params: idParamSchema,
+  response: {
+    200: {
+      type: 'object',
+      required: ['success', 'data', 'timestamp'],
+      properties: {
+        success: { type: 'boolean', enum: [true] },
+        data: {
+          type: 'object',
+          required: [
+            'id',
+            'name',
+            'created_at',
+            'last_used_at',
+            'total_requests',
+            'requests_last_24h',
+            'requests_last_7d',
+            'requests_last_30d',
+          ],
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            name: { type: 'string' },
+            created_at: { type: 'string', format: 'date-time' },
+            last_used_at: { type: ['string', 'null'], format: 'date-time' },
+            total_requests: { type: 'number' },
+            requests_last_24h: { type: 'number' },
+            requests_last_7d: { type: 'number' },
+            requests_last_30d: { type: 'number' },
+          },
+        },
+        timestamp: { type: 'string', format: 'date-time' },
+      },
+    },
+  },
+} as const;
+
+/**
  * GET /api/v1/api-keys/:id/audit - Get audit log
  */
 export const getApiKeyAuditSchema = {

--- a/packages/backend/src/db/repositories/api-key.repository.ts
+++ b/packages/backend/src/db/repositories/api-key.repository.ts
@@ -438,16 +438,19 @@ export class ApiKeyRepository extends BaseRepository<ApiKey, ApiKeyInsert, ApiKe
    * `bigint` (COUNT) as a string so we parse explicitly.
    */
   async getUsageStats(apiKeyId: string): Promise<ApiKeyUsageStats | null> {
+    // The LATERAL subquery's COUNT(*) is never NULL (returns 0 with no
+    // matches), and `ON true` always yields a row, so the outer SELECT
+    // can read `u.*` directly — no COALESCE needed.
     const query = `
       SELECT
         k.id,
         k.name,
         k.created_at,
         k.last_used_at,
-        COALESCE(u.total_requests, 0)     AS total_requests,
-        COALESCE(u.requests_last_24h, 0)  AS requests_last_24h,
-        COALESCE(u.requests_last_7d, 0)   AS requests_last_7d,
-        COALESCE(u.requests_last_30d, 0)  AS requests_last_30d
+        u.total_requests,
+        u.requests_last_24h,
+        u.requests_last_7d,
+        u.requests_last_30d
       FROM ${this.schema}.${this.tableName} k
       LEFT JOIN LATERAL (
         SELECT

--- a/packages/backend/src/db/repositories/api-key.repository.ts
+++ b/packages/backend/src/db/repositories/api-key.repository.ts
@@ -25,6 +25,24 @@ import { createFilter } from '../filter-builder.js';
 import { createPagination } from '../pagination-builder.js';
 
 /**
+ * Aggregate rolling-window usage statistics for an API key, returned by
+ * `ApiKeyRepository.getUsageStats`. The service layer and route handler
+ * both reference this shape; pulling it into a named type keeps the
+ * three sites (repo, service, route response schema) honest if a window
+ * is ever added/renamed.
+ */
+export interface ApiKeyUsageStats {
+  id: string;
+  name: string;
+  created_at: Date;
+  last_used_at: Date | null;
+  total_requests: number;
+  requests_last_24h: number;
+  requests_last_7d: number;
+  requests_last_30d: number;
+}
+
+/**
  * API Key Repository
  * Handles all database operations for API keys, usage tracking, and rate limiting
  */
@@ -407,6 +425,56 @@ export class ApiKeyRepository extends BaseRepository<ApiKey, ApiKeyInsert, ApiKe
     ];
 
     await this.pool.query(query, values);
+  }
+
+  /**
+   * Get rolling-window usage statistics for an API key. Distinct from
+   * `findByIdWithStats` (which returns calendar-month / today buckets
+   * for the platform-admin detail view) — the dashboard usage dialog
+   * shows 24h / 7d / 30d rolling windows.
+   *
+   * Returns null when the key does not exist; the route translates
+   * this into a 404. Counts are returned as JS numbers; pg returns
+   * `bigint` (COUNT) as a string so we parse explicitly.
+   */
+  async getUsageStats(apiKeyId: string): Promise<ApiKeyUsageStats | null> {
+    const query = `
+      SELECT
+        k.id,
+        k.name,
+        k.created_at,
+        k.last_used_at,
+        COALESCE(u.total_requests, 0)     AS total_requests,
+        COALESCE(u.requests_last_24h, 0)  AS requests_last_24h,
+        COALESCE(u.requests_last_7d, 0)   AS requests_last_7d,
+        COALESCE(u.requests_last_30d, 0)  AS requests_last_30d
+      FROM ${this.schema}.${this.tableName} k
+      LEFT JOIN LATERAL (
+        SELECT
+          COUNT(*) AS total_requests,
+          COUNT(*) FILTER (WHERE timestamp >= NOW() - INTERVAL '24 hours') AS requests_last_24h,
+          COUNT(*) FILTER (WHERE timestamp >= NOW() - INTERVAL '7 days')   AS requests_last_7d,
+          COUNT(*) FILTER (WHERE timestamp >= NOW() - INTERVAL '30 days')  AS requests_last_30d
+        FROM ${this.schema}.api_key_usage
+        WHERE api_key_id = k.id
+      ) u ON true
+      WHERE k.id = $1
+    `;
+    const result = await this.pool.query(query, [apiKeyId]);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      name: row.name,
+      created_at: row.created_at,
+      last_used_at: row.last_used_at,
+      total_requests: parseInt(row.total_requests, 10) || 0,
+      requests_last_24h: parseInt(row.requests_last_24h, 10) || 0,
+      requests_last_7d: parseInt(row.requests_last_7d, 10) || 0,
+      requests_last_30d: parseInt(row.requests_last_30d, 10) || 0,
+    };
   }
 
   /**

--- a/packages/backend/src/services/api-key/api-key-service.ts
+++ b/packages/backend/src/services/api-key/api-key-service.ts
@@ -20,6 +20,7 @@ import type {
   PaginatedResult,
   PaginationOptions,
 } from '../../db/types.js';
+import type { ApiKeyUsageStats } from '../../db/repositories/api-key.repository.js';
 
 // Import cache service
 import { getCacheService } from '../../cache/index.js';
@@ -613,6 +614,10 @@ export class ApiKeyService {
     offset: number = 0
   ): Promise<ApiKeyUsage[]> {
     return this.db.apiKeys.getUsageLogs(keyId, limit, offset);
+  }
+
+  async getUsageStats(keyId: string): Promise<ApiKeyUsageStats | null> {
+    return this.db.apiKeys.getUsageStats(keyId);
   }
 
   async getKeyWithStats(keyId: string): Promise<ApiKeyWithUsageStats | null> {

--- a/packages/backend/tests/api/api-keys.test.ts
+++ b/packages/backend/tests/api/api-keys.test.ts
@@ -1284,6 +1284,71 @@ describe('API Key Routes', () => {
     });
   });
 
+  describe('GET /api/v1/api-keys/:id/usage-stats', () => {
+    it('should return aggregate stats with the expected shape and numeric types', async () => {
+      const createResponse = await server.inject({
+        method: 'POST',
+        url: '/api/v1/api-keys',
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { name: 'Stats Test Key', type: 'development', permission_scope: 'full' },
+      });
+      const keyId = createResponse.json().data.key_details.id;
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/api-keys/${keyId}/usage-stats`,
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const data = response.json().data;
+      // Shape — every field the dashboard dialog reads.
+      expect(data).toHaveProperty('id', keyId);
+      expect(data).toHaveProperty('name', 'Stats Test Key');
+      expect(data).toHaveProperty('created_at');
+      expect(data).toHaveProperty('last_used_at');
+      expect(data).toHaveProperty('total_requests');
+      expect(data).toHaveProperty('requests_last_24h');
+      expect(data).toHaveProperty('requests_last_7d');
+      expect(data).toHaveProperty('requests_last_30d');
+      // Types — pg returns COUNT as a string; the repo's parseInt
+      // must coerce to a JS number, otherwise the dashboard's
+      // `Math.round(... / 30)` arithmetic would silently break.
+      expect(typeof data.total_requests).toBe('number');
+      expect(typeof data.requests_last_24h).toBe('number');
+      expect(typeof data.requests_last_7d).toBe('number');
+      expect(typeof data.requests_last_30d).toBe('number');
+    });
+
+    it('should reject access to other user keys for non-admin', async () => {
+      const createResponse = await server.inject({
+        method: 'POST',
+        url: '/api/v1/api-keys',
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { name: 'Stats Auth Test Key', type: 'development', permission_scope: 'full' },
+      });
+      const keyId = createResponse.json().data.key_details.id;
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/v1/api-keys/${keyId}/usage-stats`,
+        headers: { authorization: `Bearer ${userToken}` },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it('should 404 for an unknown api key id', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/api-keys/00000000-0000-0000-0000-000000000000/usage-stats',
+        headers: { authorization: `Bearer ${adminToken}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
   describe('GET /api/v1/api-keys/:id/audit', () => {
     it('should get audit logs', async () => {
       const createResponse = await server.inject({

--- a/packages/backend/tests/db/api-key-repository.test.ts
+++ b/packages/backend/tests/db/api-key-repository.test.ts
@@ -631,6 +631,47 @@ describe('ApiKeyRepository', () => {
       expect(keyWithStats?.usage_stats.unique_ips).toBeGreaterThanOrEqual(2);
     });
 
+    it('should get rolling-window usage stats (getUsageStats)', async () => {
+      // 3 recent rows → all should land in 24h / 7d / 30d / total
+      for (let i = 0; i < 3; i++) {
+        await db.apiKeys.trackUsage({
+          api_key_id: testKey.id,
+          endpoint: `/api/bugs/${i}`,
+          method: 'POST',
+          status_code: 201,
+        });
+      }
+      // 1 older row at -10d → counts in 30d + total but NOT in 7d/24h
+      await db.apiKeys.trackUsage({
+        api_key_id: testKey.id,
+        endpoint: '/api/bugs/old',
+        method: 'POST',
+        status_code: 201,
+        timestamp: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      });
+
+      const stats = await db.apiKeys.getUsageStats(testKey.id);
+
+      expect(stats).not.toBeNull();
+      expect(stats?.id).toBe(testKey.id);
+      expect(stats?.name).toBe(testKey.name);
+      expect(stats?.created_at).toBeInstanceOf(Date);
+      // `testKey` is fresh per-`beforeEach`, so counts on its
+      // `api_key_id` are deterministic: 4 events total, 3 inside
+      // the 24h/7d windows and 1 at -10d that only the 30d/total
+      // counters catch. Exact-equality (vs. `>=`) so an overcount
+      // regression doesn't slip through silently.
+      expect(stats?.total_requests).toBe(4);
+      expect(stats?.requests_last_30d).toBe(4);
+      expect(stats?.requests_last_7d).toBe(3);
+      expect(stats?.requests_last_24h).toBe(3);
+    });
+
+    it('getUsageStats returns null for unknown api key id', async () => {
+      const stats = await db.apiKeys.getUsageStats('00000000-0000-0000-0000-000000000000');
+      expect(stats).toBeNull();
+    });
+
     it('should calculate client error rate (4xx) correctly', async () => {
       const keyData = createTestApiKey('Error Rate Test Key');
       const testKey = await db.apiKeys.create(keyData);


### PR DESCRIPTION
## Summary

The admin Usage dialog rendered "Created: Invalid Date", "Last used: Never", all counters as 0, and the 7d / 30d averages as NaN.

Root cause is a never-matched contract: the UI's \`apiKeyService.getUsage()\` types its response as \`ApiKeyUsage\` (aggregate stats — \`total_requests\`, \`requests_last_24h/7d/30d\`, \`name\`, \`created_at\`, \`last_used_at\`) but the backend's \`/api/v1/api-keys/:id/usage\` route returns a raw \`api_key_usage\` log array. The wrong object lands in the dialog props, every property read is undefined, the date formatters and number formatters render their sentinel values, and the averages divide undefined → NaN.

(Supersedes #161 — same code, rebased on current main and squashed into one commit, with all post-review fixes folded in: route-level tests, exact-equality assertions, admin test URL fix, request + response schemas on the new route, and a named \`ApiKeyUsageStats\` type used by repo + service.)

## What lands

- New \`GET /api/v1/api-keys/:id/usage-stats\` returning the aggregate shape the dialog wants: \`id\`, \`name\`, \`created_at\`, \`last_used_at\`, plus \`total_requests\` and three rolling windows (24h / 7d / 30d).
- New \`ApiKeyRepository.getUsageStats(id)\` doing the LATERAL filter \`COUNT\` in a single query; returns null for unknown id (route maps to 404).
- New exported \`ApiKeyUsageStats\` interface on the repository module — both repo + service reference it so the three sites (repo, service, route response schema) can't drift.
- \`ApiKeyService.getUsageStats\` explicitly typed \`Promise<ApiKeyUsageStats | null>\` to match every other service method in the file.
- New \`getApiKeyUsageStatsSchema\` with both \`params\` AND \`response\` definitions. Response schema is intentional (the older \`/usage\` / \`/audit\` lack one): this endpoint exists *because of* a UI/backend contract mismatch, so validating the response at the fastify boundary makes the next regression of that shape fail fast in the suite.
- UI's \`apiKeys.usage\` URL constant now points at \`/usage-stats\`. Admin unit test updated to assert the new URL.
- Existing \`/usage\` log-array endpoint and its tests untouched; future log-viewer UIs can use it as-is.

## Tests

- 2 new DB-backed tests in \`tests/db/api-key-repository.test.ts\`: rolling-window math with exact counts (\`total=4\`, \`30d=4\`, \`7d=3\`, \`24h=3\`) + null-on-unknown-id.
- 3 new route tests in \`tests/api/api-keys.test.ts\`: shape + numeric-type assertions (pg COUNT returns string — parseInt coercion is the only thing standing between the dashboard and \`Math.round(... / 30) === NaN\`), 403 for non-admin on a foreign key, 404 for unknown id.

## Test plan

- [x] Backend src typecheck clean
- [x] Backend unit 2782/2782 (\`tests/db/\` runs separately against real Postgres in CI)
- [x] Admin lint clean
- [x] Admin unit 71 files / 901 tests pass (\`api-key-service.test.ts\` 16/16)
- [x] Admin build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)