### PR TITLE
feat(analytics): honor ?organization_id= filter for platform admins

### DIFF
--- a/apps/admin/src/pages/dashboard.tsx
+++ b/apps/admin/src/pages/dashboard.tsx
@@ -1,14 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { analyticsService } from '../services/api';
+import { useOrgFilter } from '../hooks/use-org-filter';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
 import { Activity, FolderKanban, Users, AlertCircle } from 'lucide-react';
 
 export default function DashboardPage() {
   const { t } = useTranslation();
+  // Platform-admin sidebar filter narrows cross-org dashboard to a single tenant.
+  // Backend ignores the param for non-admins; this is just plumbing.
+  const { selectedOrgId: adminOrgScope } = useOrgFilter();
   const { data, isLoading, error } = useQuery({
-    queryKey: ['analytics-dashboard'],
-    queryFn: () => analyticsService.getDashboard(),
+    queryKey: ['analytics-dashboard', adminOrgScope],
+    queryFn: () => analyticsService.getDashboard(adminOrgScope),
     refetchInterval: 60000, // Refresh every minute
     retry: 1, // Only retry once
   });

--- a/apps/admin/src/services/analytics-service.ts
+++ b/apps/admin/src/services/analytics-service.ts
@@ -6,25 +6,34 @@
 import { api, API_ENDPOINTS } from '../lib/api-client';
 import type { AnalyticsDashboard, ReportTrend, ProjectStats } from '../types';
 
+// Platform admin can narrow the cross-org view via `?organization_id=`.
+// Backend ignores the param for non-admins (security boundary lives in
+// resolveAnalyticsScope). Matches the call shape used by project-service,
+// bug-report-service, user-service, and api-key-service.
 export const analyticsService = {
-  getDashboard: async (): Promise<AnalyticsDashboard> => {
+  getDashboard: async (organizationId?: string | null): Promise<AnalyticsDashboard> => {
     const response = await api.get<{ success: boolean; data: AnalyticsDashboard }>(
-      API_ENDPOINTS.analytics.dashboard()
+      API_ENDPOINTS.analytics.dashboard(),
+      { params: organizationId ? { organization_id: organizationId } : undefined }
     );
     return response.data.data;
   },
 
-  getReportTrend: async (days: number = 30): Promise<ReportTrend> => {
+  getReportTrend: async (
+    days: number = 30,
+    organizationId?: string | null
+  ): Promise<ReportTrend> => {
     const response = await api.get<{ success: boolean; data: ReportTrend }>(
       API_ENDPOINTS.analytics.reportsTrend(),
-      { params: { days } }
+      { params: { days, ...(organizationId && { organization_id: organizationId }) } }
     );
     return response.data.data;
   },
 
-  getProjectStats: async (): Promise<ProjectStats[]> => {
+  getProjectStats: async (organizationId?: string | null): Promise<ProjectStats[]> => {
     const response = await api.get<{ success: boolean; data: ProjectStats[] }>(
-      API_ENDPOINTS.analytics.projectsStats()
+      API_ENDPOINTS.analytics.projectsStats(),
+      { params: organizationId ? { organization_id: organizationId } : undefined }
     );
     return response.data.data;
   },

--- a/apps/admin/src/tests/pages/admin-org-scope-effects.test.tsx
+++ b/apps/admin/src/tests/pages/admin-org-scope-effects.test.tsx
@@ -25,13 +25,19 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { useOrgFilter } from '../../hooks/use-org-filter';
-import { bugReportService, userService, projectService } from '../../services/api';
+import {
+  bugReportService,
+  userService,
+  projectService,
+  analyticsService,
+} from '../../services/api';
 import { apiKeyService } from '../../services/api-key-service';
 import { organizationService } from '../../services/organization-service';
 import BugReportsPage from '../../pages/bug-reports';
 import ApiKeysPage from '../../pages/api-keys';
 import UsersPage from '../../pages/users';
 import ProjectsPage from '../../pages/projects';
+import DashboardPage from '../../pages/dashboard';
 
 // ---- Service mocks. Each test resets the relevant spy. -------------------
 //
@@ -45,6 +51,11 @@ import ProjectsPage from '../../pages/projects';
 vi.mock('../../services/api', () => ({
   bugReportService: { getAll: vi.fn(), delete: vi.fn() },
   userService: { getAll: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  analyticsService: {
+    getDashboard: vi.fn(),
+    getReportTrend: vi.fn(),
+    getProjectStats: vi.fn(),
+  },
   projectService: {
     getAll: vi.fn(),
     create: vi.fn(),
@@ -177,6 +188,16 @@ beforeEach(() => {
     pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
   } as never);
   vi.mocked(projectService.getAll).mockResolvedValue([] as never);
+  vi.mocked(analyticsService.getDashboard).mockResolvedValue({
+    bug_reports: {
+      by_status: { open: 0, in_progress: 0, resolved: 0, closed: 0, total: 0 },
+      by_priority: { low: 0, medium: 0, high: 0, critical: 0 },
+    },
+    projects: { total: 0, total_reports: 0, avg_reports_per_project: 0 },
+    users: { total: 0 },
+    time_series: [],
+    top_projects: [],
+  } as never);
   vi.mocked(organizationService.list).mockResolvedValue({
     data: [
       { id: 'acme', name: 'Acme', subdomain: 'acme' } as never,
@@ -344,5 +365,43 @@ describe('projects.tsx auto-seed gate', () => {
     // Empty string = the placeholder "Select an organization" option.
     // Crucially NOT 'ghost' — that would mean the gate is broken.
     expect(select.value).toBe('');
+  });
+});
+
+describe('dashboard.tsx — analyticsService.getDashboard receives the org filter', () => {
+  // Unlike the four list pages above, dashboard.tsx has no in-page state
+  // (no pagination, no filters) so the only thing to assert is that the
+  // service call carries the orgId from useOrgFilter, and re-fires when
+  // the URL param changes. Without the wiring, the dashboard would stay
+  // on the cross-org aggregate regardless of sidebar selection.
+
+  it('passes the URL ?organizationId= through to analyticsService.getDashboard', async () => {
+    renderWithOrgFilterControls(<DashboardPage />, ['/dashboard?organizationId=acme']);
+
+    await waitFor(() => expect(analyticsService.getDashboard).toHaveBeenCalled());
+    const lastCall = vi.mocked(analyticsService.getDashboard).mock.calls.at(-1)!;
+    expect(lastCall[0]).toBe('acme');
+  });
+
+  it('refetches with the new org id when the filter changes', async () => {
+    const { setOrg } = renderWithOrgFilterControls(<DashboardPage />, [
+      '/dashboard?organizationId=acme',
+    ]);
+    await waitFor(() => expect(analyticsService.getDashboard).toHaveBeenCalled());
+    vi.mocked(analyticsService.getDashboard).mockClear();
+
+    setOrg('initech');
+
+    await waitFor(() => expect(analyticsService.getDashboard).toHaveBeenCalled());
+    const lastCall = vi.mocked(analyticsService.getDashboard).mock.calls.at(-1)!;
+    expect(lastCall[0]).toBe('initech');
+  });
+
+  it('passes null when no org filter is set (cross-org view for platform admin)', async () => {
+    renderWithOrgFilterControls(<DashboardPage />, ['/dashboard']);
+
+    await waitFor(() => expect(analyticsService.getDashboard).toHaveBeenCalled());
+    const lastCall = vi.mocked(analyticsService.getDashboard).mock.calls.at(-1)!;
+    expect(lastCall[0]).toBeNull();
   });
 });

--- a/packages/backend/src/analytics/analytics-scope.ts
+++ b/packages/backend/src/analytics/analytics-scope.ts
@@ -24,8 +24,10 @@ export interface AnalyticsScope {
  * Resolution priority:
  * 1. Self-hosted mode → null (no filter, all data)
  * 2. SaaS mode with request.organizationId (from tenant middleware) → [orgId]
- * 3. SaaS mode, no org context → aggregate across user's org memberships
- * 4. SaaS mode, no org context, no memberships → throw 403
+ * 3. SaaS mode, platform admin with ?organization_id= query param → [orgId]
+ * 4. SaaS mode, platform admin without query param → null (cross-org)
+ * 5. SaaS mode, no org context → aggregate across user's org memberships
+ * 6. SaaS mode, no org context, no memberships → throw 403
  */
 export async function resolveAnalyticsScope(
   request: FastifyRequest,
@@ -43,9 +45,15 @@ export async function resolveAnalyticsScope(
     return { organizationIds: [request.organizationId] };
   }
 
-  // Platform admin on hub domain: full analytics access (no org filter)
+  // Platform admin on hub domain.
+  // Honor ?organization_id= to narrow the cross-org view to a single tenant —
+  // matches the convention used by /api/v1/projects and the other list
+  // endpoints (see projects.ts). Without the param, fall through to the
+  // full cross-org aggregate.
+  // Param is only consulted for platform admins; regular users never reach it.
   if (isPlatformAdmin(request)) {
-    return { organizationIds: null };
+    const orgScope = (request.query as { organization_id?: string } | undefined)?.organization_id;
+    return { organizationIds: orgScope ? [orgScope] : null };
   }
 
   // SaaS mode but no org context (hub domain / no subdomain)

--- a/packages/backend/src/api/routes/analytics.ts
+++ b/packages/backend/src/api/routes/analytics.ts
@@ -35,6 +35,33 @@ const orgIdParams = {
   },
 } as const;
 
+// `organization_id` is honored for platform admins only — see
+// resolveAnalyticsScope for the security boundary. Declared in the
+// schema so Fastify exposes it as typed query and doesn't silently
+// strip it under `removeAdditional`.
+const orgIdQuery = {
+  organization_id: { type: 'string', format: 'uuid' },
+} as const;
+
+const flatDashboardQuerystring = {
+  type: 'object',
+  properties: { ...orgIdQuery },
+} as const;
+
+const flatTrendQuerystring = {
+  type: 'object',
+  properties: {
+    days: { type: 'integer', minimum: 1, maximum: 365, default: 30 },
+    ...orgIdQuery,
+  },
+} as const;
+
+const flatProjectStatsQuerystring = {
+  type: 'object',
+  properties: { ...orgIdQuery },
+} as const;
+
+// Org-param routes don't accept the query — the URL `:id` is the scope.
 const trendQuerystring = {
   type: 'object',
   properties: {
@@ -53,11 +80,15 @@ const analyticsSchemas = {
   projectStats: {
     params: orgIdParams,
   },
-  flatDashboard: {},
-  flatTrend: {
-    querystring: trendQuerystring,
+  flatDashboard: {
+    querystring: flatDashboardQuerystring,
   },
-  flatProjectStats: {},
+  flatTrend: {
+    querystring: flatTrendQuerystring,
+  },
+  flatProjectStats: {
+    querystring: flatProjectStatsQuerystring,
+  },
 };
 
 export function analyticsRoutes(
@@ -70,7 +101,7 @@ export function analyticsRoutes(
   // ==========================================================================
 
   // GET /api/v1/analytics/dashboard
-  fastify.get(
+  fastify.get<{ Querystring: { organization_id?: string } }>(
     '/api/v1/analytics/dashboard',
     {
       preHandler: [requireUser, requireAnalyticsAccess(db)],
@@ -88,7 +119,7 @@ export function analyticsRoutes(
   );
 
   // GET /api/v1/analytics/reports/trend
-  fastify.get<{ Querystring: { days?: number } }>(
+  fastify.get<{ Querystring: { days?: number; organization_id?: string } }>(
     '/api/v1/analytics/reports/trend',
     {
       preHandler: [requireUser, requireAnalyticsAccess(db)],
@@ -107,7 +138,7 @@ export function analyticsRoutes(
   );
 
   // GET /api/v1/analytics/projects/stats
-  fastify.get(
+  fastify.get<{ Querystring: { organization_id?: string } }>(
     '/api/v1/analytics/projects/stats',
     {
       preHandler: [requireUser, requireAnalyticsAccess(db)],

--- a/packages/backend/tests/analytics/analytics-scope.test.ts
+++ b/packages/backend/tests/analytics/analytics-scope.test.ts
@@ -115,6 +115,68 @@ describe('resolveAnalyticsScope', () => {
     expect(scope.organizationIds).toEqual(['org-tenant']);
   });
 
+  it('should narrow to ?organization_id= for SaaS platform admin on hub domain', async () => {
+    process.env.DEPLOYMENT_MODE = 'saas';
+    resetDeploymentConfig();
+
+    const request = {
+      authUser: { id: 'admin-1', role: 'admin' },
+      query: { organization_id: 'org-target' },
+    } as unknown as FastifyRequest;
+
+    const mockDb = {
+      organizationMembers: {
+        findByUserId: async () => {
+          throw new Error('should not be called');
+        },
+      },
+    } as never;
+
+    const scope = await resolveAnalyticsScope(request, mockDb);
+    expect(scope.organizationIds).toEqual(['org-target']);
+  });
+
+  it('should let subdomain context win over ?organization_id= for platform admin', async () => {
+    process.env.DEPLOYMENT_MODE = 'saas';
+    resetDeploymentConfig();
+
+    // A platform admin already on acme.kz.bugspotter.io cannot widen / cross
+    // to a different org via the query param.
+    const request = {
+      authUser: { id: 'admin-1', role: 'admin' },
+      organizationId: 'org-subdomain',
+      query: { organization_id: 'org-other' },
+    } as unknown as FastifyRequest;
+
+    const db = {} as never;
+
+    const scope = await resolveAnalyticsScope(request, db);
+    expect(scope.organizationIds).toEqual(['org-subdomain']);
+  });
+
+  it('should ignore ?organization_id= for non-admin users (security boundary)', async () => {
+    process.env.DEPLOYMENT_MODE = 'saas';
+    resetDeploymentConfig();
+
+    // Non-admin user attempts to scope to an org they don't administer.
+    // The query param branch is only reached for platform admins; everyone
+    // else falls through to the memberships aggregation.
+    const request = {
+      authUser: { id: 'user-1' },
+      query: { organization_id: 'org-foreign' },
+    } as unknown as FastifyRequest;
+
+    const mockDb = {
+      organizationMembers: {
+        findByUserId: async () => [{ organization_id: 'org-a', role: 'admin' }],
+      },
+    } as never;
+
+    const scope = await resolveAnalyticsScope(request, mockDb);
+    expect(scope.organizationIds).toEqual(['org-a']);
+    expect(scope.organizationIds).not.toContain('org-foreign');
+  });
+
   it('should throw 401 when SaaS mode, no org context, no auth user', async () => {
     process.env.DEPLOYMENT_MODE = 'saas';
     resetDeploymentConfig();

--- a/packages/backend/tests/api/analytics-routes.test.ts
+++ b/packages/backend/tests/api/analytics-routes.test.ts
@@ -205,4 +205,46 @@ describe('Analytics Routes — response body shape', () => {
       expect(data[0].total_reports).toBe(4);
     });
   });
+
+  // Schema-level guard for the platform-admin org-filter feature.
+  // The end-to-end scope-resolution behavior (which orgs get queried for
+  // which user shape) lives in tests/analytics/analytics-scope.test.ts —
+  // here we just verify the flat-route schemas accept the query param
+  // instead of rejecting it with a 400 / silently stripping it.
+
+  describe('?organization_id= query param on flat routes', () => {
+    const targetOrgId = '11111111-1111-4111-8111-111111111111';
+
+    it('GET /api/v1/analytics/dashboard accepts ?organization_id=<uuid>', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/analytics/dashboard?organization_id=${targetOrgId}`,
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('GET /api/v1/analytics/reports/trend accepts both days and organization_id', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/analytics/reports/trend?days=7&organization_id=${targetOrgId}`,
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('GET /api/v1/analytics/projects/stats accepts ?organization_id=<uuid>', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: `/api/v1/analytics/projects/stats?organization_id=${targetOrgId}`,
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('rejects a non-UUID organization_id with 400', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/api/v1/analytics/dashboard?organization_id=not-a-uuid',
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
 });

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
       'tests/api/auth-handlers.test.ts',
       'tests/api/trust-proxy.test.ts',
       'tests/api/analytics-routes.test.ts',
+      // Pure unit (mocked DB) — no testcontainer needed.
+      'tests/analytics/analytics-scope.test.ts',
+      'tests/analytics/analytics-auth.test.ts',
       // Only include pure unit tests from middleware (no database/server)
       'tests/api/middleware/authorization.test.ts',
       'tests/api/middleware/require-project-role.test.ts',


### PR DESCRIPTION
The `/dashboard` page in the admin UI had no way to narrow the cross-org view to a single tenant. Other list pages (Projects, Bug Reports, API Keys, Users) already do this via the sidebar `useOrgFilter` widget, which writes `?organizationId=` into the URL — but the analytics endpoints didn't read it.

## Changes

**Backend** — `resolveAnalyticsScope` now honors `?organization_id=` for platform admins on the hub domain, mirroring the convention used by `GET /api/v1/projects`. The query param is only consulted inside the `isPlatformAdmin` branch; non-admins still fall through to memberships aggregation. Tenant-subdomain context wins over the query param (a platform admin on `acme.kz.bugspotter.io` cannot widen to a different org via the param). Flat-route schemas declare `organization_id` as a UUID so junk input 400s instead of silently widening.

**Frontend** — `analyticsService.*` accepts optional `organizationId`; `dashboard.tsx` subscribes to `useOrgFilter` and threads it into the React Query key + service call.

## Tests

- `analytics-scope.test.ts`: param honored for platform admin, subdomain wins over param, param ignored for non-admin (security boundary).
- `analytics-routes.test.ts`: flat routes accept `?organization_id=<uuid>`, reject non-UUID with 400.
- `admin-org-scope-effects.test.tsx`: dashboard refetches with new org id on filter change, passes `null` on no filter.

## Test plan
- [ ] `pnpm --filter @bugspotter/backend test:unit` — full suite passes (2928 local)
- [ ] `pnpm --filter @bugspotter/admin test` — full suite passes (943 local)
- [ ] On `app.kz.bugspotter.io/dashboard`, the sidebar org dropdown narrows the metrics to the selected tenant
- [ ] On a tenant subdomain (e.g. `acme.kz.bugspotter.io/dashboard`), `?organization_id=other` is ignored — subdomain wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)