### PR TITLE
docs: ADRs, repo conventions, and backup-health skill

### DIFF
--- a/.claude/skills/bs-backup-health/SKILL.md
+++ b/.claude/skills/bs-backup-health/SKILL.md
@@ -44,6 +44,13 @@ Report which provider is being used so the user has context.
 
 **Never** print full secret keys back to the user.
 
+### Step 4 — Source-side tooling (`yc` CLI)
+
+The object-count parity check (below) reads the source bucket via the Yandex Cloud CLI.
+
+- Verify it is installed and authenticated first: `yc --version` and `yc config list` (or `yc iam create-token`).
+- **If `yc` is missing or unauthenticated** → skip the parity check and report it as "not verified (yc unavailable)" rather than failing; the freshness check still stands. Fallback: read object count from the YC console or the Object Storage REST API.
+
 ## Procedure
 
 Check three backup sources in order. For each, report Status (OK / STALE / MISSING / CORRUPT), latest file, age, size.
@@ -80,7 +87,7 @@ aws s3 ls s3://${BACKUP_S3_BUCKET}/storage/ \
 Validate:
 
 - **Freshness:** rclone sync runs hourly → newest object should be ≤2h old
-- **Object-count parity:** backup count should be ≥99% of source. Get source count:
+- **Object-count parity:** backup count should be ≥99% of source. Requires `yc` (see Step 4); skip if unavailable. Get source count:
   ```bash
   yc storage bucket get bugspotter-storage-kz --format json | jq '{size_bytes, object_count}'
   ```

--- a/.claude/skills/bs-backup-health/SKILL.md
+++ b/.claude/skills/bs-backup-health/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: bs-backup-health
+description: Check whether BugSpotter production backups in the off-site KZ bucket are fresh and restorable. Reports last-backup timestamps per data source (main Postgres, intelligence-db, YC Object Storage), validates file size sanity, surfaces stale or missing backups with remediation suggestions. TRIGGER when user asks about backup status, backup health, "проверь бэкапы", DR readiness; before running a migration drill; before production migration; as a weekly health check.
+---
+
+# bs-backup-health
+
+Verifies that BugSpotter prod data is safely backed up to a second (non-YC) KZ cloud and ready for restoration. **Does NOT modify anything** — read-only inspection.
+
+## When to invoke
+
+- User asks about backup state (any phrasing: "backups", "бэкапы", "data safety", "DR readiness", "backup freshness")
+- Before any migration operation: drill, precheck, production migration
+- After deploying changes to the `backup` profile in `docker-compose.yml`
+- Weekly/monthly ops review
+
+## Prerequisites (always check first)
+
+### Step 1 — Is backup infrastructure even deployed?
+
+Grep `docker-compose.yml` and `docker-compose.*.yml` for a service named `pg-backup` (or any service under `profiles: [backup]`).
+
+- **If NOT found** → backup not yet implemented. Output:
+
+  > Backup infrastructure not yet deployed in this repo. The plan is in `multi-cloud-architecture.html` and `migration-strategy.html` Phase 1. Cannot check health of something that doesn't exist.
+
+  STOP. Do not attempt further checks.
+
+- **If found** → continue.
+
+### Step 2 — Identify the backup bucket
+
+From `.env.example`, `docker-compose.yml`, or `.env.sops`, extract:
+
+- `BACKUP_S3_BUCKET` (expected: `bugspotter-backup-kz`)
+- `BACKUP_S3_ENDPOINT` (PS.KZ or Pro-Data endpoint)
+
+Report which provider is being used so the user has context.
+
+### Step 3 — Credentials availability
+
+- If `aws` CLI exists locally AND `BACKUP_S3_ACCESS_KEY` is set → run checks directly via Bash.
+- If credentials are only on prod VM → output the commands for the user to run on prod, ask them to paste output.
+
+**Never** print full secret keys back to the user.
+
+## Procedure
+
+Check three backup sources in order. For each, report Status (OK / STALE / MISSING / CORRUPT), latest file, age, size.
+
+### A. Main Postgres backup
+
+```bash
+aws s3 ls s3://${BACKUP_S3_BUCKET}/postgres/ \
+  --endpoint-url=${BACKUP_S3_ENDPOINT} \
+  --recursive | sort | tail -5
+```
+
+Validate:
+
+- **Freshness:** latest file ≤12 hours old (pg-backup runs every 6h; 12h means we missed a cycle)
+- **Size sanity:** file >1 MB. Zero-byte or KB-range = likely corrupted pg_dump
+- **Naming:** matches `postgres/YYYYMMDD-HH.pgdump` (or current scripts/backup-pg.sh convention)
+- **History depth:** at least 7 daily + 4 weekly snapshots present (per retention policy)
+
+### B. Intelligence-db backup
+
+Same checks against `s3://${BACKUP_S3_BUCKET}/intelligence/`.
+
+This is the embeddings DB — losing it means hours of LLM re-computation on recovery. Treat staleness as seriously as the main DB.
+
+### C. Object Storage replication
+
+```bash
+aws s3 ls s3://${BACKUP_S3_BUCKET}/storage/ \
+  --endpoint-url=${BACKUP_S3_ENDPOINT} \
+  --summarize | tail -5
+```
+
+Validate:
+
+- **Freshness:** rclone sync runs hourly → newest object should be ≤2h old
+- **Object-count parity:** backup count should be ≥99% of source. Get source count:
+  ```bash
+  yc storage bucket get bugspotter-storage-kz --format json | jq '{size_bytes, object_count}'
+  ```
+  Then compare.
+
+## Output format
+
+Produce a structured ASCII report. Example:
+
+```
+BugSpotter Backup Health Check — 2026-05-22 14:32 +05
+═══════════════════════════════════════════════════════
+
+POSTGRES (main)
+  Status:    ✓ OK
+  Latest:    postgres/20260522-14.pgdump  (32 min ago, 142 MB)
+  History:   7 daily + 4 weekly snapshots
+  Bucket:    bugspotter-backup-kz @ PS.KZ
+
+INTELLIGENCE-DB
+  Status:    ✓ OK
+  Latest:    intelligence/20260522-14.pgdump  (32 min ago, 8 MB)
+  Embeddings rows: 1,243
+
+OBJECT STORAGE
+  Status:    ⚠ STALE
+  Last sync: 26h ago  (expected ≤2h)
+  Source:    bugspotter-storage-kz  (4,892 objects, 12.4 GB)
+  Backup:    bugspotter-backup-kz/storage  (4,591 objects, 11.8 GB)
+  Delta:     301 missing objects, 600 MB
+
+═══════════════════════════════════════════════════════
+Verdict: ⚠ ATTENTION — Object Storage sync stale (others OK)
+Action:  SSH prod →
+         docker compose --profile backup logs --tail=200 storage-sync
+         Check for rclone errors (auth, network, quota)
+═══════════════════════════════════════════════════════
+```
+
+If everything is fine, end with:
+
+```
+Verdict: ✓ ALL OK — backups fresh, restoration-ready
+Last restore-test: docs/BACKUP_VERIFICATION_2026-04-15.md (37 days ago)
+```
+
+If the last restore test is >90 days old, recommend running `bs-restore-test`.
+
+## Escalation criteria
+
+| Symptom                              | Action                                                   |
+| ------------------------------------ | -------------------------------------------------------- |
+| Any backup >24h old                  | Immediate — investigate same day                         |
+| PG dump <10% of usual size           | Possible corruption — block any migration until verified |
+| Cannot list bucket at all            | Credentials or network — escalate to founder             |
+| Backup count regression vs yesterday | Lifecycle policy misbehaving — review bucket rules       |
+| Object Storage delta >5% of source   | Sync broken — check rclone logs                          |
+
+## What this skill does NOT do
+
+- Does NOT restore anything (use `bs-restore-test`)
+- Does NOT modify backup configuration
+- Does NOT SSH to prod automatically — surfaces commands for human-in-loop execution
+- Does NOT alert anyone — just reports status
+
+## References
+
+- Migration strategy: `migration-strategy.html` Phase 1 (backup setup) and Phase 4 (drill)
+- Architecture context: `multi-cloud-architecture.html`
+- Compose backup profile: `docker-compose.yml` (services with `profiles: [backup]`)
+- Related skills: [[bs-restore-test]], [[bs-migration-precheck]], [[bs-migration-drill]], [[bs-migration-inventory]]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ SaaS bug-reporting platform. pnpm + TypeScript, Docker-native dev loop.
 
 - `packages/` — backend (Fastify), billing, types, utils, message-broker, payment-service
 - `apps/` — admin (React/Vite), demo (showcase)
-- `docker-compose*.yml` — dev stack; `./dev.sh start` brings everything up including Postgres + Redis + MinIO. `./dev.sh help` lists the other subcommands.
+- `docker-compose*.yml` — dev stack; `./dev.sh start` brings everything up including Postgres + Redis + MinIO. `./dev.sh help` lists the other subcommands. (`./dev.sh` is a bash script — on Windows run it from git-bash or WSL, not PowerShell.)
 - **Dozzle** (optional live log viewer) is behind the `monitoring` profile — NOT started by `./dev.sh start`. Bring it up with `docker compose --profile monitoring up -d dozzle`; then `http://localhost:9999`.
 
 ## Deployment modes
@@ -21,13 +21,23 @@ Flags that depend on mode are declared in `packages/backend/src/config.ts`.
 ## Common commands
 
 ```bash
-./dev.sh start                                   # bring up the stack
-pnpm --filter @bugspotter/backend dev            # API on :3000
+./dev.sh start                                   # bring up the full stack
+pnpm --filter @bugspotter/backend dev            # API on :3000 (single service, no full stack)
 pnpm --filter @bugspotter/backend typecheck      # src-only typecheck
 pnpm --filter @bugspotter/backend test:unit      # no docker needed
 pnpm --filter @bugspotter/backend migrate        # run DB migrations
 pnpm --filter @bugspotter/admin dev              # admin UI on :5173
 ```
+
+## Conventions
+
+- **Branch off `main`** for any new work or follow-up fix — squash-merged source branches still exist but are dead, don't build on them.
+- **Run `test:unit` before pushing** behavior changes — a passing `typecheck`/build is not sufficient.
+- **Prefer purely-additive slices**; verify deploy state before assuming. Avoid regressions over cleverness.
+
+## Skills
+
+`.claude/skills/` holds repo-specific Claude Code skills (procedural runbooks loaded on demand). Currently: `bs-backup-health` (read-only prod backup freshness/DR check). Invoke via the skill name or its trigger phrases.
 
 ## Where things live
 

--- a/docs/adr/0001-pnpm-typescript-monorepo.md
+++ b/docs/adr/0001-pnpm-typescript-monorepo.md
@@ -1,0 +1,31 @@
+# ADR-0001: pnpm + TypeScript workspace monorepo
+
+- Status: Accepted
+- Area: build / repo structure
+- Source: `bugspotter-public/CLAUDE.md`, `CONTRIBUTING.md`, `pnpm-workspace.yaml`
+- Date: Foundational (not precisely dated)
+
+## Context
+
+The backend, billing, message broker, payment service, shared types, shared utils, and the admin UI evolve together and share TypeScript types. They need atomic cross-package changes, a single dependency graph, and one CI pipeline.
+
+## Decision
+
+Use a **pnpm workspace monorepo** (`pnpm@9.14.4`, Node 22) with `packages/*` (backend, backend-mock, billing, message-broker, payment-service, types, utils) and `apps/*` (admin, demo). Cross-package work is filtered via `pnpm --filter`.
+
+## Consequences
+
+### Positive
+
+- Shared `@bugspotter/types`, `@bugspotter/utils`, and `@bugspotter/common` keep contracts in one place.
+- One install, one lockfile, one CI workflow (`.github/workflows/ci.yml`).
+- Atomic refactors across packages in a single commit/PR.
+
+### Negative / Trade-offs
+
+- The SDK and the browser extension are deliberately **separate** repos (different release cadence, different licenses — see [0003](0003-dual-licensing-fsl-and-mit.md)), so some shared logic (`@bugspotter/common`) must be duplicated/published rather than imported across the workspace boundary.
+- CI must understand the workspace layout; structural changes require editing `ci.yml`.
+
+## Alternatives considered
+
+Not recorded in docs. Polyrepo for every package would have lost atomic cross-package changes; the team kept a monorepo for the server-side platform and split only the independently-shipped clients out.

--- a/docs/adr/0002-fastify-typescript-backend.md
+++ b/docs/adr/0002-fastify-typescript-backend.md
@@ -1,0 +1,30 @@
+# ADR-0002: Fastify / TypeScript backend as the API core
+
+- Status: Accepted
+- Area: backend
+- Source: `bugspotter-public/CLAUDE.md`, `packages/backend/`
+- Date: Foundational (not precisely dated)
+
+## Context
+
+The platform needs an HTTP API for SDK ingest, the admin dashboard, billing, and integrations, plus a background worker. It must be type-safe end to end against the shared `@bugspotter/types`.
+
+## Decision
+
+Build the API and worker as a **TypeScript Fastify** application in `packages/backend`, with the worker sharing the same codebase (separate `worker:dev` / `worker:start` entry points) rather than a separate service.
+
+## Consequences
+
+### Positive
+
+- Schema-based validation and serialization fit Fastify's model; JSON Schema is reused at the edge.
+- One codebase for API + worker simplifies type sharing and deployment (see [0006](0006-docker-compose-not-kubernetes.md)).
+- `test:unit` runs without Docker; `test:integration` needs the dev stack.
+
+### Negative / Trade-offs
+
+- API and worker share a dependency surface even though they scale differently; separation is by process, not by package.
+
+## Alternatives considered
+
+Not recorded in docs (no Express-vs-Fastify rationale is written down). Recorded here so the stack choice is traceable; revisit this ADR if the framework is reconsidered.

--- a/docs/adr/0003-dual-licensing-fsl-and-mit.md
+++ b/docs/adr/0003-dual-licensing-fsl-and-mit.md
@@ -1,0 +1,35 @@
+# ADR-0003: Dual licensing — FSL-1.1-Apache-2.0 platform, MIT SDK
+
+- Status: Accepted
+- Area: licensing
+- Source: `bugspotter-public/LICENSE.md`, `bugspotter-sdk/LICENSE`, `README.md`, `CONTRIBUTING.md`
+- Date: Decided at first release; platform license converts to Apache 2.0 on **2028-04-09**
+
+## Context
+
+The business needs commercial sustainability (prevent a competitor from reselling the platform as a SaaS) while still allowing customers to self-host, inspect, and modify — and the embeddable SDK must carry zero licensing friction because it runs inside third-party apps.
+
+## Decision
+
+Two licenses by component:
+
+- **Platform** (backend, admin, intelligence, and the rest): **FSL-1.1-Apache-2.0** (Functional Source License) — source-available, no competing-SaaS use, **auto-converts to Apache 2.0 on 2028-04-09**.
+- **SDK** (`@bugspotter/sdk`): **MIT** — so customers can bundle it freely.
+
+## Consequences
+
+### Positive
+
+- Self-hosting, internal use, and contributions are allowed today; the Apache-2.0 future date removes any forced re-licensing decision later.
+- The SDK has no adoption friction.
+
+### Negative / Trade-offs
+
+- Two license regimes to track; contributor terms differ by repo (CONTRIBUTING.md must state FSL for the platform).
+- "Open-source platform" is an inaccurate description until 2028 — only the SDK is OSI-open. Public/marketing copy must say "source-available."
+
+## Alternatives considered
+
+- **MIT everywhere** — would permit a competing managed service. Rejected.
+- **Fully proprietary** — locks out self-hosting and community. Rejected.
+- **Pure Apache 2.0 now** — gives up the competing-SaaS protection during the commercial window. Deferred to 2028 via FSL's change date.

--- a/docs/adr/0004-runtime-deployment-mode.md
+++ b/docs/adr/0004-runtime-deployment-mode.md
@@ -1,0 +1,34 @@
+# ADR-0004: Single codebase, runtime `DEPLOYMENT_MODE` (saas / selfhosted)
+
+- Status: Accepted
+- Area: deployment / architecture
+- Source: `bugspotter-public/CLAUDE.md`, `LOCAL_DEVELOPMENT.md`, `packages/backend/src/config.ts`, `packages/backend/docs/architecture.md`
+- Date: Foundational
+
+## Context
+
+The product ships two ways: a multi-tenant SaaS on `*.kz.bugspotter.io`, and a single-tenant self-hostable build for customers. Maintaining two forks would diverge quickly.
+
+## Decision
+
+One codebase gated by a runtime env var **`DEPLOYMENT_MODE`**:
+
+- `saas` — multi-tenancy, billing, quota enforcement, self-service signup, tenant-resolution middleware.
+- `selfhosted` — single tenant, no billing, no signup endpoint.
+
+Mode-dependent flags are declared centrally in `packages/backend/src/config.ts`; SaaS-only code lives under `packages/backend/src/saas/` and never runs in self-hosted mode. The application schema is portable; the SaaS schema (organizations, billing) is a purely **additive** bolt-on layer.
+
+## Consequences
+
+### Positive
+
+- One build, one test matrix; features are toggled, not forked.
+- The additive SaaS schema means self-hosted installs run a strict subset.
+
+### Negative / Trade-offs
+
+- Config flags must stay synchronized across the codebase; a missing gate can leak SaaS behavior into self-hosted (covered by config tests).
+
+## Alternatives considered
+
+Not recorded in docs. A separate self-hosted fork was implicitly rejected in favor of runtime gating.

--- a/docs/adr/0005-core-data-plane-postgres-redis-s3.md
+++ b/docs/adr/0005-core-data-plane-postgres-redis-s3.md
@@ -1,0 +1,37 @@
+# ADR-0005: Core data plane — Postgres 16 + Redis 7 + S3/MinIO
+
+- Status: Accepted
+- Area: data / infra
+- Source: `bugspotter-deploy/docker-compose.yml`, `bugspotter-deploy/README.md`, `bugspotter-public/DOCKER.md`
+- Date: Foundational
+
+## Context
+
+The platform needs durable relational state (bugs, orgs, rules), a job queue + cache, file storage for screenshots and replays, and — for the AI tier — vector similarity. It must run on customer infrastructure with no cloud-vendor lock-in.
+
+## Decision
+
+Three infrastructure services:
+
+- **PostgreSQL 16** — primary relational store, with the **pgvector** extension for embeddings (see [0027](0027-pgvector-ivfflat-similarity.md)).
+- **Redis 7** — BullMQ job queue (see [0011](0011-bullmq-per-type-queues-concurrency.md)) and cache.
+- **MinIO** — S3-compatible object storage for screenshots/replays; backable by local disk or any external S3.
+
+## Consequences
+
+### Positive
+
+- pgvector keeps vectors in the same ACID store — no separate vector DB to operate.
+- S3-compatibility means no vendor lock-in; the same code targets MinIO on-prem or a cloud S3.
+- Standard, battle-tested components available everywhere.
+
+### Negative / Trade-offs
+
+- Three persistent volumes to back up, each with its own strategy (`pg_dump`, MinIO sync, Redis AOF).
+- Postgres needs tuning (`shm_size` set explicitly) to avoid OOM under load.
+
+## Alternatives considered
+
+- **MongoDB** — loses transactional guarantees. Rejected.
+- **A dedicated vector database** — extra operational surface; pgvector was sufficient. Rejected.
+- **RabbitMQ** instead of Redis — more complex than the queue needs. Rejected.

--- a/docs/adr/0006-docker-compose-not-kubernetes.md
+++ b/docs/adr/0006-docker-compose-not-kubernetes.md
@@ -1,0 +1,32 @@
+# ADR-0006: Docker Compose single-host orchestration (not Kubernetes)
+
+- Status: Accepted
+- Area: infra / deployment
+- Source: `bugspotter-deploy/docker-compose.yml`, `bugspotter-deploy/README.md`, `bugspotter-public/DOCKER.md`
+- Date: Foundational
+
+## Context
+
+BugSpotter is deployed both as SaaS (on VMs) and self-hosted by customers ranging from one-person teams to small enterprises. Operators need something they can audit, modify, and debug without a platform team.
+
+## Decision
+
+**Docker Compose v2** is the orchestration and IaC. A base `docker-compose.yml` carries production-safe defaults (no infra ports exposed); an auto-loaded `docker-compose.override.yml` binds infra to `127.0.0.1` for dev. A root `Dockerfile` can also build a single unified image (supervisord running API + worker + nginx) for PaaS targets. Kubernetes is explicitly out of scope for now.
+
+## Consequences
+
+### Positive
+
+- One YAML file per deployment shape; easy to inspect and change.
+- In-place upgrades are `docker compose pull && docker compose up -d`.
+- The unified-image option covers Railway/Render/Fly without changing source.
+
+### Negative / Trade-offs
+
+- Horizontal scaling needs a sidecar/reverse-proxy pattern; stateful services are single-replica unless manually backed up.
+- Dev vs prod is a two-file model operators must understand (prod must exclude the override).
+
+## Alternatives considered
+
+- **Kubernetes** — CNCF-standard but over-specified for single-host installs (CRDs, RBAC, etcd operational burden). Deferred to a possible stage-2; not the right shape today.
+- **systemd units** / **Terraform / Pulumi** — fragile or heavyweight for single-host. Rejected.

--- a/docs/adr/0007-polyglot-python-intelligence-service.md
+++ b/docs/adr/0007-polyglot-python-intelligence-service.md
@@ -1,0 +1,30 @@
+# ADR-0007: Polyglot — separate Python intelligence service over HTTP + circuit breaker
+
+- Status: Accepted
+- Area: architecture / integration
+- Source: `bugspotter-public/packages/backend/docs/architecture.md`, `bugspotter-intelligence/README.md`, `ONBOARDING.md`
+- Date: Foundational to the AI tier
+
+## Context
+
+Duplicate detection and enrichment need ML (embeddings, LLM reranking). The core backend is TypeScript; the AI/ML ecosystem (sentence-transformers, pgvector tooling) is Python-native. Coupling ML into the Node process would force language compromises and tie failure domains together.
+
+## Decision
+
+Run a **separate Python FastAPI service** (`bugspotter-intelligence`) decoupled from the backend via **HTTP + a circuit breaker**. The backend degrades gracefully (dedup/enrichment skipped) when the intelligence service is unavailable.
+
+## Consequences
+
+### Positive
+
+- Independent scaling and language choice for ML; failure isolation via circuit breaker.
+- The AI tier is optional (see [0033](0033-offline-model-caching-docker.md) and the deploy `--profile intelligence`).
+
+### Negative / Trade-offs
+
+- **Schema must stay in lockstep across repos**: the `DedupRule` shape is defined as Zod (TS) and Pydantic (Python) and the two must not drift.
+- Network latency on dedup calls; an extra service to deploy and observe.
+
+## Alternatives considered
+
+Not recorded in docs. Embedding ML inside the Node backend was implicitly rejected for the language and failure-isolation reasons above.

--- a/docs/adr/0008-triple-auth-model.md
+++ b/docs/adr/0008-triple-auth-model.md
@@ -1,0 +1,36 @@
+# ADR-0008: Triple auth — JWT user / API key ingest / share-token
+
+- Status: Accepted
+- Area: auth
+- Source: `bugspotter-public/packages/backend/docs/auth.md`, `ACCESS_CONTROL.md`
+- Date: Foundational; dual-header audit fix in PR-105/107
+
+## Context
+
+Three callers authenticate differently: dashboard users (interactive), the SDK/extension ingesting reports (machine), and public replay sharing (anonymous, scoped). One auth artifact cannot serve all three.
+
+## Decision
+
+Three orthogonal auth artifacts, applied by middleware in precedence order **share-token → API key → JWT**:
+
+- `request.authUser` — JWT (dashboard users).
+- `request.apiKey` — `X-API-Key` header (SDK ingest; can be single-project or full-scope).
+- `request.authShareToken` — query param (public replay shares).
+
+Authentication is separated from authorization; API keys have bypass rules for platform permissions (a machine has no "role"). Lock-in tests document the bypass behavior to catch silent regressions.
+
+## Consequences
+
+### Positive
+
+- Fine-grained scoping (single-project keys); anonymous sharing without exposing user identity.
+- Precedence rules are explicit and tested.
+
+### Negative / Trade-offs
+
+- All three fields can coexist on one request; when JWT + API key are both present, a **single-project key constraint** is needed for safe audit attribution (the PR-105/107 fix).
+- Middleware state is non-trivial; bypass rules must be kept honest by the lock-in tests.
+
+## Alternatives considered
+
+Not recorded in docs.

--- a/docs/adr/0009-multi-tenancy-api-key-tenant-isolation.md
+++ b/docs/adr/0009-multi-tenancy-api-key-tenant-isolation.md
@@ -1,0 +1,30 @@
+# ADR-0009: Multi-tenancy via API-key → tenant_id isolation
+
+- Status: Accepted
+- Area: auth / data
+- Source: `bugspotter-intelligence/src/.../auth/service.py`, `db/migrations.py`; `bugspotter-public` SaaS schema
+- Date: Intelligence Phase 2 (v0.2.0); backend SaaS foundational
+
+## Context
+
+In SaaS mode, every customer's data must be strictly isolated, but the system already authenticates machine callers by API key. A heavyweight tenant model would duplicate that.
+
+## Decision
+
+Resolve **API key → `tenant_id`** and filter **every** query by `tenant_id`. Tenant context is injected via dependency injection (FastAPI) / middleware (backend) for testability. `tenant_id` is **nullable** for backwards compatibility with pre-multi-tenant rows. There is **no global super-admin scope** — admin is per-tenant — to prevent BOLA (broken object-level authorization).
+
+## Consequences
+
+### Positive
+
+- Reuses existing API-key auth; no separate tenant login.
+- New tables get `tenant_id` by convention; isolation is uniform.
+
+### Negative / Trade-offs
+
+- Every new query must remember to filter by `tenant_id`; a missed filter is a cross-tenant leak.
+- Nullable `tenant_id` means legacy rows need careful handling during reads.
+
+## Alternatives considered
+
+Not recorded in docs. Schema-per-tenant and database-per-tenant were not adopted (operational cost for many small tenants).

--- a/docs/adr/0010-unified-rbac-legacy-coexistence.md
+++ b/docs/adr/0010-unified-rbac-legacy-coexistence.md
@@ -1,0 +1,36 @@
+# ADR-0010: Unified RBAC with legacy `permissions` coexistence
+
+- Status: Accepted (legacy deprecation in progress)
+- Area: auth
+- Source: `bugspotter-public/packages/backend/docs/db-schema.md` (migration 015), `ACCESS_CONTROL.md`
+- Date: Migration 015 introduced modern flags; legacy drop pending
+
+## Context
+
+The platform evolved from a legacy `users.role` + `permissions` table toward modern RBAC, but a big-bang schema change would be risky on a live system.
+
+## Decision
+
+Run **three coexisting RBAC layers**, migrating incrementally:
+
+- **Platform** — `users.security` JSONB (e.g. `is_platform_admin`).
+- **Org** — organization membership.
+- **Project** — `project_members.role` + `project_roles`.
+
+The legacy `users.role` and `permissions` table remain load-bearing; helpers like `isPlatformAdmin` have fallbacks. The migration to drop the legacy `role` column is **not yet written**.
+
+## Consequences
+
+### Positive
+
+- Incremental migration with no breaking change; old and new paths coexist.
+
+### Negative / Trade-offs
+
+- Three RBAC mechanisms live in production simultaneously — real complexity for new engineers.
+- Deprecation is unfinished; this ADR will be **superseded** by one that records dropping the legacy column.
+
+## Alternatives considered
+
+- **Immediate full migration** — breaking and risky. Rejected.
+- **Stay on legacy** — no forward progress. Rejected.

--- a/docs/adr/0011-bullmq-per-type-queues-concurrency.md
+++ b/docs/adr/0011-bullmq-per-type-queues-concurrency.md
@@ -1,0 +1,32 @@
+# ADR-0011: BullMQ per-type job queues with per-type concurrency
+
+- Status: Accepted
+- Area: infra
+- Source: `bugspotter-public/DOCKER.md`, `packages/backend/docs/architecture.md`, `bugspotter-deploy/.env.example`
+- Date: Foundational; tuning ongoing
+
+## Context
+
+Async work has very different cost profiles: screenshots and replays are heavy (Playwright/CPU), integrations and notifications are light I/O. A single shared queue would let a slow replay block a fast notification (head-of-line blocking).
+
+## Decision
+
+**BullMQ on Redis, one queue per job type**, with **per-type concurrency** tunable via env (no redeploy):
+`WORKER_SCREENSHOT_CONCURRENCY=5`, `WORKER_REPLAY_CONCURRENCY=3`, `WORKER_INTEGRATION_CONCURRENCY=10`, `WORKER_NOTIFICATION_CONCURRENCY=5`, `WORKER_INTELLIGENCE_CONCURRENCY=1` (CPU-bound LLM, kept at 1 to not starve inference).
+
+## Consequences
+
+### Positive
+
+- Fault isolation and fair scheduling per job type; tune to the host without code changes.
+- Worker health checks simplified (no per-job-type endpoints).
+
+### Negative / Trade-offs
+
+- Operators must tune concurrency to their hardware; over-provisioning OOMs, under-provisioning backs up queues.
+- Redis memory must account for queue backlogs; dead-letter handling is per queue.
+
+## Alternatives considered
+
+- **Single shared queue** — head-of-line blocking. Rejected.
+- **Separate worker process per type** — deployment complexity. Rejected in favor of one worker with per-queue concurrency.

--- a/docs/adr/0012-transactional-outbox-ticket-filing.md
+++ b/docs/adr/0012-transactional-outbox-ticket-filing.md
@@ -1,0 +1,30 @@
+# ADR-0012: Transactional outbox for external ticket filing
+
+- Status: Accepted
+- Area: data / integration
+- Source: `bugspotter-public/packages/backend/docs/architecture.md`, `db-schema.md` (migrations 001, 021)
+- Date: Foundational (001); dedup-grace enhancement (021)
+
+## Context
+
+Creating a bug report and filing an external ticket (Jira/Linear/webhook) must not produce duplicate tickets on retry, but filing is async and can fail. Inline synchronous filing couples ingest to third-party uptime.
+
+## Decision
+
+File tickets through a **`ticket_creation_outbox`** table (transactional-outbox pattern). A row is inserted in the **same transaction** as the bug report; a worker polls and advances a state machine. An `idempotency_key` prevents duplicates. A **dedup grace window** (migration 021) lets the intelligence service mark duplicates _before_ filing proceeds.
+
+## Consequences
+
+### Positive
+
+- Decouples ingest from integration filing; exactly-once semantics for external systems.
+- Retries are safe; the dedup grace window avoids filing tickets for soon-to-be-merged duplicates.
+
+### Negative / Trade-offs
+
+- Extra table, worker polling overhead, and state-machine logic to maintain.
+
+## Alternatives considered
+
+- **Inline synchronous filing** — tight coupling, cascading failures. Rejected.
+- **Naive async** (fire-and-forget) — duplicate tickets on retry. Rejected.

--- a/docs/adr/0013-integration-plugin-sandbox-ssrf.md
+++ b/docs/adr/0013-integration-plugin-sandbox-ssrf.md
@@ -1,0 +1,31 @@
+# ADR-0013: Integration plugin sandbox + SSRF-hardened HTTP
+
+- Status: Accepted
+- Area: security / integration
+- Source: `bugspotter-public/packages/backend/docs/architecture.md` (Integrations)
+- Date: Foundational to integrations
+
+## Context
+
+Customer-configured integrations (Jira, Linear, generic webhooks) are effectively untrusted: a malicious or misconfigured target URL could reach internal services or exfiltrate data (SSRF).
+
+## Decision
+
+Route **all** plugin HTTP through `security/hardened-http.ts` + `security/ssrf-validator.ts`, which block private IPs and localhost, and run plugins inside a `security/plugin-executor.ts` sandbox. HTTP policy is enforced centrally, not per integration.
+
+## Consequences
+
+### Positive
+
+- Prevents SSRF, credential leakage, and internal-service access from one choke point.
+- New integrations inherit the protections automatically.
+
+### Negative / Trade-offs
+
+- All integration code must route through the hardened layer (slight latency).
+- Legitimate internal backends need an explicit SSRF allowlist entry.
+
+## Alternatives considered
+
+- **Trust plugin targets** — security risk. Rejected.
+- **Per-integration whitelist** — fragile and duplicated. Rejected in favor of centralized policy.

--- a/docs/adr/0014-per-org-data-residency-routing.md
+++ b/docs/adr/0014-per-org-data-residency-routing.md
@@ -1,0 +1,31 @@
+# ADR-0014: Per-organization data residency routing
+
+- Status: Accepted
+- Area: data / compliance
+- Source: `bugspotter-public/packages/backend/docs/architecture.md`, `db-schema.md` (projects table)
+- Date: Foundational to SaaS
+
+## Context
+
+Multi-tenant SaaS serves customers in different regulatory regions (KZ, RF, EU, US) with data-localization requirements. A single global bucket would be a compliance risk.
+
+## Decision
+
+A `projects.data_residency_region` enum (`kz` / `rf` / `eu` / `us` / `global`) drives a storage-backend router (`regional-storage-router.ts`) that selects the S3 bucket per region. Routing happens at the **storage layer**, transparent to application code. An audit log tracks residency violations. Settings propagate via `organization_settings` JSONB.
+
+## Consequences
+
+### Positive
+
+- Compliance with regional data laws without per-feature special-casing.
+- Application code is region-agnostic; routing is centralized.
+
+### Negative / Trade-offs
+
+- Must provision an S3 bucket per region.
+- Cross-region reads are impossible **by design** (a constraint, not a bug).
+
+## Alternatives considered
+
+- **Single global bucket** — compliance risk. Rejected.
+- **Customer-managed regions** — operational burden on customers. Rejected.

--- a/docs/adr/0015-dual-capture-screenshot-and-replay.md
+++ b/docs/adr/0015-dual-capture-screenshot-and-replay.md
@@ -1,0 +1,31 @@
+# ADR-0015: Dual capture — screenshot + rrweb session replay
+
+- Status: Accepted
+- Area: capture
+- Source: `bugspotter-sdk/README.md`, `CHANGELOG.md` (v0.1.0, v0.2.0); `bugspotter-extension/CLAUDE.md`
+- Date: SDK v0.1.0 (2025-11-01); replay added v0.2.0 (2025-11-21)
+
+## Context
+
+A bug report needs both visual proof (what the screen looked like) and causal context (the sequence of interactions that led there). A screenshot alone misses the sequence; a replay alone misses point-in-time visual state.
+
+## Decision
+
+Capture **both**: a mandatory **screenshot** (via `html-to-image`, CSP-safe) plus an optional **rrweb session replay** (a bounded ~15–30s buffer). Both are compressed and uploaded via presigned URLs (see [0016](0016-presigned-url-direct-uploads.md)). rrweb is the industry-standard DOM-mutation recorder.
+
+## Consequences
+
+### Positive
+
+- Screenshot = point-in-time proof; replay = causality. Together they make reports reproducible.
+
+### Negative / Trade-offs
+
+- ~500ms screenshot latency and rrweb memory overhead; two payloads to upload.
+- Pulls in both `rrweb` and `html-to-image` dependencies.
+
+## Alternatives considered
+
+- **Screenshot only** — loses interaction context. Rejected.
+- **Replay only** — loses visual state. Rejected.
+- **Video capture** — bandwidth-prohibitive. Rejected.

--- a/docs/adr/0016-presigned-url-direct-uploads.md
+++ b/docs/adr/0016-presigned-url-direct-uploads.md
@@ -1,0 +1,32 @@
+# ADR-0016: Presigned-URL direct-to-storage uploads
+
+- Status: Accepted
+- Area: transport
+- Source: `bugspotter-sdk/README.md`, `core/file-upload-handler.ts`; `bugspotter-extension/src/background/service-worker.ts`
+- Date: SDK v0.1.0 (2025-11-01)
+
+## Context
+
+Screenshots (~500KB) and replays (~2MB) are large. Proxying them through the API ties up the API server's bandwidth and the extension's service worker, and is slower than going straight to object storage.
+
+## Decision
+
+A **three-request flow**: (1) `POST /api/v1/reports` with flags → returns the bug id + **presigned PUT URLs**; (2) the client `PUT`s screenshot/replay **directly to S3** (in parallel); (3) `POST confirm-upload` per file. The report row exists after step 1, so artifact upload failures are **non-fatal** (the report still lands).
+
+## Consequences
+
+### Positive
+
+- ~40% fewer requests vs the legacy 5-request flow; file bytes bypass the API server.
+- Presigned URLs are time-limited and scoped to one upload; HTTPS enforced on all URLs.
+- Graceful degradation: a failed replay/screenshot upload doesn't lose the report.
+
+### Negative / Trade-offs
+
+- Requires backend object storage and presigned-URL generation.
+- The client must handle gzip content-type and parallel blob uploads.
+
+## Alternatives considered
+
+- **Single POST through the API** — simpler but slower and bandwidth-heavy. Rejected.
+- **Multipart upload** — added complexity for these sizes. Rejected.

--- a/docs/adr/0017-backend-controlled-replay-settings.md
+++ b/docs/adr/0017-backend-controlled-replay-settings.md
@@ -1,0 +1,31 @@
+# ADR-0017: Backend-controlled, cached replay quality settings
+
+- Status: Accepted
+- Area: settings / capture
+- Source: `bugspotter-sdk/src/index.ts`, `docs/SESSION_REPLAY.md`; `bugspotter-public` API_DOCUMENTATION.md (`/api/v1/settings/replay`)
+- Date: SDK v0.3.0 (2025-12-20)
+
+## Context
+
+Different deployments and pricing tiers want different replay fidelity (inline images, fonts, canvas recording). Hardcoding this in the SDK would mean a redeploy of every customer's embedded SDK to change a setting.
+
+## Decision
+
+On `init()`, the SDK fetches **`GET /api/v1/settings/replay`** for project-level quality settings and caches them (5-minute TTL). Explicit user config **overrides** server settings; if the endpoint is unreachable, the SDK **soft-fails to hardcoded safe defaults**. The endpoint returns `200 OK` with defaults even on DB failure, and is per-API-key rate-limited (10 req/min).
+
+## Consequences
+
+### Positive
+
+- Admins tune replay quality per project with no SDK redeploy.
+- Caching reduces backend load; user overrides always win.
+
+### Negative / Trade-offs
+
+- One extra HTTP call during `init()` (~50ms typical).
+- A misconfigured backend silently yields default fidelity (acceptable, but invisible).
+
+## Alternatives considered
+
+- **Hardcoded SDK defaults** — inflexible. Rejected.
+- **Per-request negotiation** — latency on every capture. Rejected.

--- a/docs/adr/0018-cross-navigation-replay-persistence.md
+++ b/docs/adr/0018-cross-navigation-replay-persistence.md
@@ -1,0 +1,36 @@
+# ADR-0018: Cross-navigation replay persistence (IndexedDB / storage.session)
+
+- Status: Accepted
+- Area: replay / storage
+- Source: `bugspotter-sdk/core/storage/replay-persistence.ts`; `bugspotter-extension/src/background/replay-store.ts`, `CLAUDE.md`
+- Date: SDK v0.2.0 (2025-11-21); extension cross-navigation phase
+
+## Context
+
+A user often reports a bug _after_ a full-page navigation or reload, but the interesting interactions happened on the previous page. In-memory replay buffers are lost across navigations. The two clients run in different environments (page context vs MV3 service worker) with different storage primitives.
+
+## Decision
+
+Persist the replay buffer across navigations, **opt-in**, with a per-environment mechanism:
+
+- **SDK** (page context): a time-based circular buffer flushed to **IndexedDB** on `pagehide`/`visibilitychange`, restored on `init()`. Opt-in via a `dbName` (multi-tenant safety); atomic read+clear at restore.
+- **Extension** (service worker): per-tab buffers in **`chrome.storage.session`**, keyed by `tabId`, cleared on tab close; per-tab write queue serializes appends.
+
+Both: soft-fail if storage is unavailable; handle the restore race by queuing events emitted during restore.
+
+## Consequences
+
+### Positive
+
+- Captures pre-reload activity; replays survive full-page navigations.
+- IndexedDB (~100MB+) and `storage.session` (~10MB) both exceed the old localStorage 5MB limit.
+
+### Negative / Trade-offs
+
+- Quota handling required: on overflow, halve events while preserving the latest `FullSnapshot` anchor.
+- Two implementations of the same concept (environment-dictated); kept behind the same opt-in contract.
+
+## Alternatives considered
+
+- **localStorage / sessionStorage** — 5MB cap, unavailable to the service worker. Rejected.
+- **Server-side buffering** — privacy concern (streams pre-report data). Rejected.

--- a/docs/adr/0019-shared-pii-sanitization.md
+++ b/docs/adr/0019-shared-pii-sanitization.md
@@ -1,0 +1,31 @@
+# ADR-0019: Shared local-first PII sanitization via `@bugspotter/common`
+
+- Status: Accepted
+- Area: capture / privacy
+- Source: `bugspotter-sdk/README.md`, `docs/SESSION_REPLAY.md`; `bugspotter-extension/CLAUDE.md`, `src/content/content-main.ts`
+- Date: SDK/extension v0.1.0
+
+## Context
+
+Captured console/network/DOM data can contain PII and secrets (emails, phones, cards, national IDs, API keys, tokens). Regulated customers (finance, healthcare) need a compliance guarantee, and the redaction logic must not diverge between the SDK, the extension, and the backend.
+
+## Decision
+
+PII patterns live in a **shared `@bugspotter/common`** package and run **locally, before transmission**. Built-in patterns (email, phone, credit card, SSN/IIN, IP, API key, token, password) plus preset profiles (minimal, financial, kazakhstan, gdpr, pci) and **custom regex**; `excludeSelectors` exempt legitimate DOM. The backend sanitizes **again** as defense-in-depth.
+
+## Consequences
+
+### Positive
+
+- One pattern library keeps client and server in sync; local-first redaction means PII never leaves the device unredacted.
+- Defense-in-depth: a client gap is still caught server-side.
+
+### Negative / Trade-offs
+
+- Redacted tokens are unrecoverable by design; rare false positives (user can `exclude`).
+- Capture **blocks on sanitizer init**; if init fails, capture is disabled on that page (fail-safe) and events buffered during async init are retroactively sanitized.
+
+## Alternatives considered
+
+- **Backend-only sanitization** — unredacted data crosses the wire. Rejected.
+- **Duplicated per-client patterns** — drift risk. Rejected in favor of the shared package.

--- a/docs/adr/0020-client-offline-queue-retry.md
+++ b/docs/adr/0020-client-offline-queue-retry.md
@@ -1,0 +1,34 @@
+# ADR-0020: Client offline queue with backoff retry
+
+- Status: Accepted
+- Area: transport / storage
+- Source: `bugspotter-sdk/core/offline-queue.ts`, `core/transport.ts`; `bugspotter-extension/src/utils/offline-queue.ts`
+- Date: SDK v0.1.0 / v0.3.0
+
+## Context
+
+Users go offline or hit transient network failures. A report should not be lost on page close, but unbounded retries waste battery/bandwidth and retrying auth/quota errors is pointless.
+
+## Decision
+
+Persist failed reports (network errors only) to a bounded local queue and retry with **jittered exponential backoff**:
+
+- **SDK** — `localStorage` queue (up to 10 items), backoff 1–30s, retry on 502/503/504/429, never on auth errors.
+- **Extension** — `chrome.storage.local` queue with a **7-day TTL**, retried on service-worker startup; drops items >100KB, after 5 attempts, on insecure endpoints, or on expiry; strips sensitive headers and screenshot/replay flags before queuing.
+
+## Consequences
+
+### Positive
+
+- No report lost to a brief outage; backoff + jitter avoids thundering herd.
+- Auth/quota errors fail fast (retrying wouldn't help).
+
+### Negative / Trade-offs
+
+- Queue competes for local storage quota; on overflow the oldest item is dropped.
+- Queued extension reports lose screenshot/replay artifacts (still useful for repro).
+
+## Alternatives considered
+
+- **In-memory queue** — lost on reload. Rejected.
+- **Unbounded queue / fixed backoff** — storage pressure / CPU spikes. Rejected.

--- a/docs/adr/0021-shadow-dom-widget-isolation.md
+++ b/docs/adr/0021-shadow-dom-widget-isolation.md
@@ -1,0 +1,31 @@
+# ADR-0021: Shadow DOM widget isolation
+
+- Status: Accepted
+- Area: widget
+- Source: `bugspotter-sdk/widget/modal.ts`; `bugspotter-extension/src/content/content-main.ts`
+- Date: SDK v0.1.0 (2025-11-01)
+
+## Context
+
+The bug-report widget (button, modal, annotation overlay) is injected into arbitrary customer pages. Host-page CSS and JS must not leak into the widget, and the widget's styles must not bleed into the host.
+
+## Decision
+
+Render the modal/overlay inside a **Shadow DOM** host with inline styles (CSP-safe). The SDK modal uses `attachShadow({mode:'open'})`; the extension annotation overlay uses a closed Shadow DOM at `document.body`. The floating button sits at top-level DOM with max `z-index` (2147483647) for reliable stacking.
+
+## Consequences
+
+### Positive
+
+- Style encapsulation in both directions; works on any site without CSP violations from injected `<style>`.
+- Open mode (SDK) still allows intentional host customization.
+
+### Negative / Trade-offs
+
+- Very old browsers lacking Shadow DOM fall back to light DOM; `::part` host customization is limited.
+- Slightly slower initial render.
+
+## Alternatives considered
+
+- **CSS namespacing** — fragile, collisions possible. Rejected.
+- **iframe** — slow, cross-frame communication overhead. Rejected.

--- a/docs/adr/0022-client-side-duplicate-dedup.md
+++ b/docs/adr/0022-client-side-duplicate-dedup.md
@@ -1,0 +1,31 @@
+# ADR-0022: Client-side duplicate-report dedup
+
+- Status: Accepted
+- Area: capture / integration
+- Source: `bugspotter-sdk/core/bug-reporter.ts`; `bugspotter-extension/src/background/service-worker.ts` (via `@bugspotter/common` `BugReportDeduplicator`)
+- Date: SDK v0.3.0 (2025-12-20)
+
+## Context
+
+Users re-submit the same report in quick succession (double-click, retry confusion). Catching this only at the backend means the duplicate payload has already been uploaded and the user sees a late error.
+
+## Decision
+
+A shared `BugReportDeduplicator` (from `@bugspotter/common`) hashes `title + description (+ error stacks)` and blocks a re-submit within a configurable grace window, tracking both in-progress and recently-completed reports. The backend keeps a fallback check.
+
+## Consequences
+
+### Positive
+
+- Stops accidental duplicates before upload; no PII in the hash; works offline.
+- In-progress tracking allows immediate legitimate retry without waiting out the window.
+
+### Negative / Trade-offs
+
+- Dedup state is per-instance / per-service-worker (reset on eviction — acceptable, since a duplicate implies one active session).
+- A slightly changed description defeats the hash (false negative); user must edit title/description to force a resubmit.
+
+## Alternatives considered
+
+- **Server-only dedup** — duplicate already uploaded; late error. Rejected as the sole mechanism.
+- **UUID-based** — overkill. Rejected.

--- a/docs/adr/0023-framework-agnostic-async-singleton-init.md
+++ b/docs/adr/0023-framework-agnostic-async-singleton-init.md
@@ -1,0 +1,31 @@
+# ADR-0023: Framework-agnostic async singleton SDK `init()`
+
+- Status: Accepted
+- Area: build / SDK API
+- Source: `bugspotter-sdk/src/index.ts`, `CHANGELOG.md` (v0.3.0)
+- Date: SDK v0.3.0 (2025-12-20)
+
+## Context
+
+The SDK must work the same in React, Vue, Angular, Next.js, plain JS, and via CDN. Initialization is inherently async (it fetches backend replay settings — see [0017](0017-backend-controlled-replay-settings.md)), and multiple `init()` calls would duplicate observers/network interception/DOM hooks.
+
+## Decision
+
+A static **`async BugSpotter.init()` returning `Promise<BugSpotter>`** that enforces a **singleton**: it warns on re-init and **coalesces concurrent init calls** (first call wins). `destroy()` is required before re-initializing with new config.
+
+## Consequences
+
+### Positive
+
+- One instance prevents duplicate interception; framework-agnostic (no framework adapter needed).
+- Async contract lets `init()` fetch backend config cleanly.
+
+### Negative / Trade-offs
+
+- Callers must `await init()` and call `destroy()` to reconfigure.
+- The implicit singleton adds coupling in tests.
+
+## Alternatives considered
+
+- **Factory per call** — duplicate interception and memory leaks. Rejected.
+- **Synchronous init** — can't fetch backend config. Rejected.

--- a/docs/adr/0024-extension-mv3-stateless-service-worker.md
+++ b/docs/adr/0024-extension-mv3-stateless-service-worker.md
@@ -1,0 +1,29 @@
+# ADR-0024: Browser extension on MV3 stateless service worker
+
+- Status: Accepted
+- Area: extension architecture
+- Source: `bugspotter-extension/CLAUDE.md`, `src/background/service-worker.ts`
+- Date: Chrome MV3 migration (platform-mandated)
+
+## Context
+
+Chrome Manifest V3 removed persistent background pages. The service worker can be evicted after ~30s of inactivity, so any state held in module-level variables is lost across navigations and re-injections.
+
+## Decision
+
+Implement a **fully stateless service worker**: no module-level state; all persistent data lives in `chrome.storage` (`session` for transient per-tab buffers — see [0018](0018-cross-navigation-replay-persistence.md); `local` for the offline queue — see [0020](0020-client-offline-queue-retry.md)). Every event handler reads state from storage rather than memory.
+
+## Consequences
+
+### Positive
+
+- Survives worker eviction, tab navigation, and re-injection without data loss — MV3-compliant.
+
+### Negative / Trade-offs
+
+- Async storage reads on every event add latency and require per-tab write-queue serialization to avoid read-modify-write races.
+
+## Alternatives considered
+
+- **MV2 background page** — deprecated by Chrome. Rejected (forced).
+- **In-memory buffers** — unsafe under eviction. Rejected.

--- a/docs/adr/0025-main-world-injection-capture.md
+++ b/docs/adr/0025-main-world-injection-capture.md
@@ -1,0 +1,32 @@
+# ADR-0025: Main-world injection for CSP-proof console/network capture
+
+- Status: Accepted
+- Area: capture
+- Source: `bugspotter-extension/src/background/service-worker.ts`, `public/main-world-capture.js`
+- Date: Console/network capture phase
+
+## Context
+
+Capturing `console`, `fetch`, and `XHR` requires access to the page's JavaScript globals, but content scripts run in an **isolated world** and cannot see page globals. Injecting a `<script>` tag is blocked by strict CSP on banking/finance sites.
+
+## Decision
+
+Register a **main-world** capture script via `chrome.scripting.registerContentScripts` with `world: 'MAIN'` and `runAt: 'document_start'`. It patches `console`, `fetch`, `XHR`, and error handlers, and relays events to the isolated-world content script via `window.postMessage`. `chrome.scripting` bypasses page CSP (a Chrome privilege); `document_start` ensures capture begins before page scripts run.
+
+## Consequences
+
+### Positive
+
+- Works on CSP-strict sites where `<script>` injection fails; captures from the very first page script.
+- `postMessage` bridges isolated and main worlds without granting the page access to extension internals.
+
+### Negative / Trade-offs
+
+- The main-world script is **plain JS** (not TypeScript, not bundled) to stay simple, adding ~2KB.
+- Duplicate browser `error` events must be de-duplicated within ~2s windows.
+
+## Alternatives considered
+
+- **`<script>` tag injection** — blocked by CSP. Rejected.
+- **PerformanceObserver** — timing only, not full network detail. Rejected.
+- **Debugger protocol** — unavailable to extensions. Rejected.

--- a/docs/adr/0026-local-bge-m3-embeddings.md
+++ b/docs/adr/0026-local-bge-m3-embeddings.md
@@ -1,0 +1,30 @@
+# ADR-0026: Local BAAI/bge-m3 embeddings (self-hosted, multilingual)
+
+- Status: Accepted
+- Area: embeddings
+- Source: `bugspotter-intelligence/services/embedding_service.py`, `Dockerfile`, `ROADMAP.md`
+- Date: Intelligence Phase 1 (v0.1.0)
+
+## Context
+
+Semantic dedup needs embeddings. The product serves a multilingual market (EN/RU/KK), and external embedding APIs add per-call cost, latency, and a data-egress/compliance concern incompatible with self-hosting.
+
+## Decision
+
+Use **BAAI/bge-m3** (1024-dim) via `sentence-transformers`, generated **locally**. The model is **pre-downloaded into the Docker image** (see [0033](0033-offline-model-caching-docker.md)) for predictable cold starts. OpenAI `text-embedding-3-small` remains a configurable fallback for cloud deployments.
+
+## Consequences
+
+### Positive
+
+- High-quality multilingual embeddings; no API cost or data egress; self-hostable and air-gappable.
+
+### Negative / Trade-offs
+
+- Docker image ~3GB; ~268ms latency per embedding on CPU.
+- Embedding dimension (1024) must match `migrations.py` `target_dim`; switching models means re-embedding.
+
+## Alternatives considered
+
+- **OpenAI `text-embedding-3-small`** — kept as fallback, not default (cost/egress).
+- **all-MiniLM-L6-v2 (384-dim)** — lower quality, weaker multilingual. Rejected.

--- a/docs/adr/0027-pgvector-ivfflat-similarity.md
+++ b/docs/adr/0027-pgvector-ivfflat-similarity.md
@@ -1,0 +1,30 @@
+# ADR-0027: pgvector + IVFFlat for similarity search (no separate vector DB)
+
+- Status: Accepted
+- Area: embeddings / data
+- Source: `bugspotter-intelligence/docker-compose.yml`, `ROADMAP.md` (Phase 1 & 7), `README.md`
+- Date: Intelligence Phase 1 (v0.1.0); index retuning planned Phase 7
+
+## Context
+
+Dedup needs fast cosine-similarity search over thousands of bug embeddings, multi-tenant-filtered. Postgres is already the primary store (see [0005](0005-core-data-plane-postgres-redis-s3.md)).
+
+## Decision
+
+Use the **pgvector** extension with an **IVFFlat** index on `bug_embeddings.embedding`, cosine distance (`<=>`), and composite indexes that include `tenant_id` for tenant-filtered search. Runs on `pgvector/pgvector:pg16`.
+
+## Consequences
+
+### Positive
+
+- No separate vector database to operate; ACID guarantees; vectors co-located with relational data and tenant filters.
+
+### Negative / Trade-offs
+
+- IVFFlat may need retuning at scale (an explicit Phase 7 evaluation, including HNSW).
+- Requires the pgvector extension in Postgres 16+.
+
+## Alternatives considered
+
+- **Dedicated vector DB** (e.g. Pinecone/Qdrant) — extra operational surface and egress. Rejected.
+- **HNSW index** — under evaluation for Phase 7; IVFFlat chosen first for simplicity.

--- a/docs/adr/0028-tunable-similarity-thresholds.md
+++ b/docs/adr/0028-tunable-similarity-thresholds.md
@@ -1,0 +1,29 @@
+# ADR-0028: Tunable similarity thresholds (0.68 / 0.85), per-tenant
+
+- Status: Accepted
+- Area: dedup
+- Source: `bugspotter-intelligence/config.py`, `ROADMAP.md` (Phase 1)
+- Date: Intelligence Phase 1 (v0.1.0)
+
+## Context
+
+Embedding similarity must be turned into a yes/no "is this a duplicate?" decision. The right cut-off depends on the embedding model's space and on a customer's tolerance for false merges, so it can't be a single universal constant.
+
+## Decision
+
+Two configurable thresholds, defaulting to values empirically tuned for bge-m3: **`similarity_threshold = 0.68`** (related/similar) and **`duplicate_threshold = 0.85`** (auto-duplicate). Tunable per-tenant. Responses expose `threshold_used` for transparency.
+
+## Consequences
+
+### Positive
+
+- Customers can tune precision/recall after deployment without a code change.
+- Exposing `threshold_used` makes dedup decisions auditable.
+
+### Negative / Trade-offs
+
+- Thresholds are **model-specific** — a different embedding model (e.g. OpenAI) requires re-tuning (couples to [0026](0026-local-bge-m3-embeddings.md)).
+
+## Alternatives considered
+
+- **Fixed thresholds** — can't adapt to customer tolerance or model changes. Rejected.

--- a/docs/adr/0029-llm-provider-abstraction-ollama-default.md
+++ b/docs/adr/0029-llm-provider-abstraction-ollama-default.md
@@ -1,0 +1,31 @@
+# ADR-0029: LLM provider abstraction; Ollama `llama3.2:3b` default
+
+- Status: Accepted
+- Area: ml-model
+- Source: `bugspotter-intelligence/llm/factory.py`, `llm/base.py`, `llm/ollama.py`, `README.md`, `ROADMAP.md`
+- Date: Intelligence Phase 1 (v0.1.0); cloud providers Phase 4+
+
+## Context
+
+The AI tier needs LLM inference for reranking, rule parsing, and Q&A. Self-hosted/air-gapped deployments need a local, GPU-free option; production SaaS may prefer a stronger hosted model. The code must not hard-wire one vendor.
+
+## Decision
+
+An abstract **`LLMProvider`** base class with a **factory + registry** (`register_provider` decorator); the factory instantiates a provider from settings. Every provider implements `generate()` and **`generate_with_usage()`** (token counts for observability — see [0032](0032-ai-observability-event-feedback-tables.md)). **Ollama (`llama3.2:3b`)** is the default for dev/self-hosted (CPU-only); Claude Sonnet is recommended for production (Phase 4+). Ollama and Claude/OpenAI are configured; Ollama is fully implemented.
+
+## Consequences
+
+### Positive
+
+- New providers register themselves without touching the factory; all expose token usage uniformly.
+- Local default avoids GPU cost (~$1–3K/mo) and enables air-gapped installs.
+
+### Negative / Trade-offs
+
+- `llama3.2:3b` is lower quality than GPT-4o/Sonnet; ~120s Ollama timeout (`OLLAMA_TIMEOUT` tunable).
+- Claude/OpenAI providers are configured but not yet fully implemented (Phase 4 work).
+
+## Alternatives considered
+
+- **Conditional import/instantiation per vendor** — scatters vendor logic, hard to extend. Rejected for the registry pattern.
+- **Cloud-only LLM** — breaks air-gapped/self-hosted. Rejected as default.

--- a/docs/adr/0030-smart-search-llm-rerank-fallback.md
+++ b/docs/adr/0030-smart-search-llm-rerank-fallback.md
@@ -1,0 +1,30 @@
+# ADR-0030: Smart search — LLM rerank with timeout fallback
+
+- Status: Accepted
+- Area: ml-model / search
+- Source: `bugspotter-intelligence/services/reranker.py`, `config.py`
+- Date: Intelligence Phase 3 (v0.3.0)
+
+## Context
+
+Pure vector search returns nearest neighbors that aren't always the most _relevant_ results. LLM reranking improves quality but is slow and can hang, so it can't sit on the critical path unguarded.
+
+## Decision
+
+`POST /api/v1/search` with **`mode=smart`** retrieves the top-20 candidates via pgvector, has the LLM score relevance (0.0–1.0), and returns the top-5 reranked. A **10s timeout** falls back to the raw vector results if the LLM is slow/unavailable. `mode=fast` skips reranking entirely. Candidate and return limits are configurable.
+
+## Consequences
+
+### Positive
+
+- Better relevance without model retraining; graceful degradation to vector-only on timeout.
+- Callers choose the cost/latency trade-off per query (`fast` vs `smart`).
+
+### Negative / Trade-offs
+
+- Smart mode adds latency (sub-1s typical, up to 10s on timeout) and LLM cost per search.
+- Timeout must be tuned per deployment/model.
+
+## Alternatives considered
+
+- **Vector-only search** — kept as `mode=fast`; insufficient as the only mode for relevance.

--- a/docs/adr/0031-nl-dedup-rule-parsing.md
+++ b/docs/adr/0031-nl-dedup-rule-parsing.md
@@ -1,0 +1,31 @@
+# ADR-0031: Natural-language dedup-rule parsing via few-shot JSON
+
+- Status: Accepted
+- Area: prompt / dedup
+- Source: `bugspotter-intelligence/services/rule_parser_service.py`
+- Date: Rules pipeline (Phase 0.5 / Phase 4+ integration)
+
+## Context
+
+Operators want to describe dedup rules in plain English ("merge crashes from the same stack trace into one ticket"), but the engine needs a validated structured `DedupRule` (triggers / conditions / actions).
+
+## Decision
+
+A **few-shot system prompt** defines the ontology and covers the B1/B2/B3 persona cases plus an ambiguous case. Generation runs at **low temperature (0.1)** for determinism; available integrations are injected as context so the LLM doesn't invent targets. Output is extracted from markdown fences with a **character-level brace counter** (handles arbitrary nesting), then **validated with Pydantic**; validation failures return a `null` draft plus a `clarifications` list.
+
+## Consequences
+
+### Positive
+
+- Operators author rules in natural language; structured output is schema-validated before it touches the engine.
+- Injecting real integrations prevents hallucinated targets.
+
+### Negative / Trade-offs
+
+- Operator experience depends on prompt quality; ambiguous input yields clarification requests rather than a rule.
+- The NL endpoint is kept but full pipeline integration was **deferred** (see project notes); the executor is the load-bearing path.
+
+## Alternatives considered
+
+- **Regex-based parsing** — brittle. Rejected.
+- **Chain-of-thought** — verbose, less deterministic for JSON extraction. Rejected in favor of low-temp few-shot.

--- a/docs/adr/0032-ai-observability-event-feedback-tables.md
+++ b/docs/adr/0032-ai-observability-event-feedback-tables.md
@@ -1,0 +1,35 @@
+# ADR-0032: AI observability — `intelligence_event` + `intelligence_feedback`
+
+- Status: Accepted (observability Phase 1; rollout planned)
+- Area: observability
+- Source: `bugspotter-intelligence/docs/ai-observability-design.md`, `db/migrations.py`
+- Date: Intelligence Phase 7 (v0.7.0, production hardening)
+
+## Context
+
+Every LLM call needs auditing (tokens, latency, cost, confidence) and a way to measure decision quality over time, per tenant — and multiple reviewers may disagree about whether a given AI decision was correct.
+
+## Decision
+
+Two tables:
+
+- **`intelligence_event`** — immutable audit record per LLM call (token counts, latency, `cost_micros_usd` from a `MODEL_PRICING` map, status, confidence, rationale capped at 4 KiB, `meta` JSONB).
+- **`intelligence_feedback`** — user verdicts (correct / incorrect / partial) with `event_id` FK and `user_ref` for multi-reviewer consensus; `tenant_id` denormalized for fast per-tenant aggregation.
+
+Three call sites (reranker, rule parser, `ask`) are wrapped with `record_generate()`; `generate_with_usage()` on the provider base class (see [0029](0029-llm-provider-abstraction-ollama-default.md)) supplies the token data. Admin endpoints `/observability/{summary,events,accuracy}` require an admin key.
+
+## Consequences
+
+### Positive
+
+- Events stay immutable while feedback accumulates separately; reviewers can disagree without mutating the audit record.
+- Cost and accuracy are measurable per tenant — the basis for the AI eval/monitoring roadmap.
+
+### Negative / Trade-offs
+
+- Two new tables and write-path wrapping at each call site; `meta` JSONB is intentionally un-GIN-indexed (kept lean).
+
+## Alternatives considered
+
+- **Single table with feedback columns** — pollutes the immutable audit record. Rejected.
+- **No feedback capture** — can't measure accuracy. Rejected.

--- a/docs/adr/0033-offline-model-caching-docker.md
+++ b/docs/adr/0033-offline-model-caching-docker.md
@@ -1,0 +1,30 @@
+# ADR-0033: Offline embedding-model caching in a multi-stage Docker image
+
+- Status: Accepted
+- Area: infra
+- Source: `bugspotter-intelligence/Dockerfile`, `config.py`
+- Date: Intelligence Phase 1 (v0.1.0)
+
+## Context
+
+If the bge-m3 model (see [0026](0026-local-bge-m3-embeddings.md)) is downloaded lazily on first request, cold starts are unpredictable and a lazy load can race a worker timeout into an OOM. Air-gapped deployments can't reach HuggingFace Hub at all.
+
+## Decision
+
+A **multi-stage Docker build** pre-downloads BAAI/bge-m3 in the builder stage; the runtime sets **`TRANSFORMERS_OFFLINE=1`** and **`HF_HUB_OFFLINE=1`** to forbid network calls. Production runs as a non-root user on `python:3.12-slim`.
+
+## Consequences
+
+### Positive
+
+- Predictable startup (60s healthcheck start-period); no first-request download latency; works air-gapped.
+
+### Negative / Trade-offs
+
+- Image ~3GB (vs ~1GB without the model).
+- The Dockerfile's model and `migrations.py` `target_dim` must be coordinated exactly (couples build to schema).
+
+## Alternatives considered
+
+- **Lazy loading** — smaller image but unpredictable starts and OOM race. Rejected.
+- **Separate model volume** — extra provisioning step per host. Rejected in favor of baking it in.

--- a/docs/adr/0034-astro-static-islands-landing.md
+++ b/docs/adr/0034-astro-static-islands-landing.md
@@ -1,0 +1,32 @@
+# ADR-0034: Astro static + islands for the landing site
+
+- Status: Accepted
+- Area: framework
+- Source: `bugspotter-landing/astro.config.mjs`, `CLAUDE.md`, `README.md`
+- Date: Landing phase 1
+
+## Context
+
+The landing site is mostly marketing content in three languages that must load fast and rank well, with a few interactive pieces (signup/registration forms). A full SPA would ship needless JS; plain HTML would duplicate structure across languages.
+
+## Decision
+
+Use **Astro 5 with `output: 'static'`** and the **islands architecture**: pages are pre-rendered HTML, and React is hydrated only for interactive islands (forms) via `client:load`. Deployed static behind a CDN (Vercel adapter).
+
+## Consequences
+
+### Positive
+
+- Zero-JS marketing content; React downloaded only when a form island renders.
+- CDN-cacheable static output; pages pre-rendered at build.
+
+### Negative / Trade-offs
+
+- Every deploy regenerates all pages; server API routes must opt out of prerender.
+- Page-level i18n needs separate files per language (see [0035](0035-type-safe-file-based-i18n.md)).
+
+## Alternatives considered
+
+- **Next.js SSR** — server cost for mostly-static content. Rejected.
+- **Pure React SPA** — bloated initial load, worse SEO. Rejected.
+- **Hand-written HTML** — duplication across languages. Rejected.

--- a/docs/adr/0035-type-safe-file-based-i18n.md
+++ b/docs/adr/0035-type-safe-file-based-i18n.md
@@ -1,0 +1,30 @@
+# ADR-0035: Type-safe file-based i18n (props-only to React)
+
+- Status: Accepted
+- Area: i18n
+- Source: `bugspotter-landing/src/i18n/index.ts`, `CLAUDE.md`, `src/pages/{en,ru,kk}/index.astro`
+- Date: Landing phase 1
+
+## Context
+
+Three languages (en, ru, kk) must stay in sync and be type-checked across both Astro and React components, without coupling React to an i18n runtime (which would complicate Playwright testing).
+
+## Decision
+
+Translations live in `src/i18n/{en,ru,kk}.ts` as typed objects with a `TranslationKeys` type derived from `en.ts`. Astro pages resolve strings via `t(lang)`; **React components receive pre-resolved labels as props only** — they never import the i18n runtime. Three page files per route share the same components.
+
+## Consequences
+
+### Positive
+
+- Compile-time type checking catches missing keys; React stays environment-agnostic and testable without i18n setup.
+- No react-i18next runtime coupling.
+
+### Negative / Trade-offs
+
+- en/ru/kk files and the three page files must be kept in sync manually; all three locales deploy together.
+
+## Alternatives considered
+
+- **i18next / react-i18next** — couples React to an i18n runtime. Rejected.
+- **Dynamic `[lang]` routing** — more complex redirect/canonical handling. Rejected for explicit per-language files.

--- a/docs/adr/0036-self-service-signup-fragment-handoff.md
+++ b/docs/adr/0036-self-service-signup-fragment-handoff.md
@@ -1,0 +1,31 @@
+# ADR-0036: Self-service signup with URL-fragment token handoff
+
+- Status: Accepted
+- Area: signup / integration
+- Source: `bugspotter-landing/src/components/useSignupSubmit.ts`, `SelfServiceSignupForm.tsx`; backend `/api/v1/auth/signup`
+- Date: Landing phase 2
+
+## Context
+
+Free-tier users sign up on the landing site (one origin) and must land authenticated in the admin dashboard (a different org-subdomain origin) — without the landing site holding server-side session state, and without leaking the API key into logs or `Referer` headers.
+
+## Decision
+
+The React form POSTs to the backend **`/api/v1/auth/signup`**, receives an access token + `api_key`, and constructs a **URL fragment** `#handoff=<base64url-json>` pointing at the org subdomain's `/onboarding` page. The browser navigates cross-origin (`credentials: include` so the refresh-token cookie sticks). The backend response is **strictly validated** and fields are **explicitly mapped** (not spread) before building the URL; the subdomain is validated against RFC-1123 shape to prevent open redirects.
+
+## Consequences
+
+### Positive
+
+- The fragment is never sent in `Referer` or server logs; `base64url` preserves special chars; UTF-8 round-trip supports Cyrillic/Kazakh names.
+- No server-side session on the landing site; explicit field mapping blocks leaking future backend additions.
+
+### Negative / Trade-offs
+
+- The handoff payload shape couples the landing encoder to the admin decoder.
+- Subdomain validation lives on the landing side; a 15s fetch timeout guards hung backends; errors mapped by status (409 taken, 429 rate-limited).
+
+## Alternatives considered
+
+- **Query param** — leaks the key in `Referer`. Rejected.
+- **Shared session cookie / POST to admin** — cross-origin coupling, exposes creds to admin server logs. Rejected.

--- a/docs/adr/0037-mcp-dual-mode-transport.md
+++ b/docs/adr/0037-mcp-dual-mode-transport.md
@@ -1,0 +1,30 @@
+# ADR-0037: Dual-mode MCP transport (stdio + HTTP)
+
+- Status: Accepted
+- Area: mcp-transport
+- Source: `bugspotter-mcp/README.md`, `package.json` (bin entries), `docs/architecture.md`, `deploy/DEPLOYMENT.md`
+- Date: MCP v0.3.0 (HTTP added)
+
+## Context
+
+AI agents consume BugSpotter in two shapes: individuals running a per-user subprocess (Claude Code, Cursor, desktop), and teams wanting a hosted multi-tenant endpoint. One transport can't serve both efficiently.
+
+## Decision
+
+Ship two entry points from one codebase: **`bugspotter-mcp`** (stdio, per-user, key in the environment) and **`bugspotter-mcp-http`** (HTTP, multi-tenant, each request carrying `Authorization: Bearer bgs_<key>`). HTTP sessions are stateful and in-process with a 30-minute inactivity TTL; clients echo an `Mcp-Session-Id` bound to their bearer token (mismatch → 403).
+
+## Consequences
+
+### Positive
+
+- Stdio keeps the key local and is trivial for desktop clients; HTTP multiplexes many users on one process.
+
+### Negative / Trade-offs
+
+- HTTP mode is stateful → **sticky routing required** at scale (LB routes on `Mcp-Session-Id`).
+- Operators must choose the deployment shape upfront; reverse proxies need a 600s read timeout and disabled buffering for long `ask` (LLM) calls and SSE.
+
+## Alternatives considered
+
+- **Single unified transport** — precludes efficient multi-user hosting. Rejected.
+- **Custom protocol** — reinvents what the MCP spec already standardizes. Rejected.

--- a/docs/adr/0038-mcp-deliberate-six-tool-surface.md
+++ b/docs/adr/0038-mcp-deliberate-six-tool-surface.md
@@ -1,0 +1,31 @@
+# ADR-0038: Deliberate six-tool MCP surface
+
+- Status: Accepted
+- Area: mcp-tools
+- Source: `bugspotter-mcp/docs/architecture.md` (Design decisions), `README.md` (tool table)
+- Date: MCP v0.1.0
+
+## Context
+
+No MCP server exists for a bug tracker yet (no precedent). Exposing too much overloads the agent's choice space and creates write-blast-radius liability; exposing too little frustrates real triage workflows.
+
+## Decision
+
+Exactly **six tools**, grouped by triage-workflow frequency: `search_bugs`, `find_similar`, `ask` (discovery); `get_bug`, `list_bugs` (inspection); **`update_bug_status`** (the single write). Omissions are deliberate: `create_bug` (high blast radius without human gates), `add_comment` (no backend table yet), `attach_session_replay` (needs multi-step presigned URLs), `suggest_fix` (async-polling, doesn't map to one MCP call).
+
+## Consequences
+
+### Positive
+
+- A small, workflow-aligned surface agents can reason about; exactly one write keeps liability bounded.
+- Behavioral logs (see [0040](0040-mcp-behavioral-jsonl-logging.md)) reveal how agents use the surface (over-drilling, under-using `ask`).
+
+### Negative / Trade-offs
+
+- Tool descriptions must be precise — agents get validation errors if they misread the `mode` enum or required fields.
+- Closure workflows that need create/comment aren't fully served yet (intentional, revisitable).
+
+## Alternatives considered
+
+- **Full CRUD** — dangerous writes. Rejected.
+- **Read-only** — frustrates status-closure workflows. Rejected.

--- a/docs/adr/0039-mcp-ajv-json-schema-validation.md
+++ b/docs/adr/0039-mcp-ajv-json-schema-validation.md
@@ -1,0 +1,31 @@
+# ADR-0039: Ajv + JSON Schema validation (single source of truth)
+
+- Status: Accepted
+- Area: mcp-tools
+- Source: `bugspotter-mcp/docs/architecture.md` (Design decisions: "Why JSON Schema + Ajv?")
+- Date: MCP v0.1.0
+
+## Context
+
+The MCP spec mandates that each tool's `inputSchema` is **JSON Schema** sent over the wire. Tool arguments must be validated at dispatch, and the validation must not drift from what the agent sees.
+
+## Decision
+
+Validate with **Ajv against the same JSON Schema** that is published on the wire — one source of truth. No separate code-level schema (e.g. Zod) that would have to be kept in sync with the wire schema.
+
+## Consequences
+
+### Positive
+
+- The schema the agent sees **is** the schema that validates — no drift; tweaks are immediately visible to agents.
+- Ajv errors are format-exact, feeding precise behavioral logs (validation class, `args_size_bytes`).
+
+### Negative / Trade-offs
+
+- JSON Schema is more verbose to author by hand than a Zod schema with inferred types.
+
+## Alternatives considered
+
+- **Zod with codegen to JSON Schema** — adds a build step and a sync failure mode. Rejected.
+- **Manual validation** — error-prone. Rejected.
+- **TypeScript types only** — no runtime checks. Rejected.

--- a/docs/adr/0040-mcp-behavioral-jsonl-logging.md
+++ b/docs/adr/0040-mcp-behavioral-jsonl-logging.md
@@ -1,0 +1,32 @@
+# ADR-0040: Behavioral JSONL logging with scoped PII redaction
+
+- Status: Accepted
+- Area: mcp-tools / observability
+- Source: `bugspotter-mcp/docs/behavioral-logs.md`, `docs/architecture.md` (Design decisions)
+- Date: MCP v0.1.0
+
+## Context
+
+The MCP server doubles as a research artifact: a record of how AI agents reason about a bug tracker. That requires logging every tool call without leaking the PII users paste into free-text fields, and without a concurrency hazard under multi-user HTTP.
+
+## Decision
+
+Log **one JSONL record per tool dispatch**, daily-rotated. Apply **PII redaction (emails, JWTs, credit cards) only to free-text args** (`search_bugs`, `ask`) — not to schema-enforced fields (UUIDs, enums), where redaction would be a category error. The session id is `sha256(api_key)[:32]`, never the raw key. Result **bodies are not logged** (privacy); `result_count` distinguishes `null` ("not meaningful") from `0` ("empty").
+
+## Consequences
+
+### Positive
+
+- Append-only JSONL is concurrency-safe under multi-user SaaS and trivially aggregated (`jq`).
+- Enables agent-behavior research while protecting pasted PII and result contents.
+
+### Negative / Trade-offs
+
+- No result bodies means some analyses need the backend instead.
+- Redaction is intentionally partial (free-text only) — relies on the schema to keep PII out of structured fields.
+
+## Alternatives considered
+
+- **Structured logs to an external backend** — loses data locality, adds a dependency. Rejected.
+- **No logging** — makes the research goal impossible. Rejected.
+- **Universal PII redaction** — wasteful on schema-enforced fields. Rejected.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,95 @@
+# Architecture Decision Records
+
+This directory is the **cross-repo** ADR catalog for the BugSpotter platform. It captures the major architectural and technical decisions that shape the product across all code repositories:
+
+`bugspotter-public` (backend + admin) · `bugspotter-sdk` · `bugspotter-extension` · `bugspotter-intelligence` · `bugspotter-landing` · `bugspotter-mcp` · `bugspotter-deploy`
+
+## Format
+
+Each record follows a light [MADR](https://adr.github.io/madr/) shape: **Context → Decision → Consequences → Alternatives**. One decision per file, numbered. Records are immutable once `Accepted`; a reversal is a _new_ ADR that marks the old one `Superseded`.
+
+Where the source docs do not record a rationale or the alternatives that were weighed, the ADR says so ("Not recorded in docs") rather than inventing one.
+
+> **Interactive view:** open [`index.html`](index.html) in a browser for a searchable, filterable version of this catalog (live search, filter by status/repo/area, era navigation, `j`/`k` keyboard nav). It is self-contained — no build step or server needed.
+
+## How the sequence is ordered
+
+ADRs are numbered in **logical build order** — foundations first, then the backend platform, then the capture clients, then the AI tier, then signup, then the agent (MCP) surface. This is roughly the order the platform was actually built, but the number is an identifier, not a strict timestamp. Precise dates exist only where a repo records them (mostly the SDK CHANGELOG); those are noted per-ADR.
+
+## Index
+
+### Era 1 — Foundations
+
+| #                                                 | Decision                                                       | Source repo(s) |
+| ------------------------------------------------- | -------------------------------------------------------------- | -------------- |
+| [0001](0001-pnpm-typescript-monorepo.md)          | pnpm + TypeScript workspace monorepo                           | public         |
+| [0002](0002-fastify-typescript-backend.md)        | Fastify/TypeScript backend as the API core                     | public         |
+| [0003](0003-dual-licensing-fsl-and-mit.md)        | Dual licensing: FSL-1.1-Apache-2.0 platform, MIT SDK           | all            |
+| [0004](0004-runtime-deployment-mode.md)           | Single codebase, runtime `DEPLOYMENT_MODE` (saas / selfhosted) | public         |
+| [0005](0005-core-data-plane-postgres-redis-s3.md) | Core data plane: Postgres 16 + Redis 7 + S3/MinIO              | public, deploy |
+| [0006](0006-docker-compose-not-kubernetes.md)     | Docker Compose single-host orchestration (not Kubernetes)      | deploy, public |
+
+### Era 2 — Backend platform
+
+| #                                                      | Decision                                                                   | Source repo(s)       |
+| ------------------------------------------------------ | -------------------------------------------------------------------------- | -------------------- |
+| [0007](0007-polyglot-python-intelligence-service.md)   | Polyglot: separate Python intelligence service over HTTP + circuit breaker | public, intelligence |
+| [0008](0008-triple-auth-model.md)                      | Triple auth: JWT user / API key ingest / share-token                       | public               |
+| [0009](0009-multi-tenancy-api-key-tenant-isolation.md) | Multi-tenancy via API-key → tenant_id isolation                            | public, intelligence |
+| [0010](0010-unified-rbac-legacy-coexistence.md)        | Unified RBAC with legacy `permissions` coexistence                         | public               |
+| [0011](0011-bullmq-per-type-queues-concurrency.md)     | BullMQ per-type job queues with per-type concurrency                       | public, deploy       |
+| [0012](0012-transactional-outbox-ticket-filing.md)     | Transactional outbox for external ticket filing                            | public               |
+| [0013](0013-integration-plugin-sandbox-ssrf.md)        | Integration plugin sandbox + SSRF-hardened HTTP                            | public               |
+| [0014](0014-per-org-data-residency-routing.md)         | Per-organization data residency routing                                    | public               |
+
+### Era 3 — Capture clients (SDK + browser extension)
+
+| #                                                       | Decision                                                          | Source repo(s)         |
+| ------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------- |
+| [0015](0015-dual-capture-screenshot-and-replay.md)      | Dual capture: screenshot + rrweb session replay                   | sdk, extension         |
+| [0016](0016-presigned-url-direct-uploads.md)            | Presigned-URL direct-to-storage uploads                           | sdk, extension, public |
+| [0017](0017-backend-controlled-replay-settings.md)      | Backend-controlled, cached replay quality settings                | sdk, public            |
+| [0018](0018-cross-navigation-replay-persistence.md)     | Cross-navigation replay persistence (IndexedDB / storage.session) | sdk, extension         |
+| [0019](0019-shared-pii-sanitization.md)                 | Shared local-first PII sanitization via `@bugspotter/common`      | sdk, extension         |
+| [0020](0020-client-offline-queue-retry.md)              | Client offline queue with backoff retry                           | sdk, extension         |
+| [0021](0021-shadow-dom-widget-isolation.md)             | Shadow DOM widget isolation                                       | sdk, extension         |
+| [0022](0022-client-side-duplicate-dedup.md)             | Client-side duplicate-report dedup                                | sdk, extension         |
+| [0023](0023-framework-agnostic-async-singleton-init.md) | Framework-agnostic async singleton SDK `init()`                   | sdk                    |
+| [0024](0024-extension-mv3-stateless-service-worker.md)  | Browser extension on MV3 stateless service worker                 | extension              |
+| [0025](0025-main-world-injection-capture.md)            | Main-world injection for CSP-proof console/network capture        | extension              |
+
+### Era 4 — Intelligence / AI tier
+
+| #                                                       | Decision                                                         | Source repo(s) |
+| ------------------------------------------------------- | ---------------------------------------------------------------- | -------------- |
+| [0026](0026-local-bge-m3-embeddings.md)                 | Local BAAI/bge-m3 embeddings (self-hosted, multilingual)         | intelligence   |
+| [0027](0027-pgvector-ivfflat-similarity.md)             | pgvector + IVFFlat for similarity search (no separate vector DB) | intelligence   |
+| [0028](0028-tunable-similarity-thresholds.md)           | Tunable similarity thresholds (0.68 / 0.85), per-tenant          | intelligence   |
+| [0029](0029-llm-provider-abstraction-ollama-default.md) | LLM provider abstraction; Ollama `llama3.2:3b` default           | intelligence   |
+| [0030](0030-smart-search-llm-rerank-fallback.md)        | Smart search LLM rerank with timeout fallback                    | intelligence   |
+| [0031](0031-nl-dedup-rule-parsing.md)                   | Natural-language dedup-rule parsing via few-shot JSON            | intelligence   |
+| [0032](0032-ai-observability-event-feedback-tables.md)  | AI observability: `intelligence_event` + `intelligence_feedback` | intelligence   |
+| [0033](0033-offline-model-caching-docker.md)            | Offline embedding-model caching in multi-stage Docker image      | intelligence   |
+
+### Era 5 — Signup / landing
+
+| #                                                    | Decision                                            | Source repo(s)  |
+| ---------------------------------------------------- | --------------------------------------------------- | --------------- |
+| [0034](0034-astro-static-islands-landing.md)         | Astro static + islands for the landing site         | landing         |
+| [0035](0035-type-safe-file-based-i18n.md)            | Type-safe file-based i18n (props-only to React)     | landing         |
+| [0036](0036-self-service-signup-fragment-handoff.md) | Self-service signup with URL-fragment token handoff | landing, public |
+
+### Era 6 — MCP (AI agent) surface
+
+| #                                               | Decision                                              | Source repo(s) |
+| ----------------------------------------------- | ----------------------------------------------------- | -------------- |
+| [0037](0037-mcp-dual-mode-transport.md)         | Dual-mode MCP transport (stdio + HTTP)                | mcp            |
+| [0038](0038-mcp-deliberate-six-tool-surface.md) | Deliberate six-tool MCP surface                       | mcp            |
+| [0039](0039-mcp-ajv-json-schema-validation.md)  | Ajv + JSON Schema validation (single source of truth) | mcp            |
+| [0040](0040-mcp-behavioral-jsonl-logging.md)    | Behavioral JSONL logging with scoped PII redaction    | mcp            |
+
+## Consciously not promoted to ADRs
+
+The following surfaced during the doc sweep but were judged implementation detail or a consequence of an ADR above, not standalone architectural decisions. Listed here so the record is honest about scope: gzip replay compression (native `CompressionStream` / `pako`); multi-format SDK build (CJS/ESM/UMD); Vite + `@crxjs` extension build; canvas/Shadow-DOM screenshot annotation overlay; domain allowlist for capture; honeypot + rate-limit spam defense on signup; Vercel static deploy + under-construction toggle; SEO/canonical metadata; Playwright serial-mode E2E; non-root Docker user; idempotent `IF NOT EXISTS` migrations (no Alembic) in the intelligence service; Prometheus metrics cardinality protection; Redis sliding-window rate limiting (Lua) and tenant-versioned cache invalidation in the intelligence service; MCP HTTP retry policy (5xx-yes/4xx-no), per-request timeouts, and 30-minute session TTL with sticky routing.
+
+Several of these are captured as _Consequences_ inside the relevant ADR.

--- a/docs/adr/index.html
+++ b/docs/adr/index.html
@@ -1,0 +1,1716 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BugSpotter — Architecture Decision Records</title>
+    <style>
+      :root {
+        --bg: #0f1115;
+        --panel: #171a21;
+        --panel2: #1d212b;
+        --bd: #2a2f3a;
+        --tx: #e6e9ef;
+        --mut: #9aa3b2;
+        --acc: #5b9dff;
+        --acc2: #7c5cff;
+        --ok: #3ecf8e;
+        --warn: #f5a623;
+        --bad: #ff6b6b;
+        --plan: #8aa0c7;
+        --chip: #222735;
+      }
+      [data-theme='light'] {
+        --bg: #f5f6f8;
+        --panel: #ffffff;
+        --panel2: #f0f2f5;
+        --bd: #d9dde3;
+        --tx: #1a1d23;
+        --mut: #5a6472;
+        --acc: #2266dd;
+        --acc2: #6a3cff;
+        --chip: #eaeef5;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+      }
+      body {
+        background: var(--bg);
+        color: var(--tx);
+        font:
+          15px/1.55 -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif;
+        -webkit-font-smoothing: antialiased;
+      }
+      a {
+        color: var(--acc);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .app {
+        display: grid;
+        grid-template-columns: 340px 1fr;
+        height: 100vh;
+      }
+      /* sidebar */
+      .side {
+        background: var(--panel);
+        border-right: 1px solid var(--bd);
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+      .brand {
+        padding: 18px 18px 12px;
+        border-bottom: 1px solid var(--bd);
+      }
+      .brand h1 {
+        font-size: 16px;
+        margin: 0 0 2px;
+        letter-spacing: 0.2px;
+      }
+      .brand .sub {
+        color: var(--mut);
+        font-size: 12px;
+      }
+      .stats {
+        display: flex;
+        gap: 14px;
+        margin-top: 10px;
+        flex-wrap: wrap;
+      }
+      .stat {
+        font-size: 11px;
+        color: var(--mut);
+      }
+      .stat b {
+        color: var(--tx);
+        font-size: 14px;
+        display: block;
+      }
+      .search {
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--bd);
+      }
+      .search input {
+        width: 100%;
+        padding: 9px 11px;
+        border-radius: 8px;
+        border: 1px solid var(--bd);
+        background: var(--panel2);
+        color: var(--tx);
+        font-size: 13px;
+        outline: none;
+      }
+      .search input:focus {
+        border-color: var(--acc);
+      }
+      .filters {
+        padding: 10px 14px 4px;
+        border-bottom: 1px solid var(--bd);
+      }
+      .frow {
+        margin-bottom: 8px;
+      }
+      .frow .lbl {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+        color: var(--mut);
+        margin-bottom: 5px;
+      }
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px;
+      }
+      .chip {
+        font-size: 11px;
+        padding: 3px 9px;
+        border-radius: 20px;
+        background: var(--chip);
+        border: 1px solid transparent;
+        color: var(--mut);
+        cursor: pointer;
+        user-select: none;
+      }
+      .chip:hover {
+        color: var(--tx);
+      }
+      .chip.on {
+        background: var(--acc);
+        color: #fff;
+        border-color: var(--acc);
+      }
+      .chip.on.warnk {
+        background: var(--warn);
+        border-color: var(--warn);
+        color: #1a1d23;
+      }
+      .list {
+        overflow: auto;
+        flex: 1;
+        padding: 6px 8px 30px;
+      }
+      .era {
+        margin: 12px 6px 4px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.7px;
+        color: var(--acc2);
+        font-weight: 600;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .era span {
+        color: var(--mut);
+        font-weight: 400;
+      }
+      .item {
+        padding: 8px 10px;
+        border-radius: 8px;
+        cursor: pointer;
+        display: flex;
+        gap: 9px;
+        align-items: flex-start;
+      }
+      .item:hover {
+        background: var(--panel2);
+      }
+      .item.active {
+        background: var(--panel2);
+        box-shadow: inset 3px 0 0 var(--acc);
+      }
+      .item .num {
+        font-variant-numeric: tabular-nums;
+        color: var(--mut);
+        font-size: 12px;
+        min-width: 30px;
+        padding-top: 1px;
+      }
+      .item .ti {
+        font-size: 13px;
+        line-height: 1.35;
+      }
+      .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        margin-top: 5px;
+        flex: 0 0 auto;
+      }
+      .dot.accepted {
+        background: var(--ok);
+      }
+      .dot.progress {
+        background: var(--warn);
+      }
+      .dot.planned {
+        background: var(--plan);
+      }
+      .dot.superseded {
+        background: var(--bad);
+      }
+      /* main */
+      .main {
+        overflow: auto;
+        min-height: 0;
+      }
+      .topbar {
+        position: sticky;
+        top: 0;
+        background: rgba(15, 17, 21, 0.82);
+        backdrop-filter: blur(8px);
+        border-bottom: 1px solid var(--bd);
+        padding: 10px 26px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        z-index: 5;
+      }
+      [data-theme='light'] .topbar {
+        background: rgba(255, 255, 255, 0.82);
+      }
+      .topbar .crumbs {
+        font-size: 12px;
+        color: var(--mut);
+        flex: 1;
+      }
+      .btn {
+        font-size: 12px;
+        padding: 6px 11px;
+        border-radius: 7px;
+        border: 1px solid var(--bd);
+        background: var(--panel2);
+        color: var(--tx);
+        cursor: pointer;
+      }
+      .btn:hover {
+        border-color: var(--acc);
+      }
+      .wrap {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 26px 26px 80px;
+      }
+      .doc h2 {
+        font-size: 25px;
+        margin: 6px 0 4px;
+        line-height: 1.2;
+      }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 7px;
+        margin: 14px 0 22px;
+      }
+      .badge {
+        font-size: 11px;
+        padding: 3px 10px;
+        border-radius: 6px;
+        background: var(--chip);
+        color: var(--mut);
+        border: 1px solid var(--bd);
+      }
+      .badge.st-accepted {
+        color: var(--ok);
+        border-color: color-mix(in srgb, var(--ok) 40%, transparent);
+      }
+      .badge.st-progress {
+        color: var(--warn);
+        border-color: color-mix(in srgb, var(--warn) 40%, transparent);
+      }
+      .badge.st-planned {
+        color: var(--plan);
+        border-color: color-mix(in srgb, var(--plan) 40%, transparent);
+      }
+      .badge.repo {
+        color: var(--acc);
+      }
+      .sec {
+        margin: 22px 0;
+      }
+      .sec h3 {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.8px;
+        color: var(--acc2);
+        margin: 0 0 8px;
+        border-bottom: 1px solid var(--bd);
+        padding-bottom: 6px;
+      }
+      .sec p {
+        margin: 0 0 8px;
+      }
+      ul.cons {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      ul.cons li {
+        padding: 6px 0 6px 26px;
+        position: relative;
+        border-bottom: 1px dashed var(--bd);
+      }
+      ul.cons li:last-child {
+        border-bottom: 0;
+      }
+      ul.cons li:before {
+        position: absolute;
+        left: 4px;
+        top: 6px;
+        font-size: 13px;
+      }
+      ul.cons.pos li:before {
+        content: '+';
+        color: var(--ok);
+        font-weight: 700;
+      }
+      ul.cons.neg li:before {
+        content: '−';
+        color: var(--warn);
+        font-weight: 700;
+      }
+      ul.cons.alt li:before {
+        content: '✕';
+        color: var(--bad);
+        font-size: 11px;
+        top: 8px;
+      }
+      .related a {
+        display: inline-block;
+        font-size: 12px;
+        background: var(--chip);
+        padding: 4px 10px;
+        border-radius: 6px;
+        margin: 0 6px 6px 0;
+        border: 1px solid var(--bd);
+      }
+      code {
+        background: var(--chip);
+        padding: 1px 5px;
+        border-radius: 4px;
+        font-size: 0.88em;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      .empty {
+        color: var(--mut);
+        text-align: center;
+        padding: 60px 20px;
+      }
+      .kbd {
+        font-size: 11px;
+        color: var(--mut);
+      }
+      .seqbar {
+        display: flex;
+        gap: 2px;
+        margin: 10px 0 0;
+        flex-wrap: wrap;
+      }
+      .seqbar i {
+        width: 10px;
+        height: 18px;
+        border-radius: 2px;
+        background: var(--chip);
+        cursor: pointer;
+        display: inline-block;
+      }
+      .seqbar i:hover {
+        outline: 1px solid var(--acc);
+      }
+      @media (max-width: 820px) {
+        .app {
+          grid-template-columns: 1fr;
+        }
+        .side {
+          display: none;
+        }
+        .side.show {
+          display: flex;
+          position: fixed;
+          inset: 0;
+          z-index: 20;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="side" id="side">
+        <div class="brand">
+          <h1>BugSpotter ADRs</h1>
+          <div class="sub">Cross-repo architecture decision records</div>
+          <div class="stats">
+            <div class="stat"><b id="st-total">40</b>decisions</div>
+            <div class="stat"><b id="st-eras">6</b>eras</div>
+            <div class="stat"><b id="st-repos">7</b>repos</div>
+            <div class="stat"><b id="st-shown">40</b>shown</div>
+          </div>
+          <div class="seqbar" id="seqbar" title="Sequence — click a block to jump"></div>
+        </div>
+        <div class="search">
+          <input id="q" placeholder="Search decisions, areas, repos…  (/)" autocomplete="off" />
+        </div>
+        <div class="filters">
+          <div class="frow">
+            <div class="lbl">Status</div>
+            <div class="chips" id="f-status"></div>
+          </div>
+          <div class="frow">
+            <div class="lbl">Repo</div>
+            <div class="chips" id="f-repo"></div>
+          </div>
+          <div class="frow">
+            <div class="lbl">Area</div>
+            <div class="chips" id="f-area"></div>
+          </div>
+        </div>
+        <div class="list" id="list"></div>
+      </aside>
+      <main class="main">
+        <div class="topbar">
+          <button class="btn" id="menuBtn" style="display: none">☰</button>
+          <div class="crumbs" id="crumbs">Select a decision</div>
+          <span class="kbd">j / k to navigate</span>
+          <button class="btn" id="theme">◐ Theme</button>
+        </div>
+        <div class="wrap"><div id="doc"></div></div>
+      </main>
+    </div>
+    <script>
+      const ERAS = [
+        ['Foundations', 'Era 1'],
+        ['Backend platform', 'Era 2'],
+        ['Capture clients', 'Era 3'],
+        ['Intelligence / AI', 'Era 4'],
+        ['Signup / landing', 'Era 5'],
+        ['MCP agent surface', 'Era 6'],
+      ];
+      // status: accepted | progress | planned | superseded
+      const ADR = [
+        {
+          n: 1,
+          era: 0,
+          status: 'accepted',
+          title: 'pnpm + TypeScript workspace monorepo',
+          areas: ['build'],
+          repos: ['public'],
+          date: 'Foundational',
+          context:
+            'Backend, billing, broker, payment, shared types/utils and the admin UI evolve together and share TypeScript types. They need atomic cross-package changes, one dependency graph and one CI.',
+          decision:
+            'A pnpm workspace monorepo (<code>pnpm@9.14.4</code>, Node 22): <code>packages/*</code> (backend, backend-mock, billing, message-broker, payment-service, types, utils) and <code>apps/*</code> (admin, demo). Cross-package work via <code>pnpm --filter</code>.',
+          pos: [
+            'Shared <code>@bugspotter/types</code>/<code>utils</code>/<code>common</code> keep contracts in one place.',
+            'One install, lockfile and CI workflow.',
+            'Atomic cross-package refactors in one PR.',
+          ],
+          neg: [
+            'SDK and extension are deliberately separate repos (different cadence & license), so some shared logic must be published, not imported across the boundary.',
+            'CI must understand the workspace layout.',
+          ],
+          alts: [
+            'Polyrepo for every package — loses atomic cross-package changes. Rejected for the server platform; only the independently-shipped clients were split out.',
+          ],
+          rel: [3],
+        },
+        {
+          n: 2,
+          era: 0,
+          status: 'accepted',
+          title: 'Fastify / TypeScript backend as the API core',
+          areas: ['backend'],
+          repos: ['public'],
+          date: 'Foundational',
+          context:
+            'The platform needs an HTTP API for SDK ingest, the dashboard, billing and integrations, plus a worker — type-safe against shared <code>@bugspotter/types</code>.',
+          decision:
+            'API and worker are a TypeScript Fastify app in <code>packages/backend</code>; the worker shares the codebase via separate entry points rather than a separate service.',
+          pos: [
+            'Schema-based validation/serialization fits Fastify; JSON Schema reused at the edge.',
+            'One codebase for API + worker simplifies type sharing and deployment.',
+            '<code>test:unit</code> runs without Docker.',
+          ],
+          neg: [
+            'API and worker share a dependency surface though they scale differently; separation is by process, not package.',
+          ],
+          alts: [
+            'Express-vs-Fastify rationale is not recorded in docs; logged here so the stack choice is traceable.',
+          ],
+          rel: [6],
+        },
+        {
+          n: 3,
+          era: 0,
+          status: 'accepted',
+          title: 'Dual licensing — FSL-1.1-Apache-2.0 platform, MIT SDK',
+          areas: ['licensing'],
+          repos: ['all'],
+          date: 'Converts to Apache-2.0 on 2028-04-09',
+          context:
+            'Commercial sustainability (block a competing SaaS) while still allowing self-hosting and inspection — and the embeddable SDK must carry zero licensing friction inside third-party apps.',
+          decision:
+            'Two licenses by component. Platform: <b>FSL-1.1-Apache-2.0</b> (source-available, no competing-SaaS use, auto-converts to Apache-2.0 on 2028-04-09). SDK <code>@bugspotter/sdk</code>: <b>MIT</b>.',
+          pos: [
+            'Self-hosting, internal use and contributions allowed today; the Apache future date removes any forced re-licensing later.',
+            'SDK has no adoption friction.',
+          ],
+          neg: [
+            'Two license regimes to track; contributor terms differ by repo.',
+            '"Open-source platform" is inaccurate until 2028 — only the SDK is OSI-open; public copy must say "source-available".',
+          ],
+          alts: [
+            'MIT everywhere — permits a competing managed service. Rejected.',
+            'Fully proprietary — locks out self-hosting/community. Rejected.',
+            'Pure Apache now — gives up competing-SaaS protection during the commercial window. Deferred to 2028 via FSL.',
+          ],
+          rel: [],
+        },
+        {
+          n: 4,
+          era: 0,
+          status: 'accepted',
+          title: 'Single codebase, runtime DEPLOYMENT_MODE (saas / selfhosted)',
+          areas: ['deployment'],
+          repos: ['public'],
+          date: 'Foundational',
+          context:
+            'The product ships as multi-tenant SaaS on <code>*.kz.bugspotter.io</code> and as a single-tenant self-hostable build. Two forks would diverge fast.',
+          decision:
+            'One codebase gated by <code>DEPLOYMENT_MODE</code>: <code>saas</code> (multi-tenancy, billing, quotas, signup, tenant middleware) vs <code>selfhosted</code> (single tenant, none of those). Flags live in <code>config.ts</code>; SaaS-only code under <code>src/saas/</code>. The SaaS schema is a purely additive bolt-on.',
+          pos: [
+            'One build/test matrix; features toggled, not forked.',
+            'Self-hosted runs a strict subset of the schema.',
+          ],
+          neg: [
+            'Config flags must stay synchronized; a missing gate can leak SaaS behavior into self-hosted (covered by config tests).',
+          ],
+          alts: ['A separate self-hosted fork — implicitly rejected for runtime gating.'],
+          rel: [9],
+        },
+        {
+          n: 5,
+          era: 0,
+          status: 'accepted',
+          title: 'Core data plane — Postgres 16 + Redis 7 + S3/MinIO',
+          areas: ['data', 'infra'],
+          repos: ['public', 'deploy'],
+          date: 'Foundational',
+          context:
+            'Needs durable relational state, a job queue + cache, file storage for screenshots/replays, and vector similarity for the AI tier — on customer infra with no vendor lock-in.',
+          decision:
+            'PostgreSQL 16 (with pgvector), Redis 7 (BullMQ + cache), MinIO (S3-compatible object store, local-disk or external-S3 backed).',
+          pos: [
+            'pgvector keeps vectors in the same ACID store — no separate vector DB.',
+            'S3-compatibility means no lock-in.',
+            'Standard, battle-tested components.',
+          ],
+          neg: [
+            'Three persistent volumes to back up, each with its own strategy.',
+            'Postgres needs tuning (<code>shm_size</code>) to avoid OOM.',
+          ],
+          alts: [
+            'MongoDB — loses transactions. Rejected.',
+            'Dedicated vector DB — extra ops surface. Rejected.',
+            'RabbitMQ — more complex than needed. Rejected.',
+          ],
+          rel: [11, 27],
+        },
+        {
+          n: 6,
+          era: 0,
+          status: 'accepted',
+          title: 'Docker Compose single-host orchestration (not Kubernetes)',
+          areas: ['infra', 'deployment'],
+          repos: ['deploy', 'public'],
+          date: 'Foundational',
+          context:
+            'Deployed as SaaS on VMs and self-hosted by teams from one person to small enterprises — operators need something auditable without a platform team.',
+          decision:
+            'Docker Compose v2 is the orchestration/IaC. A base compose file has production-safe defaults; an auto-loaded override binds infra to <code>127.0.0.1</code> for dev. A root Dockerfile can also build a unified supervisord image (API+worker+nginx) for PaaS. Kubernetes is out of scope for now.',
+          pos: [
+            'One YAML per deployment shape; easy to inspect.',
+            'Upgrades are <code>docker compose pull && up -d</code>.',
+            'Unified-image option covers Railway/Render/Fly.',
+          ],
+          neg: [
+            'Horizontal scaling needs sidecar/reverse-proxy; stateful services single-replica unless backed up.',
+            'Dev vs prod is a two-file model operators must understand.',
+          ],
+          alts: [
+            'Kubernetes — over-specified for single-host; deferred to a possible stage-2.',
+            'systemd / Terraform / Pulumi — fragile or heavyweight. Rejected.',
+          ],
+          rel: [5],
+        },
+        {
+          n: 7,
+          era: 1,
+          status: 'accepted',
+          title: 'Polyglot — separate Python intelligence service over HTTP + circuit breaker',
+          areas: ['architecture', 'integration'],
+          repos: ['public', 'intelligence'],
+          date: 'Foundational to AI tier',
+          context:
+            'Dedup/enrichment need ML; the backend is TypeScript but the ML ecosystem is Python-native. Coupling ML into Node would force language compromises and tie failure domains together.',
+          decision:
+            'A separate Python FastAPI service (<code>bugspotter-intelligence</code>) decoupled via HTTP + a circuit breaker. The backend degrades gracefully when intelligence is down.',
+          pos: [
+            'Independent scaling and language choice for ML; failure isolation.',
+            'The AI tier is optional (deploy <code>--profile intelligence</code>).',
+          ],
+          neg: [
+            'The <code>DedupRule</code> schema is defined as Zod (TS) and Pydantic (Py) and must not drift across repos.',
+            'Network latency on dedup calls; an extra service to run.',
+          ],
+          alts: [
+            'Embedding ML in the Node backend — implicitly rejected for language and failure-isolation reasons.',
+          ],
+          rel: [31],
+        },
+        {
+          n: 8,
+          era: 1,
+          status: 'accepted',
+          title: 'Triple auth — JWT user / API key ingest / share-token',
+          areas: ['auth'],
+          repos: ['public'],
+          date: 'PR-105/107 audit fix',
+          context:
+            "Three callers authenticate differently: dashboard users (JWT), SDK ingest (API key), and public replay sharing (anonymous, scoped). One artifact can't serve all three.",
+          decision:
+            'Three orthogonal artifacts, applied by middleware in precedence share-token → API key → JWT: <code>authUser</code>, <code>apiKey</code> (X-API-Key), <code>authShareToken</code> (query param). Auth is separated from authorization; API keys have platform-permission bypass rules; lock-in tests document the bypass.',
+          pos: [
+            'Fine-grained scoping (single-project keys); anonymous sharing without exposing identity.',
+            'Precedence rules explicit and tested.',
+          ],
+          neg: [
+            'All three fields can coexist; JWT+API-key together needs a single-project-key constraint for safe audit attribution (the PR-105/107 fix).',
+          ],
+          alts: ['Not recorded in docs.'],
+          rel: [9],
+        },
+        {
+          n: 9,
+          era: 1,
+          status: 'accepted',
+          title: 'Multi-tenancy via API-key → tenant_id isolation',
+          areas: ['auth', 'data'],
+          repos: ['public', 'intelligence'],
+          date: 'Intelligence Phase 2',
+          context:
+            "Every customer's data must be strictly isolated in SaaS, but machine callers are already authenticated by API key.",
+          decision:
+            'Resolve API key → <code>tenant_id</code> and filter every query by it; tenant context injected via DI/middleware for testability. <code>tenant_id</code> is nullable for backwards compatibility. No global super-admin scope (per-tenant admin only) to prevent BOLA.',
+          pos: [
+            'Reuses API-key auth; uniform isolation.',
+            'New tables get <code>tenant_id</code> by convention.',
+          ],
+          neg: [
+            'Every new query must filter by <code>tenant_id</code> — a miss is a cross-tenant leak.',
+            'Nullable <code>tenant_id</code> needs careful read handling for legacy rows.',
+          ],
+          alts: [
+            'Schema-per-tenant / database-per-tenant — operational cost for many small tenants. Not adopted.',
+          ],
+          rel: [8, 10],
+        },
+        {
+          n: 10,
+          era: 1,
+          status: 'progress',
+          title: 'Unified RBAC with legacy permissions coexistence',
+          areas: ['auth'],
+          repos: ['public'],
+          date: 'Migration 015; legacy drop pending',
+          context:
+            'Evolving from legacy <code>users.role</code> + <code>permissions</code> toward modern RBAC, but a big-bang schema change is risky on a live system.',
+          decision:
+            'Three coexisting RBAC layers, migrating incrementally: platform (<code>users.security</code> JSONB), org (membership), project (<code>project_members.role</code> + <code>project_roles</code>). Legacy <code>role</code>/<code>permissions</code> stay load-bearing with helper fallbacks. The legacy-column drop is not yet written.',
+          pos: ['Incremental migration with no breaking change.'],
+          neg: [
+            'Three RBAC mechanisms in production — real complexity for new engineers.',
+            'Deprecation unfinished; this ADR will be superseded once the legacy column is dropped.',
+          ],
+          alts: [
+            'Immediate full migration — breaking, risky. Rejected.',
+            'Stay on legacy — no forward progress. Rejected.',
+          ],
+          rel: [9],
+        },
+        {
+          n: 11,
+          era: 1,
+          status: 'accepted',
+          title: 'BullMQ per-type job queues with per-type concurrency',
+          areas: ['infra'],
+          repos: ['public', 'deploy'],
+          date: 'Foundational; tuning ongoing',
+          context:
+            'Async work has very different costs: screenshots/replays are heavy (Playwright/CPU); integrations/notifications are light I/O. A shared queue lets a slow replay block a fast notification.',
+          decision:
+            'BullMQ on Redis, one queue per job type, with per-type concurrency via env (no redeploy): screenshot 5, replay 3, integration 10, notification 5, intelligence 1 (CPU-bound LLM, kept at 1).',
+          pos: [
+            'Fault isolation and fair scheduling per type; tune to the host without code changes.',
+            'Simplified worker health checks.',
+          ],
+          neg: [
+            'Operators must tune concurrency; over-provisioning OOMs, under-provisioning backs up queues.',
+            'Redis memory must account for backlogs.',
+          ],
+          alts: [
+            'Single shared queue — head-of-line blocking. Rejected.',
+            'Separate worker process per type — deployment complexity. Rejected.',
+          ],
+          rel: [5],
+        },
+        {
+          n: 12,
+          era: 1,
+          status: 'accepted',
+          title: 'Transactional outbox for external ticket filing',
+          areas: ['data', 'integration'],
+          repos: ['public'],
+          date: 'Migrations 001, 021',
+          context:
+            'Creating a bug and filing an external ticket must not produce duplicates on retry, but filing is async and can fail. Inline filing couples ingest to third-party uptime.',
+          decision:
+            'File via a <code>ticket_creation_outbox</code> table; a row is inserted in the same transaction as the bug report; a worker polls and advances a state machine. An <code>idempotency_key</code> prevents duplicates; a dedup grace window (migration 021) lets intelligence mark duplicates before filing.',
+          pos: [
+            'Decouples ingest from filing; exactly-once for external systems.',
+            'Retries are safe; grace window avoids filing soon-to-be-merged duplicates.',
+          ],
+          neg: ['Extra table, worker polling and state-machine logic to maintain.'],
+          alts: [
+            'Inline synchronous filing — tight coupling, cascading failures. Rejected.',
+            'Naive fire-and-forget async — duplicate tickets on retry. Rejected.',
+          ],
+          rel: [7],
+        },
+        {
+          n: 13,
+          era: 1,
+          status: 'accepted',
+          title: 'Integration plugin sandbox + SSRF-hardened HTTP',
+          areas: ['security', 'integration'],
+          repos: ['public'],
+          date: 'Foundational to integrations',
+          context:
+            'Customer-configured integrations (Jira, Linear, webhooks) are untrusted: a malicious/misconfigured URL could reach internal services or exfiltrate data (SSRF).',
+          decision:
+            'Route all plugin HTTP through <code>hardened-http.ts</code> + <code>ssrf-validator.ts</code> (block private IPs/localhost), running plugins in a <code>plugin-executor.ts</code> sandbox. HTTP policy enforced centrally.',
+          pos: [
+            'Prevents SSRF/credential-leak/internal access from one choke point.',
+            'New integrations inherit protections automatically.',
+          ],
+          neg: [
+            'All integration code must route through the hardened layer (slight latency).',
+            'Legitimate internal backends need an explicit SSRF allowlist entry.',
+          ],
+          alts: [
+            'Trust plugin targets — security risk. Rejected.',
+            'Per-integration whitelist — fragile, duplicated. Rejected.',
+          ],
+          rel: [],
+        },
+        {
+          n: 14,
+          era: 1,
+          status: 'accepted',
+          title: 'Per-organization data residency routing',
+          areas: ['data', 'compliance'],
+          repos: ['public'],
+          date: 'Foundational to SaaS',
+          context:
+            'Multi-tenant SaaS serves customers in different regulatory regions (KZ, RF, EU, US) with data-localization needs. A single global bucket is a compliance risk.',
+          decision:
+            'A <code>projects.data_residency_region</code> enum drives a storage-backend router (<code>regional-storage-router.ts</code>) selecting the S3 bucket per region — at the storage layer, transparent to app code. Violations are audit-logged; settings propagate via <code>organization_settings</code> JSONB.',
+          pos: [
+            'Compliance with regional laws without per-feature special-casing.',
+            'App code stays region-agnostic.',
+          ],
+          neg: [
+            'Must provision an S3 bucket per region.',
+            'Cross-region reads impossible by design (a constraint, not a bug).',
+          ],
+          alts: [
+            'Single global bucket — compliance risk. Rejected.',
+            'Customer-managed regions — operational burden. Rejected.',
+          ],
+          rel: [5],
+        },
+        {
+          n: 15,
+          era: 2,
+          status: 'accepted',
+          title: 'Dual capture — screenshot + rrweb session replay',
+          areas: ['capture'],
+          repos: ['sdk', 'extension'],
+          date: 'SDK v0.1.0; replay v0.2.0',
+          context:
+            'A bug report needs both visual proof (screenshot) and causal context (sequence of interactions). Each alone is incomplete.',
+          decision:
+            'Capture both: a mandatory screenshot (<code>html-to-image</code>, CSP-safe) plus an optional rrweb session replay (~15–30s buffer). Both compressed and uploaded via presigned URLs. rrweb is the industry-standard DOM recorder.',
+          pos: [
+            'Screenshot = point-in-time proof; replay = causality. Together, reproducible reports.',
+          ],
+          neg: [
+            '~500ms screenshot latency, rrweb memory overhead, two payloads.',
+            'Pulls in both <code>rrweb</code> and <code>html-to-image</code>.',
+          ],
+          alts: [
+            'Screenshot only — loses interaction context. Rejected.',
+            'Replay only — loses visual state. Rejected.',
+            'Video — bandwidth-prohibitive. Rejected.',
+          ],
+          rel: [16, 18],
+        },
+        {
+          n: 16,
+          era: 2,
+          status: 'accepted',
+          title: 'Presigned-URL direct-to-storage uploads',
+          areas: ['transport'],
+          repos: ['sdk', 'extension', 'public'],
+          date: 'SDK v0.1.0',
+          context:
+            'Screenshots (~500KB) and replays (~2MB) are large; proxying them through the API ties up server bandwidth and the extension service worker.',
+          decision:
+            'Three-request flow: POST <code>/reports</code> → bug id + presigned PUT URLs; client PUTs artifacts directly to S3 (parallel); POST confirm-upload per file. The report exists after step 1, so artifact upload failures are non-fatal.',
+          pos: [
+            '~40% fewer requests; file bytes bypass the API server.',
+            'Presigned URLs time-limited and scoped; HTTPS enforced.',
+            "Failed artifact upload doesn't lose the report.",
+          ],
+          neg: [
+            'Requires backend object storage + presigned generation.',
+            'Client handles gzip content-type and parallel blob uploads.',
+          ],
+          alts: [
+            'Single POST through the API — slower, bandwidth-heavy. Rejected.',
+            'Multipart upload — added complexity. Rejected.',
+          ],
+          rel: [15],
+        },
+        {
+          n: 17,
+          era: 2,
+          status: 'accepted',
+          title: 'Backend-controlled, cached replay quality settings',
+          areas: ['settings', 'capture'],
+          repos: ['sdk', 'public'],
+          date: 'SDK v0.3.0',
+          context:
+            "Different deployments/tiers want different replay fidelity. Hardcoding in the SDK means redeploying every customer's embedded SDK to change a setting.",
+          decision:
+            'On <code>init()</code> the SDK fetches <code>/api/v1/settings/replay</code> and caches it (5-min TTL). User config overrides; if unreachable, soft-fail to safe defaults. The endpoint returns 200 + defaults even on DB failure; per-API-key rate-limited (10/min).',
+          pos: [
+            'Admins tune quality per project with no SDK redeploy.',
+            'Caching cuts backend load; user overrides win.',
+          ],
+          neg: [
+            'One extra HTTP call during init (~50ms).',
+            'A misconfigured backend silently yields default fidelity.',
+          ],
+          alts: [
+            'Hardcoded SDK defaults — inflexible. Rejected.',
+            'Per-request negotiation — latency every capture. Rejected.',
+          ],
+          rel: [23],
+        },
+        {
+          n: 18,
+          era: 2,
+          status: 'accepted',
+          title: 'Cross-navigation replay persistence (IndexedDB / storage.session)',
+          areas: ['replay', 'storage'],
+          repos: ['sdk', 'extension'],
+          date: 'SDK v0.2.0',
+          context:
+            'Users often report a bug after a navigation/reload, but the interesting interactions were on the previous page. In-memory buffers are lost across navigations; the two clients run in different environments.',
+          decision:
+            'Persist the replay buffer across navigations, opt-in, per-environment: SDK flushes a circular buffer to IndexedDB on pagehide/visibilitychange and restores on init (opt-in via <code>dbName</code>; atomic read+clear). Extension keeps per-tab buffers in <code>chrome.storage.session</code> keyed by tabId, with a per-tab write queue. Both soft-fail and queue events emitted during restore.',
+          pos: [
+            'Captures pre-reload activity; replays survive full-page navigations.',
+            'IndexedDB (~100MB+) and storage.session (~10MB) beat the old localStorage 5MB cap.',
+          ],
+          neg: [
+            'Quota handling required: on overflow halve events while preserving the latest FullSnapshot anchor.',
+            'Two implementations of one concept, kept behind the same opt-in contract.',
+          ],
+          alts: [
+            'localStorage/sessionStorage — 5MB cap, unavailable to the worker. Rejected.',
+            'Server-side buffering — privacy concern. Rejected.',
+          ],
+          rel: [15, 24],
+        },
+        {
+          n: 19,
+          era: 2,
+          status: 'accepted',
+          title: 'Shared local-first PII sanitization via @bugspotter/common',
+          areas: ['capture', 'privacy'],
+          repos: ['sdk', 'extension'],
+          date: 'v0.1.0',
+          context:
+            'Captured data can contain PII/secrets. Regulated customers need a guarantee, and redaction must not diverge between SDK, extension and backend.',
+          decision:
+            'PII patterns live in shared <code>@bugspotter/common</code> and run locally before transmission: built-ins (email, phone, card, SSN/IIN, IP, key, token, password), presets (minimal, financial, kazakhstan, gdpr, pci), custom regex, <code>excludeSelectors</code>. The backend sanitizes again (defense-in-depth).',
+          pos: [
+            'One pattern library keeps client/server in sync; PII never leaves the device unredacted.',
+            'Defense-in-depth catches client gaps server-side.',
+          ],
+          neg: [
+            'Redacted tokens unrecoverable by design; rare false positives (user can exclude).',
+            'Capture blocks on sanitizer init; init failure disables capture on that page (fail-safe).',
+          ],
+          alts: [
+            'Backend-only — unredacted data crosses the wire. Rejected.',
+            'Duplicated per-client patterns — drift risk. Rejected.',
+          ],
+          rel: [22],
+        },
+        {
+          n: 20,
+          era: 2,
+          status: 'accepted',
+          title: 'Client offline queue with backoff retry',
+          areas: ['transport', 'storage'],
+          repos: ['sdk', 'extension'],
+          date: 'SDK v0.1.0 / v0.3.0',
+          context:
+            "Users go offline or hit transient failures. A report shouldn't be lost on page close, but unbounded retries waste resources and retrying auth/quota errors is pointless.",
+          decision:
+            'Persist failed reports (network errors only) and retry with jittered exponential backoff. SDK: localStorage queue (≤10), 1–30s, retry 502/503/504/429, never auth. Extension: chrome.storage.local with 7-day TTL, retried on worker startup; drops items >100KB / after 5 attempts / insecure / expired; strips sensitive headers and artifact flags before queuing.',
+          pos: [
+            'No report lost to a brief outage; backoff+jitter avoids thundering herd.',
+            'Auth/quota errors fail fast.',
+          ],
+          neg: [
+            'Queue competes for storage quota; overflow drops oldest.',
+            'Queued extension reports lose screenshot/replay artifacts (still useful for repro).',
+          ],
+          alts: [
+            'In-memory queue — lost on reload. Rejected.',
+            'Unbounded queue / fixed backoff — storage pressure / CPU spikes. Rejected.',
+          ],
+          rel: [16],
+        },
+        {
+          n: 21,
+          era: 2,
+          status: 'accepted',
+          title: 'Shadow DOM widget isolation',
+          areas: ['widget'],
+          repos: ['sdk', 'extension'],
+          date: 'SDK v0.1.0',
+          context:
+            'The widget (button, modal, annotation overlay) is injected into arbitrary customer pages. Host CSS/JS must not leak into the widget and vice-versa.',
+          decision:
+            'Render modal/overlay inside a Shadow DOM host with inline styles (CSP-safe). SDK modal uses open mode; extension overlay uses closed Shadow DOM. The floating button sits at top-level DOM with max z-index (2147483647).',
+          pos: [
+            'Style encapsulation both ways; works on any site without injected-<style> CSP violations.',
+            'Open mode still allows intentional host customization.',
+          ],
+          neg: [
+            'Very old browsers fall back to light DOM; <code>::part</code> customization limited.',
+            'Slightly slower initial render.',
+          ],
+          alts: [
+            'CSS namespacing — fragile, collisions. Rejected.',
+            'iframe — slow, cross-frame overhead. Rejected.',
+          ],
+          rel: [],
+        },
+        {
+          n: 22,
+          era: 2,
+          status: 'accepted',
+          title: 'Client-side duplicate-report dedup',
+          areas: ['capture', 'integration'],
+          repos: ['sdk', 'extension'],
+          date: 'SDK v0.3.0',
+          context:
+            'Users re-submit the same report in quick succession. Catching it only at the backend means the duplicate payload is already uploaded and the user sees a late error.',
+          decision:
+            'A shared <code>BugReportDeduplicator</code> (<code>@bugspotter/common</code>) hashes title+description(+error stacks) and blocks a re-submit within a configurable grace window, tracking in-progress and recently-completed reports. The backend keeps a fallback check.',
+          pos: [
+            'Stops accidental duplicates before upload; no PII in the hash; works offline.',
+            'In-progress tracking allows immediate legitimate retry.',
+          ],
+          neg: [
+            'Dedup state per-instance/per-worker (reset on eviction — acceptable).',
+            'A slightly changed description defeats the hash; user must edit to resubmit.',
+          ],
+          alts: [
+            'Server-only dedup — duplicate already uploaded. Rejected as sole mechanism.',
+            'UUID-based — overkill. Rejected.',
+          ],
+          rel: [19],
+        },
+        {
+          n: 23,
+          era: 2,
+          status: 'accepted',
+          title: 'Framework-agnostic async singleton SDK init()',
+          areas: ['build', 'sdk-api'],
+          repos: ['sdk'],
+          date: 'SDK v0.3.0',
+          context:
+            'The SDK must behave identically in React/Vue/Angular/Next/plain-JS/CDN. Init is async (fetches replay settings) and multiple inits would duplicate observers/interception/DOM hooks.',
+          decision:
+            'A static <code>async BugSpotter.init()</code> returning <code>Promise&lt;BugSpotter&gt;</code> that enforces a singleton: warns on re-init and coalesces concurrent inits (first wins). <code>destroy()</code> required before re-init.',
+          pos: [
+            'One instance prevents duplicate interception; framework-agnostic.',
+            'Async contract lets init fetch backend config cleanly.',
+          ],
+          neg: [
+            'Callers must await init and call destroy to reconfigure.',
+            'Implicit singleton adds coupling in tests.',
+          ],
+          alts: [
+            'Factory per call — duplicate interception & leaks. Rejected.',
+            "Synchronous init — can't fetch backend config. Rejected.",
+          ],
+          rel: [17],
+        },
+        {
+          n: 24,
+          era: 2,
+          status: 'accepted',
+          title: 'Browser extension on MV3 stateless service worker',
+          areas: ['extension-arch'],
+          repos: ['extension'],
+          date: 'Chrome MV3 migration',
+          context:
+            'Manifest V3 removed persistent background pages; the service worker can be evicted after ~30s, so any module-level state is lost across navigations and re-injections.',
+          decision:
+            'A fully stateless service worker: no module-level state; all persistent data in <code>chrome.storage</code> (session for transient per-tab buffers, local for the offline queue). Every handler reads from storage, not memory.',
+          pos: [
+            'Survives worker eviction, navigation and re-injection without data loss — MV3-compliant.',
+          ],
+          neg: [
+            'Async storage reads on every event add latency and require per-tab write-queue serialization to avoid read-modify-write races.',
+          ],
+          alts: [
+            'MV2 background page — deprecated by Chrome. Rejected (forced).',
+            'In-memory buffers — unsafe under eviction. Rejected.',
+          ],
+          rel: [18, 25],
+        },
+        {
+          n: 25,
+          era: 2,
+          status: 'accepted',
+          title: 'Main-world injection for CSP-proof console/network capture',
+          areas: ['capture'],
+          repos: ['extension'],
+          date: 'Console/network capture phase',
+          context:
+            'Capturing console/fetch/XHR needs page globals, but content scripts run in an isolated world; injecting a &lt;script&gt; is blocked by strict CSP on banking/finance sites.',
+          decision:
+            "Register a main-world script via <code>chrome.scripting.registerContentScripts</code> (<code>world:'MAIN'</code>, <code>runAt:'document_start'</code>) that patches console/fetch/XHR/error handlers and relays via <code>window.postMessage</code>. chrome.scripting bypasses page CSP; document_start captures before page scripts run.",
+          pos: [
+            'Works on CSP-strict sites; captures from the first page script.',
+            'postMessage bridges worlds without exposing extension internals.',
+          ],
+          neg: [
+            'Main-world script is plain JS (not TS/bundled), adding ~2KB.',
+            'Duplicate browser error events de-duplicated within ~2s windows.',
+          ],
+          alts: [
+            '&lt;script&gt; tag injection — blocked by CSP. Rejected.',
+            'PerformanceObserver — timing only. Rejected.',
+            'Debugger protocol — unavailable to extensions. Rejected.',
+          ],
+          rel: [24],
+        },
+        {
+          n: 26,
+          era: 3,
+          status: 'accepted',
+          title: 'Local BAAI/bge-m3 embeddings (self-hosted, multilingual)',
+          areas: ['embeddings'],
+          repos: ['intelligence'],
+          date: 'Intelligence Phase 1',
+          context:
+            'Semantic dedup needs embeddings for a multilingual market (EN/RU/KK). External embedding APIs add cost, latency and a data-egress/compliance concern incompatible with self-hosting.',
+          decision:
+            'BAAI/bge-m3 (1024-dim) via sentence-transformers, generated locally and pre-downloaded into the Docker image for predictable cold starts. OpenAI text-embedding-3-small remains a configurable cloud fallback.',
+          pos: ['High-quality multilingual embeddings; no API cost or egress; air-gappable.'],
+          neg: [
+            'Image ~3GB; ~268ms/embedding on CPU.',
+            'Dimension (1024) must match <code>migrations.py target_dim</code>; switching models means re-embedding.',
+          ],
+          alts: [
+            'OpenAI 3-small — kept as fallback, not default.',
+            'all-MiniLM-L6-v2 (384-dim) — lower quality, weaker multilingual. Rejected.',
+          ],
+          rel: [27, 28, 33],
+        },
+        {
+          n: 27,
+          era: 3,
+          status: 'accepted',
+          title: 'pgvector + IVFFlat for similarity search (no separate vector DB)',
+          areas: ['embeddings', 'data'],
+          repos: ['intelligence'],
+          date: 'Phase 1; retune Phase 7',
+          context:
+            'Dedup needs fast cosine search over thousands of embeddings, tenant-filtered. Postgres is already the primary store.',
+          decision:
+            'pgvector with an IVFFlat index on <code>bug_embeddings.embedding</code>, cosine (<code>&lt;=&gt;</code>), composite indexes including <code>tenant_id</code>. Runs on <code>pgvector/pgvector:pg16</code>.',
+          pos: [
+            'No separate vector DB; ACID; vectors co-located with relational data and tenant filters.',
+          ],
+          neg: [
+            'IVFFlat may need retuning at scale (explicit Phase 7 eval, incl. HNSW).',
+            'Requires pgvector in Postgres 16+.',
+          ],
+          alts: [
+            'Dedicated vector DB — extra ops & egress. Rejected.',
+            'HNSW — under Phase 7 evaluation; IVFFlat chosen first for simplicity.',
+          ],
+          rel: [5, 26],
+        },
+        {
+          n: 28,
+          era: 3,
+          status: 'accepted',
+          title: 'Tunable similarity thresholds (0.68 / 0.85), per-tenant',
+          areas: ['dedup'],
+          repos: ['intelligence'],
+          date: 'Phase 1',
+          context:
+            "Similarity must become a yes/no duplicate decision. The cut-off depends on the embedding space and a customer's tolerance for false merges, so it can't be a universal constant.",
+          decision:
+            'Two configurable thresholds defaulting to bge-m3-tuned values: <code>similarity_threshold=0.68</code> (related) and <code>duplicate_threshold=0.85</code> (auto-duplicate), tunable per-tenant. Responses expose <code>threshold_used</code>.',
+          pos: [
+            'Customers tune precision/recall post-deploy without code changes.',
+            '<code>threshold_used</code> makes decisions auditable.',
+          ],
+          neg: ['Thresholds are model-specific — a different embedding model requires re-tuning.'],
+          alts: ["Fixed thresholds — can't adapt to tolerance or model. Rejected."],
+          rel: [26],
+        },
+        {
+          n: 29,
+          era: 3,
+          status: 'accepted',
+          title: 'LLM provider abstraction; Ollama llama3.2:3b default',
+          areas: ['ml-model'],
+          repos: ['intelligence'],
+          date: 'Phase 1; cloud Phase 4+',
+          context:
+            'The AI tier needs LLM inference for rerank, rule parsing and Q&A. Self-hosted/air-gapped needs a local GPU-free option; production may prefer a hosted model. No vendor hard-wiring.',
+          decision:
+            'An abstract <code>LLMProvider</code> with a factory + registry (<code>register_provider</code>); every provider implements <code>generate()</code> and <code>generate_with_usage()</code> (token counts for observability). Ollama (<code>llama3.2:3b</code>) is the dev/self-hosted default (CPU-only); Claude Sonnet recommended for production.',
+          pos: [
+            'New providers register without touching the factory; uniform token usage.',
+            'Local default avoids GPU cost and enables air-gapped installs.',
+          ],
+          neg: [
+            'llama3.2:3b lower quality than GPT-4o/Sonnet; ~120s Ollama timeout.',
+            'Claude/OpenAI configured but not fully implemented (Phase 4).',
+          ],
+          alts: [
+            'Per-vendor conditional instantiation — scatters logic. Rejected.',
+            'Cloud-only LLM — breaks air-gapped. Rejected as default.',
+          ],
+          rel: [30, 32],
+        },
+        {
+          n: 30,
+          era: 3,
+          status: 'accepted',
+          title: 'Smart search — LLM rerank with timeout fallback',
+          areas: ['ml-model', 'search'],
+          repos: ['intelligence'],
+          date: 'Phase 3',
+          context:
+            "Pure vector search returns nearest neighbors that aren't always most relevant. LLM reranking improves quality but is slow and can hang, so it can't sit unguarded on the critical path.",
+          decision:
+            '<code>POST /search</code> with <code>mode=smart</code> retrieves top-20 via pgvector, has the LLM score relevance, returns top-5 reranked. A 10s timeout falls back to raw vector results. <code>mode=fast</code> skips reranking; limits are configurable.',
+          pos: [
+            'Better relevance without retraining; graceful degradation on timeout.',
+            'Callers pick cost/latency per query.',
+          ],
+          neg: [
+            'Smart mode adds latency (≤10s on timeout) and LLM cost.',
+            'Timeout must be tuned per deployment/model.',
+          ],
+          alts: ['Vector-only search — kept as fast mode; insufficient alone for relevance.'],
+          rel: [29],
+        },
+        {
+          n: 31,
+          era: 3,
+          status: 'accepted',
+          title: 'Natural-language dedup-rule parsing via few-shot JSON',
+          areas: ['prompt', 'dedup'],
+          repos: ['intelligence'],
+          date: 'Phase 0.5 / 4+',
+          context:
+            'Operators describe dedup rules in plain English, but the engine needs a validated structured <code>DedupRule</code> (triggers/conditions/actions).',
+          decision:
+            'A few-shot system prompt defines the ontology (B1/B2/B3 + ambiguous cases); low temperature (0.1) for determinism; available integrations injected as context; output extracted from markdown fences with a brace counter, then Pydantic-validated. Failures return a null draft + clarifications.',
+          pos: [
+            'Operators author in natural language; output is schema-validated before the engine.',
+            'Injecting real integrations prevents hallucinated targets.',
+          ],
+          neg: [
+            'UX depends on prompt quality; ambiguity yields clarification requests.',
+            'NL endpoint kept but full pipeline integration deferred — the executor is the load-bearing path.',
+          ],
+          alts: [
+            'Regex parsing — brittle. Rejected.',
+            'Chain-of-thought — verbose, less deterministic for JSON. Rejected.',
+          ],
+          rel: [7],
+        },
+        {
+          n: 32,
+          era: 3,
+          status: 'planned',
+          title: 'AI observability — intelligence_event + intelligence_feedback',
+          areas: ['observability'],
+          repos: ['intelligence'],
+          date: 'Phase 7 (rollout planned)',
+          context:
+            'Every LLM call needs auditing (tokens, latency, cost, confidence) and a way to measure decision quality per tenant — and multiple reviewers may disagree about correctness.',
+          decision:
+            'Two tables: <code>intelligence_event</code> (immutable per-call audit: tokens, latency, <code>cost_micros_usd</code>, status, confidence, 4KiB rationale, meta JSONB) and <code>intelligence_feedback</code> (correct/incorrect/partial verdicts with event_id FK + user_ref for consensus; tenant_id denormalized). Three call sites wrapped with <code>record_generate()</code>; admin endpoints require an admin key.',
+          pos: [
+            'Events stay immutable while feedback accumulates separately; reviewers disagree without mutating the audit.',
+            'Cost & accuracy measurable per tenant — basis for the eval/monitoring roadmap.',
+          ],
+          neg: ['Two new tables + write-path wrapping; meta JSONB intentionally un-GIN-indexed.'],
+          alts: [
+            'Single table with feedback columns — pollutes the immutable audit. Rejected.',
+            "No feedback — can't measure accuracy. Rejected.",
+          ],
+          rel: [29],
+        },
+        {
+          n: 33,
+          era: 3,
+          status: 'accepted',
+          title: 'Offline embedding-model caching in a multi-stage Docker image',
+          areas: ['infra'],
+          repos: ['intelligence'],
+          date: 'Phase 1',
+          context:
+            "Lazy-downloading bge-m3 on first request makes cold starts unpredictable and can race a worker timeout into OOM. Air-gapped deployments can't reach HuggingFace Hub at all.",
+          decision:
+            'A multi-stage build pre-downloads bge-m3 in the builder; runtime sets <code>TRANSFORMERS_OFFLINE=1</code> and <code>HF_HUB_OFFLINE=1</code>. Production runs as non-root on python:3.12-slim.',
+          pos: [
+            'Predictable startup (60s healthcheck); no first-request download; works air-gapped.',
+          ],
+          neg: [
+            'Image ~3GB (vs ~1GB).',
+            'Dockerfile model and <code>migrations.py target_dim</code> must be coordinated exactly.',
+          ],
+          alts: [
+            'Lazy loading — smaller image but unpredictable starts & OOM race. Rejected.',
+            'Separate model volume — extra provisioning. Rejected.',
+          ],
+          rel: [26],
+        },
+        {
+          n: 34,
+          era: 4,
+          status: 'accepted',
+          title: 'Astro static + islands for the landing site',
+          areas: ['framework'],
+          repos: ['landing'],
+          date: 'Landing phase 1',
+          context:
+            'The landing site is mostly marketing content in three languages that must load fast and rank well, with a few interactive forms. An SPA ships needless JS; plain HTML duplicates structure.',
+          decision:
+            "Astro 5 with <code>output:'static'</code> and the islands architecture: pre-rendered HTML, React hydrated only for interactive islands (forms) via <code>client:load</code>. Deployed static behind a CDN.",
+          pos: [
+            'Zero-JS marketing content; React downloaded only when a form island renders.',
+            'CDN-cacheable static output.',
+          ],
+          neg: [
+            'Every deploy regenerates all pages; server API routes must opt out of prerender.',
+            'Page-level i18n needs separate files per language.',
+          ],
+          alts: [
+            'Next.js SSR — server cost for mostly-static content. Rejected.',
+            'Pure React SPA — bloat, worse SEO. Rejected.',
+            'Hand-written HTML — duplication. Rejected.',
+          ],
+          rel: [35],
+        },
+        {
+          n: 35,
+          era: 4,
+          status: 'accepted',
+          title: 'Type-safe file-based i18n (props-only to React)',
+          areas: ['i18n'],
+          repos: ['landing'],
+          date: 'Landing phase 1',
+          context:
+            'Three languages (en, ru, kk) must stay in sync and be type-checked across Astro and React without coupling React to an i18n runtime (which complicates Playwright testing).',
+          decision:
+            'Translations in <code>src/i18n/{en,ru,kk}.ts</code> with a <code>TranslationKeys</code> type from en.ts. Astro resolves via <code>t(lang)</code>; React receives pre-resolved labels as props only — never importing the i18n runtime. Three page files per route share components.',
+          pos: [
+            'Compile-time key checking; React stays environment-agnostic and testable without i18n setup.',
+          ],
+          neg: [
+            'en/ru/kk files and the three page files kept in sync manually; all locales deploy together.',
+          ],
+          alts: [
+            'i18next/react-i18next — couples React to a runtime. Rejected.',
+            'Dynamic [lang] routing — more complex redirect/canonical handling. Rejected.',
+          ],
+          rel: [34],
+        },
+        {
+          n: 36,
+          era: 4,
+          status: 'accepted',
+          title: 'Self-service signup with URL-fragment token handoff',
+          areas: ['signup', 'integration'],
+          repos: ['landing', 'public'],
+          date: 'Landing phase 2',
+          context:
+            'Free-tier users sign up on the landing origin and must land authenticated in the admin dashboard (a different org-subdomain origin), without landing holding session state and without leaking the API key into logs/Referer.',
+          decision:
+            "The form POSTs to <code>/api/v1/auth/signup</code>, gets an access token + api_key, and builds a URL fragment <code>#handoff=&lt;base64url-json&gt;</code> at the org subdomain's /onboarding (cross-origin nav with credentials:include). The backend response is strictly validated and fields explicitly mapped; the subdomain validated against RFC-1123.",
+          pos: [
+            'Fragment never sent in Referer/logs; base64url preserves chars; UTF-8 supports Cyrillic/Kazakh names.',
+            'No landing-side session; explicit mapping blocks leaking future backend additions.',
+          ],
+          neg: [
+            'Handoff shape couples the landing encoder to the admin decoder.',
+            'Subdomain validation lives on landing; 15s fetch timeout; errors mapped by status (409/429).',
+          ],
+          alts: [
+            'Query param — leaks the key in Referer. Rejected.',
+            'Shared cookie / POST to admin — cross-origin coupling, exposes creds. Rejected.',
+          ],
+          rel: [4],
+        },
+        {
+          n: 37,
+          era: 5,
+          status: 'accepted',
+          title: 'Dual-mode MCP transport (stdio + HTTP)',
+          areas: ['mcp-transport'],
+          repos: ['mcp'],
+          date: 'MCP v0.3.0',
+          context:
+            "AI agents consume BugSpotter two ways: a per-user subprocess (Claude Code, Cursor, desktop), and a hosted multi-tenant endpoint. One transport can't serve both efficiently.",
+          decision:
+            'Two entry points from one codebase: <code>bugspotter-mcp</code> (stdio, per-user, key in env) and <code>bugspotter-mcp-http</code> (HTTP, multi-tenant, <code>Authorization: Bearer bgs_&lt;key&gt;</code>). HTTP sessions are stateful in-process with a 30-min TTL; clients echo an <code>Mcp-Session-Id</code> bound to their bearer (mismatch → 403).',
+          pos: [
+            'Stdio keeps the key local and is trivial for desktop clients; HTTP multiplexes many users on one process.',
+          ],
+          neg: [
+            'HTTP is stateful → sticky routing required at scale (route on Session-Id).',
+            'Operators choose the shape upfront; reverse proxies need a 600s read timeout and disabled buffering for long ask/SSE.',
+          ],
+          alts: [
+            'Single unified transport — precludes efficient multi-user hosting. Rejected.',
+            'Custom protocol — reinvents the MCP spec. Rejected.',
+          ],
+          rel: [38],
+        },
+        {
+          n: 38,
+          era: 5,
+          status: 'accepted',
+          title: 'Deliberate six-tool MCP surface',
+          areas: ['mcp-tools'],
+          repos: ['mcp'],
+          date: 'MCP v0.1.0',
+          context:
+            "No MCP server exists for a bug tracker (no precedent). Too much overloads the agent's choices and creates write-blast-radius liability; too little frustrates triage workflows.",
+          decision:
+            'Exactly six tools by triage frequency: <code>search_bugs</code>, <code>find_similar</code>, <code>ask</code> (discovery); <code>get_bug</code>, <code>list_bugs</code> (inspection); <code>update_bug_status</code> (the single write). Deliberate omissions: create_bug (blast radius), add_comment (no backend table yet), attach_session_replay (multi-step presigned), suggest_fix (async-polling).',
+          pos: [
+            'A small, workflow-aligned surface agents can reason about; one write bounds liability.',
+            'Behavioral logs reveal usage (over-drilling, under-using ask).',
+          ],
+          neg: [
+            'Tool descriptions must be precise — agents get validation errors on misread enums/fields.',
+            "Closure workflows needing create/comment aren't fully served yet (intentional).",
+          ],
+          alts: [
+            'Full CRUD — dangerous writes. Rejected.',
+            'Read-only — frustrates status closure. Rejected.',
+          ],
+          rel: [37, 39, 40],
+        },
+        {
+          n: 39,
+          era: 5,
+          status: 'accepted',
+          title: 'Ajv + JSON Schema validation (single source of truth)',
+          areas: ['mcp-tools'],
+          repos: ['mcp'],
+          date: 'MCP v0.1.0',
+          context:
+            "The MCP spec mandates each tool's inputSchema is JSON Schema on the wire. Arguments must be validated at dispatch without drifting from what the agent sees.",
+          decision:
+            'Validate with Ajv against the same JSON Schema published on the wire — one source of truth. No separate code-level (Zod) schema to keep in sync.',
+          pos: [
+            'The schema the agent sees is the schema that validates — no drift; tweaks immediately visible.',
+            'Ajv errors are format-exact, feeding precise behavioral logs.',
+          ],
+          neg: ['JSON Schema is more verbose to author by hand than Zod with inferred types.'],
+          alts: [
+            'Zod + codegen to JSON Schema — adds a build step and a sync failure mode. Rejected.',
+            'Manual validation — error-prone. Rejected.',
+            'TS types only — no runtime checks. Rejected.',
+          ],
+          rel: [38],
+        },
+        {
+          n: 40,
+          era: 5,
+          status: 'accepted',
+          title: 'Behavioral JSONL logging with scoped PII redaction',
+          areas: ['mcp-tools', 'observability'],
+          repos: ['mcp'],
+          date: 'MCP v0.1.0',
+          context:
+            'The MCP server doubles as a research artifact on how agents reason about a bug tracker. That needs logging every call without leaking PII pasted into free-text, and without a concurrency hazard under multi-user HTTP.',
+          decision:
+            'One JSONL record per dispatch, daily-rotated. PII redaction (emails, JWTs, cards) only on free-text args (search_bugs, ask) — not schema-enforced fields. Session id is <code>sha256(api_key)[:32]</code>, never the raw key. Result bodies not logged; <code>result_count</code> distinguishes null (not meaningful) from 0 (empty).',
+          pos: [
+            'Append-only JSONL is concurrency-safe under multi-user SaaS and trivially aggregated with jq.',
+            'Enables agent-behavior research while protecting pasted PII and result contents.',
+          ],
+          neg: [
+            'No result bodies means some analyses need the backend.',
+            'Redaction is intentionally partial (free-text only) — relies on the schema to keep PII out of structured fields.',
+          ],
+          alts: [
+            'Structured logs to an external backend — loses locality, adds a dependency. Rejected.',
+            'No logging — defeats the research goal. Rejected.',
+            'Universal redaction — wasteful on schema-enforced fields. Rejected.',
+          ],
+          rel: [38],
+        },
+      ];
+      const STATUS_LABEL = {
+        accepted: 'Accepted',
+        progress: 'In progress',
+        planned: 'Planned',
+        superseded: 'Superseded',
+      };
+      const pad = (n) => String(n).padStart(4, '0');
+      const slugOf = {
+        1: 'pnpm-typescript-monorepo',
+        2: 'fastify-typescript-backend',
+        3: 'dual-licensing-fsl-and-mit',
+        4: 'runtime-deployment-mode',
+        5: 'core-data-plane-postgres-redis-s3',
+        6: 'docker-compose-not-kubernetes',
+        7: 'polyglot-python-intelligence-service',
+        8: 'triple-auth-model',
+        9: 'multi-tenancy-api-key-tenant-isolation',
+        10: 'unified-rbac-legacy-coexistence',
+        11: 'bullmq-per-type-queues-concurrency',
+        12: 'transactional-outbox-ticket-filing',
+        13: 'integration-plugin-sandbox-ssrf',
+        14: 'per-org-data-residency-routing',
+        15: 'dual-capture-screenshot-and-replay',
+        16: 'presigned-url-direct-uploads',
+        17: 'backend-controlled-replay-settings',
+        18: 'cross-navigation-replay-persistence',
+        19: 'shared-pii-sanitization',
+        20: 'client-offline-queue-retry',
+        21: 'shadow-dom-widget-isolation',
+        22: 'client-side-duplicate-dedup',
+        23: 'framework-agnostic-async-singleton-init',
+        24: 'extension-mv3-stateless-service-worker',
+        25: 'main-world-injection-capture',
+        26: 'local-bge-m3-embeddings',
+        27: 'pgvector-ivfflat-similarity',
+        28: 'tunable-similarity-thresholds',
+        29: 'llm-provider-abstraction-ollama-default',
+        30: 'smart-search-llm-rerank-fallback',
+        31: 'nl-dedup-rule-parsing',
+        32: 'ai-observability-event-feedback-tables',
+        33: 'offline-model-caching-docker',
+        34: 'astro-static-islands-landing',
+        35: 'type-safe-file-based-i18n',
+        36: 'self-service-signup-fragment-handoff',
+        37: 'mcp-dual-mode-transport',
+        38: 'mcp-deliberate-six-tool-surface',
+        39: 'mcp-ajv-json-schema-validation',
+        40: 'mcp-behavioral-jsonl-logging',
+      };
+      const mdFile = (n) => pad(n) + '-' + slugOf[n] + '.md';
+
+      const state = { q: '', status: new Set(), repo: new Set(), area: new Set(), sel: null };
+      const allRepos = [...new Set(ADR.flatMap((a) => a.repos))].sort();
+      const allAreas = [...new Set(ADR.flatMap((a) => a.areas))].sort();
+      document.getElementById('st-total').textContent = ADR.length;
+      document.getElementById('st-repos').textContent = allRepos.filter((r) => r !== 'all').length;
+
+      function chip(text, set, val, cls) {
+        const c = document.createElement('span');
+        c.className = 'chip' + (cls || '');
+        c.textContent = text;
+        c.onclick = () => {
+          set.has(val) ? set.delete(val) : set.add(val);
+          c.classList.toggle('on');
+          render();
+        };
+        return c;
+      }
+      const fs = document.getElementById('f-status');
+      ['accepted', 'progress', 'planned'].forEach((s) =>
+        fs.appendChild(chip(STATUS_LABEL[s], state.status, s, s === 'progress' ? ' warnk' : ''))
+      );
+      const fr = document.getElementById('f-repo');
+      allRepos.forEach((r) => fr.appendChild(chip(r, state.repo, r)));
+      const fa = document.getElementById('f-area');
+      allAreas.forEach((a) => fa.appendChild(chip(a, state.area, a)));
+
+      function matches(a) {
+        if (state.status.size && !state.status.has(a.status)) return false;
+        if (state.repo.size && !a.repos.some((r) => state.repo.has(r))) return false;
+        if (state.area.size && !a.areas.some((r) => state.area.has(r))) return false;
+        if (state.q) {
+          const h = (
+            a.title +
+            ' ' +
+            a.areas.join(' ') +
+            ' ' +
+            a.repos.join(' ') +
+            ' ' +
+            a.context +
+            ' ' +
+            a.decision
+          ).toLowerCase();
+          if (!h.includes(state.q)) return false;
+        }
+        return true;
+      }
+      function render() {
+        const list = document.getElementById('list');
+        list.innerHTML = '';
+        let shown = 0;
+        ERAS.forEach((era, ei) => {
+          const items = ADR.filter((a) => a.era === ei && matches(a));
+          if (!items.length) return;
+          const h = document.createElement('div');
+          h.className = 'era';
+          h.innerHTML = `<span>${era[1]}</span> ${era[0]} <span>${items.length}</span>`;
+          list.appendChild(h);
+          items.forEach((a) => {
+            shown++;
+            const d = document.createElement('div');
+            d.className = 'item' + (state.sel === a.n ? ' active' : '');
+            d.innerHTML = `<span class="dot ${a.status}"></span><span class="num">${pad(a.n)}</span><span class="ti">${a.title}</span>`;
+            d.onclick = () => select(a.n);
+            list.appendChild(d);
+          });
+        });
+        document.getElementById('st-shown').textContent = shown;
+        if (!shown) {
+          list.innerHTML = '<div class="empty">No decisions match those filters.</div>';
+        }
+        drawSeq();
+      }
+      function drawSeq() {
+        const bar = document.getElementById('seqbar');
+        bar.innerHTML = '';
+        ADR.forEach((a) => {
+          const i = document.createElement('i');
+          const col = {
+            accepted: 'var(--ok)',
+            progress: 'var(--warn)',
+            planned: 'var(--plan)',
+            superseded: 'var(--bad)',
+          }[a.status];
+          if (matches(a)) i.style.background = col;
+          i.style.opacity = matches(a) ? 1 : 0.3;
+          i.title = pad(a.n) + ' · ' + a.title;
+          i.onclick = () => select(a.n);
+          bar.appendChild(i);
+        });
+      }
+      function consList(arr, cls) {
+        return `<ul class="cons ${cls}">` + arr.map((x) => `<li>${x}</li>`).join('') + `</ul>`;
+      }
+      function select(n) {
+        state.sel = n;
+        const a = ADR.find((x) => x.n === n);
+        document.querySelectorAll('.item').forEach((el) => el.classList.remove('active'));
+        render();
+        const doc = document.getElementById('doc');
+        document.getElementById('crumbs').innerHTML =
+          `${ERAS[a.era][1]} · ${ERAS[a.era][0]} &nbsp;›&nbsp; ADR-${pad(a.n)}`;
+        const rel = a.rel.length
+          ? `<div class="sec"><h3>Related decisions</h3><div class="related">` +
+            a.rel
+              .map((r) => {
+                const t = ADR.find((x) => x.n === r);
+                return t
+                  ? `<a href="#${r}" onclick="select(${r});return false">ADR-${pad(r)} · ${t.title}</a>`
+                  : '';
+              })
+              .join('') +
+            `</div></div>`
+          : '';
+        doc.innerHTML = `
+    <div class="doc">
+      <div style="color:var(--mut);font-size:13px">ADR-${pad(a.n)}</div>
+      <h2>${a.title}</h2>
+      <div class="meta">
+        <span class="badge st-${a.status}">${STATUS_LABEL[a.status]}</span>
+        ${a.repos.map((r) => `<span class="badge repo">${r}</span>`).join('')}
+        ${a.areas.map((r) => `<span class="badge">${r}</span>`).join('')}
+        <span class="badge">${a.date}</span>
+      </div>
+      <div class="sec"><h3>Context</h3><p>${a.context}</p></div>
+      <div class="sec"><h3>Decision</h3><p>${a.decision}</p></div>
+      <div class="sec"><h3>Consequences — positive</h3>${consList(a.pos, 'pos')}</div>
+      <div class="sec"><h3>Consequences — trade-offs</h3>${consList(a.neg, 'neg')}</div>
+      <div class="sec"><h3>Alternatives considered</h3>${consList(a.alts, 'alt')}</div>
+      ${rel}
+      <div class="sec"><a href="${mdFile(a.n)}">View source markdown · ${mdFile(a.n)}</a></div>
+    </div>`;
+        document.querySelector('.main').scrollTop = 0;
+        history.replaceState(null, '', '#' + a.n);
+      }
+      // keyboard nav
+      document.addEventListener('keydown', (e) => {
+        if (e.target.tagName === 'INPUT') {
+          if (e.key === 'Escape') e.target.blur();
+          return;
+        }
+        if (e.key === '/') {
+          e.preventDefault();
+          document.getElementById('q').focus();
+          return;
+        }
+        const vis = ADR.filter(matches);
+        if (!vis.length) return;
+        let idx = vis.findIndex((a) => a.n === state.sel);
+        if (e.key === 'j') {
+          idx = Math.min(vis.length - 1, idx + 1);
+          select(vis[Math.max(0, idx)].n);
+        }
+        if (e.key === 'k') {
+          idx = idx <= 0 ? 0 : idx - 1;
+          select(vis[idx].n);
+        }
+      });
+      document.getElementById('q').addEventListener('input', (e) => {
+        state.q = e.target.value.trim().toLowerCase();
+        render();
+      });
+      document.getElementById('theme').onclick = () => {
+        const r = document.documentElement;
+        const cur = r.getAttribute('data-theme') === 'light' ? '' : 'light';
+        r.setAttribute('data-theme', cur);
+        try {
+          localStorage.setItem('adr-theme', cur);
+        } catch (e) {}
+      };
+      try {
+        const t = localStorage.getItem('adr-theme');
+        if (t) document.documentElement.setAttribute('data-theme', t);
+      } catch (e) {}
+      // menu (mobile)
+      const mb = document.getElementById('menuBtn');
+      function syncMenu() {
+        if (window.innerWidth <= 820) {
+          mb.style.display = '';
+        } else {
+          mb.style.display = 'none';
+          document.getElementById('side').classList.remove('show');
+        }
+      }
+      mb.onclick = () => document.getElementById('side').classList.toggle('show');
+      window.addEventListener('resize', syncMenu);
+      syncMenu();
+
+      render();
+      const start = parseInt(location.hash.replace('#', '')) || 1;
+      select(ADR.find((a) => a.n === start) ? start : 1);
+    </script>
+  </body>
+</html>

--- a/docs/adr/index.html
+++ b/docs/adr/index.html
@@ -1543,13 +1543,13 @@
         fs.appendChild(chip(STATUS_LABEL[s], state.status, s, s === 'progress' ? ' warnk' : ''))
       );
       const fr = document.getElementById('f-repo');
-      allRepos.forEach((r) => fr.appendChild(chip(r, state.repo, r)));
+      allRepos.filter((r) => r !== 'all').forEach((r) => fr.appendChild(chip(r, state.repo, r)));
       const fa = document.getElementById('f-area');
       allAreas.forEach((a) => fa.appendChild(chip(a, state.area, a)));
 
       function matches(a) {
         if (state.status.size && !state.status.has(a.status)) return false;
-        if (state.repo.size && !a.repos.some((r) => state.repo.has(r))) return false;
+        if (state.repo.size && !a.repos.some((r) => state.repo.has(r) || r === 'all')) return false;
         if (state.area.size && !a.areas.some((r) => state.area.has(r))) return false;
         if (state.q) {
           const h = (


### PR DESCRIPTION
Documentation-only. No code or behavior changes.

- `docs/adr/` — 40 architecture decision records (0001-0040) + index.
- `CLAUDE.md` — Conventions + Skills sections; note that `dev.sh` needs git-bash/WSL on Windows.
- `.claude/skills/bs-backup-health/` — read-only prod backup freshness/DR runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Architecture Decision Records (ADRs)** – Added comprehensive ADR catalog documenting platform architecture, including authentication, data plane, deployment, integrations, AI/intelligence, and MCP tool design decisions.
* **Backup Health Skill** – Added operational documentation for production backup health verification.
* **Developer Setup Clarification** – Updated setup guide with platform-specific guidance for Windows environments.
* **ADR Navigation** – Added searchable ADR index and landing page for browsing recorded decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->