### PR TITLE
fix(notifications): make rule+channel writes atomic

### DIFF
--- a/packages/backend/src/db/repositories/notification-rule.repository.ts
+++ b/packages/backend/src/db/repositories/notification-rule.repository.ts
@@ -138,20 +138,61 @@ export class NotificationRuleRepository extends BaseRepository<
   }
 
   /**
+   * Run multi-statement work atomically.
+   *
+   * These rule+channel operations issue several dependent writes (rule INSERT/UPDATE,
+   * channel-link DELETE, channel-link INSERT). On their own they would auto-commit
+   * each statement separately, so a failure in a later write leaves committed partial
+   * state — e.g. an update that deletes the old channel links then fails to insert the
+   * new ones leaves the rule delivering nowhere. They must run in one transaction.
+   *
+   * If this repository was constructed with a Pool we own the transaction here. If it
+   * was constructed with a PoolClient (i.e. we are already inside `db.transaction(...)`),
+   * the caller owns the transaction — run inline so we don't nest BEGIN/COMMIT.
+   */
+  private async runAtomic<R>(work: (repo: NotificationRuleRepository) => Promise<R>): Promise<R> {
+    // A PoolClient exposes `release`; a Pool does not. Presence of `release` means
+    // we're already inside a caller-managed transaction.
+    if (typeof (this.pool as Partial<PoolClient>).release === 'function') {
+      return work(this);
+    }
+
+    const client = await (this.pool as Pool).connect();
+    try {
+      await client.query('BEGIN');
+      const result = await work(new NotificationRuleRepository(client));
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Rollback failure is secondary; surface the original error.
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
    * Create a new notification rule with channel associations
    */
   async createWithChannels(data: CreateRuleInput): Promise<NotificationRuleWithChannels> {
     const { channel_ids, ...ruleData } = data;
-    const rule = await super.create(ruleData);
 
-    if (channel_ids && channel_ids.length > 0) {
-      await this.setRuleChannels(rule.id, channel_ids);
-    }
+    return this.runAtomic(async (repo) => {
+      const rule = await repo.create(ruleData);
 
-    return {
-      ...rule,
-      channels: channel_ids || [],
-    };
+      if (channel_ids && channel_ids.length > 0) {
+        await repo.setRuleChannels(rule.id, channel_ids);
+      }
+
+      return {
+        ...rule,
+        channels: channel_ids || [],
+      };
+    });
   }
 
   /**
@@ -162,21 +203,24 @@ export class NotificationRuleRepository extends BaseRepository<
     data: UpdateRuleInput
   ): Promise<NotificationRuleWithChannels | null> {
     const { channel_ids, ...ruleData } = data;
-    const rule = await super.update(id, ruleData);
 
-    if (!rule) {
-      return null;
-    }
+    return this.runAtomic(async (repo) => {
+      const rule = await repo.update(id, ruleData);
 
-    if (channel_ids !== undefined) {
-      await this.setRuleChannels(id, channel_ids);
-    }
+      if (!rule) {
+        return null;
+      }
 
-    const channelIds = await this.getRuleChannels(id);
-    return {
-      ...rule,
-      channels: channelIds,
-    };
+      if (channel_ids !== undefined) {
+        await repo.setRuleChannels(id, channel_ids);
+      }
+
+      const channelIds = await repo.getRuleChannels(id);
+      return {
+        ...rule,
+        channels: channelIds,
+      };
+    });
   }
 
   /**

--- a/packages/backend/tests/db/notification-rule.repository.atomicity.test.ts
+++ b/packages/backend/tests/db/notification-rule.repository.atomicity.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Notification Rule Repository — atomicity tests
+ *
+ * `createWithChannels` / `updateWithChannels` perform multiple dependent writes
+ * (rule INSERT/UPDATE + channel DELETE + channel INSERT). They MUST run inside a
+ * single transaction so a failure in a later write rolls back the earlier ones.
+ *
+ * The data-loss case these guard against:
+ *   - updateWithChannels deletes all existing rule→channel rows, then inserts the
+ *     new set. If the INSERT fails and the DELETE has already committed, the rule
+ *     is left wired to ZERO channels and silently stops delivering notifications.
+ *   - createWithChannels inserts the rule, then its channels. A channel-insert
+ *     failure must not leave an orphaned, channel-less rule behind.
+ *
+ * Pure unit test: `pg` is mocked, no database required.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Pool, PoolClient } from 'pg';
+import { NotificationRuleRepository } from '../../src/db/repositories/notification-rule.repository.js';
+
+interface RecordedQuery {
+  sql: string;
+  params?: unknown[];
+}
+
+/**
+ * Build a mock pg Pool + PoolClient that record every query.
+ * - Pool has `connect()` (and no `release`) — looks like a real Pool.
+ * - Client has `release()` — looks like a real pooled client / tx client.
+ * Both `query` impls share one recording handler so the call sequence is visible
+ * regardless of whether the code runs on the pool directly or on a tx client.
+ */
+function makeDb(opts: { failChannelInsert?: boolean } = {}) {
+  const queries: RecordedQuery[] = [];
+
+  const ruleRow = {
+    id: 'rule-1',
+    project_id: 'proj-1',
+    name: 'My Rule',
+    enabled: true,
+    triggers: [],
+    filters: null,
+    throttle: null,
+    schedule: null,
+    priority: 5,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  const handle = async (sql: string, params?: unknown[]) => {
+    queries.push({ sql, params });
+    const s = sql.replace(/\s+/g, ' ').trim();
+
+    if (/INSERT INTO application\.notification_rule_channels/i.test(s)) {
+      if (opts.failChannelInsert) {
+        throw new Error('simulated channel insert failure');
+      }
+      return { rows: [], rowCount: params ? params.length - 1 : 0 };
+    }
+    if (/INSERT INTO application\.notification_rules/i.test(s)) {
+      return { rows: [ruleRow], rowCount: 1 };
+    }
+    if (/UPDATE application\.notification_rules/i.test(s)) {
+      return { rows: [ruleRow], rowCount: 1 };
+    }
+    if (/SELECT channel_id FROM application\.notification_rule_channels/i.test(s)) {
+      return { rows: [{ channel_id: 'chan-1' }], rowCount: 1 };
+    }
+    // BEGIN / COMMIT / ROLLBACK / DELETE / anything else
+    return { rows: [], rowCount: 0 };
+  };
+
+  const client = { query: vi.fn(handle), release: vi.fn() };
+  const pool = { query: vi.fn(handle), connect: vi.fn(async () => client) };
+
+  return { pool, client, queries };
+}
+
+const verbsOf = (queries: RecordedQuery[]): string[] =>
+  queries.map((q) => q.sql.replace(/\s+/g, ' ').trim().toUpperCase());
+
+describe('NotificationRuleRepository atomicity', () => {
+  it('updateWithChannels rolls back the channel DELETE when the channel INSERT fails', async () => {
+    const { pool, queries } = makeDb({ failChannelInsert: true });
+    const repo = new NotificationRuleRepository(pool as unknown as Pool);
+
+    await expect(
+      repo.updateWithChannels('rule-1', {
+        name: 'My Rule',
+        channel_ids: ['chan-1'],
+      } as never)
+    ).rejects.toThrow();
+
+    const verbs = verbsOf(queries);
+    // The whole operation must be undone — not left with the channels deleted.
+    expect(verbs).toContain('ROLLBACK');
+    expect(verbs).not.toContain('COMMIT');
+  });
+
+  it('createWithChannels rolls back the rule INSERT when the channel INSERT fails (no orphaned rule)', async () => {
+    const { pool, queries } = makeDb({ failChannelInsert: true });
+    const repo = new NotificationRuleRepository(pool as unknown as Pool);
+
+    await expect(
+      repo.createWithChannels({
+        project_id: 'proj-1',
+        name: 'My Rule',
+        triggers: [],
+        channel_ids: ['chan-1'],
+      } as never)
+    ).rejects.toThrow();
+
+    const verbs = verbsOf(queries);
+    expect(verbs).toContain('ROLLBACK');
+    expect(verbs).not.toContain('COMMIT');
+  });
+
+  it('createWithChannels commits when all writes succeed', async () => {
+    const { pool, queries } = makeDb({ failChannelInsert: false });
+    const repo = new NotificationRuleRepository(pool as unknown as Pool);
+
+    const result = await repo.createWithChannels({
+      project_id: 'proj-1',
+      name: 'My Rule',
+      triggers: [],
+      channel_ids: ['chan-1'],
+    } as never);
+
+    expect(result.channels).toEqual(['chan-1']);
+
+    const verbs = verbsOf(queries);
+    expect(verbs).toContain('BEGIN');
+    expect(verbs).toContain('COMMIT');
+    expect(verbs).not.toContain('ROLLBACK');
+  });
+
+  it('does NOT open its own transaction when already running on a caller-managed tx client', async () => {
+    // Constructed with a PoolClient (has .release) — e.g. inside db.transaction(...).
+    // The caller owns BEGIN/COMMIT; the repo must run inline and not nest a transaction.
+    const { client, queries } = makeDb();
+    const repo = new NotificationRuleRepository(client as unknown as PoolClient);
+
+    await repo.createWithChannels({
+      project_id: 'proj-1',
+      name: 'My Rule',
+      triggers: [],
+      channel_ids: ['chan-1'],
+    } as never);
+
+    const verbs = verbsOf(queries);
+    expect(verbs).not.toContain('BEGIN');
+    expect(verbs).not.toContain('COMMIT');
+    expect(verbs).not.toContain('ROLLBACK');
+  });
+});

--- a/packages/backend/tests/integration/notification-rule-atomicity.integration.test.ts
+++ b/packages/backend/tests/integration/notification-rule-atomicity.integration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Integration tests for NotificationRuleRepository transactional atomicity.
+ *
+ * Runs against REAL Postgres (testcontainers) because the property under test —
+ * "a failed write rolls back earlier writes" — can only be proven by the database,
+ * not by asserting that BEGIN/ROLLBACK were emitted.
+ *
+ * createWithChannels / updateWithChannels each perform multiple dependent writes:
+ *   rule INSERT/UPDATE  +  channel-link DELETE  +  channel-link INSERT
+ * If they don't run in one transaction, a failure in the channel-link INSERT leaves
+ * committed partial state:
+ *   - updateWithChannels: existing channel links already DELETEd → rule delivers nowhere.
+ *   - createWithChannels: rule row already committed → orphaned, channel-less rule.
+ *
+ * We force the channel-link INSERT to fail by pointing at a non-existent channel id
+ * (foreign-key violation), then assert the prior state is intact.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createTestDatabase } from '../setup.integration.js';
+import type { DatabaseClient } from '../../src/db/client.js';
+
+describe('NotificationRuleRepository — transactional atomicity (real Postgres)', () => {
+  let db: DatabaseClient;
+  let projectId: string;
+  let channelId: string;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+
+    const project = await db.projects.create({ name: 'Atomicity Test Project' });
+    projectId = project.id;
+
+    const channel = await db.notificationChannels.create({
+      project_id: projectId,
+      type: 'webhook',
+      name: 'Existing Channel',
+      config: {
+        type: 'webhook',
+        url: 'https://example.com/webhook',
+        method: 'POST',
+        auth_type: 'none',
+      },
+      active: true,
+    });
+    channelId = channel.id;
+  });
+
+  afterEach(async () => {
+    if (db) {
+      await db.close();
+    }
+  });
+
+  it('updateWithChannels preserves the existing channel link when the new set is invalid', async () => {
+    // Rule starts wired to one valid channel.
+    const rule = await db.notificationRules.createWithChannels({
+      project_id: projectId,
+      name: 'Rule under test',
+      enabled: true,
+      triggers: [{ event: 'new_bug' }],
+      channel_ids: [channelId],
+    });
+
+    // No such channel — the channel-link INSERT will violate the FK.
+    const nonExistentChannel = randomUUID();
+
+    await expect(
+      db.notificationRules.updateWithChannels(rule.id, {
+        channel_ids: [nonExistentChannel],
+      })
+    ).rejects.toThrow();
+
+    // Without a transaction the DELETE has already committed and the rule now has
+    // ZERO channels. With proper atomicity the original link is restored.
+    const after = await db.notificationRules.findByIdWithChannels(rule.id);
+    expect(after).not.toBeNull();
+    expect(after!.channels).toEqual([channelId]);
+  });
+
+  it('createWithChannels does not leave an orphaned rule when channel linkage fails', async () => {
+    const nonExistentChannel = randomUUID();
+
+    await expect(
+      db.notificationRules.createWithChannels({
+        project_id: projectId,
+        name: 'Orphan candidate',
+        enabled: true,
+        triggers: [{ event: 'new_bug' }],
+        channel_ids: [nonExistentChannel],
+      })
+    ).rejects.toThrow();
+
+    // Without a transaction the rule row is committed before the failing channel
+    // INSERT, leaving a channel-less rule behind. With atomicity, nothing persists.
+    const rules = await db.notificationRules.findAll({ project_id: projectId });
+    expect(rules.find((r) => r.name === 'Orphan candidate')).toBeUndefined();
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
       'tests/db/pagination-builder.test.ts',
       'tests/db/base-repository-validation.test.ts',
       'tests/db/base-repository-date-filter.test.ts',
+      'tests/db/notification-rule.repository.atomicity.test.ts',
       'tests/db/retry.test.ts',
       'tests/db/user-repository-org-filter.test.ts',
       // Jira config tests (pure unit, mocked repository)


### PR DESCRIPTION
## Problem

`createWithChannels` / `updateWithChannels` issued multiple dependent writes (rule INSERT/UPDATE + channel-link DELETE + INSERT) on a pooled connection with **no transaction**. A failure in the channel INSERT left committed partial state:

- **updateWithChannels**: deletes the rule's existing channel links, then fails to insert the new set → rule wired to **zero channels**, silently delivering nowhere.
- **createWithChannels**: rule row committed before the failing channel insert → orphaned, channel-less rule.

## Fix

A `runAtomic` helper wraps the work in `BEGIN`/`COMMIT`/`ROLLBACK` when the repo holds a `Pool`, and runs inline when it already holds a `PoolClient` (inside `db.transaction()`) so it never double-nests. The repository now owns its own atomicity invariant instead of relying on callers.

## Tests (TDD — written failing first)

- **Unit** (mocked pg): asserts BEGIN/COMMIT/ROLLBACK are emitted and that it does not nest inside a caller transaction.
- **Integration** (real Postgres): forces an FK failure mid-operation and asserts prior state is intact (channel link preserved; no orphan rule). Both failed before the fix, pass after.

Existing rule/throttle/evaluator integration tests (40) still pass.

## Follow-ups (not in this PR)

- `reorder()` has the same non-atomic multi-write loop.
- `integrationRules.createWithValidation`/`updateWithValidation` are called raw on the pool from routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)