### PR TITLE
feat(rules): notify.slack dispatcher (chat.postMessage + per-org token)

### DIFF
--- a/packages/backend/src/api/routes/intelligence-settings.ts
+++ b/packages/backend/src/api/routes/intelligence-settings.ts
@@ -96,6 +96,20 @@ const updateSettingsBody = {
       maxLength: 200,
       pattern: '^$|^[0-9]+:[A-Za-z0-9_-]+$',
     },
+    // Slack bot token (plaintext on the wire; encrypted on store by
+    // the service layer). `null` or empty string clears the configured
+    // bot. Pattern enforces the `xoxb-` bot-token shape — `xoxp-`
+    // user tokens are intentionally rejected because chat.postMessage
+    // permissions on user tokens depend on a workspace's individual
+    // settings and are an anti-pattern for service-account dispatch.
+    // The sender re-checks defensively; failing here gives admins
+    // immediate feedback in the editor instead of a silent dispatch
+    // skip later.
+    slack_bot_token: {
+      type: ['string', 'null'],
+      maxLength: 200,
+      pattern: '^$|^xoxb-[A-Za-z0-9-]+$',
+    },
   },
   additionalProperties: false,
 } as const;
@@ -120,6 +134,7 @@ interface UpdateSettingsBody {
   intelligence_self_service_enabled?: boolean;
   dedup_email_literal_allowlist?: string[] | null;
   telegram_bot_token?: string | null;
+  slack_bot_token?: string | null;
 }
 
 // ============================================================================

--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -743,6 +743,15 @@ export interface OrganizationSettings {
    * addition to the resolve can't quietly leak the encrypted blob.
    */
   telegram_bot_token?: string | null;
+  /**
+   * Encrypted Slack bot token (via CredentialEncryption — same
+   * shape as `telegram_bot_token`). Used by `notify.slack` dispatch.
+   * `undefined` / `null` = no Slack bot configured; dispatcher skips
+   * `notify.slack` cleanly. Never appears on the GET response
+   * because `resolveOrgIntelligenceSettings` explicitly enumerates
+   * the fields it carries through and this isn't one of them.
+   */
+  slack_bot_token?: string | null;
 }
 
 export interface Organization {

--- a/packages/backend/src/services/intelligence/key-provisioning.ts
+++ b/packages/backend/src/services/intelligence/key-provisioning.ts
@@ -61,6 +61,7 @@ export type IntelligenceSettingsUpdate = Pick<
   | 'intelligence_self_service_enabled'
   | 'dedup_email_literal_allowlist'
   | 'telegram_bot_token'
+  | 'slack_bot_token'
 >;
 
 // ============================================================================
@@ -302,6 +303,17 @@ export class IntelligenceKeyProvisioning {
           trimmed.length > 0 ? this.encryption.encrypt(trimmed) : null;
       } else {
         normalized.telegram_bot_token = null;
+      }
+    }
+    // Same shape as the telegram path: trim, encrypt, treat empty as
+    // clear. Slack bot tokens are admin-configured and never leave
+    // the server in plaintext after the PATCH lands.
+    if (normalized.slack_bot_token !== undefined) {
+      if (typeof normalized.slack_bot_token === 'string') {
+        const trimmed = normalized.slack_bot_token.trim();
+        normalized.slack_bot_token = trimmed.length > 0 ? this.encryption.encrypt(trimmed) : null;
+      } else {
+        normalized.slack_bot_token = null;
       }
     }
     const updated = await this.db.organizations.updateSettings(orgId, normalized);

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -524,8 +524,15 @@ export class DefaultActionDispatcher implements ActionDispatcher {
     //  - both unset → no target, skip cleanly
     //  - both set → don't pick arbitrarily; the wrong choice would
     //    leak bug data to a target the admin didn't intend.
-    const hasChannel = !!channel && channel.length > 0;
-    const hasUser = !!user && user.length > 0;
+    //
+    // Trim before the presence check: the schema rejects whitespace-
+    // only values via `.trim() !== ''` but doesn't normalize the
+    // stored string, so `'#x '` (admin paste with trailing space)
+    // would otherwise reach Slack unchanged.
+    const channelTrimmed = channel?.trim() ?? '';
+    const userTrimmed = user?.trim() ?? '';
+    const hasChannel = channelTrimmed.length > 0;
+    const hasUser = userTrimmed.length > 0;
     if (hasChannel === hasUser) {
       logger.info('Skipping notify.slack: requires exactly one of channel/user', {
         bugReportId: context.bugReport.id,
@@ -534,7 +541,7 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       });
       return false;
     }
-    const conversation = hasChannel ? channel! : user!;
+    const conversation = hasChannel ? channelTrimmed : userTrimmed;
     let token: string | null;
     try {
       token = await this.deps.slackTokenResolver(context.bugReport.organization_id);

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -1,16 +1,18 @@
 /**
- * Action dispatcher for the dedup-rule engine (PR-C slice).
+ * Action dispatcher for the dedup-rule engine.
  *
- * Routes `ticket.add_comment` and `ticket.transition` actions to the
- * platform-neutral capability interface introduced in PR #142.
- * `notify.email` / `notify.slack` / `notify.webhook` log a one-shot
- * info message and skip — those land in PR-C2 (email), PR-D (slack /
- * webhook), so they're recognised by the schema but no-op at runtime.
+ * Routes the schema's action variants to their respective collaborators:
+ *  - `ticket.add_comment` / `ticket.transition` → the platform-neutral
+ *    capability interface introduced in PR #142;
+ *  - `notify.email` → `EmailSender` with auth-bound reporter gating,
+ *    per-recipient throttling, and per-org literal allowlist;
+ *  - `notify.telegram` / `notify.slack` → bot-API senders with
+ *    per-org encrypted tokens resolved at dispatch time;
+ *  - `notify.webhook` → generic POST sender with SSRF revalidation.
  *
- * The dispatcher takes its dependencies via constructor so the
- * executor stays unit-testable: tests inject a stub
- * `TicketIntegrationCapabilities` instance instead of the real
- * Jira/Linear service.
+ * The dispatcher takes its dependencies via constructor (a single
+ * `ActionDispatcherDeps` object) so the executor stays unit-testable:
+ * tests inject stubs for each collaborator instead of the real service.
  */
 
 import type { DatabaseClient } from '../../db/client.js';
@@ -28,6 +30,7 @@ import type {
 } from './email-sender.js';
 import { isLiteralRecipient, resolveEmailRecipient } from './email-sender.js';
 import type { RecipientRateLimiter } from './recipient-rate-limiter.js';
+import type { SlackSender, SlackTokenResolver } from './slack-sender.js';
 import type { TelegramSender, TelegramTokenResolver } from './telegram-sender.js';
 import type { WebhookSender } from './webhook-sender.js';
 import type { ActionDispatcher, RuleEvalContext } from './types.js';
@@ -121,6 +124,18 @@ export interface ActionDispatcherDeps {
    * is the auth (per Slack/Discord incoming-webhook convention).
    */
   readonly webhookSender?: WebhookSender;
+  /**
+   * Slack Web API sender (`chat.postMessage`). Must be paired with
+   * `slackTokenResolver`; one without the other is a wiring bug and
+   * `canDispatch('notify.slack')` reflects that.
+   */
+  readonly slackSender?: SlackSender;
+  /**
+   * Resolves the org's Slack bot token (decrypted plaintext) for
+   * `notify.slack` dispatch. Returns `null` when no token is
+   * configured — dispatcher treats that as "skip cleanly".
+   */
+  readonly slackTokenResolver?: SlackTokenResolver;
 }
 
 export class DefaultActionDispatcher implements ActionDispatcher {
@@ -142,10 +157,9 @@ export class DefaultActionDispatcher implements ActionDispatcher {
         // we still report false so the rule skips cleanly.
         return this.deps.emailSender !== undefined;
       case 'notify.slack':
-        // Slack dispatcher still pending — separate PR queued after
-        // this one (needs per-org bot-token storage + chat.postMessage
-        // wiring; bigger scope than the generic webhook).
-        return false;
+        // Requires BOTH a sender and a token resolver. One without
+        // the other is a wiring bug; the rule skips cleanly.
+        return this.deps.slackSender !== undefined && this.deps.slackTokenResolver !== undefined;
       case 'notify.webhook':
         return this.deps.webhookSender !== undefined;
       case 'notify.telegram':
@@ -175,14 +189,12 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       case 'notify.webhook':
         return this.dispatchWebhook(context, action.url, action.payload ?? null);
       case 'notify.slack':
-        // Slack dispatcher pending — see canDispatch above. Log once
-        // at info on a seeded slack rule so it doesn't look like the
-        // engine is broken.
-        logger.info('Rule action type not yet implemented, skipping', {
-          actionType: action.type,
-          bugReportId: context.bugReport.id,
-        });
-        return false;
+        return this.dispatchSlack(
+          context,
+          action.channel ?? null,
+          action.user ?? null,
+          action.message
+        );
       default: {
         // Exhaustiveness check — if a new ActionSpec variant is added
         // to the schema and not handled here, the assignment fails to
@@ -478,6 +490,79 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       }
     }
     return this.deps.webhookSender.send({ url, payload: payload ?? {} });
+  }
+
+  /**
+   * Dispatch a `notify.slack` action. The schema enforces that
+   * exactly one of `channel` / `user` is set; whichever is non-null
+   * is the conversation target (Slack's `chat.postMessage` takes a
+   * channel id, channel name, or user id in the same field). Resolves
+   * the org's bot token (decrypted plaintext) via the injected
+   * resolver and hands off to the sender. Skips cleanly when no
+   * token is configured — not every org runs Slack. Fails closed on
+   * resolver errors.
+   *
+   * No PII in the success log (channel / user names are identifying);
+   * the sender's own logging carries enough for ops on the failure path.
+   */
+  private async dispatchSlack(
+    context: RuleEvalContext,
+    channel: string | null,
+    user: string | null,
+    message: string
+  ): Promise<boolean> {
+    if (!this.deps.slackSender || !this.deps.slackTokenResolver) {
+      logger.info('Skipping notify.slack: sender or token resolver not wired', {
+        bugReportId: context.bugReport.id,
+      });
+      return false;
+    }
+    // The schema's `superRefine` enforces XOR at parse time, so one
+    // of these is non-null in well-formed rules. Defensive `?? user`
+    // covers the case where a legacy row sneaks through with both
+    // unset — we'd rather skip than POST `null` as the channel.
+    const conversation = channel ?? user;
+    if (!conversation) {
+      logger.info('Skipping notify.slack: no channel or user configured on rule', {
+        bugReportId: context.bugReport.id,
+      });
+      return false;
+    }
+    let token: string | null;
+    try {
+      token = await this.deps.slackTokenResolver(context.bugReport.organization_id);
+    } catch (error) {
+      logger.warn('Skipping notify.slack: token resolver threw', {
+        bugReportId: context.bugReport.id,
+        organizationId: context.bugReport.organization_id,
+        errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+      });
+      return false;
+    }
+    if (!token) {
+      logger.info('Skipping notify.slack: no bot token configured for org', {
+        bugReportId: context.bugReport.id,
+        organizationId: context.bugReport.organization_id,
+      });
+      return false;
+    }
+    // Per-recipient throttle (shared with email / telegram / webhook)
+    // — keyed on the conversation target. Caps fan-out to one Slack
+    // channel or user across rules and canonicals.
+    if (this.deps.recipientRateLimiter) {
+      const allowed = await this.deps.recipientRateLimiter.check(
+        conversation,
+        context.bugReport.organization_id
+      );
+      if (!allowed) {
+        logger.info('Skipping notify.slack: recipient rate limit reached', {
+          bugReportId: context.bugReport.id,
+          organizationId: context.bugReport.organization_id,
+        });
+        return false;
+      }
+    }
+    return this.deps.slackSender.send({ token, channel: conversation, text: message });
   }
 
   /**

--- a/packages/backend/src/services/rules/dispatcher.ts
+++ b/packages/backend/src/services/rules/dispatcher.ts
@@ -517,17 +517,24 @@ export class DefaultActionDispatcher implements ActionDispatcher {
       });
       return false;
     }
-    // The schema's `superRefine` enforces XOR at parse time, so one
-    // of these is non-null in well-formed rules. Defensive `?? user`
-    // covers the case where a legacy row sneaks through with both
-    // unset — we'd rather skip than POST `null` as the channel.
-    const conversation = channel ?? user;
-    if (!conversation) {
-      logger.info('Skipping notify.slack: no channel or user configured on rule', {
+    // The schema's `superRefine` enforces XOR at parse time, but a
+    // legacy row, direct SQL edit, or future relaxation could slip a
+    // both-set or both-unset action through. Re-check at dispatch
+    // (same defense-in-depth shape used for SSRF in webhook-sender):
+    //  - both unset → no target, skip cleanly
+    //  - both set → don't pick arbitrarily; the wrong choice would
+    //    leak bug data to a target the admin didn't intend.
+    const hasChannel = !!channel && channel.length > 0;
+    const hasUser = !!user && user.length > 0;
+    if (hasChannel === hasUser) {
+      logger.info('Skipping notify.slack: requires exactly one of channel/user', {
         bugReportId: context.bugReport.id,
+        hasChannel,
+        hasUser,
       });
       return false;
     }
+    const conversation = hasChannel ? channel! : user!;
     let token: string | null;
     try {
       token = await this.deps.slackTokenResolver(context.bugReport.organization_id);

--- a/packages/backend/src/services/rules/slack-sender.ts
+++ b/packages/backend/src/services/rules/slack-sender.ts
@@ -100,16 +100,26 @@ export class FetchBackedSlackSender implements SlackSender {
       // missing, rate-limited). The body's `ok` flag is the source of
       // truth — without checking it, every `channel_not_found` would
       // be reported as a successful send.
-      let body: { ok?: boolean; error?: string };
+      let body: unknown;
       try {
-        body = (await response.json()) as { ok?: boolean; error?: string };
+        body = await response.json();
       } catch {
         logger.warn('SlackSender: response body was not JSON, treating as failure');
         return false;
       }
-      if (body.ok !== true) {
+      // `response.json()` can return `null` (valid JSON for an empty
+      // body), an array, or a primitive — none of which are shaped
+      // like a Slack response. Without this guard, `body.ok` on a
+      // `null` body would throw and be swallowed by the outer catch
+      // with a misleading "send threw" log line.
+      if (body === null || typeof body !== 'object') {
+        logger.warn('SlackSender: response body was not a JSON object, treating as failure');
+        return false;
+      }
+      const parsed = body as { ok?: unknown; error?: unknown };
+      if (parsed.ok !== true) {
         logger.warn('SlackSender: chat.postMessage reported failure', {
-          error: body.error,
+          error: typeof parsed.error === 'string' ? parsed.error : undefined,
         });
         return false;
       }

--- a/packages/backend/src/services/rules/slack-sender.ts
+++ b/packages/backend/src/services/rules/slack-sender.ts
@@ -1,0 +1,126 @@
+/**
+ * Slack sender for `notify.slack` actions.
+ *
+ * Wraps the Slack Web API's `chat.postMessage` endpoint. Like the
+ * Telegram sender, the surface is intentionally minimal — token +
+ * channel + text in, boolean out — and the dispatcher handles
+ * surrounding concerns (per-org token resolution, recipient
+ * throttling, error logging).
+ *
+ * Two Slack-specific quirks worth knowing:
+ *  - Auth lives in `Authorization: Bearer <token>`, not in the URL,
+ *    so the token never lands in proxy access logs.
+ *  - Slack signals failure via HTTP 200 + `{ ok: false, error: ... }`
+ *    rather than a 4xx. The sender must parse the body and treat
+ *    `ok === false` as a delivery failure, not just check `response.ok`.
+ *
+ * Token storage / decryption is handled by the wiring layer:
+ * `OrganizationSettings.slack_bot_token` carries the encrypted blob
+ * (same shape as `telegram_bot_token`), and the `SlackTokenResolver`
+ * callback decrypts on demand.
+ */
+
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+// Slack typically responds in <500ms; 10s gives plenty of headroom
+// without holding the executor up indefinitely. Matches the telegram
+// and webhook timeouts for consistency.
+const SLACK_TIMEOUT_MS = 10_000;
+
+// Slack bot tokens are `xoxb-<digits>-<digits>-<base64-ish>`. The
+// suffix uses `[A-Za-z0-9-]`. Anything else (user tokens `xoxp-`,
+// app tokens `xapp-`, garbage rows, header-injection attempts via
+// newline) is rejected before the network. Without this, a malformed
+// token like `xoxb-foo\r\nX-Smuggled: yes` would land in the
+// Authorization header and could attempt request smuggling on some
+// HTTP stacks.
+const SLACK_BOT_TOKEN_PATTERN = /^xoxb-[A-Za-z0-9-]+$/;
+
+export interface SlackSendRequest {
+  /** Plaintext bot token (`xoxb-...`). The wiring layer decrypts before reaching the sender. */
+  token: string;
+  /** Conversation target: `#channel`, channel id (`C12345`), or user id (`U12345`) for DMs. */
+  channel: string;
+  /** Message body. Plain text by default; markdown opt-in lives in a future field if needed. */
+  text: string;
+}
+
+export interface SlackSender {
+  /**
+   * Returns `true` only when Slack confirms `ok: true` in the
+   * response body. Returns `false` on any expected failure (HTTP
+   * 4xx/5xx, network, timeout, `ok: false`, malformed token, body
+   * that won't parse as JSON). Never throws — the dispatcher relies
+   * on this contract.
+   */
+  send(req: SlackSendRequest): Promise<boolean>;
+}
+
+/**
+ * Resolves the Slack bot token for a given organization. Returns
+ * `null` when the org has no token configured (`slack_bot_token`
+ * unset or empty), or when called for selfhosted bugs
+ * (`organizationId === null`). The dispatcher treats `null` as "skip
+ * cleanly" rather than as an error.
+ */
+export type SlackTokenResolver = (organizationId: string | null) => Promise<string | null>;
+
+/**
+ * Production sender — POSTs to `https://slack.com/api/chat.postMessage`
+ * with a Bearer-token Authorization header and `{ channel, text }`
+ * JSON body. Errors are logged but never thrown.
+ */
+export class FetchBackedSlackSender implements SlackSender {
+  async send(req: SlackSendRequest): Promise<boolean> {
+    if (!SLACK_BOT_TOKEN_PATTERN.test(req.token)) {
+      logger.warn('SlackSender: refused malformed token (not xoxb- bot-token shape)');
+      return false;
+    }
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), SLACK_TIMEOUT_MS);
+    try {
+      const response = await fetch('https://slack.com/api/chat.postMessage', {
+        method: 'POST',
+        headers: {
+          // Slack documents `application/json; charset=utf-8` as the
+          // canonical content type for this endpoint.
+          'Content-Type': 'application/json; charset=utf-8',
+          Authorization: `Bearer ${req.token}`,
+        },
+        body: JSON.stringify({ channel: req.channel, text: req.text }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        logger.warn('SlackSender: HTTP failure', { status: response.status });
+        return false;
+      }
+      // Slack returns 200 even on logical failures (bad token, channel
+      // missing, rate-limited). The body's `ok` flag is the source of
+      // truth — without checking it, every `channel_not_found` would
+      // be reported as a successful send.
+      let body: { ok?: boolean; error?: string };
+      try {
+        body = (await response.json()) as { ok?: boolean; error?: string };
+      } catch {
+        logger.warn('SlackSender: response body was not JSON, treating as failure');
+        return false;
+      }
+      if (body.ok !== true) {
+        logger.warn('SlackSender: chat.postMessage reported failure', {
+          error: body.error,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      logger.warn('SlackSender: send threw', {
+        errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+      });
+      return false;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/packages/backend/src/services/rules/wiring.ts
+++ b/packages/backend/src/services/rules/wiring.ts
@@ -24,6 +24,7 @@ import { ChannelBackedEmailSender } from './email-sender.js';
 import { DedupRuleExecutor } from './executor.js';
 import { ThrottleBackedRateLimiter } from './rate-limiter.js';
 import { ThrottleBackedRecipientLimiter } from './recipient-rate-limiter.js';
+import { FetchBackedSlackSender } from './slack-sender.js';
 import { FetchBackedTelegramSender } from './telegram-sender.js';
 import { FetchBackedWebhookSender } from './webhook-sender.js';
 
@@ -168,6 +169,33 @@ export function buildDedupRuleExecutor(
   // Generic-webhook sender. Stateless — the URL is the credential,
   // and SSRF revalidation happens inside the sender.
   const webhookSender = new FetchBackedWebhookSender();
+  // Slack sender + token resolver. Mirrors the telegram wiring: the
+  // resolver fetches the encrypted bot token from
+  // `organizations.settings.slack_bot_token` and decrypts on demand.
+  // Returns null when no token is configured (most orgs at launch),
+  // for selfhosted bugs (no organization_id), or if decryption fails
+  // (treated as "not configured" — same fail-closed pattern the
+  // telegram resolver uses).
+  const slackSender = new FetchBackedSlackSender();
+  const slackTokenResolver = async (organizationId: string | null): Promise<string | null> => {
+    if (!organizationId) {
+      return null;
+    }
+    const org = await db.organizations.findById(organizationId);
+    const encrypted = org?.settings?.slack_bot_token;
+    if (!encrypted || typeof encrypted !== 'string') {
+      return null;
+    }
+    try {
+      return encryption.decrypt(encrypted);
+    } catch (err) {
+      logger.warn('Slack token resolver: decryption failed', {
+        organizationId,
+        errorType: err instanceof Error ? err.name : 'NonErrorThrown',
+      });
+      return null;
+    }
+  };
   const dispatcher = new DefaultActionDispatcher({
     resolver,
     lookupService: lookup,
@@ -178,6 +206,8 @@ export function buildDedupRuleExecutor(
     telegramSender,
     telegramTokenResolver,
     webhookSender,
+    slackSender,
+    slackTokenResolver,
   });
   const rateLimiter = new ThrottleBackedRateLimiter(throttle);
   const contextProvider = new DatabaseRuleContextProvider(db);

--- a/packages/backend/tests/services/intelligence/key-provisioning.test.ts
+++ b/packages/backend/tests/services/intelligence/key-provisioning.test.ts
@@ -516,5 +516,69 @@ describe('IntelligenceKeyProvisioning', () => {
       });
       expect((resolved as unknown as Record<string, unknown>).telegram_bot_token).toBeUndefined();
     });
+
+    // Same shape as the telegram suite above. The slack token follows
+    // the same encrypt-on-store + clear-on-empty contract; mirroring
+    // the tests pins it as load-bearing.
+    it('encrypts slack_bot_token before persistence', async () => {
+      await provisioning.updateSettings('org-1', {
+        slack_bot_token: 'xoxb-1-2-abc',
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.slack_bot_token).toBe('enc:xoxb-1-2-abc');
+      expect(mockEncryption.encrypt).toHaveBeenCalledWith('xoxb-1-2-abc');
+    });
+
+    it('passes null slack_bot_token through to clear the setting', async () => {
+      await provisioning.updateSettings('org-1', {
+        slack_bot_token: null,
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.slack_bot_token).toBeNull();
+    });
+
+    it('treats an empty-string slack_bot_token as a clear (null)', async () => {
+      await provisioning.updateSettings('org-1', {
+        slack_bot_token: '',
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.slack_bot_token).toBeNull();
+    });
+
+    it('treats a whitespace-only slack_bot_token as a clear (null)', async () => {
+      await provisioning.updateSettings('org-1', {
+        slack_bot_token: '   ',
+      });
+
+      const arg = (mockDb.organizations!.updateSettings as ReturnType<typeof vi.fn>).mock
+        .calls[0][1];
+      expect(arg.slack_bot_token).toBeNull();
+    });
+
+    it('trims the slack_bot_token before encrypting', async () => {
+      await provisioning.updateSettings('org-1', {
+        slack_bot_token: '  xoxb-1-2-abc  ',
+      });
+
+      expect(mockEncryption.encrypt).toHaveBeenCalledWith('xoxb-1-2-abc');
+    });
+
+    it('does not include slack_bot_token in the resolved intelligence settings', async () => {
+      const { resolveOrgIntelligenceSettings } = await import(
+        '../../../src/services/intelligence/tenant-config.js'
+      );
+      const resolved = resolveOrgIntelligenceSettings({
+        intelligence_enabled: true,
+        intelligence_api_key: 'enc:secret',
+        slack_bot_token: 'enc:slack-tok',
+      });
+      expect((resolved as unknown as Record<string, unknown>).slack_bot_token).toBeUndefined();
+    });
   });
 });

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -1090,6 +1090,31 @@ describe('DefaultActionDispatcher', () => {
       });
     });
 
+    // Admin pastes from a UI / config file with trailing whitespace.
+    // The schema's `superRefine` accepts it (only rejects if the
+    // trimmed string is empty) but doesn't normalize the stored
+    // value, so the dispatcher must trim defensively before the
+    // rate-limit key and the Slack API call.
+    it('trims surrounding whitespace from the channel before send', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('xoxb-tok');
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '  #regressions  ',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(true);
+      expect(sender).toHaveBeenCalledWith({
+        token: 'xoxb-tok',
+        channel: '#regressions',
+        text: 'hi',
+      });
+    });
+
     // Defense-in-depth against a legacy row that sneaks past the
     // schema XOR with BOTH channel and user set. Picking one
     // arbitrarily would risk leaking bug data to the target the

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -1090,6 +1090,32 @@ describe('DefaultActionDispatcher', () => {
       });
     });
 
+    // Defense-in-depth against a legacy row that sneaks past the
+    // schema XOR with BOTH channel and user set. Picking one
+    // arbitrarily would risk leaking bug data to the target the
+    // admin didn't intend, so the dispatcher fails closed.
+    it('skips when both channel and user are set on the action', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('xoxb-tok');
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      // Bypass the schema's XOR refinement by casting — simulates a
+      // row that was inserted via raw SQL or before the refinement
+      // landed. Production parses go through the schema and reject
+      // this shape; the test pins the runtime defense.
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '#x',
+        user: 'U999',
+        message: 'hi',
+      } as unknown as Parameters<typeof d.dispatch>[1]);
+
+      expect(ok).toBe(false);
+      expect(tokens).not.toHaveBeenCalled();
+      expect(sender).not.toHaveBeenCalled();
+    });
+
     // Schema enforces XOR between `channel` and `user`. When `user` is
     // set, the sender's `channel` arg is the user id — Slack's
     // chat.postMessage takes either in the same field.

--- a/packages/backend/tests/services/rules/dispatcher.test.ts
+++ b/packages/backend/tests/services/rules/dispatcher.test.ts
@@ -21,7 +21,6 @@ import type {
   CapabilityServiceLookup,
 } from '../../../src/services/rules/dispatcher.js';
 import type { RuleEvalContext } from '../../../src/services/rules/types.js';
-import type { ActionSpec } from '../../../src/integrations/dedup-rule.schema.js';
 import type {
   CapabilityTarget,
   TicketIntegrationCapabilities,
@@ -248,26 +247,31 @@ describe('DefaultActionDispatcher', () => {
       ).toBe(false);
     });
 
-    it.each<ActionSpec>([
-      { type: 'notify.slack', channel: '#x', message: 'hi' },
-      { type: 'notify.webhook', url: 'https://example.com/hook' },
-    ])('returns false for not-yet-wired %s', (action) => {
-      // PR-D will flip these as the slack / webhook dispatchers
-      // land. The executor relies on this to skip rate-limit-
+    it('returns false for notify.slack when no sender is wired', () => {
+      // The dispatcher built in the parent `beforeEach` has no slack
+      // sender. The executor relies on this to skip rate-limit-
       // consuming fires that would do zero work.
-      expect(dispatcher.canDispatch(action)).toBe(false);
+      expect(dispatcher.canDispatch({ type: 'notify.slack', channel: '#x', message: 'hi' })).toBe(
+        false
+      );
+    });
+
+    it('returns false for notify.webhook when no sender is wired', () => {
+      expect(
+        dispatcher.canDispatch({ type: 'notify.webhook', url: 'https://example.com/hook' })
+      ).toBe(false);
     });
   });
 
-  describe('notify.slack / notify.webhook (not wired in PR-C2)', () => {
+  describe('notify.webhook (not wired in PR-C2)', () => {
     // Pinning false here means a future PR that adds real wiring also
     // has to update this test, which is the signal we want.
 
-    it.each<ActionSpec>([
-      { type: 'notify.slack', channel: '#regressions', message: 'hit' },
-      { type: 'notify.webhook', url: 'https://example.com/hook' },
-    ])('returns false for %s without touching the resolver or lookup', async (action) => {
-      const ok = await dispatcher.dispatch(makeContext(), action);
+    it('returns false for notify.webhook without touching the resolver or lookup', async () => {
+      const ok = await dispatcher.dispatch(makeContext(), {
+        type: 'notify.webhook',
+        url: 'https://example.com/hook',
+      });
       expect(ok).toBe(false);
       expect(resolver.resolve).not.toHaveBeenCalled();
       expect(lookup).not.toHaveBeenCalled();
@@ -1029,6 +1033,167 @@ describe('DefaultActionDispatcher', () => {
       expect(ok).toBe(false);
       expect(limiter).toHaveBeenCalledWith('https://hooks.example.com/x', 'org-1');
       expect(sender).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('notify.slack', () => {
+    function buildSlackDispatcher(sender: Mock, tokenResolver: Mock, limiter?: Mock) {
+      const d = new DefaultActionDispatcher({
+        resolver: resolver as unknown as CanonicalTicketResolver,
+        lookupService: lookup as CapabilityServiceLookup,
+        recipientRateLimiter: limiter
+          ? ({ check: limiter } as unknown as {
+              check: (recipient: string, organizationId: string | null) => Promise<boolean>;
+            })
+          : undefined,
+        slackSender: { send: sender } as unknown as {
+          send: (req: { token: string; channel: string; text: string }) => Promise<boolean>;
+        },
+        slackTokenResolver: tokenResolver as unknown as (
+          organizationId: string | null
+        ) => Promise<string | null>,
+      });
+      return { dispatcher: d, sender };
+    }
+
+    it('canDispatch returns true once a SlackSender is wired', () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('xoxb-tok');
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      expect(d.canDispatch({ type: 'notify.slack', channel: '#x', message: 'hi' })).toBe(true);
+    });
+
+    it('canDispatch returns false when no sender is wired', () => {
+      expect(dispatcher.canDispatch({ type: 'notify.slack', channel: '#x', message: 'hi' })).toBe(
+        false
+      );
+    });
+
+    it('sends to a channel with the resolved token, channel, text', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('xoxb-token-abc');
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '#regressions',
+        message: 'New duplicate: bug-123',
+      });
+
+      expect(ok).toBe(true);
+      expect(tokens).toHaveBeenCalledWith('org-1');
+      expect(sender).toHaveBeenCalledWith({
+        token: 'xoxb-token-abc',
+        channel: '#regressions',
+        text: 'New duplicate: bug-123',
+      });
+    });
+
+    // Schema enforces XOR between `channel` and `user`. When `user` is
+    // set, the sender's `channel` arg is the user id — Slack's
+    // chat.postMessage takes either in the same field.
+    it('routes a `user`-targeted action to the user id', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('xoxb-tok');
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        user: 'U12345',
+        message: 'hello',
+      });
+
+      expect(ok).toBe(true);
+      expect(sender).toHaveBeenCalledWith({
+        token: 'xoxb-tok',
+        channel: 'U12345',
+        text: 'hello',
+      });
+    });
+
+    it('skips when no bot token is configured for the org', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue(null);
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '#x',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+      expect(sender).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the sender reports a failure', async () => {
+      const sender = vi.fn().mockResolvedValue(false);
+      const tokens = vi.fn().mockResolvedValue('xoxb-tok');
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '#x',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+    });
+
+    it('fails closed when the token resolver throws', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockRejectedValue(new Error('db gone'));
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '#x',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+      expect(sender).not.toHaveBeenCalled();
+    });
+
+    it('consults the recipient rate limiter with the channel and skips when denied', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('xoxb-tok');
+      const limiter = vi.fn().mockResolvedValue(false);
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens, limiter);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '#target',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(false);
+      expect(limiter).toHaveBeenCalledWith('#target', 'org-1');
+      expect(sender).not.toHaveBeenCalled();
+    });
+
+    it('sends when the recipient rate limiter allows', async () => {
+      const sender = vi.fn().mockResolvedValue(true);
+      const tokens = vi.fn().mockResolvedValue('xoxb-tok');
+      const limiter = vi.fn().mockResolvedValue(true);
+      const { dispatcher: d } = buildSlackDispatcher(sender, tokens, limiter);
+      const ctx = makeContext({ bugReport: makeBug({ organization_id: 'org-1' }) });
+
+      const ok = await d.dispatch(ctx, {
+        type: 'notify.slack',
+        channel: '#target',
+        message: 'hi',
+      });
+
+      expect(ok).toBe(true);
+      expect(limiter).toHaveBeenCalledWith('#target', 'org-1');
+      expect(sender).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/backend/tests/services/rules/slack-sender.test.ts
+++ b/packages/backend/tests/services/rules/slack-sender.test.ts
@@ -102,6 +102,20 @@ describe('FetchBackedSlackSender', () => {
     expect(await sender.send({ token: 'xoxb-123-456-abc', channel: '#x', text: 'hi' })).toBe(false);
   });
 
+  // Defense-in-depth: `response.json()` can legally return `null`,
+  // an array, or a primitive (all valid JSON values). Without the
+  // type guard, `body.ok` on a `null` body would throw into the
+  // outer catch with a misleading "send threw" log.
+  it.each(['null', '[]', '42', '"a string"'])(
+    'handles a non-object JSON body as a failure: %s',
+    async (json) => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(json, { status: 200 })));
+      expect(await sender.send({ token: 'xoxb-123-456-abc', channel: '#x', text: 'hi' })).toBe(
+        false
+      );
+    }
+  );
+
   // Defensive guard against malformed tokens. Slack bot tokens start
   // with `xoxb-` and use `[A-Za-z0-9-]` after the prefix; anything
   // else is rejected without touching the network. Without this, a

--- a/packages/backend/tests/services/rules/slack-sender.test.ts
+++ b/packages/backend/tests/services/rules/slack-sender.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for `FetchBackedSlackSender`.
+ *
+ * Stubs `globalThis.fetch` per-test so the suite never reaches the
+ * real Slack API. Verifies the URL/headers/body shape, the
+ * `ok: false` JSON failure mode (Slack returns 200 + `{ok:false}` on
+ * bad-token / channel-not-found / etc), and the error containment
+ * contract the dispatcher relies on.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FetchBackedSlackSender } from '../../../src/services/rules/slack-sender.js';
+
+describe('FetchBackedSlackSender', () => {
+  let sender: FetchBackedSlackSender;
+
+  beforeEach(() => {
+    sender = new FetchBackedSlackSender();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs to chat.postMessage with bearer-token auth and JSON body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    );
+
+    const ok = await sender.send({
+      token: 'xoxb-123-456-abcDEF',
+      channel: '#regressions',
+      text: 'hello',
+    });
+
+    expect(ok).toBe(true);
+    const mock = vi.mocked(globalThis.fetch);
+    expect(mock).toHaveBeenCalledTimes(1);
+    const [url, init] = mock.mock.calls[0];
+    expect(url).toBe('https://slack.com/api/chat.postMessage');
+    expect(init?.method).toBe('POST');
+    // Bearer token in Authorization header (Slack convention) — keeps
+    // the token out of the URL so it doesn't end up in proxy access
+    // logs or referer headers.
+    expect(init?.headers).toMatchObject({
+      'Content-Type': 'application/json; charset=utf-8',
+      Authorization: 'Bearer xoxb-123-456-abcDEF',
+    });
+    expect(JSON.parse(init?.body as string)).toEqual({
+      channel: '#regressions',
+      text: 'hello',
+    });
+  });
+
+  // Slack's failure mode is HTTP 200 + `{ ok: false, error: '...' }`,
+  // not a 4xx/5xx — the sender must inspect the body to tell success
+  // from failure. Without this branch, a `channel_not_found` reply
+  // would be reported as a successful send.
+  it('returns false when Slack responds 200 with ok=false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, error: 'channel_not_found' }), {
+          status: 200,
+        })
+      )
+    );
+
+    const ok = await sender.send({
+      token: 'xoxb-123-456-abcDEF',
+      channel: '#nope',
+      text: 'hi',
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('returns false on a 4xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 429 })));
+    expect(await sender.send({ token: 'xoxb-123-456-abc', channel: '#x', text: 'hi' })).toBe(false);
+  });
+
+  it('returns false on a 5xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 502 })));
+    expect(await sender.send({ token: 'xoxb-123-456-abc', channel: '#x', text: 'hi' })).toBe(false);
+  });
+
+  it('returns false (without throwing) on a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
+    expect(await sender.send({ token: 'xoxb-123-456-abc', channel: '#x', text: 'hi' })).toBe(false);
+  });
+
+  it('returns false on AbortError without throwing', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortErr));
+    expect(await sender.send({ token: 'xoxb-123-456-abc', channel: '#x', text: 'hi' })).toBe(false);
+  });
+
+  it('handles a 200 with a non-JSON body as a failure (cannot confirm ok)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not json', { status: 200 })));
+    expect(await sender.send({ token: 'xoxb-123-456-abc', channel: '#x', text: 'hi' })).toBe(false);
+  });
+
+  // Defensive guard against malformed tokens. Slack bot tokens start
+  // with `xoxb-` and use `[A-Za-z0-9-]` after the prefix; anything
+  // else is rejected without touching the network. Without this, a
+  // legacy row or test stub with `'\r\nX-Smuggle: yes'` could attempt
+  // header injection via the Authorization value.
+  it.each([
+    '',
+    'not-a-slack-token',
+    'xoxp-123-456-abc', // user token, not a bot token
+    'xoxb-bad token with spaces',
+    'xoxb-newline\r\nX-Smuggled: yes',
+    '/../admin',
+  ])('refuses to send with a malformed token: %s', async (badToken) => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const ok = await sender.send({ token: badToken, channel: '#x', text: 'hi' });
+    expect(ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts well-formed bot tokens', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{"ok":true}', { status: 200 })));
+    expect(
+      await sender.send({
+        // Obvious placeholder shape — matches the regex but cannot be
+        // mistaken for a leaked real token by secret scanners.
+        token: 'xoxb-test-test-not-a-real-slack-bot-token',
+        channel: '#x',
+        text: 'hi',
+      })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Last C2 piece — closes the action-type surface for the dedup rule engine.

- `FetchBackedSlackSender` posts to `slack.com/api/chat.postMessage` with bearer-token auth and inspects `body.ok` because Slack returns HTTP 200 + `{ok:false,error}` on logical failures (channel-not-found, bad token) rather than 4xx.
- Per-org `slack_bot_token` lives encrypted in `organizations.settings`; resolver decrypts on demand. PATCH route validates the `xoxb-` shape; sender re-checks defensively to refuse header-injection-shaped tokens before the network.
- Dispatcher unifies `channel` and `user` (XOR per schema) into the single conversation target Slack's API takes.
- Shared per-recipient rate limiter caps fan-out across rules.

## Test plan

- [x] `pnpm vitest run tests/services/rules/` — 250 passing across 13 files (incl. 14 new slack-sender + 8 new dispatcher slack tests)
- [x] `pnpm vitest run tests/services/intelligence/key-provisioning.test.ts` — 38 passing (incl. 6 new slack token-handling tests)
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [ ] Admin UI for editing the token (separate PR — schema is in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications are now supported — send automated messages to channels and users when an org Slack bot token is configured.
  * Bot tokens are validated (must match Slack bot format), stored encrypted, and can be cleared by submitting an empty value.

* **Behavior**
  * Dispatching to Slack respects per-recipient rate limits, resolves org-scoped bot tokens at send time, skips when no token is set, and fails closed on resolver errors.

* **Tests**
  * Added comprehensive tests for Slack sending, token handling, validation, and dispatch behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->