### PR TITLE
feat(sdk): in-widget deflection — backend probe + deflect-on-submit

### DIFF
--- a/packages/backend/src/api/routes/reports.ts
+++ b/packages/backend/src/api/routes/reports.ts
@@ -87,6 +87,7 @@ export function bugReportRoutes(
         hasReplay,
         source,
         project_id: bodyProjectId,
+        deflected_to_canonical_id: deflectedToCanonicalId,
       } = request.body;
 
       // Resolve project from: authProject (single-key), body project_id, or sole allowed project
@@ -156,6 +157,25 @@ export function bugReportRoutes(
         });
       }
 
+      // Resolve deflection target if the SDK widget set one. The
+      // canonical must belong to the same project — without this
+      // check, a malicious client could deflect a new bug into
+      // another tenant's canonical and trigger downstream rule fires
+      // against unrelated data. Mirrors the cross-tenant scope check
+      // in the rule-engine's `TicketsTableResolver`.
+      let validatedDeflectionTarget: string | null = null;
+      if (deflectedToCanonicalId) {
+        const canonical = await db.bugReports.findById(deflectedToCanonicalId);
+        if (!canonical || canonical.project_id !== projectId) {
+          throw new AppError(
+            'deflected_to_canonical_id does not belong to this project',
+            400,
+            'BadRequest'
+          );
+        }
+        validatedDeflectionTarget = deflectedToCanonicalId;
+      }
+
       // Create bug report with quota leak protection
       // NOTE: Quota is reserved in middleware BEFORE this handler runs.
       // If creation fails, quota is leaked (no compensating decrement yet).
@@ -168,12 +188,22 @@ export function bugReportRoutes(
           description: description || null,
           priority: priority || BugPriority.MEDIUM,
           status: BugStatus.OPEN,
+          // When the user confirmed the deflection chip, set
+          // `duplicate_of` directly — bypasses the intelligence
+          // pre-file grace window because we already know the canonical.
+          duplicate_of: validatedDeflectionTarget,
           metadata: {
             console: report.console,
             network: report.network,
             metadata: report.metadata,
             source: source || 'api',
             apiKeyPrefix: request.apiKey?.key_prefix || null,
+            // Tags the deflection origin for analytics. Distinct from
+            // intelligence-pipeline-inferred dedup (which doesn't set
+            // this key) so we can measure widget-deflection rate.
+            ...(validatedDeflectionTarget
+              ? { deflection_source: 'sdk_user_confirmed' as const }
+              : {}),
           },
           screenshot_url: null,
           replay_url: null,

--- a/packages/backend/src/api/routes/sdk-similar.ts
+++ b/packages/backend/src/api/routes/sdk-similar.ts
@@ -1,0 +1,181 @@
+/**
+ * SDK-facing similarity endpoint.
+ *
+ * Lets the bug-report widget show "we may already know about this:
+ * #44 (Fixed in v2.3)" inline, before the user submits. Powers the
+ * deflection-acknowledge flow that finally works for anonymous /
+ * non-org-member reporters where the existing `notify.email reporter`
+ * token doesn't apply (see `dedup-reporter-design.md`).
+ *
+ * Auth: gated by `requireProject` + `requireApiKeyPermission(
+ * 'reports:write')` — the same shape the SDK ingest path uses, so
+ * an org's existing ingest-only key works without re-provisioning.
+ *
+ * Graceful degradation: if the org has intelligence disabled (or
+ * misconfigured), this returns `{ matches: [] }` rather than 503.
+ * The widget falls back to a normal submission with zero matches
+ * shown — the user never sees an error originating from the
+ * similarity probe.
+ *
+ * Response shape is intentionally narrower than the internal
+ * SearchResponse: returns `canonical_id` / `title` / `status` /
+ * `similarity` only. Description, resolution text, and timestamps
+ * are intentionally NOT exposed via an ingest-only key.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { DatabaseClient } from '../../db/client.js';
+import type { IntelligenceClient } from '../../services/intelligence/intelligence-client.js';
+import type { IntelligenceClientFactory } from '../../services/intelligence/tenant-config.js';
+import { requireProject, requireApiKeyPermission } from '../middleware/auth.js';
+import { sendSuccess } from '../utils/response.js';
+import { AppError } from '../middleware/error.js';
+import { getLogger } from '../../logger.js';
+
+const logger = getLogger();
+
+// Similarity threshold below which a match is hidden from the SDK.
+// The intelligence /search returns its top-N regardless of score; the
+// SDK has stricter UX needs (false-positive "is this the same?" chips
+// burn user trust fast). 0.6 is conservative — empirical tuning lands
+// after we have real-world deflection metrics, gated behind an org
+// setting in a follow-up.
+const SDK_SIMILARITY_FLOOR = 0.6;
+
+// Hard ceiling on response size. Lower than admin search's 50 — the
+// widget renders these inline and three is the max a user will
+// realistically scan before submitting.
+const SDK_MAX_LIMIT = 5;
+const SDK_DEFAULT_LIMIT = 3;
+
+interface SdkSimilarBody {
+  title: string;
+  description?: string;
+  limit?: number;
+}
+
+interface SdkSimilarMatch {
+  canonical_id: string;
+  title: string;
+  status: string;
+  similarity: number;
+}
+
+const sdkSimilarSchema = {
+  body: {
+    type: 'object',
+    required: ['title'],
+    additionalProperties: false,
+    properties: {
+      title: {
+        type: 'string',
+        // Match the widget's own 5-char minimum check — anything shorter
+        // produces noisy false positives from the embedding model.
+        minLength: 5,
+        maxLength: 500,
+      },
+      // Description accepted but ignored in v1 — title-only similarity
+      // is faster and matches Sentry's pattern. Adding description to
+      // the query is a v2 tuning question, not a v1 launch blocker.
+      description: { type: 'string', maxLength: 5000 },
+      limit: { type: 'integer', minimum: 1, maximum: SDK_MAX_LIMIT },
+    },
+  },
+} as const;
+
+/**
+ * Resolve a per-org intelligence client without leaking 503 errors
+ * to the SDK. Mirrors the admin-side `resolveClient` from
+ * `intelligence.ts` but degrades to `null` on the
+ * intelligence-not-configured branch rather than throwing.
+ */
+async function resolveClientSoft(
+  organizationId: string | null | undefined,
+  clientFactory: IntelligenceClientFactory | undefined,
+  globalClient: IntelligenceClient
+): Promise<IntelligenceClient | null> {
+  if (clientFactory && organizationId) {
+    try {
+      return await clientFactory.getClientForOrg(organizationId);
+    } catch (error) {
+      logger.warn('SDK similar: per-org intelligence client resolve failed', {
+        organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+  return globalClient;
+}
+
+export function sdkSimilarRoutes(
+  fastify: FastifyInstance,
+  globalClient: IntelligenceClient,
+  _db: DatabaseClient,
+  clientFactory?: IntelligenceClientFactory
+): void {
+  fastify.post<{ Body: SdkSimilarBody }>(
+    '/api/v1/sdk/similar',
+    {
+      schema: sdkSimilarSchema,
+      // `requireProject` enforces single-project ingest-key shape;
+      // `reports:write` is what the ingest-only key already carries.
+      // No new permission needed for v1.
+      preHandler: [requireProject, requireApiKeyPermission('reports:write')],
+    },
+    async (request, reply) => {
+      const { title, limit } = request.body;
+      const project = request.authProject;
+
+      // `requireProject` guarantees this, but the type guard keeps
+      // TS happy and protects against a future middleware re-order.
+      if (!project) {
+        throw new AppError('Project context required', 400, 'BadRequest');
+      }
+
+      const client = await resolveClientSoft(project.organization_id, clientFactory, globalClient);
+
+      // Soft-fail when intelligence isn't wired for this org — the
+      // widget treats an empty match list as "no deflection
+      // candidates" and proceeds with normal submission. No error
+      // surface to end-users.
+      if (!client) {
+        return sendSuccess(reply, { matches: [] });
+      }
+
+      const effectiveLimit = limit ?? SDK_DEFAULT_LIMIT;
+
+      let matches: SdkSimilarMatch[] = [];
+      try {
+        const result = await client.search({
+          query: title,
+          project_id: project.id,
+          mode: 'fast',
+          limit: effectiveLimit,
+        });
+        matches = result.results
+          // Threshold filter — see SDK_SIMILARITY_FLOOR comment.
+          .filter((r) => r.similarity >= SDK_SIMILARITY_FLOOR)
+          // Narrow projection — never leak description / resolution /
+          // timestamps through an ingest-only credential.
+          .map((r) => ({
+            canonical_id: r.bug_id,
+            title: r.title,
+            status: r.status,
+            similarity: r.similarity,
+          }));
+      } catch (error) {
+        // Same soft-fail contract: intelligence outage / circuit-
+        // breaker open / timeout — the widget should still let the
+        // user submit. Log for ops; return [] to the SDK.
+        logger.warn('SDK similar: intelligence search failed, returning empty matches', {
+          projectId: project.id,
+          organizationId: project.organization_id,
+          errorType: error instanceof Error ? error.name : 'NonErrorThrown',
+        });
+      }
+
+      return sendSuccess(reply, { matches });
+    }
+  );
+}

--- a/packages/backend/src/api/schemas/bug-report-schema.ts
+++ b/packages/backend/src/api/schemas/bug-report-schema.ts
@@ -76,6 +76,14 @@ export const createBugReportSchema = {
       // Flags to request presigned URLs for file uploads
       hasScreenshot: { type: 'boolean', default: false },
       hasReplay: { type: 'boolean', default: false },
+      // Set by the SDK widget when the user confirmed "yes, this is
+      // the same as #X" on a deflection chip. Backend writes this
+      // straight into `bug_reports.duplicate_of`, bypassing the
+      // intelligence pipeline's pre-file dedup grace. The canonical
+      // id must point to a bug in the same project — enforced in the
+      // handler. Tags `metadata.deflection_source = "sdk_user_confirmed"`
+      // for analytics.
+      deflected_to_canonical_id: { type: 'string', format: 'uuid', nullable: true },
     },
     additionalProperties: false,
   },

--- a/packages/backend/src/api/types/bug-report-types.ts
+++ b/packages/backend/src/api/types/bug-report-types.ts
@@ -73,6 +73,14 @@ export interface CreateReportBody {
   // Optimized flow - SDK tells us what files it has
   hasScreenshot?: boolean;
   hasReplay?: boolean;
+  /**
+   * Set by the SDK widget when the user confirmed "yes, this is the
+   * same as #X" on a deflection chip. Written directly to
+   * `bug_reports.duplicate_of`; validated against the project scope
+   * in the handler (same defense-in-depth as the rule-engine's
+   * canonical resolver).
+   */
+  deflected_to_canonical_id?: string | null;
 }
 
 /**

--- a/packages/backend/src/plugins/intelligence.plugin.ts
+++ b/packages/backend/src/plugins/intelligence.plugin.ts
@@ -17,6 +17,7 @@ import { IntelligenceClient } from '../services/intelligence/intelligence-client
 import { IntelligenceClientFactory } from '../services/intelligence/tenant-config.js';
 import { getEncryptionService } from '../utils/encryption.js';
 import { intelligenceRoutes } from '../api/routes/intelligence.js';
+import { sdkSimilarRoutes } from '../api/routes/sdk-similar.js';
 import { getLogger } from '../logger.js';
 import type { IServiceContainer } from '../container/service-container.js';
 
@@ -54,6 +55,10 @@ export async function setupIntelligence(fastify: FastifyInstance): Promise<void>
       getEncryptionService()
     );
     intelligenceRoutes(fastify, client, container.db, clientFactory);
+    // SDK-facing similarity endpoint — separate from the admin routes
+    // because it uses ingest-key auth and degrades to empty matches
+    // on intelligence outage instead of 503-ing the widget.
+    sdkSimilarRoutes(fastify, client, container.db, clientFactory);
     logger.info('Intelligence plugin: enabled and routes registered');
   } else {
     logger.warn(

--- a/packages/backend/tests/api/reports.test.ts
+++ b/packages/backend/tests/api/reports.test.ts
@@ -401,6 +401,105 @@ describe('Bug Report Routes', () => {
         expect(json.message).toBe('Project not found.');
       });
     });
+
+    describe('deflection (SDK widget confirmed canonical)', () => {
+      it('sets duplicate_of when deflected_to_canonical_id points to a same-project bug', async () => {
+        const canonical = await db.bugReports.create({
+          project_id: testProjectId,
+          title: 'Existing canonical',
+          status: 'open',
+          priority: 'medium',
+          metadata: {},
+        });
+
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/v1/reports',
+          headers: { 'x-api-key': testApiKey },
+          payload: {
+            title: 'Same bug, new reporter',
+            report: { console: [], network: [], metadata: {} },
+            deflected_to_canonical_id: canonical.id,
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        const created = response.json().data;
+        expect(created.duplicate_of).toBe(canonical.id);
+        // The deflection-source tag must land in metadata so analytics
+        // can distinguish widget-driven dedup from pipeline-inferred.
+        const stored = await db.bugReports.findById(created.id);
+        expect(stored?.metadata).toMatchObject({
+          deflection_source: 'sdk_user_confirmed',
+        });
+      });
+
+      it('rejects deflected_to_canonical_id that points to another project (cross-tenant scope)', async () => {
+        // Seed a canonical in a SECOND project the API key is NOT
+        // scoped to. The route must reject — without this guard, an
+        // attacker could deflect a fresh bug into a foreign canonical
+        // and pollute downstream rule fires.
+        const otherProject = await db.projects.create({
+          name: `Other project ${Date.now()}`,
+          settings: {},
+        });
+        const otherCanonical = await db.bugReports.create({
+          project_id: otherProject.id,
+          title: 'Foreign canonical',
+          status: 'open',
+          priority: 'medium',
+          metadata: {},
+        });
+
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/v1/reports',
+          headers: { 'x-api-key': testApiKey },
+          payload: {
+            title: 'Trying to deflect into foreign project',
+            report: { console: [], network: [], metadata: {} },
+            deflected_to_canonical_id: otherCanonical.id,
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.json().message).toContain('deflected_to_canonical_id');
+      });
+
+      it('rejects deflected_to_canonical_id that points to a non-existent bug', async () => {
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/v1/reports',
+          headers: { 'x-api-key': testApiKey },
+          payload: {
+            title: 'Deflecting into thin air',
+            report: { console: [], network: [], metadata: {} },
+            deflected_to_canonical_id: '00000000-0000-0000-0000-000000000000',
+          },
+        });
+
+        expect(response.statusCode).toBe(400);
+      });
+
+      it('omits deflection metadata when the field is absent', async () => {
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/v1/reports',
+          headers: { 'x-api-key': testApiKey },
+          payload: {
+            title: 'Normal submission, no deflection',
+            report: { console: [], network: [], metadata: {} },
+          },
+        });
+
+        expect(response.statusCode).toBe(201);
+        const created = response.json().data;
+        expect(created.duplicate_of).toBeNull();
+        const stored = await db.bugReports.findById(created.id);
+        // Tag must NOT appear when the user didn't confirm a chip.
+        expect(stored?.metadata).not.toHaveProperty('deflection_source');
+      });
+    });
   });
 
   describe('GET /api/v1/reports', () => {

--- a/packages/backend/tests/api/sdk-similar-routes.test.ts
+++ b/packages/backend/tests/api/sdk-similar-routes.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for the SDK-facing `/api/v1/sdk/similar` endpoint.
+ *
+ * The contract under test:
+ *  - Happy path: top-N matches above the SDK threshold are returned
+ *    with the narrow public-facing projection (no description / no
+ *    resolution / no timestamps).
+ *  - Soft-fail surface: intelligence not configured / factory throws
+ *    / search throws — all return `{ matches: [] }` with status 200,
+ *    NEVER 503. The widget can't degrade gracefully if the probe
+ *    surfaces errors to the user.
+ *  - Similarity threshold filters below-floor matches client-side
+ *    of the probe (intelligence /search doesn't enforce it).
+ *  - Limit is bounded between 1 and 5, defaults to 3.
+ *  - Per-org client is preferred over the global one when both are
+ *    available — mirrors the admin-route pattern.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import { sdkSimilarRoutes } from '../../src/api/routes/sdk-similar.js';
+
+// ---------------------------------------------------------------------------
+// Mocks: replace auth middleware with passthroughs that attach an
+// authProject the route can read. Mirrors the SDK ingest path —
+// `requireProject` sets `authProject`, `requireApiKeyPermission` is a no-op
+// for ingest-only keys that hold `reports:write`.
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'c4c6dbfb-2e28-40d9-bc25-f4e5812b5ae0';
+const ORG_ID = '0ae3f3af-4eea-400b-b8f5-39958c546c70';
+
+vi.mock('../../src/api/middleware/auth.js', () => ({
+  requireProject: async (request: any) => {
+    request.authProject = { id: PROJECT_ID, organization_id: ORG_ID };
+  },
+  requireApiKeyPermission: () => async () => {},
+}));
+
+vi.mock('../../src/logger.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSearchResult(
+  overrides: Partial<{
+    bug_id: string;
+    title: string;
+    status: string;
+    similarity: number;
+    description: string | null;
+    resolution: string | null;
+  }> = {}
+) {
+  return {
+    bug_id: overrides.bug_id ?? 'bug-xyz',
+    title: overrides.title ?? 'similar bug',
+    description: overrides.description ?? 'desc that should not leak',
+    status: overrides.status ?? 'closed',
+    resolution: overrides.resolution ?? 'fixed in v2.3',
+    similarity: overrides.similarity ?? 0.82,
+    created_at: '2026-05-22T00:00:00Z',
+  };
+}
+
+function createMockClient(searchImpl?: (req: unknown) => unknown) {
+  return {
+    search: vi.fn().mockImplementation((req) => {
+      if (searchImpl) {
+        return Promise.resolve(searchImpl(req));
+      }
+      return Promise.resolve({
+        results: [makeSearchResult()],
+        total: 1,
+        limit: 3,
+        offset: 0,
+        mode: 'fast',
+        query: 'q',
+        cached: false,
+      });
+    }),
+  } as any;
+}
+
+function createMockDb() {
+  return {} as any;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('SDK similar endpoint', () => {
+  let app: FastifyInstance;
+  let globalClient: ReturnType<typeof createMockClient>;
+
+  beforeEach(async () => {
+    app = Fastify();
+    globalClient = createMockClient();
+    sdkSimilarRoutes(app, globalClient, createMockDb());
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('happy path', () => {
+    it('returns matches with the narrow projection (no description/resolution/timestamps)', async () => {
+      globalClient.search.mockResolvedValueOnce({
+        results: [
+          makeSearchResult({
+            bug_id: 'bug-1',
+            title: 'login button broken on Firefox',
+            status: 'closed',
+            similarity: 0.91,
+          }),
+        ],
+        total: 1,
+        limit: 3,
+        offset: 0,
+        mode: 'fast',
+        query: 'login',
+        cached: false,
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'login broken' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json().data;
+      expect(body.matches).toHaveLength(1);
+      expect(body.matches[0]).toEqual({
+        canonical_id: 'bug-1',
+        title: 'login button broken on Firefox',
+        status: 'closed',
+        similarity: 0.91,
+      });
+      // Explicit no-leak assertions: an ingest-only key MUST NOT see
+      // description / resolution / created_at via this endpoint.
+      expect(body.matches[0]).not.toHaveProperty('description');
+      expect(body.matches[0]).not.toHaveProperty('resolution');
+      expect(body.matches[0]).not.toHaveProperty('created_at');
+    });
+
+    it('passes title + project_id + mode=fast to intelligence search', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'cannot submit form' },
+      });
+
+      expect(globalClient.search).toHaveBeenCalledWith({
+        query: 'cannot submit form',
+        project_id: PROJECT_ID,
+        mode: 'fast',
+        limit: 3,
+      });
+    });
+  });
+
+  describe('threshold filter', () => {
+    it('drops matches below the SDK floor (0.6) even though intelligence returned them', async () => {
+      globalClient.search.mockResolvedValueOnce({
+        results: [
+          makeSearchResult({ bug_id: 'high', similarity: 0.82 }),
+          makeSearchResult({ bug_id: 'low', similarity: 0.45 }),
+          makeSearchResult({ bug_id: 'borderline', similarity: 0.59 }),
+          makeSearchResult({ bug_id: 'just-in', similarity: 0.61 }),
+        ],
+        total: 4,
+        limit: 3,
+        offset: 0,
+        mode: 'fast',
+        query: 'x',
+        cached: false,
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'something broken' },
+      });
+
+      const ids = res.json().data.matches.map((m: { canonical_id: string }) => m.canonical_id);
+      expect(ids).toEqual(['high', 'just-in']);
+    });
+  });
+
+  describe('limit', () => {
+    it('defaults to 3 when not provided', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'broken thing' },
+      });
+      expect(globalClient.search).toHaveBeenCalledWith(expect.objectContaining({ limit: 3 }));
+    });
+
+    it('respects an explicit limit of 1', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'broken thing', limit: 1 },
+      });
+      expect(globalClient.search).toHaveBeenCalledWith(expect.objectContaining({ limit: 1 }));
+    });
+
+    it('rejects a limit above the SDK ceiling (5) at the schema layer', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'broken thing', limit: 50 },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('soft-fail surface (the launch-critical contract)', () => {
+    it('returns empty matches (200) when the intelligence search throws', async () => {
+      globalClient.search.mockRejectedValueOnce(new Error('intelligence down'));
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'whatever' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.matches).toEqual([]);
+    });
+
+    it('returns empty matches (200) when intelligence is not configured for the org', async () => {
+      // Factory exists but returns null for this org (Option C in the
+      // admin-side resolveClient — but the SDK route soft-fails here
+      // instead of 503).
+      const factory = { getClientForOrg: vi.fn().mockResolvedValue(null) };
+      const app2 = Fastify();
+      sdkSimilarRoutes(app2, globalClient, createMockDb(), factory as any);
+      await app2.ready();
+
+      const res = await app2.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'whatever' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.matches).toEqual([]);
+      // Global client should NOT have been used as a fallback when
+      // factory existed but returned null — that branch means the org
+      // explicitly hasn't enabled intelligence.
+      expect(globalClient.search).not.toHaveBeenCalled();
+      await app2.close();
+    });
+
+    it('returns empty matches (200) when the factory itself throws', async () => {
+      const factory = {
+        getClientForOrg: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+      };
+      const app2 = Fastify();
+      sdkSimilarRoutes(app2, globalClient, createMockDb(), factory as any);
+      await app2.ready();
+
+      const res = await app2.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'whatever' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.matches).toEqual([]);
+      await app2.close();
+    });
+  });
+
+  describe('input validation', () => {
+    it('rejects a title shorter than 5 characters', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/sdk/similar',
+        payload: { title: 'hi' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(globalClient.search).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Backend half of in-widget deflection — the highest-leverage UX move from `dedup-reporter-design.md` because it unlocks duplicate-acknowledgment for **all** SDK integration patterns, including anonymous public-site flows where the `reporter` email token doesn't apply.

Two slices ship together so the SDK widget has both halves to wire to.

### 1. `POST /api/v1/sdk/similar` — pre-submission probe

- Ingest-key auth (same shape as `POST /reports`). Body: `{ title, limit? }`. Returns slim matches: `{ canonical_id, title, status, similarity }`. Description / resolution / timestamps are NOT exposed via ingest-only credentials.
- **Soft-fail contract** (load-bearing): intelligence disabled / factory throws / search throws → `{ matches: [] }` at 200, never 503. The widget must degrade gracefully without surfacing errors to end-users.
- SDK-side similarity floor of 0.6 (narrower than admin `/search`) — false-positive "is this the same?" chips burn user trust fast.
- Per-org client preferred when factory + `organization_id` available; falls back to global client for selfhosted.

### 2. `POST /api/v1/reports` accepts `deflected_to_canonical_id`

- Set by the widget when the user confirmed "yes, this is the same as #X" on a deflection chip. Writes straight to `bug_reports.duplicate_of`, bypassing the intelligence pre-file dedup grace.
- **Cross-project scope check**: the canonical must belong to the same project as the new bug. Mirrors the rule-engine's `TicketsTableResolver` defense-in-depth — prevents deflecting fresh bugs into foreign tenants' canonicals.
- Tags `metadata.deflection_source = 'sdk_user_confirmed'` for analytics — distinct from intelligence-pipeline-inferred dedup, so widget-deflection rate is measurable.

## Test plan

- [x] `pnpm vitest run tests/api/sdk-similar-routes.test.ts` — 10 / 10 passing (happy path, narrow projection, threshold filter, limit bounds, all three soft-fail branches, validation)
- [x] `pnpm vitest run tests/api/reports.test.ts` — 50 / 50 passing (was 46; 4 new deflection cases: success path, cross-project rejection, non-existent canonical, no-deflection-tag-when-absent)
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [ ] SDK widget PR queues next (`bugspotter-sdk` repo) — uses both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now confirm when reporting a duplicate bug by referencing a canonical bug ID.
  * New SDK endpoint enables finding similar/duplicate bugs during report submission.
  * Deflection confirmations are tracked and tagged for analytics purposes.

* **Tests**
  * Added test coverage for duplicate report confirmation and cross-project validation.
  * Added test coverage for similarity matching endpoint and soft-failure behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->