### PR TITLE
fix(rules): per-recipient rate limit for notify.email

### DIFF
--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -23,6 +23,7 @@ import type { ActionSpec } from '../../integrations/dedup-rule.schema.js';
 import { getLogger } from '../../logger.js';
 import type { EmailSender, ReporterVerifier } from './email-sender.js';
 import { resolveEmailRecipient } from './email-sender.js';
+import type { RecipientRateLimiter } from './recipient-rate-limiter.js';
 import type { ActionDispatcher, RuleEvalContext } from './types.js';
 
 const logger = getLogger();
@@ -81,7 +82,15 @@ export class DefaultActionDispatcher implements ActionDispatcher {
      * we can't honour it unverified. Selfhosted bugs have
      * `organization_id === null` and never reach the verifier.
      */
-    private readonly verifyReporter?: ReporterVerifier
+    private readonly verifyReporter?: ReporterVerifier,
+    /**
+     * Optional per-recipient throttle. When provided, every successful
+     * recipient resolution must clear it before `emailSender.send` is
+     * called. Caps fan-out to a single address across canonicals and
+     * rules — the per-(rule, canonical) throttle alone doesn't bound
+     * this. Tests can omit it; production wiring always passes one.
+     */
+    private readonly recipientRateLimiter?: RecipientRateLimiter
   ) {}
 
   /**
@@ -257,6 +266,23 @@ export class DefaultActionDispatcher implements ActionDispatcher {
         // Email value itself is intentionally not logged — it's PII
         // and the boolean outcome is enough for ops.
         logger.info('Skipping notify.email: reporter not in org membership', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+        });
+        return false;
+      }
+    }
+    // Per-recipient throttle — caps fan-out to one address across
+    // canonicals and rules. Runs after `verifyReporter` so unverified
+    // recipients don't even count against the budget. Recipient stays
+    // out of the log (PII); the limiter logs its own throttle hit.
+    if (this.recipientRateLimiter) {
+      const allowed = await this.recipientRateLimiter.check(
+        recipient,
+        context.bugReport.organization_id
+      );
+      if (!allowed) {
+        logger.info('Skipping notify.email: recipient rate limit reached', {
           bugReportId: context.bugReport.id,
           organizationId: context.bugReport.organization_id,
         });

--- a/packages/backend/src/services/rules/recipient-rate-limiter.ts
+++ b/packages/backend/src/services/rules/recipient-rate-limiter.ts
@@ -63,10 +63,16 @@ export class ThrottleBackedRecipientLimiter implements RecipientRateLimiter {
 
   async check(recipient: string, organizationId: string | null): Promise<boolean> {
     const owner = organizationId ?? SELFHOSTED_THROTTLE_OWNER;
+    // Normalize before hashing so casing/whitespace variants land in
+    // the same bucket. Without this, `Alice@Example.com` and
+    // ` alice@example.com ` would map to different group_keys and
+    // collectively bypass the per-recipient cap. Matches the `LOWER()`
+    // pattern the reporter verifier uses on the read side.
+    const normalized = recipient.trim().toLowerCase();
     // Hash the recipient before it lands in a queryable table. SHA-256
     // truncated to 32 hex chars — 128 bits is more than enough to avoid
     // collisions across realistic recipient counts.
-    const hash = createHash('sha256').update(recipient).digest('hex').slice(0, 32);
+    const hash = createHash('sha256').update(normalized).digest('hex').slice(0, 32);
     const groupKey = `recipient:${hash}`;
     try {
       return await this.throttle.tryReserveSlot(

--- a/packages/backend/src/services/rules/recipient-rate-limiter.ts
+++ b/packages/backend/src/services/rules/recipient-rate-limiter.ts
@@ -35,8 +35,9 @@ const logger = getLogger();
  * Sentinel UUID used as the throttle's `rule_id` for selfhosted bugs
  * (which have no organization_id). All selfhosted recipient-throttle
  * rows share this owner; cleanup falls back on window_end expiry.
+ * Exported so tests can assert against the same value the limiter uses.
  */
-const SELFHOSTED_THROTTLE_OWNER = '00000000-0000-0000-0000-000000000000';
+export const SELFHOSTED_THROTTLE_OWNER = '00000000-0000-0000-0000-000000000000';
 
 /** Conservative default: at most 5 dedup emails to any one address per hour. */
 export const RECIPIENT_THROTTLE_DEFAULTS = {

--- a/packages/backend/src/services/rules/recipient-rate-limiter.ts
+++ b/packages/backend/src/services/rules/recipient-rate-limiter.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-recipient throttle for `notify.email` actions.
+ *
+ * The dedup-rule engine already has a per-(rule, canonical) rate limit
+ * via `ThrottleBackedRateLimiter` — that caps "this rule fires at most
+ * N times per canonical per window." It does NOT cap fan-out to one
+ * recipient across many canonicals or rules. An attacker fabricating
+ * duplicates of N different canonicals against an unlimited rule could
+ * still spam a single address up to N times per window.
+ *
+ * This limiter closes that gap. It hashes the recipient email and
+ * reserves a slot in the same `notification_throttle` table, keyed by
+ * `(organization_id, "recipient:<hash>", window_start)`. SHA-256 truncated
+ * to 32 hex chars; no salt because the table isn't exposed and a
+ * deterministic hash is what lets concurrent calls collide on the same
+ * group_key (the whole point).
+ *
+ * Org scoping: rule_id is the organization_id in SaaS, a sentinel UUID
+ * for selfhosted. Rule-level cleanup (migration 024's AFTER DELETE
+ * trigger on `dedup_rules`) doesn't apply to these rows; cleanup is
+ * by `window_end` via `cleanup_expired_throttle_windows()` once
+ * scheduled.
+ *
+ * Limits are global defaults today. A follow-up can surface per-org
+ * overrides via `organizations.settings`.
+ */
+
+import { createHash } from 'node:crypto';
+import type { NotificationThrottleRepository } from '../../db/repositories/notification-throttle.repository.js';
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+/**
+ * Sentinel UUID used as the throttle's `rule_id` for selfhosted bugs
+ * (which have no organization_id). All selfhosted recipient-throttle
+ * rows share this owner; cleanup falls back on window_end expiry.
+ */
+const SELFHOSTED_THROTTLE_OWNER = '00000000-0000-0000-0000-000000000000';
+
+/** Conservative default: at most 5 dedup emails to any one address per hour. */
+export const RECIPIENT_THROTTLE_DEFAULTS = {
+  maxPerWindow: 5,
+  windowMinutes: 60,
+} as const;
+
+export interface RecipientRateLimiter {
+  /**
+   * Returns true if the send is allowed (slot reserved), false if the
+   * recipient has already hit the per-window cap. Never throws — DB
+   * errors are treated as "throttled" (fail-closed) to match the
+   * existing notification-throttle behaviour.
+   */
+  check(recipient: string, organizationId: string | null): Promise<boolean>;
+}
+
+export class ThrottleBackedRecipientLimiter implements RecipientRateLimiter {
+  constructor(
+    private readonly throttle: NotificationThrottleRepository,
+    private readonly maxPerWindow: number = RECIPIENT_THROTTLE_DEFAULTS.maxPerWindow,
+    private readonly windowMinutes: number = RECIPIENT_THROTTLE_DEFAULTS.windowMinutes
+  ) {}
+
+  async check(recipient: string, organizationId: string | null): Promise<boolean> {
+    const owner = organizationId ?? SELFHOSTED_THROTTLE_OWNER;
+    // Hash the recipient before it lands in a queryable table. SHA-256
+    // truncated to 32 hex chars — 128 bits is more than enough to avoid
+    // collisions across realistic recipient counts.
+    const hash = createHash('sha256').update(recipient).digest('hex').slice(0, 32);
+    const groupKey = `recipient:${hash}`;
+    try {
+      return await this.throttle.tryReserveSlot(
+        owner,
+        groupKey,
+        this.maxPerWindow,
+        this.windowMinutes
+      );
+    } catch (error) {
+      // Fail closed. A DB hiccup shouldn't open a spam window.
+      logger.warn('RecipientRateLimiter: throttle check threw, treating as limited', {
+        organizationId,
+        groupKey,
+        errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+      });
+      return false;
+    }
+  }
+}

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -22,6 +22,7 @@ import type { CapabilityServiceLookup } from './dispatcher.js';
 import { ChannelBackedEmailSender } from './email-sender.js';
 import { DedupRuleExecutor } from './executor.js';
 import { ThrottleBackedRateLimiter } from './rate-limiter.js';
+import { ThrottleBackedRecipientLimiter } from './recipient-rate-limiter.js';
 
 const logger = getLogger();
 
@@ -119,7 +120,17 @@ export function buildDedupRuleExecutor(
   // organization_id), so wiring this here is load-bearing.
   const verifyReporter = (orgId: string, email: string): Promise<boolean> =>
     db.organizationMembers.existsByOrganizationAndEmail(orgId, email);
-  const dispatcher = new DefaultActionDispatcher(resolver, lookup, emailSender, verifyReporter);
+  // Per-recipient throttle — caps total fan-out to any one address
+  // across canonicals and rules. Uses the existing notification_throttle
+  // table with global defaults (5 emails / 60 minutes per address).
+  const recipientRateLimiter = new ThrottleBackedRecipientLimiter(throttle);
+  const dispatcher = new DefaultActionDispatcher(
+    resolver,
+    lookup,
+    emailSender,
+    verifyReporter,
+    recipientRateLimiter
+  );
   const rateLimiter = new ThrottleBackedRateLimiter(throttle);
   const contextProvider = new DatabaseRuleContextProvider(db);
   return new DedupRuleExecutor(repo, dispatcher, rateLimiter, contextProvider);

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -488,4 +488,150 @@ describe('DefaultActionDispatcher', () => {
       expect(send.mock.calls[0][0].to).toBe('ops@example.com');
     });
   });
+
+  describe('notify.email — per-recipient rate limiter', () => {
+    function buildLimitedDispatcher(limiter: Mock, verifyReporter?: Mock) {
+      const send: Mock = vi.fn().mockResolvedValue(true);
+      const emailSender = { send };
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        emailSender,
+        verifyReporter as unknown as (orgId: string, email: string) => Promise<boolean>,
+        { check: limiter } as unknown as {
+          check: (recipient: string, organizationId: string | null) => Promise<boolean>;
+        }
+      );
+      return { dispatcher: d, send };
+    }
+
+    it('sends when the limiter reserves a slot', async () => {
+      const limiter = vi.fn().mockResolvedValue(true);
+      const verify = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d, send } = buildLimitedDispatcher(limiter, verify);
+      const ctx = makeContext({
+        bugReport: makeBug({
+          organization_id: 'org-1',
+          metadata: { metadata: { user: { email: 'alice@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(limiter).toHaveBeenCalledWith('alice@example.com', 'org-1');
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips when the limiter denies (recipient hit the window cap)', async () => {
+      const limiter = vi.fn().mockResolvedValue(false);
+      const verify = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d, send } = buildLimitedDispatcher(limiter, verify);
+      const ctx = makeContext({
+        bugReport: makeBug({
+          organization_id: 'org-1',
+          metadata: { metadata: { user: { email: 'alice@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(false);
+      expect(limiter).toHaveBeenCalledTimes(1);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    // Regression scaffold for the spam-vector described in
+    // C2 carry-over #2: same recipient, N different canonicals, no
+    // per-(rule, canonical) cap. Without a per-recipient limiter, all
+    // N would land. With the limiter capped at 2, only the first two
+    // do — and the third skips with `send` never called.
+    it('caps fan-out across multiple canonicals to one recipient', async () => {
+      let allowed = 0;
+      const cap = 2;
+      const limiter = vi.fn().mockImplementation(async () => {
+        if (allowed >= cap) {
+          return false;
+        }
+        allowed += 1;
+        return true;
+      });
+      const verify = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d, send } = buildLimitedDispatcher(limiter, verify);
+
+      const results: boolean[] = [];
+      for (let i = 0; i < 3; i++) {
+        const ctx = makeContext({
+          bugReport: makeBug({
+            id: `dup-${i}`,
+            organization_id: 'org-1',
+            metadata: { metadata: { user: { email: 'alice@example.com' } } },
+          }),
+          canonical: makeBug({ id: `canonical-${i}`, duplicate_of: null }),
+        });
+        results.push(
+          await d.dispatch(ctx, {
+            type: 'notify.email',
+            to: 'reporter',
+            template: 'dedup_ack',
+          })
+        );
+      }
+
+      expect(results).toEqual([true, true, false]);
+      expect(send).toHaveBeenCalledTimes(2);
+    });
+
+    it('runs the verifier first — denied recipients do not consume the budget', async () => {
+      const limiter = vi.fn().mockResolvedValue(true);
+      const verify = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d, send } = buildLimitedDispatcher(limiter, verify);
+      const ctx = makeContext({
+        bugReport: makeBug({
+          organization_id: 'org-1',
+          metadata: { metadata: { user: { email: 'alice@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(false);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expect(limiter).not.toHaveBeenCalled();
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('passes recipient and null organization_id through on the selfhosted path', async () => {
+      const limiter = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d, send } = buildLimitedDispatcher(limiter);
+      const ctx = makeContext({
+        bugReport: makeBug({
+          organization_id: null,
+          metadata: { metadata: { user: { email: 'alice@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(limiter).toHaveBeenCalledWith('alice@example.com', null);
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/backend/tests/services/rules/recipient-rate-limiter.test.ts
+++ b/packages/backend/tests/services/rules/recipient-rate-limiter.test.ts
@@ -12,11 +12,10 @@ import { describe, it, expect, vi, type Mock } from 'vitest';
 import { createHash } from 'node:crypto';
 import {
   RECIPIENT_THROTTLE_DEFAULTS,
+  SELFHOSTED_THROTTLE_OWNER,
   ThrottleBackedRecipientLimiter,
 } from '../../../src/services/rules/recipient-rate-limiter.js';
 import type { NotificationThrottleRepository } from '../../../src/db/repositories/notification-throttle.repository.js';
-
-const SELFHOSTED_OWNER = '00000000-0000-0000-0000-000000000000';
 
 function hash(recipient: string): string {
   // Mirrors the limiter's normalize-then-hash shape.
@@ -50,7 +49,7 @@ describe('ThrottleBackedRecipientLimiter', () => {
 
     await limiter.check('alice@example.com', null);
 
-    expect(reserve.mock.calls[0][0]).toBe(SELFHOSTED_OWNER);
+    expect(reserve.mock.calls[0][0]).toBe(SELFHOSTED_THROTTLE_OWNER);
   });
 
   it('returns false when the throttle reports the slot is taken', async () => {

--- a/packages/backend/tests/services/rules/recipient-rate-limiter.test.ts
+++ b/packages/backend/tests/services/rules/recipient-rate-limiter.test.ts
@@ -19,7 +19,9 @@ import type { NotificationThrottleRepository } from '../../../src/db/repositorie
 const SELFHOSTED_OWNER = '00000000-0000-0000-0000-000000000000';
 
 function hash(recipient: string): string {
-  return createHash('sha256').update(recipient).digest('hex').slice(0, 32);
+  // Mirrors the limiter's normalize-then-hash shape.
+  const normalized = recipient.trim().toLowerCase();
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 32);
 }
 
 function buildMockRepo(reserve: Mock): NotificationThrottleRepository {
@@ -87,5 +89,17 @@ describe('ThrottleBackedRecipientLimiter', () => {
     await limiter.check('alice@example.com', 'org-1');
 
     expect(reserve.mock.calls[0][1]).toBe(reserve.mock.calls[1][1]);
+  });
+
+  it('normalizes casing and whitespace before hashing (bypass guard)', async () => {
+    const reserve = vi.fn().mockResolvedValue(true);
+    const limiter = new ThrottleBackedRecipientLimiter(buildMockRepo(reserve));
+
+    await limiter.check('Alice@Example.com', 'org-1');
+    await limiter.check(' alice@example.com ', 'org-1');
+    await limiter.check('alice@example.com', 'org-1');
+
+    const groupKeys = reserve.mock.calls.map((c) => c[1]);
+    expect(new Set(groupKeys).size).toBe(1);
   });
 });

--- a/packages/backend/tests/services/rules/recipient-rate-limiter.test.ts
+++ b/packages/backend/tests/services/rules/recipient-rate-limiter.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for `ThrottleBackedRecipientLimiter`.
+ *
+ * The integration story (real Postgres, concurrent reservation, FK
+ * polymorphism) is covered by the existing `notification_throttle`
+ * integration tests. This file pins the dedup-engine adapter's own
+ * contract: recipient hashing, org-id passthrough vs selfhosted
+ * sentinel, default limit application, fail-closed on throttle errors.
+ */
+
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  RECIPIENT_THROTTLE_DEFAULTS,
+  ThrottleBackedRecipientLimiter,
+} from '../../../src/services/rules/recipient-rate-limiter.js';
+import type { NotificationThrottleRepository } from '../../../src/db/repositories/notification-throttle.repository.js';
+
+const SELFHOSTED_OWNER = '00000000-0000-0000-0000-000000000000';
+
+function hash(recipient: string): string {
+  return createHash('sha256').update(recipient).digest('hex').slice(0, 32);
+}
+
+function buildMockRepo(reserve: Mock): NotificationThrottleRepository {
+  return { tryReserveSlot: reserve } as unknown as NotificationThrottleRepository;
+}
+
+describe('ThrottleBackedRecipientLimiter', () => {
+  it('passes the org_id through as the throttle rule_id and hashes the recipient', async () => {
+    const reserve = vi.fn().mockResolvedValue(true);
+    const limiter = new ThrottleBackedRecipientLimiter(buildMockRepo(reserve));
+
+    const ok = await limiter.check('alice@example.com', 'org-1');
+
+    expect(ok).toBe(true);
+    expect(reserve).toHaveBeenCalledWith(
+      'org-1',
+      `recipient:${hash('alice@example.com')}`,
+      RECIPIENT_THROTTLE_DEFAULTS.maxPerWindow,
+      RECIPIENT_THROTTLE_DEFAULTS.windowMinutes
+    );
+  });
+
+  it('uses the selfhosted sentinel UUID when organization_id is null', async () => {
+    const reserve = vi.fn().mockResolvedValue(true);
+    const limiter = new ThrottleBackedRecipientLimiter(buildMockRepo(reserve));
+
+    await limiter.check('alice@example.com', null);
+
+    expect(reserve.mock.calls[0][0]).toBe(SELFHOSTED_OWNER);
+  });
+
+  it('returns false when the throttle reports the slot is taken', async () => {
+    const reserve = vi.fn().mockResolvedValue(false);
+    const limiter = new ThrottleBackedRecipientLimiter(buildMockRepo(reserve));
+
+    const ok = await limiter.check('alice@example.com', 'org-1');
+
+    expect(ok).toBe(false);
+  });
+
+  it('fails closed when the throttle layer throws', async () => {
+    const reserve = vi.fn().mockRejectedValue(new Error('db gone'));
+    const limiter = new ThrottleBackedRecipientLimiter(buildMockRepo(reserve));
+
+    const ok = await limiter.check('alice@example.com', 'org-1');
+
+    expect(ok).toBe(false);
+  });
+
+  it('honours the constructor overrides for count and window', async () => {
+    const reserve = vi.fn().mockResolvedValue(true);
+    const limiter = new ThrottleBackedRecipientLimiter(buildMockRepo(reserve), 2, 15);
+
+    await limiter.check('alice@example.com', 'org-1');
+
+    expect(reserve.mock.calls[0][2]).toBe(2);
+    expect(reserve.mock.calls[0][3]).toBe(15);
+  });
+
+  it('hashes deterministically so concurrent calls collide on the same group_key', async () => {
+    const reserve = vi.fn().mockResolvedValue(true);
+    const limiter = new ThrottleBackedRecipientLimiter(buildMockRepo(reserve));
+
+    await limiter.check('alice@example.com', 'org-1');
+    await limiter.check('alice@example.com', 'org-1');
+
+    expect(reserve.mock.calls[0][1]).toBe(reserve.mock.calls[1][1]);
+  });
+});


### PR DESCRIPTION
## Summary

C2 carry-over #2 from Phase 0.5. The existing per-(rule, canonical) throttle caps "rule R fires at most N times per canonical per window" but does NOT cap fan-out to one recipient across many canonicals or rules. An attacker fabricating duplicates of N distinct canonicals against an unlimited rule can still spam a single address up to N times per window.

PR #158's auth-bound reporter check closed that on the \`'reporter'\` branch (only org members get emails). This PR closes the same vector for the literal-recipient branch and adds defence-in-depth for the reporter branch.

## What lands

- New \`ThrottleBackedRecipientLimiter\` in \`services/rules/\`. Hashes the recipient (SHA-256 truncated to 32 hex) and reserves a slot in the existing \`notification_throttle\` table via the atomic \`tryReserveSlot\` helper. Group key is \`recipient:<hash>\`; the throttle's polymorphic \`rule_id\` slot carries the bug's \`organization_id\` (or a sentinel UUID for selfhosted, where there is no org). Conservative defaults: **5 emails per recipient per 60 minutes**.
- \`DefaultActionDispatcher\` accepts an optional \`RecipientRateLimiter\` and consults it on the \`notify.email\` path **after reporter verification, before \`emailSender.send\`**. Unverified recipients don't consume the budget — the verifier short-circuits first.
- Wiring in \`buildDedupRuleExecutor\` instantiates the limiter with defaults and threads it into the dispatcher.

## Tests

- 6 unit tests on the limiter itself: hashing determinism, org-id passthrough, selfhosted sentinel, fail-closed on throttle errors, constructor overrides.
- 5 new dispatcher tests covering the integration: limiter allows vs denies, **the multi-canonical regression scaffold** (cap=2 → only first 2 sends land), verifier-runs-first (denied recipients don't burn budget), selfhosted org_id=null passthrough.

## Out of scope

- Per-org configuration of the limit (currently hard-coded defaults).
- Scheduling \`cleanup_expired_throttle_windows()\` — selfhosted-sentinel and per-org rows don't get the rule-delete cascade trigger; they expire by \`window_end\`, which the cleanup function handles when wired.

## Test plan

- [x] Backend src typecheck clean
- [x] Backend unit 2793 tests (+11 new); 1 failure on the known-flaky \`rpc-bridge-security.test.ts\`, unrelated
- [x] Admin lint clean (no admin changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented per-recipient email rate limiting with a maximum of 5 emails per 60-minute window per recipient.
  * Email verification now occurs before throttle budget is consumed, ensuring unverified recipients don't count against limits.
  * Self-hosted deployments receive the same throttle protection as cloud instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->