### PR TITLE
feat(admin): per-day cost & usage breakdown + CSV export

### DIFF
--- a/apps/admin/src/components/intelligence/observability-formatters.ts
+++ b/apps/admin/src/components/intelligence/observability-formatters.ts
@@ -5,6 +5,22 @@
  * functions can be unit-tested without rendering anything.
  */
 
+import type { ObservabilityDayStat } from '../../types/intelligence';
+
+/**
+ * Build a CSV (header + one row per day) for the per-day cost/usage export.
+ * Cost is emitted in dollars (micros / 1e6, 6dp) so the file is human-usable;
+ * tokens and calls are the raw counts.
+ */
+export function buildByDayCsv(rows: ObservabilityDayStat[]): string {
+  const header = 'day,calls,tokens_in,tokens_out,cost_usd';
+  const lines = rows.map(
+    (r) =>
+      `${r.day},${r.calls},${r.tokens_in},${r.tokens_out},${(r.cost_micros_usd / 1_000_000).toFixed(6)}`
+  );
+  return [header, ...lines].join('\n');
+}
+
 /** Upstream stores cost in micro-dollars. NULL means "unknown / not priced
  *  by the local pricing map" (Ollama etc.), distinct from $0. */
 export function formatCostUsd(micros: number | null | undefined, locale?: string): string {

--- a/apps/admin/src/components/intelligence/observability-panel.tsx
+++ b/apps/admin/src/components/intelligence/observability-panel.tsx
@@ -12,8 +12,24 @@ import { useTranslation } from 'react-i18next';
 import { AlertTriangle, Brain, ChevronDown, ChevronRight, Gauge } from 'lucide-react';
 import { Badge } from '../ui/badge';
 import { intelligenceService } from '../../services/intelligence-service';
-import type { ObservabilityEvent } from '../../types/intelligence';
-import { formatCostUsd, formatLatencyMs, formatPercent } from './observability-formatters';
+import type { ObservabilityDayStat, ObservabilityEvent } from '../../types/intelligence';
+import {
+  buildByDayCsv,
+  formatCostUsd,
+  formatLatencyMs,
+  formatPercent,
+} from './observability-formatters';
+
+/** Trigger a client-side CSV download of the per-day cost/usage rollup. */
+function downloadByDayCsv(rows: ObservabilityDayStat[]): void {
+  const blob = new Blob([buildByDayCsv(rows)], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = 'ai-cost-by-day.csv';
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
 
 interface ObservabilityPanelProps {
   orgId: string;
@@ -143,6 +159,67 @@ export function ObservabilityPanel({ orgId }: ObservabilityPanelProps) {
                     ))}
                   </tbody>
                 </table>
+              </div>
+            )}
+
+            {summaryQuery.data && (summaryQuery.data.by_day?.length ?? 0) > 0 && (
+              <div className="mt-4">
+                <div className="flex items-center justify-between mb-2">
+                  <h4 className="text-sm font-medium text-gray-700">
+                    {t('intelligence.observability.summary.byDayHeading')}
+                  </h4>
+                  <button
+                    type="button"
+                    onClick={() => downloadByDayCsv(summaryQuery.data?.by_day ?? [])}
+                    className="text-xs text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary rounded"
+                  >
+                    {t('intelligence.observability.summary.exportCsv')}
+                  </button>
+                </div>
+                <div className="border rounded-lg overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead className="bg-gray-50 text-gray-600 text-xs uppercase">
+                      <tr>
+                        <th className="text-left px-3 py-2 font-medium">
+                          {t('intelligence.observability.summary.colDay')}
+                        </th>
+                        <th className="text-right px-3 py-2 font-medium">
+                          {t('intelligence.observability.summary.calls')}
+                        </th>
+                        <th className="text-right px-3 py-2 font-medium">
+                          {t('intelligence.observability.summary.colTokensIn')}
+                        </th>
+                        <th className="text-right px-3 py-2 font-medium">
+                          {t('intelligence.observability.summary.colTokensOut')}
+                        </th>
+                        <th className="text-right px-3 py-2 font-medium">
+                          {t('intelligence.observability.summary.cost')}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                      {(summaryQuery.data.by_day ?? []).map((row) => (
+                        <tr key={row.day}>
+                          <td className="px-3 py-2 font-mono text-xs whitespace-nowrap">
+                            {row.day}
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            {row.calls.toLocaleString(locale)}
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            {row.tokens_in.toLocaleString(locale)}
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            {row.tokens_out.toLocaleString(locale)}
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            {formatCostUsd(row.cost_micros_usd, locale)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               </div>
             )}
           </section>

--- a/apps/admin/src/components/intelligence/observability-panel.tsx
+++ b/apps/admin/src/components/intelligence/observability-panel.tsx
@@ -27,7 +27,11 @@ function downloadByDayCsv(rows: ObservabilityDayStat[]): void {
   const anchor = document.createElement('a');
   anchor.href = url;
   anchor.download = 'ai-cost-by-day.csv';
+  // Attach to the DOM before click() — a detached anchor's click() is ignored
+  // in some browsers (older Firefox/Safari, sandboxed iframes).
+  document.body.appendChild(anchor);
   anchor.click();
+  anchor.remove();
   // Defer the revoke — revoking synchronously after click() can cancel the
   // download in Firefox/Safari before it starts (matches the health-export pattern).
   setTimeout(() => URL.revokeObjectURL(url), 100);

--- a/apps/admin/src/components/intelligence/observability-panel.tsx
+++ b/apps/admin/src/components/intelligence/observability-panel.tsx
@@ -28,7 +28,9 @@ function downloadByDayCsv(rows: ObservabilityDayStat[]): void {
   anchor.href = url;
   anchor.download = 'ai-cost-by-day.csv';
   anchor.click();
-  URL.revokeObjectURL(url);
+  // Defer the revoke — revoking synchronously after click() can cancel the
+  // download in Firefox/Safari before it starts (matches the health-export pattern).
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 interface ObservabilityPanelProps {

--- a/apps/admin/src/i18n/locales/en.json
+++ b/apps/admin/src/i18n/locales/en.json
@@ -1873,6 +1873,11 @@
         "p50Hint": "p50 {{value}}",
         "errorRate": "Error rate",
         "colOperation": "Operation",
+        "byDayHeading": "Cost & usage by day",
+        "exportCsv": "Export CSV",
+        "colDay": "Day",
+        "colTokensIn": "Tokens in",
+        "colTokensOut": "Tokens out",
         "loadFailed": "Could not load summary."
       },
       "accuracy": {

--- a/apps/admin/src/i18n/locales/kk.json
+++ b/apps/admin/src/i18n/locales/kk.json
@@ -1873,6 +1873,11 @@
         "p50Hint": "p50 {{value}}",
         "errorRate": "Қателер үлесі",
         "colOperation": "Операция",
+        "byDayHeading": "Күн бойынша шығын мен қолданыс",
+        "exportCsv": "CSV экспорттау",
+        "colDay": "Күн",
+        "colTokensIn": "Кіріс токендер",
+        "colTokensOut": "Шығыс токендер",
         "loadFailed": "Жиынтықты жүктеу мүмкін болмады."
       },
       "accuracy": {

--- a/apps/admin/src/i18n/locales/ru.json
+++ b/apps/admin/src/i18n/locales/ru.json
@@ -1873,6 +1873,11 @@
         "p50Hint": "p50 {{value}}",
         "errorRate": "Доля ошибок",
         "colOperation": "Операция",
+        "byDayHeading": "Стоимость и использование по дням",
+        "exportCsv": "Экспорт CSV",
+        "colDay": "День",
+        "colTokensIn": "Входные токены",
+        "colTokensOut": "Выходные токены",
         "loadFailed": "Не удалось загрузить сводку."
       },
       "accuracy": {

--- a/apps/admin/src/tests/components/intelligence/observability-formatters.test.ts
+++ b/apps/admin/src/tests/components/intelligence/observability-formatters.test.ts
@@ -1,9 +1,28 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildByDayCsv,
   formatCostUsd,
   formatLatencyMs,
   formatPercent,
 } from '../../../components/intelligence/observability-formatters';
+
+describe('buildByDayCsv', () => {
+  it('emits a header and one row per day, with cost in dollars', () => {
+    const csv = buildByDayCsv([
+      { day: '2026-06-13', calls: 3, cost_micros_usd: 1_200_000, tokens_in: 500, tokens_out: 200 },
+      { day: '2026-06-14', calls: 1, cost_micros_usd: 0, tokens_in: 40, tokens_out: 10 },
+    ]);
+    expect(csv).toBe(
+      'day,calls,tokens_in,tokens_out,cost_usd\n' +
+        '2026-06-13,3,500,200,1.200000\n' +
+        '2026-06-14,1,40,10,0.000000'
+    );
+  });
+
+  it('returns just the header for no rows', () => {
+    expect(buildByDayCsv([])).toBe('day,calls,tokens_in,tokens_out,cost_usd');
+  });
+});
 
 describe('formatCostUsd', () => {
   it('returns the em-dash sentinel for null / undefined / NaN', () => {

--- a/apps/admin/src/tests/components/intelligence/observability-panel.test.tsx
+++ b/apps/admin/src/tests/components/intelligence/observability-panel.test.tsx
@@ -90,6 +90,50 @@ describe('<ObservabilityPanel>', () => {
     expect(screen.getByText('2.0%')).toBeInTheDocument();
   });
 
+  it('renders the per-day cost & usage breakdown (with CSV export) when by_day is present', async () => {
+    vi.mocked(intelligenceService.getObservabilitySummary).mockResolvedValueOnce({
+      tenant_id: 'tenant-1',
+      from_ts: null,
+      to_ts: null,
+      calls: 4,
+      cost_micros_usd: 1_200_000,
+      p50_ms: 100,
+      p95_ms: 200,
+      error_rate: 0,
+      by_operation: [],
+      by_day: [
+        {
+          day: '2026-06-13',
+          calls: 3,
+          cost_micros_usd: 1_200_000,
+          tokens_in: 500,
+          tokens_out: 200,
+        },
+      ],
+    });
+    vi.mocked(intelligenceService.getObservabilityAccuracy).mockResolvedValueOnce({
+      tenant_id: 'tenant-1',
+      operation: null,
+      feedback_count: 0,
+      correct: 0,
+      incorrect: 0,
+      partial: 0,
+      precision: null,
+    });
+    vi.mocked(intelligenceService.getObservabilityEvents).mockResolvedValueOnce({
+      events: [],
+      limit: 50,
+      offset: 0,
+    });
+
+    render(<ObservabilityPanel orgId={ORG_ID} />, { wrapper });
+
+    expect(await screen.findByText('Cost & usage by day')).toBeInTheDocument();
+    expect(screen.getByText('2026-06-13')).toBeInTheDocument();
+    expect(screen.getByText('500')).toBeInTheDocument(); // tokens_in
+    expect(screen.getByRole('button', { name: 'Export CSV' })).toBeInTheDocument();
+  });
+
   it('shows the "not configured" alert when the summary endpoint returns 503', async () => {
     const err = Object.assign(new Error('not configured'), {
       response: { status: 503 },

--- a/apps/admin/src/types/intelligence.ts
+++ b/apps/admin/src/types/intelligence.ts
@@ -190,6 +190,15 @@ export interface ObservabilityOpStat {
   cost_micros_usd: number;
 }
 
+export interface ObservabilityDayStat {
+  /** ISO date (YYYY-MM-DD). */
+  day: string;
+  calls: number;
+  cost_micros_usd: number;
+  tokens_in: number;
+  tokens_out: number;
+}
+
 export interface ObservabilitySummary {
   tenant_id: string | null;
   from_ts: string | null;
@@ -201,6 +210,8 @@ export interface ObservabilitySummary {
   /** 0..1 fraction of calls with status=error in the window. */
   error_rate: number;
   by_operation: ObservabilityOpStat[];
+  /** Per-day cost + token rollup; optional — absent from older/cached upstream. */
+  by_day?: ObservabilityDayStat[];
 }
 
 export interface ObservabilityEvent {

--- a/packages/backend/src/services/intelligence/types.ts
+++ b/packages/backend/src/services/intelligence/types.ts
@@ -236,6 +236,15 @@ export interface ObservabilityOpStat {
   cost_micros_usd: number;
 }
 
+export interface ObservabilityDayStat {
+  /** ISO date (YYYY-MM-DD). */
+  day: string;
+  calls: number;
+  cost_micros_usd: number;
+  tokens_in: number;
+  tokens_out: number;
+}
+
 export interface ObservabilitySummaryResponse {
   tenant_id: string | null;
   from_ts: string | null;
@@ -246,6 +255,8 @@ export interface ObservabilitySummaryResponse {
   p95_ms: number | null;
   error_rate: number;
   by_operation: ObservabilityOpStat[];
+  /** Per-day rollup; optional — absent from older/cached upstream responses. */
+  by_day?: ObservabilityDayStat[];
 }
 
 export interface ObservabilityEvent {


### PR DESCRIPTION
Consumes the upstream `by_day` rollup (intelligence#41) to give operators the per-org cost dashboard (Sprint 2 #4) on the observability panel.

- **Per-day table**: day, calls, tokens in/out, cost — **tokens-led** (always populated, incl. Ollama), with **cost as the derived $ estimate** (dash when unpriced).
- **CSV export** of the per-day rollup (`buildByDayCsv`, extracted as a tested pure helper; download is thin DOM glue).
- `by_day` typed **optional** on both summary types; the section hides when absent, so it's safe during the deploy/cache window before #41 is everywhere. The proxy route has no response schema, so the field passes through untouched.
- en/ru/kk i18n.

Validated: i18n synced (1857×3), formatters + panel tests 16/16 (incl. CSV-builder + by_day render), admin lint 0, strict build, backend typecheck clean.

PR 2 of 2 for the cost dashboard. Deferred sub-feature: **alert thresholds** (a separate piece — per-org budget setting + alerting, not just a dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Cost & usage by day” section to the observability summary when per-day data is available.
  * Added client-side “Export CSV” to download the by-day usage and cost breakdown.
* **Documentation/Localization**
  * Added new localization strings for the by-day view, CSV export label, and related column headers (English, Kazakh, Russian).
* **Tests**
  * Added/updated tests to verify CSV output formatting and that the by-day UI renders correctly with an export button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->