### PR TITLE
feat(rules): notify.telegram action — first-class Telegram dispatch

### DIFF
--- a/packages/backend/src/api/routes/intelligence-settings.ts
+++ b/packages/backend/src/api/routes/intelligence-settings.ts
@@ -82,6 +82,13 @@ const updateSettingsBody = {
       maxItems: 100,
       uniqueItems: true,
     },
+    // Telegram bot token (plaintext on the wire; encrypted on store
+    // by the service layer). `null` or empty string clears the
+    // configured bot. Token shape is `<bot_id>:<35-char-secret>` per
+    // BotFather output, but bot ids vary in length — we cap maxLength
+    // defensively rather than enforce a regex that could lock out
+    // edge cases.
+    telegram_bot_token: { type: ['string', 'null'], maxLength: 200 },
   },
   additionalProperties: false,
 } as const;
@@ -105,6 +112,7 @@ interface UpdateSettingsBody {
   intelligence_pre_file_dedup_grace_ms?: number | null;
   intelligence_self_service_enabled?: boolean;
   dedup_email_literal_allowlist?: string[] | null;
+  telegram_bot_token?: string | null;
 }
 
 // ============================================================================

--- a/packages/backend/src/api/routes/intelligence-settings.ts
+++ b/packages/backend/src/api/routes/intelligence-settings.ts
@@ -84,11 +84,18 @@ const updateSettingsBody = {
     },
     // Telegram bot token (plaintext on the wire; encrypted on store
     // by the service layer). `null` or empty string clears the
-    // configured bot. Token shape is `<bot_id>:<35-char-secret>` per
-    // BotFather output, but bot ids vary in length — we cap maxLength
-    // defensively rather than enforce a regex that could lock out
-    // edge cases.
-    telegram_bot_token: { type: ['string', 'null'], maxLength: 200 },
+    // configured bot. The BotFather-issued shape is enforced via
+    // pattern: `<bot_id>:<35-char-secret>` where bot ids are positive
+    // integers and the secret uses `[A-Za-z0-9_-]`. Without the
+    // pattern a token like `/../admin` would escape the bot path on
+    // URL build in the sender; the sender re-checks defensively but
+    // failing here gives admins immediate feedback instead of a silent
+    // dispatch skip later. Empty string is also accepted (clears).
+    telegram_bot_token: {
+      type: ['string', 'null'],
+      maxLength: 200,
+      pattern: '^$|^[0-9]+:[A-Za-z0-9_-]+$',
+    },
   },
   additionalProperties: false,
 } as const;

--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -732,6 +732,14 @@ export interface OrganizationSettings {
    * and compared case-insensitively.
    */
   dedup_email_literal_allowlist?: string[] | null;
+  /**
+   * Encrypted Telegram bot token (via CredentialEncryption — same
+   * shape as `intelligence_api_key`). Used by `notify.telegram`
+   * dispatch. `undefined` / `null` = no Telegram bot configured;
+   * dispatcher skips `notify.telegram` cleanly. Never returned to
+   * the client on GET — the settings route strips it on response.
+   */
+  telegram_bot_token?: string | null;
 }
 
 export interface Organization {

--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -736,8 +736,11 @@ export interface OrganizationSettings {
    * Encrypted Telegram bot token (via CredentialEncryption — same
    * shape as `intelligence_api_key`). Used by `notify.telegram`
    * dispatch. `undefined` / `null` = no Telegram bot configured;
-   * dispatcher skips `notify.telegram` cleanly. Never returned to
-   * the client on GET — the settings route strips it on response.
+   * dispatcher skips `notify.telegram` cleanly. Never appears on the
+   * GET response because `resolveOrgIntelligenceSettings` explicitly
+   * enumerates the fields it carries through and this isn't one of
+   * them — `key-provisioning.test.ts` pins that contract so a future
+   * addition to the resolve can't quietly leak the encrypted blob.
    */
   telegram_bot_token?: string | null;
 }

--- a/packages/backend/src/integrations/dedup-rule.schema.ts
+++ b/packages/backend/src/integrations/dedup-rule.schema.ts
@@ -231,10 +231,14 @@ const actionWebhookSchema = z.object({
 // `@channel_username` references for public channels. The dispatcher
 // passes the value straight to the bot-API as a string, which is what
 // the API documents as canonical.
+// `message` is capped at 4096 — Telegram's sendMessage hard limit on
+// the `text` field. Fail-fast at parse time so admin authors see the
+// error in the rule editor rather than as a 400 from the bot API days
+// later when the rule fires.
 const actionTelegramSchema = z.object({
   type: z.literal('notify.telegram'),
   chat_id: z.string().min(1),
-  message: z.string().min(1),
+  message: z.string().min(1).max(4096),
 });
 
 // Plain `z.union` instead of `discriminatedUnion`: the latter requires

--- a/packages/backend/src/integrations/dedup-rule.schema.ts
+++ b/packages/backend/src/integrations/dedup-rule.schema.ts
@@ -225,6 +225,18 @@ const actionWebhookSchema = z.object({
   payload: z.record(z.unknown()).nullable().optional(),
 });
 
+// `chat_id` is a string because Telegram supports both numeric ids
+// (group / supergroup ids are large negatives, well outside JS-safe
+// integer range when one accidentally serializes them as Number) and
+// `@channel_username` references for public channels. The dispatcher
+// passes the value straight to the bot-API as a string, which is what
+// the API documents as canonical.
+const actionTelegramSchema = z.object({
+  type: z.literal('notify.telegram'),
+  chat_id: z.string().min(1),
+  message: z.string().min(1),
+});
+
 // Plain `z.union` instead of `discriminatedUnion`: the latter requires
 // every variant to be a `ZodObject`, but `actionSlackSchema` is a
 // `ZodEffects` (wraps `.superRefine` for the XOR check). The union
@@ -236,6 +248,7 @@ export const actionSpecSchema = z.union([
   actionEmailSchema,
   actionSlackSchema,
   actionWebhookSchema,
+  actionTelegramSchema,
 ]);
 
 export type ActionSpec = z.infer<typeof actionSpecSchema>;

--- a/packages/backend/src/services/intelligence/key-provisioning.ts
+++ b/packages/backend/src/services/intelligence/key-provisioning.ts
@@ -60,6 +60,7 @@ export type IntelligenceSettingsUpdate = Pick<
   | 'intelligence_pre_file_dedup_grace_ms'
   | 'intelligence_self_service_enabled'
   | 'dedup_email_literal_allowlist'
+  | 'telegram_bot_token'
 >;
 
 // ============================================================================
@@ -284,6 +285,22 @@ export class IntelligenceKeyProvisioning {
       normalized.dedup_email_literal_allowlist = Array.from(
         new Set(normalized.dedup_email_literal_allowlist.map((e) => e.trim().toLowerCase()))
       );
+    }
+    // Telegram bot token comes in as plaintext from the admin PATCH.
+    // Encrypt before persistence (same shape `provisionKey` uses for
+    // `intelligence_api_key`). An empty string is treated as a clear
+    // — without this, we'd store `enc:''` which would later decrypt to
+    // an empty token and break dispatch silently. `null` passes
+    // through to the JSONB merge to clear the field.
+    if (normalized.telegram_bot_token !== undefined) {
+      if (
+        typeof normalized.telegram_bot_token === 'string' &&
+        normalized.telegram_bot_token !== ''
+      ) {
+        normalized.telegram_bot_token = this.encryption.encrypt(normalized.telegram_bot_token);
+      } else {
+        normalized.telegram_bot_token = null;
+      }
     }
     const updated = await this.db.organizations.updateSettings(orgId, normalized);
     if (!updated) {

--- a/packages/backend/src/services/intelligence/key-provisioning.ts
+++ b/packages/backend/src/services/intelligence/key-provisioning.ts
@@ -293,11 +293,13 @@ export class IntelligenceKeyProvisioning {
     // an empty token and break dispatch silently. `null` passes
     // through to the JSONB merge to clear the field.
     if (normalized.telegram_bot_token !== undefined) {
-      if (
-        typeof normalized.telegram_bot_token === 'string' &&
-        normalized.telegram_bot_token !== ''
-      ) {
-        normalized.telegram_bot_token = this.encryption.encrypt(normalized.telegram_bot_token);
+      if (typeof normalized.telegram_bot_token === 'string') {
+        // Trim before encrypting so leading/trailing whitespace
+        // doesn't end up in the cipher. Empty / whitespace-only
+        // input clears the field.
+        const trimmed = normalized.telegram_bot_token.trim();
+        normalized.telegram_bot_token =
+          trimmed.length > 0 ? this.encryption.encrypt(trimmed) : null;
       } else {
         normalized.telegram_bot_token = null;
       }

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -408,6 +408,23 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       });
       return false;
     }
+    // Per-recipient throttle (shared with notify.email) — keyed on
+    // chat_id here. Caps fan-out to one Telegram chat across rules /
+    // canonicals, same way it does for email recipients. Runs after
+    // token resolution so an unconfigured org doesn't burn budget.
+    if (this.recipientRateLimiter) {
+      const allowed = await this.recipientRateLimiter.check(
+        chatId,
+        context.bugReport.organization_id
+      );
+      if (!allowed) {
+        logger.info('Skipping notify.telegram: recipient rate limit reached', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+        });
+        return false;
+      }
+    }
     return this.telegramSender.send({ token, chatId, text: message });
   }
 

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -28,6 +28,7 @@ import type {
 } from './email-sender.js';
 import { isLiteralRecipient, resolveEmailRecipient } from './email-sender.js';
 import type { RecipientRateLimiter } from './recipient-rate-limiter.js';
+import type { TelegramSender, TelegramTokenResolver } from './telegram-sender.js';
 import type { ActionDispatcher, RuleEvalContext } from './types.js';
 
 const logger = getLogger();
@@ -102,7 +103,21 @@ export class DefaultActionDispatcher implements ActionDispatcher {
      * preserves legacy trust-the-admin behaviour; a configured list
      * makes the check strict.
      */
-    private readonly literalRecipientAllowlist?: LiteralRecipientAllowlistProvider
+    private readonly literalRecipientAllowlist?: LiteralRecipientAllowlistProvider,
+    /**
+     * Optional Telegram bot-API sender. When provided alongside a
+     * token resolver, `notify.telegram` actions dispatch through it.
+     * Tests inject a stub; production wires `FetchBackedTelegramSender`.
+     */
+    private readonly telegramSender?: TelegramSender,
+    /**
+     * Resolves the org's bot token (decrypted plaintext) for
+     * `notify.telegram` dispatch. Returns `null` when no token is
+     * configured — dispatcher treats that as "skip cleanly". Must be
+     * paired with `telegramSender`; one without the other is a wiring
+     * bug and `canDispatch('notify.telegram')` reflects that.
+     */
+    private readonly telegramTokenResolver?: TelegramTokenResolver
   ) {}
 
   /**
@@ -122,9 +137,14 @@ export class DefaultActionDispatcher implements ActionDispatcher {
         return this.emailSender !== undefined;
       case 'notify.slack':
       case 'notify.webhook':
-        // PR-D flips these to true as the slack / webhook wiring
-        // lands.
+        // Slack / generic webhook dispatchers still pending —
+        // separate PRs queued behind notify.telegram (KZ launch
+        // priority).
         return false;
+      case 'notify.telegram':
+        // Requires BOTH a sender and a token resolver. One without
+        // the other is a wiring bug; the rule skips cleanly.
+        return this.telegramSender !== undefined && this.telegramTokenResolver !== undefined;
       default: {
         const _exhaustive: never = action;
         void _exhaustive;
@@ -141,6 +161,8 @@ export class DefaultActionDispatcher implements ActionDispatcher {
         return this.dispatchTicketTransition(context, action.to);
       case 'notify.email':
         return this.dispatchEmail(context, action.to, action.template);
+      case 'notify.telegram':
+        return this.dispatchTelegram(context, action.chat_id, action.message);
       case 'notify.slack':
       case 'notify.webhook':
         // Recognised but not yet wired — log once at info so deploys
@@ -344,6 +366,49 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       templateId,
       vars: this.buildEmailVars(context),
     });
+  }
+
+  /**
+   * Dispatch a `notify.telegram` action. Resolves the org's bot
+   * token (decrypted plaintext) via the injected resolver and hands
+   * off to the sender. Skips cleanly when no token is configured —
+   * not every org runs Telegram. Fails closed on resolver errors.
+   *
+   * No PII in the success log (chat_id is identifying); the sender's
+   * own logging carries enough for ops on the failure path.
+   */
+  private async dispatchTelegram(
+    context: RuleEvalContext,
+    chatId: string,
+    message: string
+  ): Promise<boolean> {
+    if (!this.telegramSender || !this.telegramTokenResolver) {
+      // `canDispatch` already excludes this — defensive no-op if a
+      // subclass overrides one of the two.
+      logger.info('Skipping notify.telegram: sender or token resolver not wired', {
+        bugReportId: context.bugReport.id,
+      });
+      return false;
+    }
+    let token: string | null;
+    try {
+      token = await this.telegramTokenResolver(context.bugReport.organization_id);
+    } catch (error) {
+      logger.warn('Skipping notify.telegram: token resolver threw', {
+        bugReportId: context.bugReport.id,
+        organizationId: context.bugReport.organization_id,
+        errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+      });
+      return false;
+    }
+    if (!token) {
+      logger.info('Skipping notify.telegram: no bot token configured for org', {
+        bugReportId: context.bugReport.id,
+        organizationId: context.bugReport.organization_id,
+      });
+      return false;
+    }
+    return this.telegramSender.send({ token, chatId, text: message });
   }
 
   /**

--- a/packages/backend/src/services/rules/telegram-sender.ts
+++ b/packages/backend/src/services/rules/telegram-sender.ts
@@ -62,15 +62,16 @@ export class FetchBackedTelegramSender implements TelegramSender {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), TELEGRAM_TIMEOUT_MS);
     try {
-      const response = await fetch(
-        `https://api.telegram.org/bot${encodeURIComponent(req.token)}/sendMessage`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ chat_id: req.chatId, text: req.text }),
-          signal: controller.signal,
-        }
-      );
+      // Token goes literally in the path — Telegram expects the raw
+      // `<bot_id>:<secret>` and the secret only uses URL-safe chars
+      // (`[A-Za-z0-9_-]`). `encodeURIComponent` would escape the `:`
+      // separator to `%3A` and the request would 404.
+      const response = await fetch(`https://api.telegram.org/bot${req.token}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: req.chatId, text: req.text }),
+        signal: controller.signal,
+      });
       if (!response.ok) {
         // Pull `description` out of the body if present — it's the
         // bot API's human-readable error. Suppress otherwise; raw

--- a/packages/backend/src/services/rules/telegram-sender.ts
+++ b/packages/backend/src/services/rules/telegram-sender.ts
@@ -23,6 +23,15 @@ const logger = getLogger();
 // up indefinitely.
 const TELEGRAM_TIMEOUT_MS = 10_000;
 
+// BotFather-issued token shape: `<bot_id>:<35-char-secret>`. Bot ids
+// are positive integers; the secret uses `[A-Za-z0-9_-]`. The PATCH
+// route validates this format too, but the sender re-checks
+// defensively — without the check, a malformed token like
+// `/../admin` (legacy row, test stub, manual SQL) would escape the
+// bot path on URL build (`bot/../admin/sendMessage` →
+// `/admin/sendMessage` after URL normalization).
+const TELEGRAM_TOKEN_PATTERN = /^[0-9]+:[A-Za-z0-9_-]+$/;
+
 export interface TelegramSendRequest {
   /** Plaintext bot token. The wiring layer decrypts before reaching the sender. */
   token: string;
@@ -59,6 +68,11 @@ export type TelegramTokenResolver = (organizationId: string | null) => Promise<s
  */
 export class FetchBackedTelegramSender implements TelegramSender {
   async send(req: TelegramSendRequest): Promise<boolean> {
+    // Defensive token-shape check — see TELEGRAM_TOKEN_PATTERN above.
+    if (!TELEGRAM_TOKEN_PATTERN.test(req.token)) {
+      logger.warn('TelegramSender: refused malformed token (not BotFather shape)');
+      return false;
+    }
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), TELEGRAM_TIMEOUT_MS);
     try {

--- a/packages/backend/src/services/rules/telegram-sender.ts
+++ b/packages/backend/src/services/rules/telegram-sender.ts
@@ -1,0 +1,104 @@
+/**
+ * Telegram sender for `notify.telegram` actions.
+ *
+ * Wraps the Telegram Bot API's `sendMessage` endpoint. The sender is
+ * intentionally minimal — token + chat_id + text in, boolean out —
+ * because the dedup-rule dispatcher handles surrounding concerns
+ * (token resolution per org, recipient throttling, error logging).
+ *
+ * Token storage / decryption is handled by the wiring layer:
+ * `OrganizationSettings.telegram_bot_token` carries the encrypted
+ * blob (same shape as `intelligence_api_key`), and the
+ * `TelegramTokenResolver` callback decrypts on demand. Selfhosted
+ * deployments either configure a global token via env (future) or
+ * skip — `notify.telegram` is currently SaaS-only on the hot path.
+ */
+
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+// Bot API timeout — typically responds in <500ms; 10s gives plenty of
+// headroom for transient network slowness without holding the executor
+// up indefinitely.
+const TELEGRAM_TIMEOUT_MS = 10_000;
+
+export interface TelegramSendRequest {
+  /** Plaintext bot token. The wiring layer decrypts before reaching the sender. */
+  token: string;
+  /** Chat id — numeric-as-string (e.g. `-1001234567890`) or `@username`. */
+  chatId: string;
+  /** Message body. Plain text (no parse_mode by default). */
+  text: string;
+}
+
+export interface TelegramSender {
+  /**
+   * Returns `true` when the message was accepted by the bot API,
+   * `false` on any expected failure (network, timeout, 4xx, 5xx).
+   * Never throws — the dispatcher relies on this contract.
+   */
+  send(req: TelegramSendRequest): Promise<boolean>;
+}
+
+/**
+ * Resolves the bot token for a given organization. Returns `null`
+ * when the org has no token configured (`telegram_bot_token` unset
+ * or empty), or when called for selfhosted bugs (`organizationId ===
+ * null`). The dispatcher treats `null` as "skip cleanly" rather than
+ * as an error.
+ *
+ * Production wires this to the encryption service so the plaintext
+ * token only exists briefly in memory at dispatch time.
+ */
+export type TelegramTokenResolver = (organizationId: string | null) => Promise<string | null>;
+
+/**
+ * Production sender — POSTs to `https://api.telegram.org/bot<TOKEN>/sendMessage`
+ * with `{ chat_id, text }`. Errors are logged but never thrown.
+ */
+export class FetchBackedTelegramSender implements TelegramSender {
+  async send(req: TelegramSendRequest): Promise<boolean> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TELEGRAM_TIMEOUT_MS);
+    try {
+      const response = await fetch(
+        `https://api.telegram.org/bot${encodeURIComponent(req.token)}/sendMessage`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat_id: req.chatId, text: req.text }),
+          signal: controller.signal,
+        }
+      );
+      if (!response.ok) {
+        // Pull `description` out of the body if present — it's the
+        // bot API's human-readable error. Suppress otherwise; raw
+        // 4xx/5xx codes alone are usually enough for ops.
+        let description: string | undefined;
+        try {
+          const body = (await response.json()) as { description?: string };
+          description = body.description;
+        } catch {
+          // ignore — non-JSON body
+        }
+        logger.warn('TelegramSender: bot API reported failure', {
+          status: response.status,
+          description,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      // AbortError, network failure, malformed url, etc. Log type
+      // only — `error.message` from fetch is often unstable across
+      // node versions and not useful to ops.
+      logger.warn('TelegramSender: send threw', {
+        errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+      });
+      return false;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -19,10 +19,12 @@ import { EmailChannelHandler } from '../notifications/email-handler.js';
 import { DatabaseRuleContextProvider } from './context-provider.js';
 import { DefaultActionDispatcher, TicketsTableResolver } from './dispatcher.js';
 import type { CapabilityServiceLookup } from './dispatcher.js';
+import { getEncryptionService } from '../../utils/encryption.js';
 import { ChannelBackedEmailSender } from './email-sender.js';
 import { DedupRuleExecutor } from './executor.js';
 import { ThrottleBackedRateLimiter } from './rate-limiter.js';
 import { ThrottleBackedRecipientLimiter } from './recipient-rate-limiter.js';
+import { FetchBackedTelegramSender } from './telegram-sender.js';
 
 const logger = getLogger();
 
@@ -135,13 +137,42 @@ export function buildDedupRuleExecutor(
     const org = await db.organizations.findById(orgId);
     return org?.settings?.dedup_email_literal_allowlist ?? null;
   };
+  // Telegram sender + token resolver. The resolver fetches the
+  // encrypted bot token from `organizations.settings.telegram_bot_token`
+  // and decrypts on demand. Returns null when no token is configured
+  // (most orgs at launch), for selfhosted bugs (no organization_id),
+  // or if decryption fails (treated as "not configured" rather than
+  // an error — matches the verifier-throws fail-closed pattern).
+  const telegramSender = new FetchBackedTelegramSender();
+  const encryption = getEncryptionService();
+  const telegramTokenResolver = async (organizationId: string | null): Promise<string | null> => {
+    if (!organizationId) {
+      return null;
+    }
+    const org = await db.organizations.findById(organizationId);
+    const encrypted = org?.settings?.telegram_bot_token;
+    if (!encrypted || typeof encrypted !== 'string') {
+      return null;
+    }
+    try {
+      return encryption.decrypt(encrypted);
+    } catch (err) {
+      logger.warn('Telegram token resolver: decryption failed', {
+        organizationId,
+        errorType: err instanceof Error ? err.name : 'NonErrorThrown',
+      });
+      return null;
+    }
+  };
   const dispatcher = new DefaultActionDispatcher(
     resolver,
     lookup,
     emailSender,
     verifyReporter,
     recipientRateLimiter,
-    literalRecipientAllowlist
+    literalRecipientAllowlist,
+    telegramSender,
+    telegramTokenResolver
   );
   const rateLimiter = new ThrottleBackedRateLimiter(throttle);
   const contextProvider = new DatabaseRuleContextProvider(db);

--- a/packages/backend/tests/integrations/dedup-rule.schema.test.ts
+++ b/packages/backend/tests/integrations/dedup-rule.schema.test.ts
@@ -384,6 +384,26 @@ describe('dedupRuleSchema — actions', () => {
       })
     ).toThrow();
   });
+
+  it('notify.telegram rejects messages over 4096 characters', () => {
+    // Telegram's sendMessage caps `text` at 4096 chars; failing here
+    // beats a 400 from the bot API at runtime.
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.telegram', chat_id: '@chan', message: 'a'.repeat(4097) }],
+      })
+    ).toThrow();
+  });
+
+  it('notify.telegram accepts a 4096-character message at the boundary', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.telegram', chat_id: '@chan', message: 'a'.repeat(4096) }],
+      })
+    ).not.toThrow();
+  });
 });
 
 describe('dedupRuleSchema — top-level', () => {

--- a/packages/backend/tests/integrations/dedup-rule.schema.test.ts
+++ b/packages/backend/tests/integrations/dedup-rule.schema.test.ts
@@ -334,6 +334,56 @@ describe('dedupRuleSchema — actions', () => {
       })
     ).toThrow();
   });
+
+  // notify.telegram — KZ launch needs a first-class action because raw
+  // webhook is too friction-heavy for the typical org admin. chat_id is
+  // a string (Telegram supports negative numeric ids and @usernames),
+  // message is plain text (no parse mode by default — markdown/HTML
+  // expansion lands later if needed).
+  it('notify.telegram accepts numeric chat_id', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.telegram', chat_id: '-1001234567890', message: 'hi' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('notify.telegram accepts @username chat_id', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.telegram', chat_id: '@my_channel', message: 'hi' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('notify.telegram rejects an empty chat_id', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.telegram', chat_id: '', message: 'hi' }],
+      })
+    ).toThrow();
+  });
+
+  it('notify.telegram rejects an empty message', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.telegram', chat_id: '@chan', message: '' }],
+      })
+    ).toThrow();
+  });
+
+  it('notify.telegram rejects missing chat_id', () => {
+    expect(() =>
+      dedupRuleSchema.parse({
+        ...baseRule,
+        then: [{ type: 'notify.telegram', message: 'hi' }],
+      })
+    ).toThrow();
+  });
 });
 
 describe('dedupRuleSchema — top-level', () => {

--- a/packages/backend/tests/services/intelligence/key-provisioning.test.ts
+++ b/packages/backend/tests/services/intelligence/key-provisioning.test.ts
@@ -444,5 +444,40 @@ describe('IntelligenceKeyProvisioning', () => {
         .calls[0][1];
       expect(arg.dedup_email_literal_allowlist).toBeNull();
     });
+
+    it('encrypts telegram_bot_token before persistence', async () => {
+      await provisioning.updateSettings('org-1', {
+        telegram_bot_token: 'bot:abc:secret',
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      // The mock encrypt returns `enc:<input>` — the prefix proves
+      // the encryption call ran (vs. a passthrough).
+      expect(arg.telegram_bot_token).toBe('enc:bot:abc:secret');
+      expect(mockEncryption.encrypt).toHaveBeenCalledWith('bot:abc:secret');
+    });
+
+    it('passes null telegram_bot_token through to clear the setting', async () => {
+      await provisioning.updateSettings('org-1', {
+        telegram_bot_token: null,
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.telegram_bot_token).toBeNull();
+    });
+
+    it('treats an empty-string telegram_bot_token as a clear (null)', async () => {
+      await provisioning.updateSettings('org-1', {
+        telegram_bot_token: '',
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      // Empty string should not survive as an encrypted blob of "".
+      // Coerce to null so the JSONB merge clears the field cleanly.
+      expect(arg.telegram_bot_token).toBeNull();
+    });
   });
 });

--- a/packages/backend/tests/services/intelligence/key-provisioning.test.ts
+++ b/packages/backend/tests/services/intelligence/key-provisioning.test.ts
@@ -479,5 +479,42 @@ describe('IntelligenceKeyProvisioning', () => {
       // Coerce to null so the JSONB merge clears the field cleanly.
       expect(arg.telegram_bot_token).toBeNull();
     });
+
+    it('treats a whitespace-only telegram_bot_token as a clear (null)', async () => {
+      await provisioning.updateSettings('org-1', {
+        telegram_bot_token: '   ',
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.telegram_bot_token).toBeNull();
+    });
+
+    it('trims the telegram_bot_token before encrypting', async () => {
+      await provisioning.updateSettings('org-1', {
+        telegram_bot_token: '  bot:abc:secret  ',
+      });
+
+      // Surrounding whitespace must NOT survive into the cipher; the
+      // trimmed value is what gets encrypted.
+      expect(mockEncryption.encrypt).toHaveBeenCalledWith('bot:abc:secret');
+    });
+
+    // Regression for the GET-response leak Claude bot flagged. The
+    // current shape is structurally safe (`OrgIntelligenceSettings`
+    // doesn't carry `telegram_bot_token`), but pinning the contract
+    // here means a future addition to `resolveOrgIntelligenceSettings`
+    // can't quietly leak the encrypted blob.
+    it('does not include telegram_bot_token in the resolved intelligence settings', async () => {
+      const { resolveOrgIntelligenceSettings } = await import(
+        '../../../src/services/intelligence/tenant-config.js'
+      );
+      const resolved = resolveOrgIntelligenceSettings({
+        intelligence_enabled: true,
+        intelligence_api_key: 'enc:secret',
+        telegram_bot_token: 'enc:tg-token',
+      });
+      expect((resolved as unknown as Record<string, unknown>).telegram_bot_token).toBeUndefined();
+    });
   });
 });

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -795,4 +795,105 @@ describe('DefaultActionDispatcher', () => {
       expect(send).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('notify.telegram', () => {
+    function buildTelegramDispatcher(sender: Mock, tokenResolver: Mock) {
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { send: sender } as unknown as {
+          send: (req: { token: string; chatId: string; text: string }) => Promise<boolean>;
+        },
+        tokenResolver as unknown as (organizationId: string | null) => Promise<string | null>
+      );
+      return { dispatcher: d, sender };
+    }
+
+    it('canDispatch returns true once a TelegramSender is wired', () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('bot-token');
+      const { dispatcher: d } = buildTelegramDispatcher(sender, tokens);
+      expect(d.canDispatch({ type: 'notify.telegram', chat_id: '@chan', message: 'hi' })).toBe(
+        true
+      );
+    });
+
+    it('canDispatch returns false when no sender is wired', () => {
+      expect(
+        dispatcher.canDispatch({ type: 'notify.telegram', chat_id: '@chan', message: 'hi' })
+      ).toBe(false);
+    });
+
+    it('sends the message via the sender with the resolved token, chat_id, text', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('bot:token-abc');
+      const { dispatcher: d } = buildTelegramDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.telegram',
+        chat_id: '@kz_engineering',
+        message: 'New duplicate: bug-123',
+      });
+
+      expect(ok).toBe(true);
+      expect(tokens).toHaveBeenCalledWith('org-1');
+      expect(sender).toHaveBeenCalledWith({
+        token: 'bot:token-abc',
+        chatId: '@kz_engineering',
+        text: 'New duplicate: bug-123',
+      });
+    });
+
+    it('skips when no bot token is configured for the org', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue(null);
+      const { dispatcher: d } = buildTelegramDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.telegram',
+        chat_id: '@chan',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+      expect(sender).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the sender reports a failure', async () => {
+      const sender = vi.fn().mockResolvedValue(false);
+      const tokens = vi.fn().mockResolvedValue('bot:tok');
+      const { dispatcher: d } = buildTelegramDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.telegram',
+        chat_id: '@chan',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+    });
+
+    it('fails closed when the token resolver throws', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockRejectedValue(new Error('db gone'));
+      const { dispatcher: d } = buildTelegramDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.telegram',
+        chat_id: '@chan',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+      expect(sender).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -797,13 +797,17 @@ describe('DefaultActionDispatcher', () => {
   });
 
   describe('notify.telegram', () => {
-    function buildTelegramDispatcher(sender: Mock, tokenResolver: Mock) {
+    function buildTelegramDispatcher(sender: Mock, tokenResolver: Mock, limiter?: Mock) {
       const d = new DefaultActionDispatcher(
         resolver as unknown as CanonicalTicketResolver,
         lookup as CapabilityServiceLookup,
         undefined,
         undefined,
-        undefined,
+        limiter
+          ? ({ check: limiter } as unknown as {
+              check: (recipient: string, organizationId: string | null) => Promise<boolean>;
+            })
+          : undefined,
         undefined,
         { send: sender } as unknown as {
           send: (req: { token: string; chatId: string; text: string }) => Promise<boolean>;
@@ -894,6 +898,42 @@ describe('DefaultActionDispatcher', () => {
 
       expect(ok).toBe(false);
       expect(sender).not.toHaveBeenCalled();
+    });
+
+    it('consults the recipient rate limiter with chat_id and skips when denied', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('bot:tok');
+      const limiter = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d } = buildTelegramDispatcher(sender, tokens, limiter);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.telegram',
+        chat_id: '@target_chat',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+      expect(limiter).toHaveBeenCalledWith('@target_chat', 'org-1');
+      expect(sender).not.toHaveBeenCalled();
+    });
+
+    it('sends when the recipient rate limiter allows', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('bot:tok');
+      const limiter = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d } = buildTelegramDispatcher(sender, tokens, limiter);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.telegram',
+        chat_id: '@target_chat',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(true);
+      expect(limiter).toHaveBeenCalledWith('@target_chat', 'org-1');
+      expect(sender).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/backend/tests/services/rules/telegram-sender.test.ts
+++ b/packages/backend/tests/services/rules/telegram-sender.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for `FetchBackedTelegramSender`.
+ *
+ * Stubs `globalThis.fetch` per-test (same pattern used by
+ * `rpc-bridge-security.test.ts` after the flake fix) so the suite
+ * never reaches the real Telegram API. Verifies the URL shape, JSON
+ * body, response handling, and error containment contract the
+ * dispatcher relies on.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FetchBackedTelegramSender } from '../../../src/services/rules/telegram-sender.js';
+
+describe('FetchBackedTelegramSender', () => {
+  let sender: FetchBackedTelegramSender;
+
+  beforeEach(() => {
+    sender = new FetchBackedTelegramSender();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs to the bot-specific sendMessage URL with the expected JSON body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    );
+
+    const ok = await sender.send({
+      token: 'bot:secret-123',
+      chatId: '-1001234567890',
+      text: 'hello',
+    });
+
+    expect(ok).toBe(true);
+    const mock = vi.mocked(globalThis.fetch);
+    expect(mock).toHaveBeenCalledTimes(1);
+    const [url, init] = mock.mock.calls[0];
+    // Token is URL-encoded in the path; `:` becomes %3A.
+    expect(url).toBe(
+      'https://api.telegram.org/bot' + encodeURIComponent('bot:secret-123') + '/sendMessage'
+    );
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init?.body as string)).toEqual({
+      chat_id: '-1001234567890',
+      text: 'hello',
+    });
+  });
+
+  it('returns false on a 4xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, description: 'Bad Request: chat not found' }), {
+          status: 400,
+        })
+      )
+    );
+
+    const ok = await sender.send({ token: 't', chatId: '@unknown', text: 'hi' });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false on a 5xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 502 })));
+    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+  });
+
+  it('returns false on a network error (fetch throws)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
+    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+  });
+
+  it('returns false on AbortError without throwing', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortErr));
+    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+  });
+
+  it('handles a 4xx with a non-JSON body without throwing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('plain text error', { status: 400 }))
+    );
+    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+  });
+});

--- a/packages/backend/tests/services/rules/telegram-sender.test.ts
+++ b/packages/backend/tests/services/rules/telegram-sender.test.ts
@@ -29,7 +29,7 @@ describe('FetchBackedTelegramSender', () => {
     );
 
     const ok = await sender.send({
-      token: 'bot:secret-123',
+      token: '123:ABCdef',
       chatId: '-1001234567890',
       text: 'hello',
     });
@@ -42,7 +42,7 @@ describe('FetchBackedTelegramSender', () => {
     // the raw `<bot_id>:<secret>` format, and `:` is RFC-3986-safe in
     // the path component. Encoding via `encodeURIComponent` would
     // escape `:` to `%3A` and break the request.
-    expect(url).toBe('https://api.telegram.org/botbot:secret-123/sendMessage');
+    expect(url).toBe('https://api.telegram.org/bot123:ABCdef/sendMessage');
     expect(init?.method).toBe('POST');
     expect(init?.headers).toMatchObject({ 'Content-Type': 'application/json' });
     expect(JSON.parse(init?.body as string)).toEqual({
@@ -61,25 +61,25 @@ describe('FetchBackedTelegramSender', () => {
       )
     );
 
-    const ok = await sender.send({ token: 't', chatId: '@unknown', text: 'hi' });
+    const ok = await sender.send({ token: '123:ABCdef', chatId: '@unknown', text: 'hi' });
     expect(ok).toBe(false);
   });
 
   it('returns false on a 5xx response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 502 })));
-    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+    expect(await sender.send({ token: '123:ABCdef', chatId: '@c', text: 'hi' })).toBe(false);
   });
 
   it('returns false on a network error (fetch throws)', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
-    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+    expect(await sender.send({ token: '123:ABCdef', chatId: '@c', text: 'hi' })).toBe(false);
   });
 
   it('returns false on AbortError without throwing', async () => {
     const abortErr = new Error('aborted');
     abortErr.name = 'AbortError';
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortErr));
-    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+    expect(await sender.send({ token: '123:ABCdef', chatId: '@c', text: 'hi' })).toBe(false);
   });
 
   it('handles a 4xx with a non-JSON body without throwing', async () => {
@@ -87,6 +87,30 @@ describe('FetchBackedTelegramSender', () => {
       'fetch',
       vi.fn().mockResolvedValue(new Response('plain text error', { status: 400 }))
     );
-    expect(await sender.send({ token: 't', chatId: '@c', text: 'hi' })).toBe(false);
+    expect(await sender.send({ token: '123:ABCdef', chatId: '@c', text: 'hi' })).toBe(false);
+  });
+
+  // Defensive guard against path-traversal-shaped tokens. The PATCH
+  // route validates token shape, but the sender double-checks so a
+  // legacy row or test stub with a malformed token can't escape the
+  // bot path on URL build (e.g. token = `/../admin` would otherwise
+  // produce `https://api.telegram.org/bot/../admin/sendMessage` →
+  // normalized to `/admin/sendMessage`).
+  it.each(['/../admin', 'bad token', '', '123:abc/extra', '../escape'])(
+    'refuses to send with a malformed token: %s',
+    async (badToken) => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+      vi.stubGlobal('fetch', fetchMock);
+      const ok = await sender.send({ token: badToken, chatId: '@c', text: 'hi' });
+      expect(ok).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('accepts BotFather-shaped tokens', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{"ok":true}', { status: 200 })));
+    expect(await sender.send({ token: '123456:AbCdEf_GhI-jKlMnO', chatId: '@c', text: 'hi' })).toBe(
+      true
+    );
   });
 });

--- a/packages/backend/tests/services/rules/telegram-sender.test.ts
+++ b/packages/backend/tests/services/rules/telegram-sender.test.ts
@@ -38,10 +38,11 @@ describe('FetchBackedTelegramSender', () => {
     const mock = vi.mocked(globalThis.fetch);
     expect(mock).toHaveBeenCalledTimes(1);
     const [url, init] = mock.mock.calls[0];
-    // Token is URL-encoded in the path; `:` becomes %3A.
-    expect(url).toBe(
-      'https://api.telegram.org/bot' + encodeURIComponent('bot:secret-123') + '/sendMessage'
-    );
+    // Token is passed literally in the path — Telegram's API expects
+    // the raw `<bot_id>:<secret>` format, and `:` is RFC-3986-safe in
+    // the path component. Encoding via `encodeURIComponent` would
+    // escape `:` to `%3A` and break the request.
+    expect(url).toBe('https://api.telegram.org/botbot:secret-123/sendMessage');
     expect(init?.method).toBe('POST');
     expect(init?.headers).toMatchObject({ 'Content-Type': 'application/json' });
     expect(JSON.parse(init?.body as string)).toEqual({


### PR DESCRIPTION
## Summary

Telegram is the dominant team-chat channel in the KZ market (more so than Slack), so it gets priority over `notify.slack` and `notify.webhook` in the remaining Phase 0.5 C2 dispatcher work.

## What lands

- **Schema** — new `notify.telegram` action variant: `{ chat_id, message }`. \`chat_id\` is a string (Telegram supports negative-numeric ids and \`@channel_usernames\`).
- **Storage** — encrypted \`telegram_bot_token\` on \`OrganizationSettings\` (same shape as \`intelligence_api_key\`). Set via the existing intelligence-settings PATCH; plaintext on the wire, encrypted before persistence; empty-string coerced to null so \`enc:''\` doesn't accumulate.
- **Sender** — \`FetchBackedTelegramSender\` POSTs to \`https://api.telegram.org/bot<TOKEN>/sendMessage\` with \`{chat_id, text}\`. 10s AbortController timeout. Errors logged with \`error.name\` only (no \`error.message\` — fetch error strings can leak chat ids).
- **Dispatcher** — \`dispatchTelegram\` resolves the org's decrypted token, hands off to the sender. \`canDispatch('notify.telegram')\` requires both sender and resolver wired. No token configured → skip cleanly. Resolver throws → fail closed.
- **Wiring** — \`buildDedupRuleExecutor\` instantiates the sender and a token resolver that fetches+decrypts on demand.

## Tests (TDD-led, all 3 slices)

- 5 schema tests (accepts numeric / \`@username\`, rejects empty/missing fields)
- 6 dispatcher tests (canDispatch wired vs unwired, send success, no-token skip, sender failure, resolver throws)
- 6 sender tests (URL+body shape, 4xx/5xx, network error, AbortError, non-JSON body)
- 4 key-provisioning tests (encrypt before persist, null clears, empty→null coerce)

Total: +21 tests; backend unit 2824/0 failures (authoritative JUnit).

## Out of scope

- Admin UI for managing the bot token (separate PR — same as the literal-recipient allowlist UI gap).
- Message templating (\`{{path.to.value}}\` substitution like email templates). Slack also doesn't have it today; can add as a shared concern.
- \`notify.slack\` and \`notify.webhook\` dispatchers — still queued as the original Phase 0.5 C2 #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telegram as a notification channel for deduplication rules (send alerts to Telegram chats)
  * Organizations can configure Telegram bot tokens in intelligence settings; tokens are handled securely and not exposed in settings responses
  * Telegram messages validated with chat ID formats and a 4096-character message limit

* **Tests**
  * Added comprehensive tests for Telegram notification behavior, token handling, and schema validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->