### PR TITLE
feat(admin): platform-admin proxy for intelligence service status

### DIFF
--- a/packages/backend/src/api/routes/admin-intelligence.ts
+++ b/packages/backend/src/api/routes/admin-intelligence.ts
@@ -1,0 +1,48 @@
+/**
+ * Admin Intelligence Routes
+ * Platform-admin (operator) view of the intelligence service.
+ *
+ * GET /api/v1/admin/intelligence/status proxies the upstream master-key
+ * endpoint GET /api/v1/admin/status — active provider/model, cloud-key
+ * presence (booleans only), thresholds, and embedding-pipeline health.
+ * Service-global (one intelligence service), so it uses the master-key
+ * admin channel rather than a per-org client.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { sendSuccess } from '../utils/response.js';
+import { requirePlatformAdmin } from '../middleware/auth.js';
+import { AppError } from '../middleware/error.js';
+import { getIntelligenceConfig } from '../../config/intelligence.config.js';
+import { IntelligenceClient } from '../../services/intelligence/intelligence-client.js';
+
+export async function adminIntelligenceRoutes(fastify: FastifyInstance): Promise<void> {
+  const config = getIntelligenceConfig();
+
+  // Construct the master-keyed admin client once (the status endpoint is
+  // service-global). Null when the master channel isn't configured.
+  const adminClient =
+    config.masterApiKey && config.adminBaseUrl
+      ? new IntelligenceClient({
+          ...config.client,
+          baseUrl: config.adminBaseUrl,
+          apiKey: config.masterApiKey,
+        })
+      : null;
+
+  /**
+   * GET /api/v1/admin/intelligence/status
+   * Operator service status. Requires: platform admin.
+   */
+  fastify.get(
+    '/api/v1/admin/intelligence/status',
+    { onRequest: [requirePlatformAdmin()] },
+    async (_request, reply) => {
+      if (!config.enabled || !adminClient) {
+        throw new AppError('Intelligence service is not configured', 503, 'ServiceUnavailable');
+      }
+      const status = await adminClient.getServiceStatus();
+      return sendSuccess(reply, status);
+    }
+  );
+}

--- a/packages/backend/src/api/server.ts
+++ b/packages/backend/src/api/server.ts
@@ -44,6 +44,7 @@ import { registerDedupRuleRoutes } from './routes/dedup-rules.js';
 import { registerAdminIntegrationRoutes } from './routes/admin-integrations.js';
 import { adminRoutes } from './routes/admin.js';
 import { adminJobsRoutes } from './routes/admin-jobs.js';
+import { adminIntelligenceRoutes } from './routes/admin-intelligence.js';
 import { adminOrganizationRoutes } from './routes/admin-organizations.js';
 import { invitationRoutes } from './routes/invitations.js';
 import { organizationRequestRoutes } from './routes/organization-requests.js';
@@ -460,6 +461,7 @@ export async function createServer(options: ServerOptions): Promise<FastifyInsta
   signupRoutes(fastify, db);
   await adminRoutes(fastify, db, options.pluginRegistry);
   await adminJobsRoutes(fastify);
+  await adminIntelligenceRoutes(fastify);
   await setupRoutes(fastify, db);
   userRoutes(fastify, db.users);
   apiKeyRoutes(fastify, db);

--- a/packages/backend/src/services/intelligence/intelligence-client.ts
+++ b/packages/backend/src/services/intelligence/intelligence-client.ts
@@ -31,6 +31,7 @@ import type {
   AskResponse,
   BugDetailResponse,
   HealthResponse,
+  ServiceStatus,
 } from './types.js';
 
 const logger = getLogger();
@@ -255,6 +256,17 @@ export class IntelligenceClient {
       undefined,
       { params }
     );
+  }
+
+  // ==========================================================================
+  // Service status (platform-admin)
+  //
+  // Requires a MASTER-key client (the upstream gate is require_master_key);
+  // construct this client with adminBaseUrl + masterApiKey, not a per-org key.
+  // ==========================================================================
+
+  async getServiceStatus(): Promise<ServiceStatus> {
+    return this.request<ServiceStatus>('GET', '/api/v1/admin/status');
   }
 
   // ==========================================================================

--- a/packages/backend/src/services/intelligence/types.ts
+++ b/packages/backend/src/services/intelligence/types.ts
@@ -302,6 +302,33 @@ export interface ObservabilityAccuracyQuery {
 }
 
 // ============================================================================
+// Service status (platform-admin, master-key)
+// Mirrors the upstream ServiceStatusResponse from GET /api/v1/admin/status.
+// ============================================================================
+
+export interface IntelligenceEmbeddingHealth {
+  provider: string;
+  model: string | null;
+  total: number;
+  /** Rows with a NULL embedding — > 0 signals a dimension mismatch. */
+  nulls: number;
+  min_dim: number | null;
+  healthy: boolean;
+}
+
+export interface ServiceStatus {
+  version: string;
+  llm_provider: string;
+  llm_model: string | null;
+  /** Booleans only — the upstream never returns secret key values. */
+  anthropic_key_configured: boolean;
+  openai_key_configured: boolean;
+  similarity_threshold: number;
+  duplicate_threshold: number;
+  embeddings: IntelligenceEmbeddingHealth;
+}
+
+// ============================================================================
 // Intelligence Job Data (for BullMQ queue)
 // ============================================================================
 

--- a/packages/backend/tests/services/intelligence/intelligence-client.test.ts
+++ b/packages/backend/tests/services/intelligence/intelligence-client.test.ts
@@ -235,4 +235,40 @@ describe('IntelligenceClient', () => {
       expect(state.state).toBe('closed');
     });
   });
+
+  describe('getServiceStatus', () => {
+    const STATUS = {
+      version: '0.1.0',
+      llm_provider: 'ollama',
+      llm_model: 'llama3.2:3b',
+      anthropic_key_configured: false,
+      openai_key_configured: false,
+      similarity_threshold: 0.68,
+      duplicate_threshold: 0.85,
+      embeddings: {
+        provider: 'local',
+        model: 'BAAI/bge-m3',
+        total: 10,
+        nulls: 0,
+        min_dim: 1024,
+        healthy: true,
+      },
+    };
+
+    it('GETs /api/v1/admin/status and returns the parsed status', async () => {
+      mockAxiosInstance.request.mockResolvedValue({ status: 200, data: STATUS });
+
+      const result = await client.getServiceStatus();
+
+      expect(result).toEqual(STATUS);
+      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'GET', url: '/api/v1/admin/status' })
+      );
+    });
+
+    it('propagates an IntelligenceError on upstream failure', async () => {
+      mockAxiosInstance.request.mockRejectedValue(createAxiosError(503, 'unavailable'));
+      await expect(client.getServiceStatus()).rejects.toThrow(IntelligenceError);
+    });
+  });
 });


### PR DESCRIPTION
Adds `GET /api/v1/admin/intelligence/status` (behind `requirePlatformAdmin`) that proxies the intelligence service's master-key endpoint `GET /api/v1/admin/status` — reporting the active generation provider/model, cloud-key presence (booleans only, no secrets), dedup thresholds, and embedding-pipeline health (total / NULL count / sampled dim).

Adds `IntelligenceClient.getServiceStatus()` + `ServiceStatus` types (mirroring the upstream Pydantic shape). The status endpoint is service-global and gated by `require_master_key` upstream, so it uses a master-keyed admin client (`adminBaseUrl` + `masterApiKey`) constructed once at route registration — not a per-org client. Returns 503 when the master channel isn't configured.

Status surface PR B of 3 (the platform-admin UI panel, PR C, consumes this). Depends on intelligence#40 (the upstream `/admin/status`, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new admin-only endpoint for monitoring intelligence service health and operational status. Platform administrators can view service version, model configuration, enabled features, similarity and duplicate detection thresholds, and embedding system performance metrics for service oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->