### PR TITLE
fix(compose): default CLAUDE_MODEL to claude-sonnet-4-6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -938,7 +938,7 @@ services:
       OLLAMA_TIMEOUT: ${INTELLIGENCE_OLLAMA_TIMEOUT:-240}
       # Claude (optional, if using Claude instead of Ollama)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      CLAUDE_MODEL: ${CLAUDE_MODEL:-claude-sonnet-4-20250514}
+      CLAUDE_MODEL: ${CLAUDE_MODEL:-claude-sonnet-4-6}
       # Embedding. The intelligence service migrates the bug_embeddings
       # column to vector(1024) on startup (see migrations.py). The active
       # embedding model MUST produce 1024-dim vectors — i.e. BAAI/bge-m3.


### PR DESCRIPTION
`claude-sonnet-4-20250514` retired 2026-06-15, so the compose default makes every Claude enrichment 404 unless `CLAUDE_MODEL` is set in `.env`. Point the default at the current Sonnet id. Verified in prod: with `claude-sonnet-4-6`, enrichment succeeds and cost records correctly (paired with bs-intelligence #46).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model version used by the intelligence service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->