### PR TITLE
feat(rules): notify.webhook dispatcher (generic POST + SSRF revalidation)

### DIFF
--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -29,6 +29,7 @@ import type {
 import { isLiteralRecipient, resolveEmailRecipient } from './email-sender.js';
 import type { RecipientRateLimiter } from './recipient-rate-limiter.js';
 import type { TelegramSender, TelegramTokenResolver } from './telegram-sender.js';
+import type { WebhookSender } from './webhook-sender.js';
 import type { ActionDispatcher, RuleEvalContext } from './types.js';
 
 const logger = getLogger();
@@ -117,7 +118,15 @@ export class DefaultActionDispatcher implements ActionDispatcher {
      * paired with `telegramSender`; one without the other is a wiring
      * bug and `canDispatch('notify.telegram')` reflects that.
      */
-    private readonly telegramTokenResolver?: TelegramTokenResolver
+    private readonly telegramTokenResolver?: TelegramTokenResolver,
+    /**
+     * Optional generic-webhook sender. When wired, `notify.webhook`
+     * actions POST their payload to the rule's URL. No per-org
+     * credential — the URL itself is the auth (per Slack/Discord
+     * incoming-webhook convention). Tests inject a stub; production
+     * wires `FetchBackedWebhookSender`.
+     */
+    private readonly webhookSender?: WebhookSender
   ) {}
 
   /**
@@ -136,11 +145,12 @@ export class DefaultActionDispatcher implements ActionDispatcher {
         // we still report false so the rule skips cleanly.
         return this.emailSender !== undefined;
       case 'notify.slack':
-      case 'notify.webhook':
-        // Slack / generic webhook dispatchers still pending —
-        // separate PRs queued behind notify.telegram (KZ launch
-        // priority).
+        // Slack dispatcher still pending — separate PR queued after
+        // this one (needs per-org bot-token storage + chat.postMessage
+        // wiring; bigger scope than the generic webhook).
         return false;
+      case 'notify.webhook':
+        return this.webhookSender !== undefined;
       case 'notify.telegram':
         // Requires BOTH a sender and a token resolver. One without
         // the other is a wiring bug; the rule skips cleanly.
@@ -163,11 +173,12 @@ export class DefaultActionDispatcher implements ActionDispatcher {
         return this.dispatchEmail(context, action.to, action.template);
       case 'notify.telegram':
         return this.dispatchTelegram(context, action.chat_id, action.message);
-      case 'notify.slack':
       case 'notify.webhook':
-        // Recognised but not yet wired — log once at info so deploys
-        // running with a seeded rule of this shape don't look broken,
-        // but we don't spam the error stream.
+        return this.dispatchWebhook(context, action.url, action.payload ?? null);
+      case 'notify.slack':
+        // Slack dispatcher pending — see canDispatch above. Log once
+        // at info on a seeded slack rule so it doesn't look like the
+        // engine is broken.
         logger.info('Rule action type not yet implemented, skipping', {
           actionType: action.type,
           bugReportId: context.bugReport.id,
@@ -426,6 +437,45 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       }
     }
     return this.telegramSender.send({ token, chatId, text: message });
+  }
+
+  /**
+   * Dispatch a `notify.webhook` action. POSTs the payload as JSON to
+   * the rule's URL. No per-org credential — the URL itself is the
+   * auth (matches the Slack/Discord incoming-webhook convention).
+   * Re-runs SSRF validation inside the sender as defense in depth.
+   *
+   * `payload` defaults to `{}` when the rule's action doesn't carry
+   * one — the receiver gets a known shape even if the admin only
+   * configured the URL. Templating (`{{bug.id}}` etc.) is a
+   * follow-up if a real consumer asks for it.
+   */
+  private async dispatchWebhook(
+    context: RuleEvalContext,
+    url: string,
+    payload: Record<string, unknown> | null
+  ): Promise<boolean> {
+    if (!this.webhookSender) {
+      logger.info('Skipping notify.webhook: sender not wired', {
+        bugReportId: context.bugReport.id,
+      });
+      return false;
+    }
+    // Per-recipient throttle — keyed on URL. Caps fan-out to one
+    // webhook endpoint the same way the email and telegram paths
+    // cap their respective channels. Shared limiter, distinct hash
+    // namespace (the input is the raw URL).
+    if (this.recipientRateLimiter) {
+      const allowed = await this.recipientRateLimiter.check(url, context.bugReport.organization_id);
+      if (!allowed) {
+        logger.info('Skipping notify.webhook: recipient rate limit reached', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+        });
+        return false;
+      }
+    }
+    return this.webhookSender.send({ url, payload: payload ?? {} });
   }
 
   /**

--- a/packages/backend/src/services/rules/webhook-sender.ts
+++ b/packages/backend/src/services/rules/webhook-sender.ts
@@ -1,0 +1,107 @@
+/**
+ * Webhook sender for `notify.webhook` actions.
+ *
+ * POSTs the configured payload as JSON to the rule's URL. The schema
+ * already SSRF-validates the URL at parse time; this sender
+ * re-validates at dispatch time as defense in depth — without that,
+ * a malicious `organization.settings` PATCH against an older row
+ * (or a future schema relaxation) could bypass the parse-time check.
+ *
+ * Known gap: DNS rebinding for outbound `fetch`. The URL-string
+ * SSRF check validates IP literals + cloud-metadata hostnames, but
+ * does not resolve DNS and pin the connection. A malicious admin
+ * who controls DNS for an attacker-owned hostname could flip the
+ * record to a private IP between validation and the fetch hop. The
+ * codebase's `pinHostnameToIp` + `createPinnedAgent` solve this for
+ * `https.request` / `axios` callers, but Node's undici-backed
+ * `fetch` does not honour an `agent` option (see hardened-http.ts
+ * header comment, lines 26–29), so plumbing it through `fetch`
+ * requires an undici `Dispatcher` rewrite. Deferred — the threat
+ * model is "admin is the attacker" since webhook URLs are admin-
+ * configured. Tracked for the next security pass.
+ *
+ * No HMAC signing in v1. Receivers that need authenticity should
+ * verify via the URL itself (single-use webhook secrets in the
+ * path/query are the common pattern for Slack/Discord-style hooks).
+ * Signed-payload support is a follow-up if a real consumer asks.
+ */
+
+import { getLogger } from '../../logger.js';
+import { validateSSRFProtection } from '../../integrations/security/ssrf-validator.js';
+
+const logger = getLogger();
+
+// Webhook receivers typically ack quickly (<2s); 10s gives generous
+// headroom for slow third-party services without holding the executor.
+const WEBHOOK_TIMEOUT_MS = 10_000;
+
+export interface WebhookSendRequest {
+  /** Public HTTPS/HTTP endpoint (SSRF-validated by the schema). */
+  url: string;
+  /** Arbitrary JSON object; `{}` when the rule's action carries no payload. */
+  payload: Record<string, unknown>;
+}
+
+export interface WebhookSender {
+  /**
+   * Returns `true` when the receiver responded with a 2xx, `false`
+   * on any expected failure (SSRF rejection at dispatch, network
+   * error, timeout, 4xx, 5xx). Never throws.
+   */
+  send(req: WebhookSendRequest): Promise<boolean>;
+}
+
+export class FetchBackedWebhookSender implements WebhookSender {
+  async send(req: WebhookSendRequest): Promise<boolean> {
+    // Re-validate SSRF at dispatch time. The schema check at parse
+    // time catches admin-written rules, but a stored row could have
+    // been edited via direct SQL since (e.g. ops poking the JSONB
+    // settings column) and we don't want to trust the at-rest data.
+    //
+    // Capture the URL object so we can (a) pass a normalized URL to
+    // `fetch` instead of the raw string, and (b) log only hostname on
+    // failure paths — webhook URLs often carry tokens in the
+    // path/query that must not land in logs.
+    let validatedUrl: URL;
+    try {
+      validatedUrl = validateSSRFProtection(req.url);
+    } catch (error) {
+      logger.warn('WebhookSender: SSRF revalidation rejected URL', {
+        errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+      });
+      return false;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+    try {
+      const response = await fetch(validatedUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req.payload),
+        signal: controller.signal,
+        // Block redirect-based SSRF: a public URL that 302s to a
+        // private IP would slip past the upfront check. `manual`
+        // surfaces the 3xx as a non-ok response; we treat it as a
+        // failed delivery rather than chase the trampoline.
+        redirect: 'manual',
+      });
+      if (!response.ok) {
+        logger.warn('WebhookSender: receiver reported failure', {
+          status: response.status,
+          hostname: validatedUrl.hostname,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      logger.warn('WebhookSender: send threw', {
+        errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+        hostname: validatedUrl.hostname,
+      });
+      return false;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -25,6 +25,7 @@ import { DedupRuleExecutor } from './executor.js';
 import { ThrottleBackedRateLimiter } from './rate-limiter.js';
 import { ThrottleBackedRecipientLimiter } from './recipient-rate-limiter.js';
 import { FetchBackedTelegramSender } from './telegram-sender.js';
+import { FetchBackedWebhookSender } from './webhook-sender.js';
 
 const logger = getLogger();
 
@@ -164,6 +165,9 @@ export function buildDedupRuleExecutor(
       return null;
     }
   };
+  // Generic-webhook sender. Stateless — the URL is the credential,
+  // and SSRF revalidation happens inside the sender.
+  const webhookSender = new FetchBackedWebhookSender();
   const dispatcher = new DefaultActionDispatcher(
     resolver,
     lookup,
@@ -172,7 +176,8 @@ export function buildDedupRuleExecutor(
     recipientRateLimiter,
     literalRecipientAllowlist,
     telegramSender,
-    telegramTokenResolver
+    telegramTokenResolver,
+    webhookSender
   );
   const rateLimiter = new ThrottleBackedRateLimiter(throttle);
   const contextProvider = new DatabaseRuleContextProvider(db);

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -936,4 +936,102 @@ describe('DefaultActionDispatcher', () => {
       expect(sender).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('notify.webhook', () => {
+    function buildWebhookDispatcher(sender: Mock, limiter?: Mock) {
+      const d = new DefaultActionDispatcher(
+        resolver as unknown as CanonicalTicketResolver,
+        lookup as CapabilityServiceLookup,
+        undefined,
+        undefined,
+        limiter
+          ? ({ check: limiter } as unknown as {
+              check: (recipient: string, organizationId: string | null) => Promise<boolean>;
+            })
+          : undefined,
+        undefined,
+        undefined,
+        undefined,
+        { send: sender } as unknown as {
+          send: (req: { url: string; payload: Record<string, unknown> }) => Promise<boolean>;
+        }
+      );
+      return { dispatcher: d, sender };
+    }
+
+    it('canDispatch returns true once a WebhookSender is wired', () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d } = buildWebhookDispatcher(sender);
+      expect(d.canDispatch({ type: 'notify.webhook', url: 'https://hooks.example.com/x' })).toBe(
+        true
+      );
+    });
+
+    it('canDispatch returns false when no sender is wired', () => {
+      expect(
+        dispatcher.canDispatch({ type: 'notify.webhook', url: 'https://hooks.example.com/x' })
+      ).toBe(false);
+    });
+
+    it('sends to the URL with the configured payload', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d } = buildWebhookDispatcher(sender);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.webhook',
+        url: 'https://hooks.example.com/dedup',
+        payload: { event: 'duplicate_detected', priority: 'high' },
+      });
+
+      expect(ok).toBe(true);
+      expect(sender).toHaveBeenCalledWith({
+        url: 'https://hooks.example.com/dedup',
+        payload: { event: 'duplicate_detected', priority: 'high' },
+      });
+    });
+
+    it('sends an empty payload object when none is configured', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d } = buildWebhookDispatcher(sender);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.webhook',
+        url: 'https://hooks.example.com/dedup',
+      });
+
+      expect(ok).toBe(true);
+      expect(sender.mock.calls[0][0].payload).toEqual({});
+    });
+
+    it('returns false when the sender reports a failure', async () => {
+      const sender = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d } = buildWebhookDispatcher(sender);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.webhook',
+        url: 'https://hooks.example.com/x',
+      });
+
+      expect(ok).toBe(false);
+    });
+
+    it('consults the recipient rate limiter with the URL and skips when denied', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const limiter = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d } = buildWebhookDispatcher(sender, limiter);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.webhook',
+        url: 'https://hooks.example.com/x',
+      });
+
+      expect(ok).toBe(false);
+      expect(limiter).toHaveBeenCalledWith('https://hooks.example.com/x', 'org-1');
+      expect(sender).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/backend/tests/services/rules/webhook-sender.test.ts
+++ b/packages/backend/tests/services/rules/webhook-sender.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for `FetchBackedWebhookSender`.
+ *
+ * Stubs `globalThis.fetch` per-test so the suite never reaches a real
+ * endpoint. Verifies POST shape, SSRF revalidation, and the error
+ * containment contract the dispatcher relies on.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FetchBackedWebhookSender } from '../../../src/services/rules/webhook-sender.js';
+
+describe('FetchBackedWebhookSender', () => {
+  let sender: FetchBackedWebhookSender;
+
+  beforeEach(() => {
+    sender = new FetchBackedWebhookSender();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the payload as JSON to the configured URL', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })));
+
+    const ok = await sender.send({
+      url: 'https://hooks.example.com/dedup',
+      payload: { event: 'duplicate_detected', priority: 'high' },
+    });
+
+    expect(ok).toBe(true);
+    const mock = vi.mocked(globalThis.fetch);
+    const [url, init] = mock.mock.calls[0];
+    // The sender now passes a normalized URL object (not a raw string)
+    // so non-ASCII / encoding edge cases settle the same way every hop.
+    expect(url).toBeInstanceOf(URL);
+    expect((url as URL).toString()).toBe('https://hooks.example.com/dedup');
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init?.body as string)).toEqual({
+      event: 'duplicate_detected',
+      priority: 'high',
+    });
+    // Block redirect-based SSRF — `manual` surfaces 3xx as non-ok
+    // rather than following a 302 to a private IP.
+    expect(init?.redirect).toBe('manual');
+  });
+
+  it('returns false on a 4xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+    expect(await sender.send({ url: 'https://hooks.example.com/x', payload: {} })).toBe(false);
+  });
+
+  it('returns false on a 5xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 502 })));
+    expect(await sender.send({ url: 'https://hooks.example.com/x', payload: {} })).toBe(false);
+  });
+
+  it('returns false (without throwing) on a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
+    expect(await sender.send({ url: 'https://hooks.example.com/x', payload: {} })).toBe(false);
+  });
+
+  it('refuses to send to a private-network URL (SSRF revalidation)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // The schema rejects these at parse time; this test pins the
+    // sender-side defense in case a stored row was edited via direct
+    // SQL or a future relaxation slips one through.
+    for (const bad of [
+      'http://127.0.0.1/hook',
+      'http://localhost/hook',
+      'http://10.0.0.1/hook',
+      'http://169.254.169.254/latest/meta-data/',
+    ]) {
+      const ok = await sender.send({ url: bad, payload: {} });
+      expect(ok).toBe(false);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false on AbortError without throwing', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortErr));
+    expect(await sender.send({ url: 'https://hooks.example.com/x', payload: {} })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The schema accepted \`notify.webhook\` since PR-D but the dispatcher logged-and-skipped. This wires it. Last C2 piece before \`notify.slack\`.

## What lands

- \`FetchBackedWebhookSender\` POSTs the payload as JSON to the rule's URL. Re-runs SSRF validation inside the sender (defense in depth against direct-SQL edits or future schema relaxations). \`redirect: 'manual'\` blocks redirect-based SSRF — a public URL that 302s to a private IP would otherwise slip past the upfront check.
- \`dispatchWebhook\` resolves payload (defaults to \`{}\`) and routes through the existing \`recipientRateLimiter\` keyed on URL — same cap-fan-out shape the email and telegram paths use.
- No per-org credential: the URL itself is the auth, per the Slack/Discord incoming-webhook convention. HMAC signing is a follow-up if a real consumer asks.

## Tests

TDD-led: +4 dispatcher tests (canDispatch wired/unwired, send with payload, default-empty payload, rate-limiter skip) + 6 sender tests (POST shape, 4xx, 5xx, network error, SSRF revalidation across 4 private hosts, AbortError). Total 2849/0 backend unit (authoritative JUnit).

## What's left

\`notify.slack\` — needs per-org bot-token storage + \`chat.postMessage\` wiring + per-channel routing. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook notifications added for rule actions, allowing POSTs with optional JSON payloads.

* **Reliability & Security**
  * Delivery includes timeout handling, redirect blocking, SSRF validation, per-URL rate limiting, and graceful failure behavior.

* **Tests**
  * Unit tests added for webhook delivery and dispatcher behavior (success, failure, SSRF and rate-limit cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->