### PR TITLE
feat(intelligence): persist + surface enrichment rationale

### DIFF
--- a/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
+++ b/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
@@ -15,6 +15,7 @@ interface AIEnrichmentCardProps {
 export function AIEnrichmentCard({ bugReportId }: AIEnrichmentCardProps) {
   const { t } = useTranslation();
   const [showRationale, setShowRationale] = useState(false);
+  const rationalePanelId = `enrichment-rationale-${bugReportId}`;
 
   const {
     data: enrichment,
@@ -143,6 +144,7 @@ export function AIEnrichmentCard({ bugReportId }: AIEnrichmentCardProps) {
               type="button"
               onClick={() => setShowRationale((v) => !v)}
               aria-expanded={showRationale}
+              aria-controls={rationalePanelId}
               className="flex items-center gap-1 text-xs font-medium text-purple-700 uppercase tracking-wider focus:outline-none focus:ring-2 focus:ring-primary rounded"
             >
               {showRationale ? (
@@ -153,7 +155,9 @@ export function AIEnrichmentCard({ bugReportId }: AIEnrichmentCardProps) {
               {t('intelligence.enrichment.rationaleTitle')}
             </button>
             {showRationale && (
-              <p className="text-sm text-gray-700 mt-1 break-words">{enrichment.rationale}</p>
+              <p id={rationalePanelId} className="text-sm text-gray-700 mt-1 break-words">
+                {enrichment.rationale}
+              </p>
             )}
           </div>
         )}

--- a/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
+++ b/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Brain, ChevronDown, ChevronRight, Tag } from 'lucide-react';
@@ -16,6 +16,12 @@ export function AIEnrichmentCard({ bugReportId }: AIEnrichmentCardProps) {
   const { t } = useTranslation();
   const [showRationale, setShowRationale] = useState(false);
   const rationalePanelId = `enrichment-rationale-${bugReportId}`;
+
+  // The card stays mounted across bug navigation (its query is keyed on
+  // bugReportId), so reset the accordion when the bug changes.
+  useEffect(() => {
+    setShowRationale(false);
+  }, [bugReportId]);
 
   const {
     data: enrichment,

--- a/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
+++ b/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Brain, ChevronDown, ChevronRight, Tag } from 'lucide-react';
@@ -18,10 +18,14 @@ export function AIEnrichmentCard({ bugReportId }: AIEnrichmentCardProps) {
   const rationalePanelId = `enrichment-rationale-${bugReportId}`;
 
   // The card stays mounted across bug navigation (its query is keyed on
-  // bugReportId), so reset the accordion when the bug changes.
-  useEffect(() => {
+  // bugReportId), so reset the accordion when the bug changes. Render-phase
+  // reset — React's recommended pattern for adjusting state on a prop change
+  // (no extra effect pass, no flash of the previous state on cached data).
+  const [prevBugReportId, setPrevBugReportId] = useState(bugReportId);
+  if (bugReportId !== prevBugReportId) {
+    setPrevBugReportId(bugReportId);
     setShowRationale(false);
-  }, [bugReportId]);
+  }
 
   const {
     data: enrichment,

--- a/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
+++ b/apps/admin/src/components/bug-reports/ai-enrichment-card.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Brain, Tag } from 'lucide-react';
+import { Brain, ChevronDown, ChevronRight, Tag } from 'lucide-react';
 import { Badge } from '../ui/badge';
 import { intelligenceService } from '../../services/intelligence-service';
 import { formatDate } from '../../utils/format';
@@ -13,6 +14,7 @@ interface AIEnrichmentCardProps {
 // intelligence_enabled is true, so no self-gating is needed here.
 export function AIEnrichmentCard({ bugReportId }: AIEnrichmentCardProps) {
   const { t } = useTranslation();
+  const [showRationale, setShowRationale] = useState(false);
 
   const {
     data: enrichment,
@@ -131,6 +133,28 @@ export function AIEnrichmentCard({ bugReportId }: AIEnrichmentCardProps) {
                 </Badge>
               ))}
             </div>
+          </div>
+        )}
+
+        {/* Why AI decided this — collapsible rationale (hidden when absent) */}
+        {enrichment.rationale?.trim() && (
+          <div className="pt-2 border-t border-purple-100">
+            <button
+              type="button"
+              onClick={() => setShowRationale((v) => !v)}
+              aria-expanded={showRationale}
+              className="flex items-center gap-1 text-xs font-medium text-purple-700 uppercase tracking-wider focus:outline-none focus:ring-2 focus:ring-primary rounded"
+            >
+              {showRationale ? (
+                <ChevronDown className="w-3 h-3" aria-hidden="true" />
+              ) : (
+                <ChevronRight className="w-3 h-3" aria-hidden="true" />
+              )}
+              {t('intelligence.enrichment.rationaleTitle')}
+            </button>
+            {showRationale && (
+              <p className="text-sm text-gray-700 mt-1 break-words">{enrichment.rationale}</p>
+            )}
           </div>
         )}
       </div>

--- a/apps/admin/src/i18n/locales/en.json
+++ b/apps/admin/src/i18n/locales/en.json
@@ -1809,7 +1809,8 @@
       "enrichedAt": "Enriched on {{date}}",
       "notEnriched": "Not yet enriched",
       "enriching": "Enriching...",
-      "components": "Components"
+      "components": "Components",
+      "rationaleTitle": "Why AI decided this"
     },
     "analysis": {
       "title": "Analysis",

--- a/apps/admin/src/i18n/locales/kk.json
+++ b/apps/admin/src/i18n/locales/kk.json
@@ -1809,7 +1809,8 @@
       "enrichedAt": "{{date}} байытылды",
       "notEnriched": "Әлі байытылмаған",
       "enriching": "Байыту...",
-      "components": "Компоненттер"
+      "components": "Компоненттер",
+      "rationaleTitle": "ЖИ неге осылай шешті"
     },
     "analysis": {
       "title": "Талдау",

--- a/apps/admin/src/i18n/locales/ru.json
+++ b/apps/admin/src/i18n/locales/ru.json
@@ -1809,7 +1809,8 @@
       "enrichedAt": "Обогащён {{date}}",
       "notEnriched": "Ещё не обогащён",
       "enriching": "Обогащение...",
-      "components": "Компоненты"
+      "components": "Компоненты",
+      "rationaleTitle": "Почему ИИ так решил"
     },
     "analysis": {
       "title": "Анализ",

--- a/apps/admin/src/tests/components/bug-reports/ai-enrichment-card.test.tsx
+++ b/apps/admin/src/tests/components/bug-reports/ai-enrichment-card.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { AIEnrichmentCard } from '../../../components/bug-reports/ai-enrichment-card';
+import { intelligenceService } from '../../../services/intelligence-service';
+
+vi.mock('react-i18next', async () => {
+  const en = (await import('../../../i18n/locales/en.json')).default;
+  const get = (key: string): string | undefined =>
+    key
+      .split('.')
+      .reduce<unknown>(
+        (obj, part) =>
+          obj != null && typeof obj === 'object'
+            ? (obj as Record<string, unknown>)[part]
+            : undefined,
+        en
+      ) as string | undefined;
+  return {
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) => {
+        const raw = get(key) ?? key;
+        if (!opts) {
+          return raw;
+        }
+        return raw.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? ''));
+      },
+      i18n: { language: 'en-US' },
+    }),
+  };
+});
+
+vi.mock('../../../services/intelligence-service', () => ({
+  intelligenceService: {
+    getEnrichment: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const BASE = {
+  id: 'enr-1',
+  bug_report_id: 'bug-1',
+  project_id: 'proj-1',
+  organization_id: 'org-1',
+  category: 'ui_rendering',
+  suggested_severity: 'medium',
+  tags: [],
+  root_cause_summary: 'CSS overflow',
+  affected_components: [],
+  confidence_category: 0.9,
+  confidence_severity: 0.8,
+  confidence_tags: 0.7,
+  confidence_root_cause: 0.8,
+  confidence_components: 0.7,
+  enrichment_version: 1,
+  created_at: '2026-03-16T00:00:00Z',
+  updated_at: '2026-03-16T00:00:00Z',
+};
+
+describe('<AIEnrichmentCard> rationale accordion', () => {
+  beforeEach(() => {
+    vi.mocked(intelligenceService.getEnrichment).mockReset();
+  });
+
+  it('reveals the rationale only after the "Why AI decided this" toggle is clicked', async () => {
+    vi.mocked(intelligenceService.getEnrichment).mockResolvedValueOnce({
+      ...BASE,
+      rationale: 'Marked critical: payment flow blocked for all users.',
+    });
+
+    render(<AIEnrichmentCard bugReportId="bug-1" />, { wrapper });
+
+    const toggle = await screen.findByRole('button', { name: /Why AI decided this/i });
+    // Collapsed by default.
+    expect(screen.queryByText(/payment flow blocked/i)).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.getByText(/payment flow blocked/i)).toBeInTheDocument();
+  });
+
+  it('renders no rationale toggle when rationale is null', async () => {
+    vi.mocked(intelligenceService.getEnrichment).mockResolvedValueOnce({
+      ...BASE,
+      rationale: null,
+    });
+
+    render(<AIEnrichmentCard bugReportId="bug-1" />, { wrapper });
+
+    expect(await screen.findByText('AI Enrichment')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Why AI decided this/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/tests/components/bug-reports/ai-enrichment-card.test.tsx
+++ b/apps/admin/src/tests/components/bug-reports/ai-enrichment-card.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { AIEnrichmentCard } from '../../../components/bug-reports/ai-enrichment-card';
@@ -93,5 +93,23 @@ describe('<AIEnrichmentCard> rationale accordion', () => {
 
     expect(await screen.findByText('AI Enrichment')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Why AI decided this/i })).not.toBeInTheDocument();
+  });
+
+  it('collapses the accordion when the card switches to a different bug', async () => {
+    vi.mocked(intelligenceService.getEnrichment).mockResolvedValue({
+      ...BASE,
+      rationale: 'Marked critical: payment flow blocked for all users.',
+    });
+
+    const { rerender } = render(<AIEnrichmentCard bugReportId="bug-1" />, { wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Why AI decided this/i }));
+    expect(screen.getByText(/payment flow blocked/i)).toBeInTheDocument();
+
+    // Switching bug reports (card stays mounted) resets the accordion.
+    rerender(<AIEnrichmentCard bugReportId="bug-2" />);
+    await waitFor(() => {
+      expect(screen.queryByText(/payment flow blocked/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/admin/src/types/intelligence.ts
+++ b/apps/admin/src/types/intelligence.ts
@@ -107,6 +107,10 @@ export interface IntelligenceEnrichment {
   confidence_root_cause: number;
   confidence_components: number;
   enrichment_version: number;
+  /** LLM one-sentence "why" for the chosen severity/category; null for older rows. */
+  rationale?: string | null;
+  /** Upstream intelligence_event id for this enrichment LLM call. */
+  event_id?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/packages/backend/src/db/migrations/026_enrichment_rationale.sql
+++ b/packages/backend/src/db/migrations/026_enrichment_rationale.sql
@@ -1,0 +1,18 @@
+-- Migration 026: rationale + event_id on bug_enrichments
+--
+-- Persist the LLM's one-sentence severity/category rationale and the upstream
+-- intelligence_event id alongside the enrichment, so the admin "Why AI decided
+-- this" accordion and observability cross-links work without re-running the LLM.
+--
+-- Both nullable: rows enriched before this migration, and enrichments from a
+-- pre-rationale upstream, won't have them. No FK on event_id — the
+-- intelligence_event lives in the separate intelligence service DB.
+
+SET search_path TO application;
+
+ALTER TABLE bug_enrichments
+    ADD COLUMN IF NOT EXISTS rationale TEXT,
+    ADD COLUMN IF NOT EXISTS event_id UUID;
+
+COMMENT ON COLUMN bug_enrichments.rationale IS 'LLM one-sentence justification for the chosen severity/category (nullable; pre-migration rows are NULL)';
+COMMENT ON COLUMN bug_enrichments.event_id IS 'Upstream intelligence_event id for this enrichment LLM call (no FK; lives in the intelligence DB)';

--- a/packages/backend/src/services/intelligence/enrichment-service.ts
+++ b/packages/backend/src/services/intelligence/enrichment-service.ts
@@ -32,6 +32,10 @@ export interface BugEnrichmentRow {
   confidence_root_cause: number;
   confidence_components: number;
   enrichment_version: number;
+  /** LLM one-sentence justification for the chosen severity/category. */
+  rationale: string | null;
+  /** Upstream intelligence_event id for this enrichment LLM call. */
+  event_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -61,8 +65,8 @@ export class IntelligenceEnrichmentService {
         (bug_report_id, project_id, organization_id, category, suggested_severity,
          tags, root_cause_summary, affected_components,
          confidence_category, confidence_severity, confidence_tags,
-         confidence_root_cause, confidence_components, enrichment_version)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 1)
+         confidence_root_cause, confidence_components, rationale, event_id, enrichment_version)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, 1)
       ON CONFLICT (bug_report_id) DO UPDATE SET
         category = EXCLUDED.category,
         suggested_severity = EXCLUDED.suggested_severity,
@@ -74,6 +78,8 @@ export class IntelligenceEnrichmentService {
         confidence_tags = EXCLUDED.confidence_tags,
         confidence_root_cause = EXCLUDED.confidence_root_cause,
         confidence_components = EXCLUDED.confidence_components,
+        rationale = EXCLUDED.rationale,
+        event_id = EXCLUDED.event_id,
         enrichment_version = ${TABLE}.enrichment_version + 1,
         updated_at = NOW()
       RETURNING *
@@ -95,6 +101,8 @@ export class IntelligenceEnrichmentService {
         response.confidence.tags,
         response.confidence.root_cause,
         response.confidence.components,
+        response.rationale ?? null,
+        response.event_id ?? null,
       ]);
 
     const row = result.rows[0];

--- a/packages/backend/src/services/intelligence/enrichment-service.ts
+++ b/packages/backend/src/services/intelligence/enrichment-service.ts
@@ -85,25 +85,25 @@ export class IntelligenceEnrichmentService {
       RETURNING *
     `;
 
-    const result = await this.db
-      .getPool()
-      .query(query, [
-        bugReportId,
-        projectId,
-        organizationId ?? null,
-        response.category,
-        response.suggested_severity,
-        response.tags,
-        response.root_cause_summary,
-        response.affected_components,
-        response.confidence.category,
-        response.confidence.severity,
-        response.confidence.tags,
-        response.confidence.root_cause,
-        response.confidence.components,
-        response.rationale ?? null,
-        response.event_id ?? null,
-      ]);
+    const result = await this.db.getPool().query(query, [
+      bugReportId,
+      projectId,
+      organizationId ?? null,
+      response.category,
+      response.suggested_severity,
+      response.tags,
+      response.root_cause_summary,
+      response.affected_components,
+      response.confidence.category,
+      response.confidence.severity,
+      response.confidence.tags,
+      response.confidence.root_cause,
+      response.confidence.components,
+      // Coerce empty/whitespace to null — an empty string in the UUID
+      // event_id column would throw, and an empty rationale should read as absent.
+      response.rationale?.trim() || null,
+      response.event_id?.trim() || null,
+    ]);
 
     const row = result.rows[0];
 

--- a/packages/backend/src/services/intelligence/types.ts
+++ b/packages/backend/src/services/intelligence/types.ts
@@ -193,6 +193,8 @@ export interface EnrichBugResponse {
   };
   /** intelligence_event id for this enrichment LLM call. */
   event_id?: string | null;
+  /** One-sentence "why" the LLM chose this severity/category; null/absent for older payloads. */
+  rationale?: string | null;
 }
 
 // ============================================================================

--- a/packages/backend/tests/services/intelligence/enrichment-service.test.ts
+++ b/packages/backend/tests/services/intelligence/enrichment-service.test.ts
@@ -109,7 +109,27 @@ describe('IntelligenceEnrichmentService', () => {
         0.78,
         0.88,
         0.72,
+        null,
+        null,
       ]);
+    });
+
+    it('persists rationale and event_id when present', async () => {
+      const db = createMockDb([{ rows: [{ id: 'enr-1', enrichment_version: 1 }] }]);
+      const service = new IntelligenceEnrichmentService(db as DatabaseClient);
+      const response = createEnrichResponse({
+        rationale: 'Marked critical: payment flow blocked for all users.',
+        event_id: 'evt-123',
+      });
+
+      await service.saveEnrichment('bug-1', 'proj-1', 'org-1', response);
+
+      const [sql, params] = getQuery(db).mock.calls[0];
+      expect(sql).toContain('rationale');
+      expect(sql).toContain('event_id');
+      // rationale + event_id are params 14 and 15 (0-indexed 13 and 14).
+      expect(params[13]).toBe('Marked critical: payment flow blocked for all users.');
+      expect(params[14]).toBe('evt-123');
     });
 
     it('passes null for organizationId when undefined', async () => {

--- a/packages/backend/tests/services/intelligence/enrichment-service.test.ts
+++ b/packages/backend/tests/services/intelligence/enrichment-service.test.ts
@@ -117,9 +117,10 @@ describe('IntelligenceEnrichmentService', () => {
     it('persists rationale and event_id when present', async () => {
       const db = createMockDb([{ rows: [{ id: 'enr-1', enrichment_version: 1 }] }]);
       const service = new IntelligenceEnrichmentService(db as DatabaseClient);
+      const eventId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
       const response = createEnrichResponse({
         rationale: 'Marked critical: payment flow blocked for all users.',
-        event_id: 'evt-123',
+        event_id: eventId,
       });
 
       await service.saveEnrichment('bug-1', 'proj-1', 'org-1', response);
@@ -129,7 +130,7 @@ describe('IntelligenceEnrichmentService', () => {
       expect(sql).toContain('event_id');
       // rationale + event_id are params 14 and 15 (0-indexed 13 and 14).
       expect(params[13]).toBe('Marked critical: payment flow blocked for all users.');
-      expect(params[14]).toBe('evt-123');
+      expect(params[14]).toBe(eventId);
     });
 
     it('passes null for organizationId when undefined', async () => {


### PR DESCRIPTION
Surfaces the LLM's one-sentence "why I chose this severity/category" rationale on the bug-report enrichment card, for compliance/explainability — the second and final piece of Sprint 2 #3 UI.

**Backend**: migration `026` adds nullable `rationale TEXT` + `event_id UUID` to `application.bug_enrichments`. `saveEnrichment` threads `EnrichBugResponse.rationale` + `event_id` into the upsert (the worker already passes the full response; the GET route passes them through via the schema's `additionalProperties`). `EnrichBugResponse` / `BugEnrichmentRow` gain the fields.

**Frontend**: a collapsible "Why AI decided this" accordion on the enrichment card — hidden when the rationale is absent (older rows), `break-words`, focus ring, en/ru/kk i18n.

**Tests**: backend asserts the two columns are persisted; a new card test covers reveal-on-toggle and hidden-when-null. Validated: i18n synced, admin lint 0, strict build, full admin suite 988 + backend intelligence suite 147 green.

Depends on intelligence#35/#36 (upstream `EnrichBugResponse.rationale`, already merged). After this merges I'll mark Sprint 2 #3 UI complete in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible "Why AI decided this" rationale added to AI enrichment cards; remembers collapse when switching reports and toggles visibility.

* **Localization**
  * Rationale title added and translated (en, ru, kk).

* **Accessibility**
  * Toggle exposes proper aria attributes and updates chevron direction.

* **Tests**
  * Tests added for visibility, toggle behavior, absence when missing, and collapse-on-rerender.

* **Chores**
  * Rationale and event reference persisted alongside enrichments; DB migration and type updates included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->