### PR TITLE
fix(analytics): drop response schemas that stripped data to {}

### DIFF
--- a/packages/backend/src/api/routes/analytics.ts
+++ b/packages/backend/src/api/routes/analytics.ts
@@ -22,27 +22,11 @@ import type { AnalyticsService } from '../../analytics/analytics-service.js';
 import { resolveAnalyticsScope } from '../../analytics/analytics-scope.js';
 import { requireAnalyticsAccess } from '../../analytics/analytics-auth.js';
 
-// Shared response shapes
-const objectDataResponse = {
-  200: {
-    type: 'object',
-    properties: {
-      success: { type: 'boolean' },
-      data: { type: 'object' },
-    },
-  },
-} as const;
-
-const arrayDataResponse = {
-  200: {
-    type: 'object',
-    properties: {
-      success: { type: 'boolean' },
-      data: { type: 'array', items: { type: 'object' } },
-    },
-  },
-} as const;
-
+// Request validation schemas only — no response schemas.
+// fast-json-stringify strips properties not declared in a response schema,
+// so a `data: { type: 'object' }` (no properties) silently serializes to `{}`.
+// Match the project convention used elsewhere (admin-organizations, etc.)
+// and skip the response schema; the handlers' return shape is the contract.
 const orgIdParams = {
   type: 'object',
   required: ['id'],
@@ -61,27 +45,19 @@ const trendQuerystring = {
 const analyticsSchemas = {
   dashboard: {
     params: orgIdParams,
-    response: objectDataResponse,
   },
   trend: {
     params: orgIdParams,
     querystring: trendQuerystring,
-    response: objectDataResponse,
   },
   projectStats: {
     params: orgIdParams,
-    response: arrayDataResponse,
   },
-  flatDashboard: {
-    response: objectDataResponse,
-  },
+  flatDashboard: {},
   flatTrend: {
     querystring: trendQuerystring,
-    response: objectDataResponse,
   },
-  flatProjectStats: {
-    response: arrayDataResponse,
-  },
+  flatProjectStats: {},
 };
 
 export function analyticsRoutes(

--- a/packages/backend/tests/api/analytics-routes.test.ts
+++ b/packages/backend/tests/api/analytics-routes.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Analytics Routes Tests
+ *
+ * Regression guard for a long-standing bug where the response schema
+ * declared `data: { type: 'object' }` with no `properties` /
+ * `additionalProperties`, causing fast-json-stringify to strip every
+ * field from `data` on the wire (`{"success":true,"data":{}}`).
+ *
+ * These tests exercise the routes through a real Fastify instance so
+ * the response serializer actually runs — that's the layer the bug
+ * lived in, and the layer the existing service/scope/auth unit tests
+ * never crossed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { analyticsRoutes } from '../../src/api/routes/analytics.js';
+import type { AnalyticsService } from '../../src/analytics/analytics-service.js';
+import type { DatabaseClient } from '../../src/db/client.js';
+
+// Mock requireUser to attach a stub authUser
+vi.mock('../../src/api/middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/api/middleware/auth.js')>();
+  return {
+    ...actual,
+    requireUser: async (request: import('fastify').FastifyRequest) => {
+      (request as unknown as { authUser: unknown }).authUser = {
+        id: 'test-user-id',
+        email: 'admin@example.com',
+        role: 'admin',
+      };
+    },
+  };
+});
+
+// Mock the analytics auth + scope so the test focuses on the routes/serializer
+vi.mock('../../src/analytics/analytics-auth.js', () => ({
+  requireAnalyticsAccess: () => async () => {},
+}));
+
+vi.mock('../../src/analytics/analytics-scope.js', () => ({
+  resolveAnalyticsScope: async () => ({ organizationIds: null }),
+}));
+
+// Mock the org-role middleware used by the org-param routes
+vi.mock('../../src/api/middleware/org-access.js', () => ({
+  requireOrgRole: () => async () => {},
+}));
+
+// Realistic payloads returned by the service — exactly what we expect the
+// wire response's `data` field to equal.
+const DASHBOARD_METRICS = {
+  bug_reports: {
+    by_status: { open: 3, in_progress: 1, resolved: 2, closed: 0, total: 6 },
+    by_priority: { low: 1, medium: 2, high: 2, critical: 1 },
+  },
+  projects: { total: 2, total_reports: 6, avg_reports_per_project: 3 },
+  users: { total: 4 },
+  time_series: [{ date: '2026-05-20', count: 2 }],
+  top_projects: [{ id: 'proj-1', name: 'Acme', report_count: 4 }],
+};
+
+const TREND = {
+  days: 7,
+  trend: [
+    { date: '2026-05-20', total: 2, open: 1, in_progress: 0, resolved: 1, closed: 0 },
+    { date: '2026-05-21', total: 1, open: 1, in_progress: 0, resolved: 0, closed: 0 },
+  ],
+};
+
+const PROJECT_STATS = [
+  {
+    id: 'proj-1',
+    name: 'Acme',
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    total_reports: 4,
+    open_reports: 2,
+    in_progress_reports: 1,
+    resolved_reports: 1,
+    closed_reports: 0,
+    critical_reports: 1,
+    last_report_at: new Date('2026-05-22T00:00:00Z'),
+  },
+];
+
+function createMockAnalyticsService(): AnalyticsService {
+  return {
+    getDashboardMetrics: vi.fn().mockResolvedValue(DASHBOARD_METRICS),
+    getReportTrend: vi.fn().mockResolvedValue(TREND),
+    getProjectStats: vi.fn().mockResolvedValue(PROJECT_STATS),
+  } as unknown as AnalyticsService;
+}
+
+describe('Analytics Routes — response body shape', () => {
+  let server: FastifyInstance;
+
+  beforeEach(async () => {
+    server = Fastify({ logger: false });
+    const analytics = createMockAnalyticsService();
+    const db = {} as unknown as DatabaseClient;
+    analyticsRoutes(server, analytics, db);
+    await server.ready();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  // --- Flat routes ----------------------------------------------------------
+
+  describe('GET /api/v1/analytics/dashboard', () => {
+    it('returns the full dashboard payload (not an empty {})', async () => {
+      const res = await server.inject({ method: 'GET', url: '/api/v1/analytics/dashboard' });
+      expect(res.statusCode).toBe(200);
+      const json = res.json();
+      expect(json.success).toBe(true);
+      // Guards against the historical regression where every field was stripped.
+      expect(json.data).toEqual(DASHBOARD_METRICS);
+      expect(json.data.bug_reports.by_status.total).toBe(6);
+      expect(Array.isArray(json.data.time_series)).toBe(true);
+      expect(Array.isArray(json.data.top_projects)).toBe(true);
+    });
+  });
+
+  describe('GET /api/v1/analytics/reports/trend', () => {
+    it('returns the trend payload with days and a populated trend array', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/v1/analytics/reports/trend?days=7',
+      });
+      expect(res.statusCode).toBe(200);
+      const json = res.json();
+      expect(json.success).toBe(true);
+      expect(json.data.days).toBe(7);
+      expect(json.data.trend).toHaveLength(2);
+      expect(json.data.trend[0]).toMatchObject({
+        date: '2026-05-20',
+        total: 2,
+        open: 1,
+        resolved: 1,
+      });
+    });
+  });
+
+  describe('GET /api/v1/analytics/projects/stats', () => {
+    it('returns an array of project rows with all fields populated (not [{},{}])', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/v1/analytics/projects/stats',
+      });
+      expect(res.statusCode).toBe(200);
+      const json = res.json();
+      expect(json.success).toBe(true);
+      expect(Array.isArray(json.data)).toBe(true);
+      expect(json.data).toHaveLength(1);
+      // Pre-fix, fast-json-stringify reduced each item to `{}`.
+      expect(json.data[0].id).toBe('proj-1');
+      expect(json.data[0].name).toBe('Acme');
+      expect(json.data[0].total_reports).toBe(4);
+      expect(json.data[0].critical_reports).toBe(1);
+    });
+  });
+
+  // --- Org-param routes -----------------------------------------------------
+  //
+  // Same response-schema bug existed here too. One spot-check per route is
+  // enough to lock the contract — handlers are nearly identical to the flat
+  // routes and share the schema definitions.
+
+  const orgId = '00000000-0000-4000-8000-000000000001';
+
+  describe('GET /api/v1/organizations/:id/analytics/dashboard', () => {
+    it('returns the full dashboard payload for the org', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/organizations/${orgId}/analytics/dashboard`,
+      });
+      expect(res.statusCode).toBe(200);
+      const json = res.json();
+      expect(json.data).toEqual(DASHBOARD_METRICS);
+    });
+  });
+
+  describe('GET /api/v1/organizations/:id/analytics/reports/trend', () => {
+    it('returns trend with days + populated trend array', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/organizations/${orgId}/analytics/reports/trend?days=7`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.trend).toHaveLength(2);
+    });
+  });
+
+  describe('GET /api/v1/organizations/:id/analytics/projects/stats', () => {
+    it('returns an array of project rows with all fields populated', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/organizations/${orgId}/analytics/projects/stats`,
+      });
+      expect(res.statusCode).toBe(200);
+      const data = res.json().data;
+      expect(data).toHaveLength(1);
+      expect(data[0].name).toBe('Acme');
+      expect(data[0].total_reports).toBe(4);
+    });
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       'tests/api/auth-responses.test.ts',
       'tests/api/auth-handlers.test.ts',
       'tests/api/trust-proxy.test.ts',
+      'tests/api/analytics-routes.test.ts',
       // Only include pure unit tests from middleware (no database/server)
       'tests/api/middleware/authorization.test.ts',
       'tests/api/middleware/require-project-role.test.ts',


### PR DESCRIPTION
The analytics routes declared `data: { type: 'object' }` on every endpoint. `fast-json-stringify` strips properties not listed in the schema, so `/api/v1/analytics/dashboard` silently returned `{"success":true,"data":{}}` while the service layer had the right object in hand. Same shape for `/reports/trend` and `/projects/stats` (the latter as `[{},{},…]`).

Bug landed in `dab1f3c` (Oct 17 2025) and was copy-pasted into the flat routes by #817; the three existing analytics tests (service / scope / auth) never exercised the Fastify request/response cycle, which is the only layer where the serializer runs.

Fix removes the response blocks (matches the convention used by `admin-organizations.ts` and other route files in the same package). New `tests/api/analytics-routes.test.ts` is a route-level guard via `fastify.inject` — verified it fails against the broken schema (`expected DASHBOARD_METRICS, received {}`) and passes after the fix.

## Test plan
- [ ] `pnpm --filter @bugspotter/backend test:unit` — full suite passes (2896 tests in local run)
- [ ] In staging: `curl -H "Authorization: Bearer <admin>" https://app.kz.bugspotter.io/api/v1/analytics/dashboard` returns populated `data.bug_reports`, `data.projects`, etc.
- [ ] Admin dashboard at `https://app.kz.bugspotter.io/dashboard` renders metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for analytics routes to verify response data handling and prevent regressions.

* **Refactor**
  * Streamlined analytics route schema validation configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/apex-bridge/bugspotter/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->