### PR TITLE
feat(admin): intelligence service status panel on system-health

### DIFF
--- a/apps/admin/src/components/intelligence/intelligence-service-status.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-service-status.tsx
@@ -1,0 +1,133 @@
+/**
+ * Intelligence Service Status (platform-admin)
+ *
+ * Operator readout of the intelligence service, rendered on the system-health
+ * page. Self-fetches GET /api/v1/admin/intelligence/status. Degrades quietly:
+ * a 503 (master channel not configured) shows a muted note, not an error.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, Brain, CheckCircle } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { intelligenceService } from '../../services/intelligence-service';
+
+type TFn = (key: string, options?: Record<string, unknown>) => string;
+
+function KeyBadge({ configured, t }: { configured: boolean; t: TFn }) {
+  return (
+    <Badge variant={configured ? 'secondary' : 'outline'} className="text-xs">
+      {configured
+        ? t('intelligence.serviceStatus.keyConfigured')
+        : t('intelligence.serviceStatus.keyMissing')}
+    </Badge>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-1.5 border-b border-gray-100 last:border-0">
+      <dt className="text-gray-500">{label}</dt>
+      <dd className="font-medium text-gray-900 text-right">{children}</dd>
+    </div>
+  );
+}
+
+export function IntelligenceServiceStatus() {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language;
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['intelligence-service-status'],
+    queryFn: intelligenceService.getServiceStatus,
+    retry: false,
+  });
+
+  // 503 = master channel not configured → a quiet note, not an error.
+  const notConfigured =
+    isError && (error as { response?: { status?: number } })?.response?.status === 503;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <Brain className="w-5 h-5 text-gray-500" aria-hidden="true" />
+            {t('intelligence.serviceStatus.title')}
+          </CardTitle>
+          {data ? (
+            data.embeddings.healthy ? (
+              <span className="flex items-center gap-1 text-green-600 text-sm" role="status">
+                <CheckCircle className="w-4 h-4" aria-hidden="true" />
+                {t('intelligence.serviceStatus.healthy')}
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 text-amber-600 text-sm" role="status">
+                <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+                {t('intelligence.serviceStatus.degraded')}
+              </span>
+            )
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <p className="text-sm text-gray-500">{t('intelligence.serviceStatus.loading')}</p>
+        ) : notConfigured ? (
+          <p className="text-sm text-gray-500 italic">
+            {t('intelligence.serviceStatus.notConfigured')}
+          </p>
+        ) : isError ? (
+          <div role="alert" className="text-sm text-red-700">
+            {t('intelligence.serviceStatus.unavailable')}
+          </div>
+        ) : data ? (
+          <dl className="text-sm">
+            <Row label={t('intelligence.serviceStatus.provider')}>
+              <span className="font-mono">{data.llm_provider}</span>
+            </Row>
+            <Row label={t('intelligence.serviceStatus.model')}>
+              <span className="font-mono">
+                {data.llm_model ?? t('intelligence.serviceStatus.none')}
+              </span>
+            </Row>
+            <Row label={t('intelligence.serviceStatus.anthropicKey')}>
+              <KeyBadge configured={data.anthropic_key_configured} t={t} />
+            </Row>
+            <Row label={t('intelligence.serviceStatus.openaiKey')}>
+              <KeyBadge configured={data.openai_key_configured} t={t} />
+            </Row>
+            <Row label={t('intelligence.serviceStatus.similarityThreshold')}>
+              {data.similarity_threshold.toLocaleString(locale)}
+            </Row>
+            <Row label={t('intelligence.serviceStatus.duplicateThreshold')}>
+              {data.duplicate_threshold.toLocaleString(locale)}
+            </Row>
+            <Row label={t('intelligence.serviceStatus.embeddings')}>
+              <span className="font-mono">
+                {data.embeddings.model ?? data.embeddings.provider}
+                {data.embeddings.min_dim != null ? ` (${data.embeddings.min_dim})` : ''}
+              </span>
+            </Row>
+            <Row label={t('intelligence.serviceStatus.embeddingRows')}>
+              {data.embeddings.nulls > 0 ? (
+                <span className="text-amber-700">
+                  {t('intelligence.serviceStatus.embeddingNulls', {
+                    nulls: data.embeddings.nulls.toLocaleString(locale),
+                    total: data.embeddings.total.toLocaleString(locale),
+                  })}
+                </span>
+              ) : (
+                data.embeddings.total.toLocaleString(locale)
+              )}
+            </Row>
+            <Row label={t('intelligence.serviceStatus.version')}>
+              <span className="font-mono">{data.version}</span>
+            </Row>
+          </dl>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/admin/src/components/intelligence/intelligence-service-status.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-service-status.tsx
@@ -42,6 +42,9 @@ export function IntelligenceServiceStatus() {
     queryKey: ['intelligence-service-status'],
     queryFn: intelligenceService.getServiceStatus,
     retry: false,
+    // Refresh on the system-health page like the other cards. Config /
+    // embedding-health change slowly, so 30s is proportionate (vs the page's 10s).
+    refetchInterval: 30000,
   });
 
   // 503 = master channel not configured → a quiet note, not an error.

--- a/apps/admin/src/components/intelligence/intelligence-service-status.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-service-status.tsx
@@ -42,9 +42,11 @@ export function IntelligenceServiceStatus() {
     queryKey: ['intelligence-service-status'],
     queryFn: intelligenceService.getServiceStatus,
     retry: false,
-    // Refresh on the system-health page like the other cards. Config /
-    // embedding-health change slowly, so 30s is proportionate (vs the page's 10s).
-    refetchInterval: 30000,
+    // Refresh on the system-health page like the other cards (30s — config /
+    // embedding-health change slowly, vs the page's 10s). Stop polling once it
+    // errors (e.g. 503 not-configured) so we don't re-hit it every 30s and
+    // spam server logs.
+    refetchInterval: (query) => (query.state.error ? false : 30000),
   });
 
   // 503 = master channel not configured → a quiet note, not an error.

--- a/apps/admin/src/components/intelligence/intelligence-service-status.tsx
+++ b/apps/admin/src/components/intelligence/intelligence-service-status.tsx
@@ -15,6 +15,18 @@ import { intelligenceService } from '../../services/intelligence-service';
 
 type TFn = (key: string, options?: Record<string, unknown>) => string;
 
+const STATUS_REFETCH_MS = 30_000;
+
+/**
+ * Poll the status card every 30s. Stop permanently on a 503 (service not
+ * configured) so we don't re-hit it forever; keep polling on transient errors
+ * (502/504/network) so the card self-heals once the upstream recovers.
+ */
+export function statusRefetchInterval(error: unknown): number | false {
+  const status = (error as { response?: { status?: number } } | null)?.response?.status;
+  return status === 503 ? false : STATUS_REFETCH_MS;
+}
+
 function KeyBadge({ configured, t }: { configured: boolean; t: TFn }) {
   return (
     <Badge variant={configured ? 'secondary' : 'outline'} className="text-xs">
@@ -42,11 +54,9 @@ export function IntelligenceServiceStatus() {
     queryKey: ['intelligence-service-status'],
     queryFn: intelligenceService.getServiceStatus,
     retry: false,
-    // Refresh on the system-health page like the other cards (30s — config /
-    // embedding-health change slowly, vs the page's 10s). Stop polling once it
-    // errors (e.g. 503 not-configured) so we don't re-hit it every 30s and
-    // spam server logs.
-    refetchInterval: (query) => (query.state.error ? false : 30000),
+    // 30s refresh like the other health cards; only a 503 (not configured)
+    // stops it — see statusRefetchInterval.
+    refetchInterval: (query) => statusRefetchInterval(query.state.error),
   });
 
   // 503 = master channel not configured → a quiet note, not an error.

--- a/apps/admin/src/i18n/locales/en.json
+++ b/apps/admin/src/i18n/locales/en.json
@@ -1893,6 +1893,27 @@
         "rationaleToggle": "AI rationale for {{operation}}"
       }
     },
+    "serviceStatus": {
+      "title": "AI service",
+      "healthy": "Healthy",
+      "degraded": "Degraded",
+      "loading": "Loading...",
+      "notConfigured": "AI service is not configured.",
+      "unavailable": "Could not load AI service status.",
+      "provider": "Provider",
+      "model": "Model",
+      "none": "None",
+      "anthropicKey": "Anthropic key",
+      "openaiKey": "OpenAI key",
+      "keyConfigured": "Configured",
+      "keyMissing": "Not set",
+      "similarityThreshold": "Similarity threshold",
+      "duplicateThreshold": "Duplicate threshold",
+      "embeddings": "Embedding model",
+      "embeddingRows": "Embedding rows",
+      "embeddingNulls": "{{nulls}} of {{total}} missing",
+      "version": "Version"
+    },
     "feedback": {
       "helpful": "Helpful?",
       "thumbsUp": "Mark as helpful",

--- a/apps/admin/src/i18n/locales/kk.json
+++ b/apps/admin/src/i18n/locales/kk.json
@@ -1893,6 +1893,27 @@
         "rationaleToggle": "{{operation}} үшін ЖИ негіздемесі"
       }
     },
+    "serviceStatus": {
+      "title": "ЖИ қызметі",
+      "healthy": "Қалыпты",
+      "degraded": "Нашарлаған",
+      "loading": "Жүктелуде...",
+      "notConfigured": "ЖИ қызметі бапталмаған.",
+      "unavailable": "ЖИ қызметінің күйін жүктеу мүмкін болмады.",
+      "provider": "Провайдер",
+      "model": "Модель",
+      "none": "Жоқ",
+      "anthropicKey": "Anthropic кілті",
+      "openaiKey": "OpenAI кілті",
+      "keyConfigured": "Бапталған",
+      "keyMissing": "Орнатылмаған",
+      "similarityThreshold": "Ұқсастық шегі",
+      "duplicateThreshold": "Дубликат шегі",
+      "embeddings": "Эмбеддинг моделі",
+      "embeddingRows": "Эмбеддинг жолдары",
+      "embeddingNulls": "{{total}} ішінен {{nulls}} жоқ",
+      "version": "Нұсқа"
+    },
     "feedback": {
       "helpful": "Пайдалы ма?",
       "thumbsUp": "Пайдалы деп белгілеу",

--- a/apps/admin/src/i18n/locales/ru.json
+++ b/apps/admin/src/i18n/locales/ru.json
@@ -1893,6 +1893,27 @@
         "rationaleToggle": "Обоснование ИИ для {{operation}}"
       }
     },
+    "serviceStatus": {
+      "title": "Сервис ИИ",
+      "healthy": "Исправен",
+      "degraded": "Деградация",
+      "loading": "Загрузка...",
+      "notConfigured": "Сервис ИИ не настроен.",
+      "unavailable": "Не удалось загрузить статус сервиса ИИ.",
+      "provider": "Провайдер",
+      "model": "Модель",
+      "none": "Нет",
+      "anthropicKey": "Ключ Anthropic",
+      "openaiKey": "Ключ OpenAI",
+      "keyConfigured": "Настроен",
+      "keyMissing": "Не задан",
+      "similarityThreshold": "Порог похожести",
+      "duplicateThreshold": "Порог дубликатов",
+      "embeddings": "Модель эмбеддингов",
+      "embeddingRows": "Строк эмбеддингов",
+      "embeddingNulls": "{{nulls}} из {{total}} отсутствуют",
+      "version": "Версия"
+    },
     "feedback": {
       "helpful": "Полезно?",
       "thumbsUp": "Отметить как полезное",

--- a/apps/admin/src/lib/api-constants.ts
+++ b/apps/admin/src/lib/api-constants.ts
@@ -289,6 +289,8 @@ export const API_ENDPOINTS = {
   // Intelligence endpoints
   intelligence: {
     status: (orgId: string) => `${API_VERSION}/organizations/${orgId}/intelligence/status`,
+    // Platform-admin (operator) service status — global, not org-scoped.
+    serviceStatus: () => `${API_VERSION}/admin/intelligence/status`,
     settings: (orgId: string) => `${API_VERSION}/organizations/${orgId}/intelligence/settings`,
     provisionKey: (orgId: string) => `${API_VERSION}/organizations/${orgId}/intelligence/key`,
     generateKey: (orgId: string) =>

--- a/apps/admin/src/pages/health.tsx
+++ b/apps/admin/src/pages/health.tsx
@@ -9,6 +9,7 @@ import { HealthWorkers } from '../components/health/health-workers';
 import { HealthQueues } from '../components/health/health-queues';
 import { HealthPlugins } from '../components/health/health-plugins';
 import { HealthMetrics } from '../components/health/health-metrics';
+import { IntelligenceServiceStatus } from '../components/intelligence/intelligence-service-status';
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 // Type for translation function
@@ -253,6 +254,9 @@ export default function HealthPage() {
       </Card>
 
       <HealthServices services={health?.services} getStatusColor={getStatusColor} />
+
+      {/* AI/intelligence service status (operator view; self-fetches, quiet when off) */}
+      <IntelligenceServiceStatus />
 
       <HealthWorkers
         workers={health?.workers || []}

--- a/apps/admin/src/services/intelligence-service.ts
+++ b/apps/admin/src/services/intelligence-service.ts
@@ -7,6 +7,7 @@ import { api, API_ENDPOINTS } from '../lib/api-client';
 import type {
   IntelligenceSettings,
   IntelligenceStatus,
+  IntelligenceServiceStatus,
   UpdateIntelligenceSettingsInput,
   ProvisionKeyResult,
   IntelligenceEnrichment,
@@ -40,6 +41,13 @@ export const intelligenceService = {
 
   getSettings: async (orgId: string): Promise<IntelligenceSettings> => {
     const response = await api.get(API_ENDPOINTS.intelligence.settings(orgId));
+    return response.data.data;
+  },
+
+  // Platform-admin (operator) service status — global, not org-scoped.
+  // 503 when the intelligence master channel isn't configured.
+  getServiceStatus: async (): Promise<IntelligenceServiceStatus> => {
+    const response = await api.get(API_ENDPOINTS.intelligence.serviceStatus());
     return response.data.data;
   },
 

--- a/apps/admin/src/tests/components/intelligence/intelligence-service-status.test.tsx
+++ b/apps/admin/src/tests/components/intelligence/intelligence-service-status.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
-import { IntelligenceServiceStatus } from '../../../components/intelligence/intelligence-service-status';
+import {
+  IntelligenceServiceStatus,
+  statusRefetchInterval,
+} from '../../../components/intelligence/intelligence-service-status';
 import { intelligenceService } from '../../../services/intelligence-service';
 
 vi.mock('react-i18next', async () => {
@@ -105,5 +108,22 @@ describe('<IntelligenceServiceStatus>', () => {
       expect(screen.getByText('AI service is not configured.')).toBeInTheDocument();
     });
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('statusRefetchInterval', () => {
+  it('polls every 30s when there is no error', () => {
+    expect(statusRefetchInterval(null)).toBe(30000);
+  });
+
+  it('stops polling on a 503 (not configured, permanent)', () => {
+    expect(statusRefetchInterval({ response: { status: 503 } })).toBe(false);
+  });
+
+  it('keeps polling on transient errors so the card self-heals', () => {
+    expect(statusRefetchInterval({ response: { status: 502 } })).toBe(30000);
+    expect(statusRefetchInterval({ response: { status: 504 } })).toBe(30000);
+    // Network error — no response object.
+    expect(statusRefetchInterval(new Error('ECONNREFUSED'))).toBe(30000);
   });
 });

--- a/apps/admin/src/tests/components/intelligence/intelligence-service-status.test.tsx
+++ b/apps/admin/src/tests/components/intelligence/intelligence-service-status.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { IntelligenceServiceStatus } from '../../../components/intelligence/intelligence-service-status';
+import { intelligenceService } from '../../../services/intelligence-service';
+
+vi.mock('react-i18next', async () => {
+  const en = (await import('../../../i18n/locales/en.json')).default;
+  const get = (key: string): string | undefined =>
+    key
+      .split('.')
+      .reduce<unknown>(
+        (obj, part) =>
+          obj != null && typeof obj === 'object'
+            ? (obj as Record<string, unknown>)[part]
+            : undefined,
+        en
+      ) as string | undefined;
+  return {
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) => {
+        const raw = get(key) ?? key;
+        if (!opts) {
+          return raw;
+        }
+        return raw.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? ''));
+      },
+      i18n: { language: 'en-US' },
+    }),
+  };
+});
+
+vi.mock('../../../services/intelligence-service', () => ({
+  intelligenceService: {
+    getServiceStatus: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const HEALTHY = {
+  version: '0.1.0',
+  llm_provider: 'ollama',
+  llm_model: 'llama3.2:3b',
+  anthropic_key_configured: false,
+  openai_key_configured: true,
+  similarity_threshold: 0.68,
+  duplicate_threshold: 0.85,
+  embeddings: {
+    provider: 'local',
+    model: 'BAAI/bge-m3',
+    total: 100,
+    nulls: 0,
+    min_dim: 1024,
+    healthy: true,
+  },
+};
+
+describe('<IntelligenceServiceStatus>', () => {
+  beforeEach(() => {
+    vi.mocked(intelligenceService.getServiceStatus).mockReset();
+  });
+
+  it('renders provider, model, version, key badges, and a healthy indicator', async () => {
+    vi.mocked(intelligenceService.getServiceStatus).mockResolvedValueOnce(HEALTHY);
+
+    render(<IntelligenceServiceStatus />, { wrapper });
+
+    expect(await screen.findByText('ollama')).toBeInTheDocument();
+    expect(screen.getByText('llama3.2:3b')).toBeInTheDocument();
+    expect(screen.getByText('0.1.0')).toBeInTheDocument();
+    expect(screen.getByText('Healthy')).toBeInTheDocument();
+    // One key configured, one not.
+    expect(screen.getByText('Configured')).toBeInTheDocument();
+    expect(screen.getByText('Not set')).toBeInTheDocument();
+  });
+
+  it('flags degraded with a NULL-embedding count when nulls > 0', async () => {
+    vi.mocked(intelligenceService.getServiceStatus).mockResolvedValueOnce({
+      ...HEALTHY,
+      embeddings: { ...HEALTHY.embeddings, nulls: 3, healthy: false },
+    });
+
+    render(<IntelligenceServiceStatus />, { wrapper });
+
+    expect(await screen.findByText('Degraded')).toBeInTheDocument();
+    expect(screen.getByText(/3 of 100 missing/)).toBeInTheDocument();
+  });
+
+  it('shows a quiet "not configured" note on 503, not an error', async () => {
+    const err = Object.assign(new Error('not configured'), {
+      response: { status: 503 },
+    });
+    vi.mocked(intelligenceService.getServiceStatus).mockRejectedValueOnce(err);
+
+    render(<IntelligenceServiceStatus />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('AI service is not configured.')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/types/intelligence.ts
+++ b/apps/admin/src/types/intelligence.ts
@@ -14,6 +14,33 @@ export interface IntelligenceStatus {
   intelligence_enabled: boolean;
 }
 
+/** Embedding-pipeline health within the platform-admin service status. */
+export interface IntelligenceEmbeddingHealth {
+  provider: string;
+  model: string | null;
+  total: number;
+  /** Rows with a NULL embedding — > 0 signals a dimension mismatch. */
+  nulls: number;
+  min_dim: number | null;
+  healthy: boolean;
+}
+
+/**
+ * Operator (platform-admin) status of the intelligence service. Mirrors the
+ * backend ServiceStatus, which proxies the upstream GET /admin/status.
+ * Cloud-key fields are booleans only — secret values never cross the wire.
+ */
+export interface IntelligenceServiceStatus {
+  version: string;
+  llm_provider: string;
+  llm_model: string | null;
+  anthropic_key_configured: boolean;
+  openai_key_configured: boolean;
+  similarity_threshold: number;
+  duplicate_threshold: number;
+  embeddings: IntelligenceEmbeddingHealth;
+}
+
 export interface IntelligenceSettings {
   intelligence_enabled: boolean;
   intelligence_provider: string | null;


### PR DESCRIPTION
Adds an operator-facing **AI service** card to the platform-admin `/system-health` page, consuming `GET /api/v1/admin/intelligence/status` (#188): active generation provider/model, cloud-key presence (badges — no secrets), dedup thresholds, embedding-pipeline health (amber warning when `nulls > 0`), and service version.

Self-fetching, with a green "Healthy" / amber "Degraded" indicator. Degrades quietly: a 503 (intelligence master channel not configured) renders a muted "not configured" note rather than an error, so non-AI deployments aren't disrupted. Platform-admin only (lives behind the existing `AdminRoute`-gated health page) — no per-org surface.

Status surface PR C of 3 (final). Adds the endpoint constant, `IntelligenceServiceStatus` type + service method, en/ru/kk i18n, and a component test (healthy / degraded / not-configured). Validated: i18n synced, lint 0, strict admin build, full admin suite 983 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Intelligence Service Status to the admin system health page: shows overall health (Healthy/Degraded), provider/model, service version, API key configuration badges, similarity/duplicate thresholds, and embeddings diagnostics including null-count warnings.

* **Localization**
  * Added translations for the service status UI in English, Kazakh, and Russian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->