### PR TITLE
feat(saas): reserve mcp/agents/bot subdomains for AI product surfaces

### DIFF
--- a/packages/backend/src/saas/middleware/tenant.ts
+++ b/packages/backend/src/saas/middleware/tenant.ts
@@ -20,9 +20,9 @@ const ACTIVE_STATUSES: Set<SubscriptionStatus> = new Set([
 ]);
 
 // Reserved subdomains that cannot be used for organizations.
-// Both blocks the tenant-resolver middleware (so requests to e.g.
-// mcp.kz.bugspotter.io aren't treated as tenant lookups) and the signup
-// flow (so customers can't grab these slugs). Future product surfaces
+// This set both blocks the tenant-resolver middleware (so requests to
+// e.g. mcp.kz.bugspotter.io aren't treated as tenant lookups) and gates
+// signup (so customers can't grab these slugs). Future product surfaces
 // — AI gateways, bots, integrations — are pre-reserved to avoid having
 // to reclaim them from existing tenants later.
 export const RESERVED_SUBDOMAINS = new Set([
@@ -47,10 +47,11 @@ export const RESERVED_SUBDOMAINS = new Set([
   'signup',
   'demo',
   'payment',
-  // AI / agent surfaces (mcp.kz.bugspotter.io ships in v0.3 of bugspotter-mcp).
-  // Note: 2-letter names like "ai" are already implicitly blocked by the
-  // 3-char minimum-length rule in validateFormat(), so they don't need
-  // to be listed here.
+  // AI / agent surfaces. `mcp.kz.bugspotter.io` ships in v0.3 of
+  // bugspotter-mcp; the others are pre-reserved. `ai` is listed
+  // explicitly even though MIN_SUBDOMAIN_LENGTH (3) implicitly blocks
+  // it today — defensive against any future relaxation of that rule.
+  'ai',
   'mcp',
   'agents',
   'bot',

--- a/packages/backend/src/saas/middleware/tenant.ts
+++ b/packages/backend/src/saas/middleware/tenant.ts
@@ -19,8 +19,14 @@ const ACTIVE_STATUSES: Set<SubscriptionStatus> = new Set([
   SUBSCRIPTION_STATUS.PAST_DUE,
 ]);
 
-// Reserved subdomains that cannot be used for organizations
+// Reserved subdomains that cannot be used for organizations.
+// Both blocks the tenant-resolver middleware (so requests to e.g.
+// mcp.kz.bugspotter.io aren't treated as tenant lookups) and the signup
+// flow (so customers can't grab these slugs). Future product surfaces
+// — AI gateways, bots, integrations — are pre-reserved to avoid having
+// to reclaim them from existing tenants later.
 export const RESERVED_SUBDOMAINS = new Set([
+  // Existing platform surfaces
   'www',
   'admin',
   'api',
@@ -41,6 +47,13 @@ export const RESERVED_SUBDOMAINS = new Set([
   'signup',
   'demo',
   'payment',
+  // AI / agent surfaces (mcp.kz.bugspotter.io ships in v0.3 of bugspotter-mcp).
+  // Note: 2-letter names like "ai" are already implicitly blocked by the
+  // 3-char minimum-length rule in validateFormat(), so they don't need
+  // to be listed here.
+  'mcp',
+  'agents',
+  'bot',
 ]);
 
 // Route prefixes exempt from tenant resolution — these operate at

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -61,7 +61,7 @@ export const SIGNUP_ONLY_RESERVED: ReadonlySet<string> = new Set([
   'metrics',
 ]);
 
-export const RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
+export const ALL_RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
   ...TENANT_RESERVED_SUBDOMAINS,
   ...SIGNUP_ONLY_RESERVED,
 ]);
@@ -116,7 +116,7 @@ export class SubdomainService {
         'ValidationError'
       );
     }
-    if (RESERVED_SUBDOMAINS.has(subdomain)) {
+    if (ALL_RESERVED_SUBDOMAINS.has(subdomain)) {
       throw new AppError('This subdomain is reserved', 400, 'ValidationError');
     }
   }
@@ -170,7 +170,7 @@ export class SubdomainService {
     }
 
     // Reserved base → fall through to suffixed attempts, which are not reserved.
-    const baseUsable = !RESERVED_SUBDOMAINS.has(base);
+    const baseUsable = !ALL_RESERVED_SUBDOMAINS.has(base);
 
     if (baseUsable && (await this.isAvailable(base))) {
       return base;
@@ -188,10 +188,10 @@ export class SubdomainService {
       }
       const candidate = `${trimmedBase}${suffix}`;
       // Defense against future reserved-list growth: if someone later adds
-      // a suffixed name like `api-2` to RESERVED_SUBDOMAINS, this loop
+      // a suffixed name like `api-2` to ALL_RESERVED_SUBDOMAINS, this loop
       // must not mint it. Today's list has no such entries so this is a
       // guard, not a reachable branch — but zero-cost to check.
-      if (RESERVED_SUBDOMAINS.has(candidate)) {
+      if (ALL_RESERVED_SUBDOMAINS.has(candidate)) {
         continue;
       }
       if (await this.isAvailable(candidate)) {

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -31,7 +31,7 @@ const SUBDOMAIN_REGEX = /^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$/;
  * router would never serve. Extras here cover environments, monitoring,
  * and platform-only names that the middleware doesn't need to know about.
  */
-const SIGNUP_ONLY_RESERVED = new Set([
+export const SIGNUP_ONLY_RESERVED = new Set([
   // Platform infra
   'media',
   'uploads',
@@ -61,7 +61,7 @@ const SIGNUP_ONLY_RESERVED = new Set([
   'metrics',
 ]);
 
-const RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
+export const RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
   ...TENANT_RESERVED_SUBDOMAINS,
   ...SIGNUP_ONLY_RESERVED,
 ]);

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -21,17 +21,13 @@ const MAX_AUTO_SUFFIX_ATTEMPTS = 50;
 const SUBDOMAIN_REGEX = /^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$/;
 
 /**
- * Subdomains reserved for platform infrastructure. Blocking these at signup
- * prevents tenants from impersonating api/admin/support surfaces or
- * colliding with existing DNS records on *.kz.bugspotter.io.
- *
- * This set is a SUPERSET of the tenant resolution middleware's reserved
- * list — anything the middleware refuses to route to must also be blocked
- * at signup, otherwise a user could register an org whose admin UI the
- * router would never serve. Extras here cover environments, monitoring,
- * and platform-only names that the middleware doesn't need to know about.
+ * Subdomains reserved at signup but NOT in the tenant-resolution
+ * middleware's `RESERVED_SUBDOMAINS`. Environments, monitoring, and
+ * platform-only names the router doesn't need to know about but
+ * customers must not be able to register. Used only to build
+ * `ALL_RESERVED_SUBDOMAINS` below — module-local.
  */
-export const SIGNUP_ONLY_RESERVED: ReadonlySet<string> = new Set([
+const SIGNUP_ONLY_RESERVED: ReadonlySet<string> = new Set([
   // Platform infra
   'media',
   'uploads',
@@ -61,6 +57,16 @@ export const SIGNUP_ONLY_RESERVED: ReadonlySet<string> = new Set([
   'metrics',
 ]);
 
+/**
+ * Full reserved set enforced at signup: the union of the tenant
+ * middleware's router-blocked list (`RESERVED_SUBDOMAINS` in
+ * `middleware/tenant.ts`) and the signup-only extras above.
+ *
+ * Invariant: this is a SUPERSET of the middleware's reserved list.
+ * Anything the router refuses to serve must also be blocked at
+ * signup, otherwise a user could register an org whose admin UI
+ * the router would never reach.
+ */
 export const ALL_RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
   ...TENANT_RESERVED_SUBDOMAINS,
   ...SIGNUP_ONLY_RESERVED,

--- a/packages/backend/src/saas/services/subdomain.service.ts
+++ b/packages/backend/src/saas/services/subdomain.service.ts
@@ -31,7 +31,7 @@ const SUBDOMAIN_REGEX = /^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$/;
  * router would never serve. Extras here cover environments, monitoring,
  * and platform-only names that the middleware doesn't need to know about.
  */
-export const SIGNUP_ONLY_RESERVED = new Set([
+export const SIGNUP_ONLY_RESERVED: ReadonlySet<string> = new Set([
   // Platform infra
   'media',
   'uploads',

--- a/packages/backend/tests/saas/subdomain.service.test.ts
+++ b/packages/backend/tests/saas/subdomain.service.test.ts
@@ -136,6 +136,11 @@ describe('SubdomainService', () => {
       // Assert any throw — short-named entries (e.g. "ai") are rejected
       // for length rather than the reserved-name message, but the
       // user-visible outcome is the same: signup refuses them.
+      //
+      // Sanity guard: if the import resolves to an empty set (bad merge,
+      // both contributing lists emptied), the for-loop would pass
+      // silently. Fail loudly instead.
+      expect(SERVICE_RESERVED_SUBDOMAINS.size).toBeGreaterThan(0);
       for (const reserved of SERVICE_RESERVED_SUBDOMAINS) {
         expect(() => service.validateFormat(reserved)).toThrow();
       }

--- a/packages/backend/tests/saas/subdomain.service.test.ts
+++ b/packages/backend/tests/saas/subdomain.service.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SubdomainService } from '../../src/saas/services/subdomain.service.js';
+import { RESERVED_SUBDOMAINS } from '../../src/saas/middleware/tenant.js';
 import type { DatabaseClient } from '../../src/db/client.js';
 
 vi.mock('../../src/logger.js', () => ({
@@ -124,7 +125,23 @@ describe('SubdomainService', () => {
       // superset of the tenant resolution middleware's reserved set.
       // Otherwise a user could register an org with a subdomain the
       // router will never serve — an unrecoverable broken state.
-      for (const reserved of ['dashboard', 'payment', 'ftp', 'api', 'admin']) {
+      //
+      // Iterate over the actual RESERVED_SUBDOMAINS set so additions to
+      // the middleware list are automatically test-covered.
+      for (const reserved of RESERVED_SUBDOMAINS) {
+        expect(() => service.validateFormat(reserved)).toThrow(/reserved/);
+      }
+    });
+
+    it('blocks AI / agent product surfaces (mcp, agents, bot)', () => {
+      // Explicit assertion that the names we reserved for the v0.3
+      // bugspotter-mcp hosted endpoint and adjacent future surfaces
+      // are rejected at signup. Drives intent — if these are ever
+      // removed from RESERVED_SUBDOMAINS, this test fails first.
+      //
+      // "ai" is 2 chars — implicitly blocked by the 3-char minimum
+      // length check, doesn't need an entry in RESERVED_SUBDOMAINS.
+      for (const reserved of ['mcp', 'agents', 'bot']) {
         expect(() => service.validateFormat(reserved)).toThrow(/reserved/);
       }
     });

--- a/packages/backend/tests/saas/subdomain.service.test.ts
+++ b/packages/backend/tests/saas/subdomain.service.test.ts
@@ -5,8 +5,10 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { SubdomainService } from '../../src/saas/services/subdomain.service.js';
-import { RESERVED_SUBDOMAINS } from '../../src/saas/middleware/tenant.js';
+import {
+  SubdomainService,
+  RESERVED_SUBDOMAINS as SERVICE_RESERVED_SUBDOMAINS,
+} from '../../src/saas/services/subdomain.service.js';
 import type { DatabaseClient } from '../../src/db/client.js';
 
 vi.mock('../../src/logger.js', () => ({
@@ -120,27 +122,33 @@ describe('SubdomainService', () => {
       expect(() => service.validateFormat('signup')).toThrow(/reserved/);
     });
 
-    it('blocks every subdomain the tenant middleware refuses to route', () => {
-      // Regression guard: the reserved list used at signup must be a
-      // superset of the tenant resolution middleware's reserved set.
-      // Otherwise a user could register an org with a subdomain the
-      // router will never serve — an unrecoverable broken state.
+    it('rejects every subdomain on the service-level reserved set', () => {
+      // Regression guard: anything in the service's `RESERVED_SUBDOMAINS`
+      // (which unions the tenant-middleware list with the signup-only
+      // list — environments, monitoring, blog/register/onboarding, etc.)
+      // must be rejected. Without this, removing an entry from either
+      // contributing set could leave a user able to register an org
+      // whose subdomain the router will never serve.
       //
-      // Iterate over the actual RESERVED_SUBDOMAINS set so additions to
-      // the middleware list are automatically test-covered.
-      for (const reserved of RESERVED_SUBDOMAINS) {
-        expect(() => service.validateFormat(reserved)).toThrow(/reserved/);
+      // Iterate over the actual set so additions to either contributing
+      // list are automatically test-covered.
+      //
+      // Assert any throw — short-named entries (e.g. "ai") are rejected
+      // for length rather than the reserved-name message, but the
+      // user-visible outcome is the same: signup refuses them.
+      for (const reserved of SERVICE_RESERVED_SUBDOMAINS) {
+        expect(() => service.validateFormat(reserved)).toThrow();
       }
     });
 
     it('blocks AI / agent product surfaces (mcp, agents, bot)', () => {
       // Explicit assertion that the names we reserved for the v0.3
       // bugspotter-mcp hosted endpoint and adjacent future surfaces
-      // are rejected at signup. Drives intent — if these are ever
-      // removed from RESERVED_SUBDOMAINS, this test fails first.
-      //
-      // "ai" is 2 chars — implicitly blocked by the 3-char minimum
-      // length check, doesn't need an entry in RESERVED_SUBDOMAINS.
+      // are rejected at signup with the "reserved" code path
+      // specifically (not length, not LDH). Stronger than the
+      // iterating test above: if mcp/agents/bot are removed from
+      // RESERVED_SUBDOMAINS, the iterating test would just iterate
+      // a shorter set and still pass — this one fails loudly.
       for (const reserved of ['mcp', 'agents', 'bot']) {
         expect(() => service.validateFormat(reserved)).toThrow(/reserved/);
       }

--- a/packages/backend/tests/saas/subdomain.service.test.ts
+++ b/packages/backend/tests/saas/subdomain.service.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   SubdomainService,
-  RESERVED_SUBDOMAINS as SERVICE_RESERVED_SUBDOMAINS,
+  ALL_RESERVED_SUBDOMAINS,
 } from '../../src/saas/services/subdomain.service.js';
 import type { DatabaseClient } from '../../src/db/client.js';
 
@@ -140,8 +140,8 @@ describe('SubdomainService', () => {
       // Sanity guard: if the import resolves to an empty set (bad merge,
       // both contributing lists emptied), the for-loop would pass
       // silently. Fail loudly instead.
-      expect(SERVICE_RESERVED_SUBDOMAINS.size).toBeGreaterThan(0);
-      for (const reserved of SERVICE_RESERVED_SUBDOMAINS) {
+      expect(ALL_RESERVED_SUBDOMAINS.size).toBeGreaterThan(0);
+      for (const reserved of ALL_RESERVED_SUBDOMAINS) {
         expect(() => service.validateFormat(reserved)).toThrow();
       }
     });


### PR DESCRIPTION
## Summary

- Reserve `mcp`, `agents`, `bot` in `RESERVED_SUBDOMAINS` so tenant signup can't grab slugs we need for upcoming AI product surfaces — first concrete one is the hosted MCP endpoint at `mcp.kz.bugspotter.io` (bugspotter-mcp v0.3).
- The same set is consumed by both the tenant-resolution middleware (so requests to e.g. `mcp.kz.bugspotter.io` are not treated as tenant lookups) and the signup-side `SubdomainService.validateFormat`.
- `ai` deliberately omitted — 2 chars, already rejected by the 3-char minimum-length rule in `validateFormat`; documented inline.

## Why now

Reserving before launch avoids ever having to reclaim a slug from a paying tenant. Cheap; one-line addition.

## Test plan

- [x] Refactored the existing regression guard to iterate the actual `RESERVED_SUBDOMAINS` set, so any future addition to the middleware list is auto-covered by signup-side tests.
- [x] Added an explicit test for `mcp`/`agents`/`bot` so removing them from the set fails a named test (drives intent).
- [x] `pnpm --filter @bugspotter/backend test:unit` → 2853/2853 pass.

## Pre-merge sanity check (reviewer / me before merge)

Confirm no existing tenant already holds one of the newly-reserved slugs:

```sql
SELECT subdomain FROM saas.organizations WHERE subdomain IN ('mcp', 'agents', 'bot');
-- expect 0 rows
```

If any row comes back, do not merge — we'd be locking an existing customer out of their own tenant on next subdomain re-validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reserved additional subdomains (`mcp`, `agents`, `bot`) for upcoming platform features, making them unavailable for custom subdomain selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->