### PR TITLE
test(rpc-bridge): fix HTTP Fetch Security flake

### DIFF
--- a/packages/backend/tests/integrations/rpc-bridge-security.test.ts
+++ b/packages/backend/tests/integrations/rpc-bridge-security.test.ts
@@ -1131,8 +1131,8 @@ describe('RPC Bridge Security', () => {
     function lastFetchHeaders(): Headers {
       const mock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
       expect(mock).toHaveBeenCalled();
-      const [, options] = mock.mock.calls[0];
-      return options.headers as Headers;
+      const [, options] = mock.mock.calls[mock.mock.calls.length - 1];
+      return (options?.headers as Headers) ?? new Headers();
     }
 
     describe('Header Sanitization', () => {

--- a/packages/backend/tests/integrations/rpc-bridge-security.test.ts
+++ b/packages/backend/tests/integrations/rpc-bridge-security.test.ts
@@ -1135,6 +1135,15 @@ describe('RPC Bridge Security', () => {
       return new Headers(options?.headers);
     }
 
+    // Pull the normalized HTTP method out of the last fetch call.
+    // Defaults to GET to match fetch's own semantics.
+    function lastFetchMethod(): string {
+      const mock = vi.mocked(globalThis.fetch);
+      expect(mock).toHaveBeenCalled();
+      const [, options] = mock.mock.calls[mock.mock.calls.length - 1];
+      return (options?.method as string) ?? 'GET';
+    }
+
     describe('Header Sanitization', () => {
       it('should block Authorization header', async () => {
         const result = await rpcBridge.handleCall({
@@ -1315,8 +1324,9 @@ describe('RPC Bridge Security', () => {
           requestId: 'req-method-1',
         });
 
-        expect(result.success).toBe(false);
-        // Will fail on SSRF validation (no mock), but method validation passes
+        expect(result.success).toBe(false); // network mock rejects
+        // The validation+normalization path reached fetch with GET intact.
+        expect(lastFetchMethod()).toBe('GET');
       });
 
       it('should allow POST method', async () => {
@@ -1333,7 +1343,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
-        // Will fail on SSRF validation
+        expect(lastFetchMethod()).toBe('POST');
       });
 
       it('should reject CONNECT method', async () => {
@@ -1381,7 +1391,8 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
-        // Will fail on SSRF validation, but method normalization works
+        // Normalization happens before fetch, so the mocked call sees uppercase.
+        expect(lastFetchMethod()).toBe('POST');
       });
     });
 
@@ -1423,7 +1434,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
-        // Will fail on SSRF validation, but Content-Type passes sanitization
+        expect(lastFetchHeaders().get('content-type')).toBe('application/json');
       });
 
       it('should allow Accept header', async () => {
@@ -1441,7 +1452,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
-        // Will fail on SSRF validation, but Accept passes sanitization
+        expect(lastFetchHeaders().get('accept')).toBe('application/json');
       });
 
       it('should allow User-Agent header', async () => {
@@ -1459,7 +1470,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
-        // Will fail on SSRF validation, but User-Agent passes sanitization
+        expect(lastFetchHeaders().get('user-agent')).toBe('BugSpotter-Plugin/1.0');
       });
 
       it('should allow custom X-Custom-Header', async () => {
@@ -1477,8 +1488,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
-        // Will fail on SSRF validation, but X-Custom-Header passes sanitization
-        // (not in blocked list)
+        expect(lastFetchHeaders().get('x-custom-header')).toBe('custom-value');
       });
     });
   });

--- a/packages/backend/tests/integrations/rpc-bridge-security.test.ts
+++ b/packages/backend/tests/integrations/rpc-bridge-security.test.ts
@@ -1117,17 +1117,12 @@ describe('RPC Bridge Security', () => {
     // synchronous network-error reject for deterministic behaviour.
     // Restored after every test so other describes that need real
     // behaviour aren't affected.
-    let originalFetch: typeof fetch;
-
     beforeEach(() => {
-      originalFetch = globalThis.fetch;
-      globalThis.fetch = vi.fn(async () => {
-        throw new TypeError('fetch failed');
-      }) as unknown as typeof fetch;
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
     });
 
     afterEach(() => {
-      globalThis.fetch = originalFetch;
+      vi.unstubAllGlobals();
     });
 
     describe('Header Sanitization', () => {

--- a/packages/backend/tests/integrations/rpc-bridge-security.test.ts
+++ b/packages/backend/tests/integrations/rpc-bridge-security.test.ts
@@ -1129,10 +1129,10 @@ describe('RPC Bridge Security', () => {
     // The handler passes a `Headers` instance (not a plain dict), so we
     // assert against `.get(name)` rather than `objectContaining`.
     function lastFetchHeaders(): Headers {
-      const mock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+      const mock = vi.mocked(globalThis.fetch);
       expect(mock).toHaveBeenCalled();
       const [, options] = mock.mock.calls[mock.mock.calls.length - 1];
-      return (options?.headers as Headers) ?? new Headers();
+      return new Headers(options?.headers);
     }
 
     describe('Header Sanitization', () => {

--- a/packages/backend/tests/integrations/rpc-bridge-security.test.ts
+++ b/packages/backend/tests/integrations/rpc-bridge-security.test.ts
@@ -3,7 +3,7 @@
  * Tests that malicious plugin code cannot escape sandbox restrictions
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RpcBridge } from '../../src/integrations/security/rpc-bridge.js';
 import type { DatabaseClient } from '../../src/db/client.js';
 import type { IStorageService } from '../../src/storage/types.js';
@@ -1107,6 +1107,29 @@ describe('RPC Bridge Security', () => {
   });
 
   describe('HTTP Fetch Security', () => {
+    // Every test in this block uses `https://api.example.com/data` as
+    // the target — a public-resolving domain that passes SSRF, so the
+    // handler reaches the real `fetch()` call. In CI / on dev machines
+    // that resolves api.example.com slowly (or not at all), the network
+    // attempt races vitest's 5s default test timeout, producing a
+    // flaky failure. Each test only asserts `result.success === false`,
+    // which a rejected fetch satisfies — so stub the global fetch to a
+    // synchronous network-error reject for deterministic behaviour.
+    // Restored after every test so other describes that need real
+    // behaviour aren't affected.
+    let originalFetch: typeof fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async () => {
+        throw new TypeError('fetch failed');
+      }) as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
     describe('Header Sanitization', () => {
       it('should block Authorization header', async () => {
         const result = await rpcBridge.handleCall({

--- a/packages/backend/tests/integrations/rpc-bridge-security.test.ts
+++ b/packages/backend/tests/integrations/rpc-bridge-security.test.ts
@@ -1125,6 +1125,16 @@ describe('RPC Bridge Security', () => {
       vi.unstubAllGlobals();
     });
 
+    // Pull the sanitized `Headers` object out of the last fetch call.
+    // The handler passes a `Headers` instance (not a plain dict), so we
+    // assert against `.get(name)` rather than `objectContaining`.
+    function lastFetchHeaders(): Headers {
+      const mock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+      expect(mock).toHaveBeenCalled();
+      const [, options] = mock.mock.calls[0];
+      return options.headers as Headers;
+    }
+
     describe('Header Sanitization', () => {
       it('should block Authorization header', async () => {
         const result = await rpcBridge.handleCall({
@@ -1142,8 +1152,10 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
-        // Should fail due to SSRF validation (no mock setup)
-        // But header sanitization happens first
+        const headers = lastFetchHeaders();
+        // The forbidden header is stripped; the safe one passes through.
+        expect(headers.get('authorization')).toBeNull();
+        expect(headers.get('content-type')).toBe('application/json');
       });
 
       it('should block Cookie header', async () => {
@@ -1162,6 +1174,9 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
+        const headers = lastFetchHeaders();
+        expect(headers.get('cookie')).toBeNull();
+        expect(headers.get('content-type')).toBe('application/json');
       });
 
       it('should block X-Api-Key header', async () => {
@@ -1180,6 +1195,9 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
+        const headers = lastFetchHeaders();
+        expect(headers.get('x-api-key')).toBeNull();
+        expect(headers.get('content-type')).toBe('application/json');
       });
 
       it('should block Proxy-Authorization header', async () => {
@@ -1197,6 +1215,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
+        expect(lastFetchHeaders().get('proxy-authorization')).toBeNull();
       });
 
       it('should block X-Forwarded-For header', async () => {
@@ -1214,6 +1233,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
+        expect(lastFetchHeaders().get('x-forwarded-for')).toBeNull();
       });
 
       it('should block all Sec-* headers', async () => {
@@ -1233,6 +1253,10 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
+        const headers = lastFetchHeaders();
+        expect(headers.get('sec-fetch-site')).toBeNull();
+        expect(headers.get('sec-fetch-mode')).toBeNull();
+        expect(headers.get('sec-websocket-key')).toBeNull();
       });
 
       it('should block Set-Cookie header', async () => {
@@ -1250,6 +1274,7 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
+        expect(lastFetchHeaders().get('set-cookie')).toBeNull();
       });
 
       it('should block header case-insensitively', async () => {
@@ -1269,6 +1294,11 @@ describe('RPC Bridge Security', () => {
         });
 
         expect(result.success).toBe(false);
+        const headers = lastFetchHeaders();
+        // All three variants must be stripped regardless of casing.
+        expect(headers.get('authorization')).toBeNull();
+        expect(headers.get('cookie')).toBeNull();
+        expect(headers.get('x-api-key')).toBeNull();
       });
     });
 


### PR DESCRIPTION
## Summary

Every test in the \`HTTP Fetch Security\` describe in \`rpc-bridge-security.test.ts\` sends an http.fetch call to \`https://api.example.com/data\` and asserts only \`result.success === false\`. That URL is public-resolving, so SSRF validation passes and the handler reaches the real \`fetch()\`. In CI / on dev machines that resolve api.example.com slowly, the network attempt races vitest's 5s default test timeout and the test fails sporadically.

I hit this flake 5+ times across this session on unrelated branches.

## Fix

Scoped \`beforeEach\` / \`afterEach\` inside the \`HTTP Fetch Security\` describe that stubs \`globalThis.fetch\` to reject synchronously with a network-error-shaped \`TypeError('fetch failed')\`. Every test in this block already asserts \`success === false\`, which a rejected fetch satisfies — no behavioural change to the assertions, just deterministic timing.

The original fetch is restored after each test so the rest of the file is untouched.

## Verification

- 5/5 consecutive local runs of \`tests/integrations/rpc-bridge-security.test.ts\` pass (prior runs intermittently produced 1–2 failures).
- The describe blocks that need real \`fetch\` behaviour live elsewhere in the file (none in HTTP Fetch Security) and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of RPC bridge security tests by stubbing network requests deterministically and restoring global state after each test.
  * Strengthened assertions to verify header stripping (including case-insensitive blocking) and HTTP method normalization.
  * Added helpers to inspect the last network call so allowed headers and methods are asserted directly rather than inferred.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->