### PR TITLE
feat(intelligence): opt-in AI severity auto-apply to bug priority

### DIFF
--- a/packages/backend/src/db/types.ts
+++ b/packages/backend/src/db/types.ts
@@ -721,6 +721,10 @@ export interface OrganizationSettings {
   intelligence_api_key_provisioned_at?: string | null;
   intelligence_api_key_provisioned_by?: string | null;
   intelligence_auto_enrich?: boolean;
+  /** Apply the AI suggested severity to the bug's priority (only when still the default 'medium'). Off by default. */
+  intelligence_auto_apply_severity?: boolean;
+  /** Minimum severity-confidence (0..1) required to auto-apply. */
+  intelligence_severity_apply_threshold?: number | null;
   /**
    * Per-org allowlist for literal `notify.email.to` values used by
    * dedup rules. `undefined` / empty = trust-the-admin (legacy

--- a/packages/backend/src/queue/workers/intelligence-worker.ts
+++ b/packages/backend/src/queue/workers/intelligence-worker.ts
@@ -29,6 +29,8 @@ import { IntelligenceError } from '../../services/intelligence/intelligence-clie
 import type { DatabaseClient } from '../../db/client.js';
 import type { IntelligenceClientFactory } from '../../services/intelligence/tenant-config.js';
 import { IntelligenceEnrichmentService } from '../../services/intelligence/enrichment-service.js';
+import { getOrgIntelligenceSettings } from '../../services/intelligence/tenant-config.js';
+import { applyAiSeverityToPriority } from '../../services/intelligence/severity-apply.js';
 import { IntelligenceMitigationService } from '../../services/intelligence/mitigation-service.js';
 import { IntelligenceDedupService } from '../../services/intelligence/dedup-service.js';
 import type { PluginRegistry } from '../../integrations/plugin-registry.js';
@@ -429,6 +431,26 @@ async function processEnrichJob(
     organizationId ?? undefined,
     enrichResponse
   );
+
+  // Step 3: optionally apply the AI severity to the bug's priority (SaaS,
+  // org-gated, opt-in). Non-fatal — a failure here must not fail enrichment.
+  if (organizationId) {
+    try {
+      const settings = await getOrgIntelligenceSettings(db, organizationId);
+      await applyAiSeverityToPriority(db, {
+        bugReportId,
+        organizationId,
+        enrichment: enrichResponse,
+        settings,
+      });
+    } catch (err) {
+      logger.warn('AI severity auto-apply failed (non-fatal)', {
+        jobId: job.id,
+        bugReportId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
 
   await progress.complete('Done');
 

--- a/packages/backend/src/services/intelligence/severity-apply.ts
+++ b/packages/backend/src/services/intelligence/severity-apply.ts
@@ -1,0 +1,114 @@
+/**
+ * AI Severity → Priority application
+ *
+ * When an org opts in (`intelligence_auto_apply_severity`) and the enrichment's
+ * severity confidence clears the threshold, set the bug's `priority` from the AI
+ * suggested severity — but ONLY while the bug is still at the default 'medium',
+ * so human triage is never overwritten. Writes an audit row when applied.
+ *
+ * Scoped to SaaS (org-gated): the worker only calls this when an organizationId
+ * is present. Self-hosted has no per-org flag, so auto-apply stays off there.
+ */
+
+import { getLogger } from '../../logger.js';
+import type { DatabaseClient } from '../../db/client.js';
+import type { EnrichBugResponse } from './types.js';
+import type { OrgIntelligenceSettings } from './tenant-config.js';
+
+const logger = getLogger();
+
+// AI `suggested_severity` vocabulary → `bug_reports.priority` values. An
+// unrecognized value is skipped (never written) so a surprise upstream label
+// can't land a bad priority.
+const SEVERITY_TO_PRIORITY: Record<string, string> = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  critical: 'critical',
+};
+
+// Only fill priority when the bug is still here — never overwrite human triage.
+const DEFAULT_PRIORITY = 'medium';
+
+export interface ApplySeverityResult {
+  applied: boolean;
+  priority?: string;
+  /** Why it didn't apply — for logging/observability, not user-facing. */
+  reason?: 'disabled' | 'below_threshold' | 'unknown_severity' | 'priority_not_default';
+}
+
+/**
+ * Conditionally apply the enrichment's suggested severity to the bug's priority.
+ * Returns `{ applied: false, reason }` for every skip path; never throws on the
+ * skip conditions (a DB error from the UPDATE itself still propagates).
+ */
+export async function applyAiSeverityToPriority(
+  db: DatabaseClient,
+  params: {
+    bugReportId: string;
+    organizationId: string;
+    enrichment: EnrichBugResponse;
+    settings: OrgIntelligenceSettings;
+  }
+): Promise<ApplySeverityResult> {
+  const { bugReportId, organizationId, enrichment, settings } = params;
+
+  if (!settings.intelligence_auto_apply_severity) {
+    return { applied: false, reason: 'disabled' };
+  }
+
+  const confidence = enrichment.confidence.severity;
+  if (confidence < settings.intelligence_severity_apply_threshold) {
+    return { applied: false, reason: 'below_threshold' };
+  }
+
+  const priority = SEVERITY_TO_PRIORITY[enrichment.suggested_severity.toLowerCase()];
+  if (!priority) {
+    logger.warn('AI suggested_severity is not a known priority; skipping auto-apply', {
+      bugReportId,
+      suggestedSeverity: enrichment.suggested_severity,
+    });
+    return { applied: false, reason: 'unknown_severity' };
+  }
+
+  // Atomic guard: only set priority if it's still the default. A single
+  // conditional UPDATE avoids a read-then-write race.
+  const result = await db.getPool().query(
+    `UPDATE application.bug_reports
+        SET priority = $1, updated_at = NOW()
+      WHERE id = $2 AND priority = $3 AND deleted_at IS NULL`,
+    [priority, bugReportId, DEFAULT_PRIORITY]
+  );
+
+  if (!result.rowCount) {
+    // Already triaged away from the default (or bug gone) — leave it.
+    return { applied: false, reason: 'priority_not_default' };
+  }
+
+  // Audit the change. A failure here must not undo the applied priority.
+  await db.auditLogs
+    .create({
+      action: 'bug_report.priority.ai_applied',
+      resource: 'bug_report',
+      resource_id: bugReportId,
+      user_id: null,
+      organization_id: organizationId,
+      success: true,
+      details: {
+        from: DEFAULT_PRIORITY,
+        to: priority,
+        suggested_severity: enrichment.suggested_severity,
+        confidence,
+        threshold: settings.intelligence_severity_apply_threshold,
+      },
+    })
+    .catch((err) => {
+      logger.warn('Failed to write audit log for AI priority apply', {
+        bugReportId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+
+  logger.info('AI severity applied to bug priority', { bugReportId, priority, confidence });
+  return { applied: true, priority };
+}

--- a/packages/backend/src/services/intelligence/severity-apply.ts
+++ b/packages/backend/src/services/intelligence/severity-apply.ts
@@ -34,7 +34,12 @@ export interface ApplySeverityResult {
   applied: boolean;
   priority?: string;
   /** Why it didn't apply — for logging/observability, not user-facing. */
-  reason?: 'disabled' | 'below_threshold' | 'unknown_severity' | 'priority_not_default';
+  reason?:
+    | 'disabled'
+    | 'below_threshold'
+    | 'unknown_severity'
+    | 'priority_already_default'
+    | 'priority_not_default';
 }
 
 /**
@@ -79,6 +84,13 @@ export async function applyAiSeverityToPriority(
       suggestedSeverity: enrichment.suggested_severity,
     });
     return { applied: false, reason: 'unknown_severity' };
+  }
+
+  if (priority === DEFAULT_PRIORITY) {
+    // Suggested severity equals the default — applying is a no-op (we only ever
+    // write when the bug is still at the default), so skip the redundant UPDATE
+    // and the misleading medium→medium audit row.
+    return { applied: false, reason: 'priority_already_default' };
   }
 
   // Atomic guard: only set priority if it's still the default. A single

--- a/packages/backend/src/services/intelligence/severity-apply.ts
+++ b/packages/backend/src/services/intelligence/severity-apply.ts
@@ -72,12 +72,19 @@ export async function applyAiSeverityToPriority(
   }
 
   // Atomic guard: only set priority if it's still the default. A single
-  // conditional UPDATE avoids a read-then-write race.
+  // conditional UPDATE avoids a read-then-write race. Tenant-scoped via the
+  // bug's project → org (bug_reports has no organization_id column), so a
+  // mismatched bugReportId/organizationId can never write across tenants.
   const result = await db.getPool().query(
     `UPDATE application.bug_reports
         SET priority = $1, updated_at = NOW()
-      WHERE id = $2 AND priority = $3 AND deleted_at IS NULL`,
-    [priority, bugReportId, DEFAULT_PRIORITY]
+      WHERE id = $2
+        AND priority = $3
+        AND deleted_at IS NULL
+        AND project_id IN (
+          SELECT id FROM application.projects WHERE organization_id = $4
+        )`,
+    [priority, bugReportId, DEFAULT_PRIORITY, organizationId]
   );
 
   if (!result.rowCount) {

--- a/packages/backend/src/services/intelligence/severity-apply.ts
+++ b/packages/backend/src/services/intelligence/severity-apply.ts
@@ -57,12 +57,22 @@ export async function applyAiSeverityToPriority(
     return { applied: false, reason: 'disabled' };
   }
 
-  const confidence = enrichment.confidence.severity;
-  if (confidence < settings.intelligence_severity_apply_threshold) {
+  // Fail safe on the confidence gate. The values are typed numbers, but this
+  // consumer trusts an upstream response that isn't runtime-validated — and a
+  // missing confidence/threshold must NOT slip through, since `undefined < n`
+  // is false and would silently bypass the gate and auto-apply.
+  const confidence = enrichment.confidence?.severity;
+  const threshold = settings.intelligence_severity_apply_threshold;
+  if (
+    typeof confidence !== 'number' ||
+    !Number.isFinite(confidence) ||
+    typeof threshold !== 'number' ||
+    confidence < threshold
+  ) {
     return { applied: false, reason: 'below_threshold' };
   }
 
-  const priority = SEVERITY_TO_PRIORITY[enrichment.suggested_severity.toLowerCase()];
+  const priority = SEVERITY_TO_PRIORITY[enrichment.suggested_severity?.toLowerCase?.() ?? ''];
   if (!priority) {
     logger.warn('AI suggested_severity is not a known priority; skipping auto-apply', {
       bugReportId,

--- a/packages/backend/src/services/intelligence/tenant-config.ts
+++ b/packages/backend/src/services/intelligence/tenant-config.ts
@@ -38,6 +38,14 @@ export interface OrgIntelligenceSettings {
   intelligence_api_key_provisioned_by: string | null;
   intelligence_auto_enrich: boolean;
   /**
+   * Apply the AI suggested severity to the bug's `priority` (only when the bug
+   * is still at the default 'medium', so human triage is never overwritten).
+   * Off by default.
+   */
+  intelligence_auto_apply_severity: boolean;
+  /** Minimum severity-confidence (0..1) required before auto-applying. */
+  intelligence_severity_apply_threshold: number;
+  /**
    * Whether the org has a Telegram bot token configured. Surfaces in
    * the GET response so the admin UI can render "configured" /
    * "not configured" without us ever returning the encrypted blob.
@@ -80,6 +88,8 @@ export const INTELLIGENCE_SETTINGS_DEFAULTS: OrgIntelligenceSettings = {
   intelligence_api_key_provisioned_at: null,
   intelligence_api_key_provisioned_by: null,
   intelligence_auto_enrich: true,
+  intelligence_auto_apply_severity: false,
+  intelligence_severity_apply_threshold: 0.8,
   telegram_bot_token_configured: false,
   slack_bot_token_configured: false,
 };
@@ -126,6 +136,12 @@ export function resolveOrgIntelligenceSettings(
       INTELLIGENCE_SETTINGS_DEFAULTS.intelligence_api_key_provisioned_by,
     intelligence_auto_enrich:
       settings.intelligence_auto_enrich ?? INTELLIGENCE_SETTINGS_DEFAULTS.intelligence_auto_enrich,
+    intelligence_auto_apply_severity:
+      settings.intelligence_auto_apply_severity ??
+      INTELLIGENCE_SETTINGS_DEFAULTS.intelligence_auto_apply_severity,
+    intelligence_severity_apply_threshold:
+      settings.intelligence_severity_apply_threshold ??
+      INTELLIGENCE_SETTINGS_DEFAULTS.intelligence_severity_apply_threshold,
     // Compute booleans from the raw fields without surfacing the
     // ciphertext. `typeof === 'string'` + non-empty handles both the
     // "unset" (undefined / null) and the "cleared" (empty string) cases.

--- a/packages/backend/tests/services/intelligence/severity-apply.test.ts
+++ b/packages/backend/tests/services/intelligence/severity-apply.test.ts
@@ -55,7 +55,9 @@ describe('applyAiSeverityToPriority', () => {
     // Conditional UPDATE guards on the bug still being at the default 'medium'.
     const [sql, args] = query.mock.calls[0];
     expect(sql).toContain('UPDATE application.bug_reports');
-    expect(args).toEqual(['high', 'bug-1', 'medium']);
+    // Tenant-scoped: only bugs whose project belongs to the org.
+    expect(sql).toContain('organization_id = $4');
+    expect(args).toEqual(['high', 'bug-1', 'medium', 'org-1']);
     expect(auditCreate).toHaveBeenCalledTimes(1);
     expect(auditCreate.mock.calls[0][0]).toMatchObject({
       action: 'bug_report.priority.ai_applied',

--- a/packages/backend/tests/services/intelligence/severity-apply.test.ts
+++ b/packages/backend/tests/services/intelligence/severity-apply.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyAiSeverityToPriority } from '../../../src/services/intelligence/severity-apply.js';
+import {
+  INTELLIGENCE_SETTINGS_DEFAULTS,
+  type OrgIntelligenceSettings,
+} from '../../../src/services/intelligence/tenant-config.js';
+import type { DatabaseClient } from '../../../src/db/client.js';
+import type { EnrichBugResponse } from '../../../src/services/intelligence/types.js';
+
+function createMockDb(rowCount: number) {
+  const query = vi.fn().mockResolvedValue({ rowCount, rows: [] });
+  const auditCreate = vi.fn().mockResolvedValue({ id: 'audit-1' });
+  const db = {
+    getPool: () => ({ query }),
+    auditLogs: { create: auditCreate },
+  } as unknown as DatabaseClient;
+  return { db, query, auditCreate };
+}
+
+function settings(overrides?: Partial<OrgIntelligenceSettings>): OrgIntelligenceSettings {
+  return {
+    ...INTELLIGENCE_SETTINGS_DEFAULTS,
+    intelligence_auto_apply_severity: true,
+    intelligence_severity_apply_threshold: 0.8,
+    ...overrides,
+  };
+}
+
+function enrichment(overrides?: Partial<EnrichBugResponse>): EnrichBugResponse {
+  return {
+    bug_id: 'bug-1',
+    category: 'ui',
+    suggested_severity: 'high',
+    tags: [],
+    root_cause_summary: 'x',
+    affected_components: [],
+    confidence: { category: 0.9, severity: 0.9, tags: 0.9, root_cause: 0.9, components: 0.9 },
+    ...overrides,
+  };
+}
+
+const PARAMS = { bugReportId: 'bug-1', organizationId: 'org-1' };
+
+describe('applyAiSeverityToPriority', () => {
+  it('applies priority when enabled, confident, and the bug is still default', async () => {
+    const { db, query, auditCreate } = createMockDb(1);
+
+    const result = await applyAiSeverityToPriority(db, {
+      ...PARAMS,
+      enrichment: enrichment({ suggested_severity: 'high' }),
+      settings: settings(),
+    });
+
+    expect(result).toEqual({ applied: true, priority: 'high' });
+    // Conditional UPDATE guards on the bug still being at the default 'medium'.
+    const [sql, args] = query.mock.calls[0];
+    expect(sql).toContain('UPDATE application.bug_reports');
+    expect(args).toEqual(['high', 'bug-1', 'medium']);
+    expect(auditCreate).toHaveBeenCalledTimes(1);
+    expect(auditCreate.mock.calls[0][0]).toMatchObject({
+      action: 'bug_report.priority.ai_applied',
+      resource: 'bug_report',
+      resource_id: 'bug-1',
+      organization_id: 'org-1',
+      user_id: null,
+    });
+  });
+
+  it('skips when the flag is off (no DB write)', async () => {
+    const { db, query } = createMockDb(1);
+    const result = await applyAiSeverityToPriority(db, {
+      ...PARAMS,
+      enrichment: enrichment(),
+      settings: settings({ intelligence_auto_apply_severity: false }),
+    });
+    expect(result).toEqual({ applied: false, reason: 'disabled' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('skips when severity confidence is below the threshold', async () => {
+    const { db, query } = createMockDb(1);
+    const result = await applyAiSeverityToPriority(db, {
+      ...PARAMS,
+      enrichment: enrichment({
+        confidence: { category: 0.9, severity: 0.5, tags: 0.9, root_cause: 0.9, components: 0.9 },
+      }),
+      settings: settings(),
+    });
+    expect(result).toEqual({ applied: false, reason: 'below_threshold' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('skips an unrecognized severity value', async () => {
+    const { db, query } = createMockDb(1);
+    const result = await applyAiSeverityToPriority(db, {
+      ...PARAMS,
+      enrichment: enrichment({ suggested_severity: 'catastrophic' }),
+      settings: settings(),
+    });
+    expect(result).toEqual({ applied: false, reason: 'unknown_severity' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('does not audit when the bug priority is no longer the default (UPDATE matched 0 rows)', async () => {
+    const { db, auditCreate } = createMockDb(0);
+    const result = await applyAiSeverityToPriority(db, {
+      ...PARAMS,
+      enrichment: enrichment(),
+      settings: settings(),
+    });
+    expect(result).toEqual({ applied: false, reason: 'priority_not_default' });
+    expect(auditCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/tests/services/intelligence/severity-apply.test.ts
+++ b/packages/backend/tests/services/intelligence/severity-apply.test.ts
@@ -104,6 +104,18 @@ describe('applyAiSeverityToPriority', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('skips when the suggested severity is already the default priority (no write/audit)', async () => {
+    const { db, query, auditCreate } = createMockDb(1);
+    const result = await applyAiSeverityToPriority(db, {
+      ...PARAMS,
+      enrichment: enrichment({ suggested_severity: 'medium' }),
+      settings: settings(),
+    });
+    expect(result).toEqual({ applied: false, reason: 'priority_already_default' });
+    expect(query).not.toHaveBeenCalled();
+    expect(auditCreate).not.toHaveBeenCalled();
+  });
+
   it('skips an unrecognized severity value', async () => {
     const { db, query } = createMockDb(1);
     const result = await applyAiSeverityToPriority(db, {

--- a/packages/backend/tests/services/intelligence/severity-apply.test.ts
+++ b/packages/backend/tests/services/intelligence/severity-apply.test.ts
@@ -92,6 +92,18 @@ describe('applyAiSeverityToPriority', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('fails safe (skips, no write) when confidence is missing — no silent bypass', async () => {
+    const { db, query } = createMockDb(1);
+    const malformed = { ...enrichment(), confidence: undefined } as unknown as EnrichBugResponse;
+    const result = await applyAiSeverityToPriority(db, {
+      ...PARAMS,
+      enrichment: malformed,
+      settings: settings(),
+    });
+    expect(result).toEqual({ applied: false, reason: 'below_threshold' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
   it('skips an unrecognized severity value', async () => {
     const { db, query } = createMockDb(1);
     const result = await applyAiSeverityToPriority(db, {


### PR DESCRIPTION
Turns the AI severity from advisory into **applied** — the original "AI auto-prioritizes" gap. (Note: the bug's real field is `priority`, not `severity`; this maps the AI `suggested_severity` onto `bug_reports.priority`.)

**Behavior** (opt-in, org-gated, off by default): in the enrich worker, when `intelligence_auto_apply_severity` is on AND `confidence.severity ≥ intelligence_severity_apply_threshold` (default 0.8) AND the suggested severity maps to a known priority — set `bug_reports.priority` via an **atomic conditional UPDATE that only matches while the bug is still at the default `'medium'`**, so human triage is never overwritten. Applied changes are audit-logged (`bug_report.priority.ai_applied`, `user_id: null`).

**Safety**: non-fatal in the worker (a failure can't fail enrichment), unknown severity values are skipped, no overwrite of triaged bugs. No DB migration — the two new settings live in the organization JSONB.

Tier 2 backend slice (1 of 2); the admin UI toggle + threshold control follows. Validated: backend intelligence suite 152 + full unit suite 116 files green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic application of AI-suggested severity to bug priority, controllable per organization with a configurable confidence threshold.

* **Tests**
  * Added comprehensive tests covering successful auto-apply, feature-disabled, low/missing confidence, unknown severities, no-op when priority already default, and no-update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->