### PR TITLE
feat(intelligence): wire 👍/👎 ranking feedback to upstream intelligence_feedback

### DIFF
--- a/apps/admin/src/components/bug-reports/semantic-search-bar.tsx
+++ b/apps/admin/src/components/bug-reports/semantic-search-bar.tsx
@@ -5,6 +5,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Badge } from '../ui/badge';
 import { ConfidenceBadge } from '../intelligence/confidence-badge';
+import { IntelligenceEventFeedback } from '../intelligence/intelligence-event-feedback';
 import { intelligenceService } from '../../services/intelligence-service';
 import type { SearchResponse } from '../../types/intelligence';
 
@@ -124,6 +125,11 @@ export function SemanticSearchBar({ projectId, onResultSelect }: SemanticSearchB
             )}
             {results.mode === 'smart' && !results.cached && (
               <ConfidenceBadge confidence={results.confidence} className="text-xs" />
+            )}
+            {results.mode === 'smart' && !results.cached && results.event_id && (
+              <div className="ml-auto">
+                <IntelligenceEventFeedback eventId={results.event_id} projectId={projectId} />
+              </div>
             )}
           </div>
 

--- a/apps/admin/src/components/bug-reports/semantic-search-bar.tsx
+++ b/apps/admin/src/components/bug-reports/semantic-search-bar.tsx
@@ -128,7 +128,14 @@ export function SemanticSearchBar({ projectId, onResultSelect }: SemanticSearchB
             )}
             {results.mode === 'smart' && !results.cached && results.event_id && (
               <div className="ml-auto">
-                <IntelligenceEventFeedback eventId={results.event_id} projectId={projectId} />
+                {/* key={event_id} forces a remount so the local verdict state
+                    resets on each new search; without it, votes from a prior
+                    search would lock the buttons for the next one. */}
+                <IntelligenceEventFeedback
+                  key={results.event_id}
+                  eventId={results.event_id}
+                  projectId={projectId}
+                />
               </div>
             )}
           </div>

--- a/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { ThumbsUp, ThumbsDown } from 'lucide-react';
+import { toast } from 'sonner';
+import { intelligenceService } from '../../services/intelligence-service';
+import { handleApiError } from '../../lib/api-client';
+import { useAuth } from '../../contexts/auth-context';
+import type { IntelligenceEventVerdict } from '../../types/intelligence';
+import { cn } from '../../lib/utils';
+
+interface IntelligenceEventFeedbackProps {
+  eventId: string;
+  projectId: string;
+}
+
+/**
+ * Thumbs-up / thumbs-down vote on a specific intelligence_event (LLM call).
+ *
+ * Different from `SuggestionFeedback`: that one writes to the local
+ * `suggestion_feedback` table keyed by `(bug_report_id, suggestion_bug_id,
+ * user_id)`; this one writes upstream to `intelligence_feedback` keyed by
+ * `event_id` and reports against an LLM-call audit row.
+ *
+ * Upstream upserts on `(event_id, user_ref)`, so re-voting is idempotent.
+ * We keep local state for the chosen verdict so the UI reflects the click
+ * immediately and disables further voting; on mount we don't fetch prior
+ * state because the upstream doesn't expose a per-event verdict read.
+ */
+export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEventFeedbackProps) {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const [verdict, setVerdict] = useState<IntelligenceEventVerdict | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (newVerdict: IntelligenceEventVerdict) =>
+      intelligenceService.submitEventFeedback({
+        project_id: projectId,
+        event_id: eventId,
+        verdict: newVerdict,
+        user_ref: user?.id ?? null,
+      }),
+    onSuccess: (_data, newVerdict) => {
+      setVerdict(newVerdict);
+      toast.success(t('intelligence.feedback.submitted'));
+    },
+    onError: (error) => {
+      toast.error(handleApiError(error));
+    },
+  });
+
+  const isSubmitting = mutation.isPending;
+
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-xs text-gray-500 mr-1">{t('intelligence.feedback.helpful')}</span>
+      <button
+        type="button"
+        onClick={() => mutation.mutate('correct')}
+        disabled={isSubmitting || verdict !== null}
+        className={cn(
+          'p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+          verdict === 'correct'
+            ? 'text-green-600 bg-green-50'
+            : 'text-gray-400 hover:text-green-600 hover:bg-green-50'
+        )}
+        aria-label={t('intelligence.feedback.thumbsUp')}
+      >
+        <ThumbsUp className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={() => mutation.mutate('incorrect')}
+        disabled={isSubmitting || verdict !== null}
+        className={cn(
+          'p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+          verdict === 'incorrect'
+            ? 'text-red-600 bg-red-50'
+            : 'text-gray-400 hover:text-red-600 hover:bg-red-50'
+        )}
+        aria-label={t('intelligence.feedback.thumbsDown')}
+      >
+        <ThumbsDown className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
@@ -56,10 +56,14 @@ export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEv
         onClick={() => mutation.mutate('correct')}
         disabled={isSubmitting || verdict !== null}
         className={cn(
-          'p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+          'p-1 rounded transition-colors disabled:cursor-not-allowed',
           verdict === 'correct'
             ? 'text-green-600 bg-green-50'
-            : 'text-gray-400 enabled:hover:text-green-600 enabled:hover:bg-green-50'
+            : 'text-gray-400 enabled:hover:text-green-600 enabled:hover:bg-green-50',
+          // Dim only when this button is NOT the chosen one — keeps the
+          // selected verdict prominent after the vote lands. During an
+          // in-flight submission both are dimmed (still ambiguous).
+          (isSubmitting || (verdict !== null && verdict !== 'correct')) && 'opacity-50'
         )}
         aria-label={t('intelligence.feedback.thumbsUp')}
         aria-pressed={verdict === 'correct'}
@@ -71,10 +75,11 @@ export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEv
         onClick={() => mutation.mutate('incorrect')}
         disabled={isSubmitting || verdict !== null}
         className={cn(
-          'p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+          'p-1 rounded transition-colors disabled:cursor-not-allowed',
           verdict === 'incorrect'
             ? 'text-red-600 bg-red-50'
-            : 'text-gray-400 enabled:hover:text-red-600 enabled:hover:bg-red-50'
+            : 'text-gray-400 enabled:hover:text-red-600 enabled:hover:bg-red-50',
+          (isSubmitting || (verdict !== null && verdict !== 'incorrect')) && 'opacity-50'
         )}
         aria-label={t('intelligence.feedback.thumbsDown')}
         aria-pressed={verdict === 'incorrect'}

--- a/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
@@ -59,7 +59,7 @@ export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEv
           'p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
           verdict === 'correct'
             ? 'text-green-600 bg-green-50'
-            : 'text-gray-400 hover:text-green-600 hover:bg-green-50'
+            : 'text-gray-400 enabled:hover:text-green-600 enabled:hover:bg-green-50'
         )}
         aria-label={t('intelligence.feedback.thumbsUp')}
         aria-pressed={verdict === 'correct'}
@@ -74,7 +74,7 @@ export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEv
           'p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
           verdict === 'incorrect'
             ? 'text-red-600 bg-red-50'
-            : 'text-gray-400 hover:text-red-600 hover:bg-red-50'
+            : 'text-gray-400 enabled:hover:text-red-600 enabled:hover:bg-red-50'
         )}
         aria-label={t('intelligence.feedback.thumbsDown')}
         aria-pressed={verdict === 'incorrect'}

--- a/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-event-feedback.tsx
@@ -5,7 +5,6 @@ import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { toast } from 'sonner';
 import { intelligenceService } from '../../services/intelligence-service';
 import { handleApiError } from '../../lib/api-client';
-import { useAuth } from '../../contexts/auth-context';
 import type { IntelligenceEventVerdict } from '../../types/intelligence';
 import { cn } from '../../lib/utils';
 
@@ -29,7 +28,6 @@ interface IntelligenceEventFeedbackProps {
  */
 export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEventFeedbackProps) {
   const { t } = useTranslation();
-  const { user } = useAuth();
   const [verdict, setVerdict] = useState<IntelligenceEventVerdict | null>(null);
 
   const mutation = useMutation({
@@ -38,7 +36,6 @@ export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEv
         project_id: projectId,
         event_id: eventId,
         verdict: newVerdict,
-        user_ref: user?.id ?? null,
       }),
     onSuccess: (_data, newVerdict) => {
       setVerdict(newVerdict);
@@ -65,6 +62,7 @@ export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEv
             : 'text-gray-400 hover:text-green-600 hover:bg-green-50'
         )}
         aria-label={t('intelligence.feedback.thumbsUp')}
+        aria-pressed={verdict === 'correct'}
       >
         <ThumbsUp className="w-3.5 h-3.5" aria-hidden="true" />
       </button>
@@ -79,6 +77,7 @@ export function IntelligenceEventFeedback({ eventId, projectId }: IntelligenceEv
             : 'text-gray-400 hover:text-red-600 hover:bg-red-50'
         )}
         aria-label={t('intelligence.feedback.thumbsDown')}
+        aria-pressed={verdict === 'incorrect'}
       >
         <ThumbsDown className="w-3.5 h-3.5" aria-hidden="true" />
       </button>

--- a/apps/admin/src/lib/api-constants.ts
+++ b/apps/admin/src/lib/api-constants.ts
@@ -306,6 +306,8 @@ export const API_ENDPOINTS = {
     mitigation: (projectId: string, bugId: string) =>
       `${API_VERSION}/intelligence/projects/${projectId}/bugs/${bugId}/mitigation`,
     search: (projectId: string) => `${API_VERSION}/intelligence/projects/${projectId}/search`,
+    eventFeedback: (projectId: string) =>
+      `${API_VERSION}/intelligence/projects/${projectId}/event-feedback`,
   },
 
   // Dedup-rule engine (Phase 0.5). Project-scoped, human-admin-only —

--- a/apps/admin/src/services/intelligence-service.ts
+++ b/apps/admin/src/services/intelligence-service.ts
@@ -13,6 +13,8 @@ import type {
   DeflectionStats,
   SubmitFeedbackInput,
   SubmitFeedbackResult,
+  SubmitEventFeedbackInput,
+  SubmitEventFeedbackResult,
   FeedbackRecord,
   FeedbackStats,
   SimilarBugsResponse,
@@ -133,6 +135,20 @@ export const intelligenceService = {
 
   search: async (projectId: string, input: SearchInput): Promise<SearchResponse> => {
     const response = await api.post(API_ENDPOINTS.intelligence.search(projectId), input);
+    return response.data.data;
+  },
+
+  /**
+   * Record a verdict on a prior LLM call (intelligence_event). Distinct from
+   * `submitFeedback` above — that one targets the local suggestion_feedback
+   * table; this one writes to the upstream intelligence_feedback via the
+   * event-feedback proxy and is keyed by `event_id`.
+   */
+  submitEventFeedback: async (
+    input: SubmitEventFeedbackInput
+  ): Promise<SubmitEventFeedbackResult> => {
+    const { project_id, ...body } = input;
+    const response = await api.post(API_ENDPOINTS.intelligence.eventFeedback(project_id), body);
     return response.data.data;
   },
 };

--- a/apps/admin/src/tests/components/intelligence/intelligence-event-feedback.test.tsx
+++ b/apps/admin/src/tests/components/intelligence/intelligence-event-feedback.test.tsx
@@ -85,10 +85,8 @@ describe('IntelligenceEventFeedback', () => {
     // Belt-and-suspenders: the call payload must not carry user_ref. The
     // backend derives it from getAuditUserId(request) so the body should
     // never advertise it as a client-controllable field.
-    const args = vi.mocked(intelligenceService.submitEventFeedback).mock.calls[0][0] as Record<
-      string,
-      unknown
-    >;
+    const args = vi.mocked(intelligenceService.submitEventFeedback).mock
+      .calls[0][0] as unknown as Record<string, unknown>;
     expect(args).not.toHaveProperty('user_ref');
   });
 

--- a/apps/admin/src/tests/components/intelligence/intelligence-event-feedback.test.tsx
+++ b/apps/admin/src/tests/components/intelligence/intelligence-event-feedback.test.tsx
@@ -7,8 +7,6 @@ import { IntelligenceEventFeedback } from '../../../components/intelligence/inte
 import { intelligenceService } from '../../../services/intelligence-service';
 import { toast } from 'sonner';
 
-const useAuthMock = vi.fn();
-
 vi.mock('react-i18next', async () => {
   const en = (await import('../../../i18n/locales/en.json')).default;
   const get = (key: string): string | undefined =>
@@ -28,8 +26,6 @@ vi.mock('react-i18next', async () => {
     }),
   };
 });
-
-vi.mock('../../../contexts/auth-context', () => ({ useAuth: () => useAuthMock() }));
 
 vi.mock('../../../services/intelligence-service', () => ({
   intelligenceService: { submitEventFeedback: vi.fn() },
@@ -51,27 +47,27 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 const EVENT = 'e1b2c3d4-0000-4000-8000-000000000001';
+const EVENT2 = 'e1b2c3d4-0000-4000-8000-000000000099';
 const PROJECT = 'p1b2c3d4-0000-4000-8000-000000000002';
-const USER = 'u-42';
 
 describe('IntelligenceEventFeedback', () => {
   beforeEach(() => {
-    useAuthMock.mockReset();
-    useAuthMock.mockReturnValue({ user: { id: USER } });
     vi.mocked(intelligenceService.submitEventFeedback).mockReset();
     vi.mocked(toast.success).mockReset();
     vi.mocked(toast.error).mockReset();
   });
 
-  it('renders both thumb buttons initially enabled', () => {
+  it('renders both thumb buttons initially enabled and aria-pressed=false', () => {
     render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
     const up = screen.getByLabelText('Mark as helpful');
     const down = screen.getByLabelText('Mark as not helpful');
     expect(up).not.toBeDisabled();
     expect(down).not.toBeDisabled();
+    expect(up).toHaveAttribute('aria-pressed', 'false');
+    expect(down).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('thumbs-up sends verdict=correct with user_ref=user.id and disables both buttons after success', async () => {
+  it('does NOT send user_ref in the request body (server-side attribution)', async () => {
     vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
       feedback_id: 'f1',
     });
@@ -84,15 +80,38 @@ describe('IntelligenceEventFeedback', () => {
         project_id: PROJECT,
         event_id: EVENT,
         verdict: 'correct',
-        user_ref: USER,
       });
     });
-    expect(toast.success).toHaveBeenCalled();
-    expect(screen.getByLabelText('Mark as helpful')).toBeDisabled();
-    expect(screen.getByLabelText('Mark as not helpful')).toBeDisabled();
+    // Belt-and-suspenders: the call payload must not carry user_ref. The
+    // backend derives it from getAuditUserId(request) so the body should
+    // never advertise it as a client-controllable field.
+    const args = vi.mocked(intelligenceService.submitEventFeedback).mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(args).not.toHaveProperty('user_ref');
   });
 
-  it('thumbs-down sends verdict=incorrect', async () => {
+  it('thumbs-up: locks both buttons and reflects aria-pressed=true on success', async () => {
+    vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
+      feedback_id: 'f1',
+    });
+    render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
+
+    await userEvent.click(screen.getByLabelText('Mark as helpful'));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
+    const up = screen.getByLabelText('Mark as helpful');
+    const down = screen.getByLabelText('Mark as not helpful');
+    expect(up).toBeDisabled();
+    expect(down).toBeDisabled();
+    expect(up).toHaveAttribute('aria-pressed', 'true');
+    expect(down).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('thumbs-down: sends verdict=incorrect and sets aria-pressed=true on the down button', async () => {
     vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
       feedback_id: 'f2',
     });
@@ -104,21 +123,8 @@ describe('IntelligenceEventFeedback', () => {
       const args = vi.mocked(intelligenceService.submitEventFeedback).mock.calls[0][0];
       expect(args.verdict).toBe('incorrect');
     });
-  });
-
-  it('falls back to user_ref=null when no auth user', async () => {
-    useAuthMock.mockReturnValue({ user: null });
-    vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
-      feedback_id: 'f3',
-    });
-    render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
-
-    await userEvent.click(screen.getByLabelText('Mark as helpful'));
-
-    await waitFor(() => {
-      const args = vi.mocked(intelligenceService.submitEventFeedback).mock.calls[0][0];
-      expect(args.user_ref).toBeNull();
-    });
+    expect(screen.getByLabelText('Mark as not helpful')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByLabelText('Mark as helpful')).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('shows error toast and does NOT lock buttons on submit failure (so user can retry)', async () => {
@@ -136,5 +142,30 @@ describe('IntelligenceEventFeedback', () => {
     // with no way to retry after a transient network blip.
     expect(screen.getByLabelText('Mark as helpful')).not.toBeDisabled();
     expect(screen.getByLabelText('Mark as not helpful')).not.toBeDisabled();
+  });
+
+  it('rerendering with a different eventId via key= resets the verdict state', async () => {
+    vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
+      feedback_id: 'f1',
+    });
+    const { rerender } = render(
+      <IntelligenceEventFeedback key={EVENT} eventId={EVENT} projectId={PROJECT} />,
+      { wrapper }
+    );
+
+    await userEvent.click(screen.getByLabelText('Mark as helpful'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Mark as helpful')).toBeDisabled();
+    });
+
+    // Same logical position in the tree, but different key — React must
+    // unmount + remount, dropping the verdict state. Without key=, the
+    // parent would keep the old instance and the buttons would stay locked
+    // for the new event.
+    rerender(<IntelligenceEventFeedback key={EVENT2} eventId={EVENT2} projectId={PROJECT} />);
+
+    expect(screen.getByLabelText('Mark as helpful')).not.toBeDisabled();
+    expect(screen.getByLabelText('Mark as not helpful')).not.toBeDisabled();
+    expect(screen.getByLabelText('Mark as helpful')).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/apps/admin/src/tests/components/intelligence/intelligence-event-feedback.test.tsx
+++ b/apps/admin/src/tests/components/intelligence/intelligence-event-feedback.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { IntelligenceEventFeedback } from '../../../components/intelligence/intelligence-event-feedback';
+import { intelligenceService } from '../../../services/intelligence-service';
+import { toast } from 'sonner';
+
+const useAuthMock = vi.fn();
+
+vi.mock('react-i18next', async () => {
+  const en = (await import('../../../i18n/locales/en.json')).default;
+  const get = (key: string): string | undefined =>
+    key
+      .split('.')
+      .reduce<unknown>(
+        (obj, part) =>
+          obj != null && typeof obj === 'object'
+            ? (obj as Record<string, unknown>)[part]
+            : undefined,
+        en
+      ) as string | undefined;
+  return {
+    useTranslation: () => ({
+      t: (key: string) => get(key) ?? key,
+      i18n: { language: 'en' },
+    }),
+  };
+});
+
+vi.mock('../../../contexts/auth-context', () => ({ useAuth: () => useAuthMock() }));
+
+vi.mock('../../../services/intelligence-service', () => ({
+  intelligenceService: { submitEventFeedback: vi.fn() },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../lib/api-client', () => ({
+  handleApiError: (e: unknown) => (e as { message?: string } | null)?.message ?? 'error',
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const EVENT = 'e1b2c3d4-0000-4000-8000-000000000001';
+const PROJECT = 'p1b2c3d4-0000-4000-8000-000000000002';
+const USER = 'u-42';
+
+describe('IntelligenceEventFeedback', () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({ user: { id: USER } });
+    vi.mocked(intelligenceService.submitEventFeedback).mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it('renders both thumb buttons initially enabled', () => {
+    render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
+    const up = screen.getByLabelText('Mark as helpful');
+    const down = screen.getByLabelText('Mark as not helpful');
+    expect(up).not.toBeDisabled();
+    expect(down).not.toBeDisabled();
+  });
+
+  it('thumbs-up sends verdict=correct with user_ref=user.id and disables both buttons after success', async () => {
+    vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
+      feedback_id: 'f1',
+    });
+    render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
+
+    await userEvent.click(screen.getByLabelText('Mark as helpful'));
+
+    await waitFor(() => {
+      expect(intelligenceService.submitEventFeedback).toHaveBeenCalledWith({
+        project_id: PROJECT,
+        event_id: EVENT,
+        verdict: 'correct',
+        user_ref: USER,
+      });
+    });
+    expect(toast.success).toHaveBeenCalled();
+    expect(screen.getByLabelText('Mark as helpful')).toBeDisabled();
+    expect(screen.getByLabelText('Mark as not helpful')).toBeDisabled();
+  });
+
+  it('thumbs-down sends verdict=incorrect', async () => {
+    vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
+      feedback_id: 'f2',
+    });
+    render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
+
+    await userEvent.click(screen.getByLabelText('Mark as not helpful'));
+
+    await waitFor(() => {
+      const args = vi.mocked(intelligenceService.submitEventFeedback).mock.calls[0][0];
+      expect(args.verdict).toBe('incorrect');
+    });
+  });
+
+  it('falls back to user_ref=null when no auth user', async () => {
+    useAuthMock.mockReturnValue({ user: null });
+    vi.mocked(intelligenceService.submitEventFeedback).mockResolvedValueOnce({
+      feedback_id: 'f3',
+    });
+    render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
+
+    await userEvent.click(screen.getByLabelText('Mark as helpful'));
+
+    await waitFor(() => {
+      const args = vi.mocked(intelligenceService.submitEventFeedback).mock.calls[0][0];
+      expect(args.user_ref).toBeNull();
+    });
+  });
+
+  it('shows error toast and does NOT lock buttons on submit failure (so user can retry)', async () => {
+    vi.mocked(intelligenceService.submitEventFeedback).mockRejectedValueOnce(
+      new Error('upstream 500')
+    );
+    render(<IntelligenceEventFeedback eventId={EVENT} projectId={PROJECT} />, { wrapper });
+
+    await userEvent.click(screen.getByLabelText('Mark as helpful'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    // Failure must leave buttons enabled — locking them would strand the user
+    // with no way to retry after a transient network blip.
+    expect(screen.getByLabelText('Mark as helpful')).not.toBeDisabled();
+    expect(screen.getByLabelText('Mark as not helpful')).not.toBeDisabled();
+  });
+});

--- a/apps/admin/src/tests/e2e/global-setup.ts
+++ b/apps/admin/src/tests/e2e/global-setup.ts
@@ -150,8 +150,18 @@ export default async function globalSetup() {
         }),
 
       // MinIO container
+      //
+      // Expose ONLY 9000 (S3 API). The console (9001) used to be exposed
+      // too, but nothing consumes it — `getMappedPort(9000)` below is the
+      // only port read out of the container. With 9001 exposed,
+      // testcontainers blocks `start()` on BOTH port-binds, so a slow
+      // console init time turns into a 60s globalSetup timeout under
+      // GH Actions load (observed: same image goes from 9s to >60s on
+      // adjacent runs). Dropping the unused port halves the wait surface
+      // — MinIO still binds the console internally, we just don't wait
+      // for it from the host.
       new GenericContainer('minio/minio:RELEASE.2024-10-13T13-34-11Z')
-        .withExposedPorts(9000, 9001)
+        .withExposedPorts(9000)
         .withEnvironment({
           MINIO_ROOT_USER: 'bugspotter-e2e-admin',
           MINIO_ROOT_PASSWORD: 'bugspotter-e2e-secret-key',

--- a/apps/admin/src/types/intelligence.ts
+++ b/apps/admin/src/types/intelligence.ts
@@ -125,12 +125,15 @@ export type IntelligenceEventVerdict = 'correct' | 'incorrect' | 'partial';
  * enrich / ask. Distinct from `SubmitFeedbackInput` which targets the local
  * suggestion_feedback table — this one writes to the upstream
  * `intelligence_feedback` table via the event-feedback proxy route.
+ *
+ * `user_ref` is intentionally NOT part of the wire shape: the backend derives
+ * it from the authenticated session via `getAuditUserId(request)` so a
+ * malicious caller can't spoof attribution to another user.
  */
 export interface SubmitEventFeedbackInput {
   project_id: string;
   event_id: string;
   verdict: IntelligenceEventVerdict;
-  user_ref?: string | null;
   note?: string | null;
 }
 

--- a/apps/admin/src/types/intelligence.ts
+++ b/apps/admin/src/types/intelligence.ts
@@ -118,6 +118,26 @@ export interface SubmitFeedbackResult {
   created: boolean;
 }
 
+export type IntelligenceEventVerdict = 'correct' | 'incorrect' | 'partial';
+
+/**
+ * Verdict on a prior intelligence_event (LLM call) returned by smart search /
+ * enrich / ask. Distinct from `SubmitFeedbackInput` which targets the local
+ * suggestion_feedback table — this one writes to the upstream
+ * `intelligence_feedback` table via the event-feedback proxy route.
+ */
+export interface SubmitEventFeedbackInput {
+  project_id: string;
+  event_id: string;
+  verdict: IntelligenceEventVerdict;
+  user_ref?: string | null;
+  note?: string | null;
+}
+
+export interface SubmitEventFeedbackResult {
+  feedback_id: string;
+}
+
 export interface FeedbackStats {
   total_feedback: number;
   positive_count: number;

--- a/packages/backend/src/api/routes/intelligence.ts
+++ b/packages/backend/src/api/routes/intelligence.ts
@@ -9,6 +9,7 @@ import type { FastifyInstance } from 'fastify';
 import { requireAuth } from '../middleware/auth.js';
 import { guard } from '../authorization/index.js';
 import { sendSuccess } from '../utils/response.js';
+import { getAuditUserId } from '../utils/audit-attribution.js';
 import { AppError } from '../middleware/error.js';
 import type { IntelligenceClient } from '../../services/intelligence/intelligence-client.js';
 import { IntelligenceError } from '../../services/intelligence/intelligence-client.js';
@@ -102,7 +103,6 @@ const eventFeedbackSchema = {
     properties: {
       event_id: { type: 'string', format: 'uuid' },
       verdict: { type: 'string', enum: ['correct', 'incorrect', 'partial'] },
-      user_ref: { type: 'string', maxLength: 200, nullable: true },
       note: { type: 'string', maxLength: 2000, nullable: true },
     },
     additionalProperties: false,
@@ -348,13 +348,18 @@ export function intelligenceRoutes(
    * Path segment is `event-feedback` (not `feedback`) to avoid colliding
    * with the existing local /api/v1/intelligence/feedback that writes to
    * the local suggestion_feedback table (different scope).
+   *
+   * `user_ref` is NOT taken from the request body — it's derived server-
+   * side via `getAuditUserId(request)`. Taking it from the body would let
+   * an authenticated caller attribute feedback to an arbitrary user id and
+   * pollute the upstream accuracy stats. Anonymous (api-key) callers
+   * resolve to `null`; the upstream falls back to its <ANON> sentinel.
    */
   fastify.post<{
     Params: { projectId: string };
     Body: {
       event_id: string;
       verdict: 'correct' | 'incorrect' | 'partial';
-      user_ref?: string | null;
       note?: string | null;
     };
   }>(
@@ -370,13 +375,13 @@ export function intelligenceRoutes(
       ],
     },
     async (request, reply) => {
-      const { event_id, verdict, user_ref, note } = request.body;
+      const { event_id, verdict, note } = request.body;
       const client = await resolveClient(request, clientFactory, intelligenceClient);
       const result = await handleIntelligenceRequest(client, (c) =>
         c.submitEventFeedback({
           event_id,
           verdict,
-          user_ref: user_ref ?? null,
+          user_ref: getAuditUserId(request),
           note: note ?? null,
         })
       );

--- a/packages/backend/src/api/routes/intelligence.ts
+++ b/packages/backend/src/api/routes/intelligence.ts
@@ -94,6 +94,21 @@ const askSchema = {
   },
 } as const;
 
+const eventFeedbackSchema = {
+  params: projectIdParam,
+  body: {
+    type: 'object',
+    required: ['event_id', 'verdict'],
+    properties: {
+      event_id: { type: 'string', format: 'uuid' },
+      verdict: { type: 'string', enum: ['correct', 'incorrect', 'partial'] },
+      user_ref: { type: 'string', maxLength: 200, nullable: true },
+      note: { type: 'string', maxLength: 2000, nullable: true },
+    },
+    additionalProperties: false,
+  },
+} as const;
+
 // ============================================================================
 // Route Registration
 // ============================================================================
@@ -314,6 +329,55 @@ export function intelligenceRoutes(
           context: context ?? null,
           temperature: temperature ?? 0.7,
           max_tokens: max_tokens ?? 500,
+        })
+      );
+      return sendSuccess(reply, result);
+    }
+  );
+
+  /**
+   * POST /api/v1/intelligence/projects/:projectId/event-feedback
+   *
+   * Record a user verdict on a prior intelligence_event (LLM call) returned
+   * by a project-scoped search. Path is scoped by projectId so we can reuse
+   * the same project guard + per-org client resolution as the search route.
+   * The upstream intelligence service additionally rejects any event whose
+   * tenant_id doesn't match the caller's API key — that's our second-layer
+   * authorization check.
+   *
+   * Path segment is `event-feedback` (not `feedback`) to avoid colliding
+   * with the existing local /api/v1/intelligence/feedback that writes to
+   * the local suggestion_feedback table (different scope).
+   */
+  fastify.post<{
+    Params: { projectId: string };
+    Body: {
+      event_id: string;
+      verdict: 'correct' | 'incorrect' | 'partial';
+      user_ref?: string | null;
+      note?: string | null;
+    };
+  }>(
+    '/api/v1/intelligence/projects/:projectId/event-feedback',
+    {
+      schema: eventFeedbackSchema,
+      preHandler: [
+        guard(db, {
+          auth: 'userOrApiKey',
+          resource: { type: 'project', paramName: 'projectId' },
+          action: 'read',
+        }),
+      ],
+    },
+    async (request, reply) => {
+      const { event_id, verdict, user_ref, note } = request.body;
+      const client = await resolveClient(request, clientFactory, intelligenceClient);
+      const result = await handleIntelligenceRequest(client, (c) =>
+        c.submitEventFeedback({
+          event_id,
+          verdict,
+          user_ref: user_ref ?? null,
+          note: note ?? null,
         })
       );
       return sendSuccess(reply, result);

--- a/packages/backend/src/services/intelligence/intelligence-client.ts
+++ b/packages/backend/src/services/intelligence/intelligence-client.ts
@@ -17,6 +17,8 @@ import type {
   MitigationResponse,
   SearchRequest,
   SearchResponse,
+  SubmitEventFeedbackRequest,
+  SubmitEventFeedbackResponse,
   UpdateResolutionRequest,
   ResolutionUpdateResponse,
   AskRequest,
@@ -161,6 +163,22 @@ export class IntelligenceClient {
    */
   async ask(request: AskRequest): Promise<AskResponse> {
     return this.request<AskResponse>('POST', '/api/v1/ask', request);
+  }
+
+  /**
+   * Record a user verdict on a previous intelligence_event.
+   * Distinct from the local suggestion-feedback flow — this lands in the
+   * upstream `intelligence_feedback` table and powers the observability
+   * /accuracy endpoint.
+   */
+  async submitEventFeedback(
+    request: SubmitEventFeedbackRequest
+  ): Promise<SubmitEventFeedbackResponse> {
+    return this.request<SubmitEventFeedbackResponse>(
+      'POST',
+      '/api/v1/intelligence/feedback',
+      request
+    );
   }
 
   // ==========================================================================

--- a/packages/backend/src/services/intelligence/types.ts
+++ b/packages/backend/src/services/intelligence/types.ts
@@ -205,6 +205,23 @@ export interface SubmitFeedbackToServiceRequest {
   suggestion_type: 'similar_bug' | 'mitigation' | 'duplicate';
 }
 
+/**
+ * Verdict on an intelligence_event recorded by the upstream observability
+ * pipeline. Distinct from `SubmitFeedbackToServiceRequest` which targets
+ * the local `suggestion_feedback` table — this one is keyed by `event_id`
+ * and lands in the upstream `intelligence_feedback` table.
+ */
+export interface SubmitEventFeedbackRequest {
+  event_id: string;
+  verdict: 'correct' | 'incorrect' | 'partial';
+  user_ref?: string | null;
+  note?: string | null;
+}
+
+export interface SubmitEventFeedbackResponse {
+  feedback_id: string;
+}
+
 // ============================================================================
 // Intelligence Job Data (for BullMQ queue)
 // ============================================================================

--- a/packages/backend/tests/api/intelligence-routes.test.ts
+++ b/packages/backend/tests/api/intelligence-routes.test.ts
@@ -75,6 +75,9 @@ function createMockClient(overrides = {}) {
       provider: 'ollama',
       model: 'llama3.1:8b',
     }),
+    submitEventFeedback: vi.fn().mockResolvedValue({
+      feedback_id: 'fb-1',
+    }),
     ...overrides,
   };
 }
@@ -240,6 +243,60 @@ describe('Intelligence Routes - Per-Org Client Resolution', () => {
 
       expect(res.statusCode).toBe(503);
       expect(globalClient.ask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('event-feedback endpoint', () => {
+    const EVENT_ID = '11111111-2222-4333-8444-555555555555';
+
+    it('uses per-org client when available', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/v1/intelligence/projects/${PROJECT_ID}/event-feedback`,
+        payload: { event_id: EVENT_ID, verdict: 'correct' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(clientFactory.getClientForOrg).toHaveBeenCalledWith(MOCK_ORG_ID);
+      expect(orgClient.submitEventFeedback).toHaveBeenCalled();
+      expect(globalClient.submitEventFeedback).not.toHaveBeenCalled();
+    });
+
+    it('derives user_ref server-side and IGNORES any body-supplied user_ref — even if a caller spoofs the field, the upstream sees only the value from getAuditUserId(request)', async () => {
+      // With no JWT / api-key user authenticated in this test harness,
+      // getAuditUserId(request) returns null. The body-supplied user_ref must
+      // NEVER reach the upstream, regardless of whether the framework strips
+      // unknown fields silently or rejects them with 400 — the contract is
+      // about the value that lands at the upstream, not about the HTTP code.
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/v1/intelligence/projects/${PROJECT_ID}/event-feedback`,
+        payload: {
+          event_id: EVENT_ID,
+          verdict: 'incorrect',
+          note: 'looks wrong',
+          user_ref: 'attacker-supplied-victim-id',
+        },
+      });
+
+      // Whichever the framework chose (200 with strip OR 400 reject), the
+      // attacker value must never reach the upstream.
+      if (res.statusCode === 200) {
+        expect(orgClient.submitEventFeedback).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event_id: EVENT_ID,
+            verdict: 'incorrect',
+            user_ref: null,
+            note: 'looks wrong',
+          })
+        );
+        // Defensive: explicitly verify the spoofed value never showed up.
+        const call = orgClient.submitEventFeedback.mock.calls[0][0];
+        expect(call.user_ref).not.toBe('attacker-supplied-victim-id');
+      } else {
+        expect(res.statusCode).toBe(400);
+        expect(orgClient.submitEventFeedback).not.toHaveBeenCalled();
+      }
     });
   });
 });

--- a/packages/backend/tests/api/intelligence-routes.test.ts
+++ b/packages/backend/tests/api/intelligence-routes.test.ts
@@ -262,6 +262,24 @@ describe('Intelligence Routes - Per-Org Client Resolution', () => {
       expect(globalClient.submitEventFeedback).not.toHaveBeenCalled();
     });
 
+    it('forwards server-derived user_ref (null in this unauth harness) on a clean payload — deterministic success-path check that the handler always sources user_ref via getAuditUserId', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/v1/intelligence/projects/${PROJECT_ID}/event-feedback`,
+        payload: { event_id: EVENT_ID, verdict: 'incorrect', note: 'looks wrong' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(orgClient.submitEventFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_id: EVENT_ID,
+          verdict: 'incorrect',
+          user_ref: null,
+          note: 'looks wrong',
+        })
+      );
+    });
+
     it('derives user_ref server-side and IGNORES any body-supplied user_ref — even if a caller spoofs the field, the upstream sees only the value from getAuditUserId(request)', async () => {
       // With no JWT / api-key user authenticated in this test harness,
       // getAuditUserId(request) returns null. The body-supplied user_ref must

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -47,6 +47,8 @@ export default defineConfig({
       'tests/api/routes/rbac-regression.test.ts',
       'tests/api/routes/signup.route.test.ts',
       'tests/api/routes/dedup-rules.route.test.ts',
+      // Intelligence proxy routes (mocked IntelligenceClient + mocked DB)
+      'tests/api/intelligence-routes.test.ts',
       'tests/api/services/**/*.test.ts',
       'tests/cache/**/*.test.ts',
       // Only include pure unit tests from tests/db/ (no database required)


### PR DESCRIPTION
PR-C of the AI-observability UI work. Builds on bugspotter-intelligence#34 (`POST /api/v1/intelligence/feedback` upstream) and #181 (`event_id` + `confidence` threaded through `SearchResponse`).

**Backend**: new `POST /api/v1/intelligence/projects/:projectId/event-feedback` proxy. Path segment is `event-feedback` (not `feedback`) to avoid colliding with the existing local `/intelligence/feedback` that writes to the unrelated `suggestion_feedback` table — same word, different storage. Reuses the per-project guard + per-org client resolution from the search route so the upstream is called with the correct tenant API key. `IntelligenceClient.submitEventFeedback()` added.

**Frontend**: new `IntelligenceEventFeedback` component (thumbs up → `verdict: 'correct'`, thumbs down → `'incorrect'`). After a successful vote both buttons lock; on submit failure they stay enabled so a transient network blip doesn't strand the user. Rendered once in the smart-search header next to `ConfidenceBadge`, only when the response carries an `event_id` (smart mode + non-cached). One vote per response is intentional — the upstream `event_id` covers the *overall* ranking, so per-row thumbs would all collapse to the same `intelligence_feedback` row. `user_ref` defaults to the authenticated user's `id`; falls back to `null` when no user.

No new i18n keys — reuses the existing `intelligence.feedback.{helpful,thumbsUp,thumbsDown,submitted}` set.

Tests: 5 new (happy paths for correct/incorrect/no-auth, lock-after-success, stay-enabled-on-error). Admin: 23 passed in the intelligence folder, lint + i18n validate clean, build clean. Backend: 2928 passed, typecheck clean.

Out of scope: admin observability dashboard (PR-D) consuming the three `GET /admin/observability/*` endpoints. Unblocked by this same plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent search results now show thumb-up/thumb-down feedback controls for events (appears for fresh smart results) and reset when viewing a different event.
  * Submitting feedback locks the controls and shows success/error notifications.

* **Tests**
  * Added tests covering feedback UI, submission payloads, success/error handling, and reset-on-rerender.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->