### PR TITLE
fix(admin): dedup-rules back button returns to projects list

### DIFF
--- a/apps/admin/src/pages/dedup-rules.tsx
+++ b/apps/admin/src/pages/dedup-rules.tsx
@@ -108,8 +108,11 @@ export default function DedupRulesPage() {
   }, [deletingRuleId, deleteRule]);
 
   const handleBackNavigation = useCallback(() => {
-    navigate(`/projects/${projectId}`);
-  }, [projectId, navigate]);
+    // There is no /projects/:projectId detail route — navigating there was a
+    // silent no-op. Return to the projects list, matching the sibling pages
+    // (project-members, project-integrations).
+    navigate('/projects');
+  }, [navigate]);
 
   if (!projectId) {
     return (

--- a/apps/admin/src/tests/pages/dedup-rules-back-nav.test.tsx
+++ b/apps/admin/src/tests/pages/dedup-rules-back-nav.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import DedupRulesPage from '../../pages/dedup-rules';
+
+// Regression: the back button used to navigate('/projects/:projectId') — a
+// route that doesn't exist (there is no project-detail page), so the click was
+// a silent no-op. It must return to the projects list like the sibling pages.
+
+const mockNavigate = vi.fn();
+const mockProjectId = '123e4567-e89b-12d3-a456-426614174000';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: vi.fn().mockResolvedValue('en') },
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../../services/dedup-rules-service', () => ({
+  dedupRulesService: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('../../hooks/use-dedup-rules', () => ({
+  DEDUP_RULES_QUERY_KEY: 'dedupRules',
+  useDedupRules: () => ({
+    create: { mutate: vi.fn() },
+    update: { mutate: vi.fn() },
+    toggleEnabled: { mutate: vi.fn() },
+    deleteRule: { mutate: vi.fn() },
+  }),
+}));
+
+vi.mock('../../hooks/use-project-permissions', () => ({
+  useProjectPermissions: () => ({ canManageIntegrations: true }),
+}));
+
+vi.mock('../../lib/api-client', () => ({
+  handleApiError: (e: unknown) => (e instanceof Error ? e.message : 'Unknown error'),
+}));
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => <div data-testid="arrow-left-icon" />,
+  Plus: () => <div data-testid="plus-icon" />,
+}));
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children?: React.ReactNode;
+}
+vi.mock('../../components/ui/button', () => ({
+  Button: ({ children, onClick, ...props }: ButtonProps) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+interface DivProps extends React.HTMLAttributes<HTMLDivElement> {
+  children?: React.ReactNode;
+}
+vi.mock('../../components/ui/card', () => ({
+  Card: ({ children, ...props }: DivProps) => <div {...props}>{children}</div>,
+  CardContent: ({ children }: DivProps) => <div>{children}</div>,
+}));
+vi.mock('../../components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: DivProps) => <div>{children}</div>,
+}));
+vi.mock('../../components/dedup-rules/rule-card', () => ({ DedupRuleCard: () => null }));
+vi.mock('../../components/dedup-rules/rule-form-dialog', () => ({
+  DedupRuleFormDialog: () => null,
+}));
+vi.mock('../../components/dedup-rules/delete-dialog', () => ({
+  DedupRuleDeleteDialog: () => null,
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/projects/${mockProjectId}/dedup-rules`]}>
+        <Routes>
+          <Route path="/projects/:projectId/dedup-rules" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('DedupRulesPage — back navigation', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('returns to the projects list (not a nonexistent project-detail route)', async () => {
+    render(<DedupRulesPage />, { wrapper });
+
+    const backButton = await screen.findByRole('button', {
+      name: /dedupRules\.backToProject/i,
+    });
+    fireEvent.click(backButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/projects');
+    // Guard the exact regression: never the unmatched /projects/:id route.
+    expect(mockNavigate).not.toHaveBeenCalledWith(`/projects/${mockProjectId}`);
+  });
+});

--- a/apps/admin/src/tests/pages/dedup-rules-back-nav.test.tsx
+++ b/apps/admin/src/tests/pages/dedup-rules-back-nav.test.tsx
@@ -79,17 +79,21 @@ vi.mock('../../components/dedup-rules/delete-dialog', () => ({
   DedupRuleDeleteDialog: () => null,
 }));
 
-function wrapper({ children }: { children: React.ReactNode }) {
+// Factory so the QueryClient is created once per test (in the closure), not on
+// every render of the wrapper component.
+function createWrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[`/projects/${mockProjectId}/dedup-rules`]}>
-        <Routes>
-          <Route path="/projects/:projectId/dedup-rules" element={children} />
-        </Routes>
-      </MemoryRouter>
-    </QueryClientProvider>
-  );
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/projects/${mockProjectId}/dedup-rules`]}>
+          <Routes>
+            <Route path="/projects/:projectId/dedup-rules" element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
 }
 
 describe('DedupRulesPage — back navigation', () => {
@@ -98,7 +102,7 @@ describe('DedupRulesPage — back navigation', () => {
   });
 
   it('returns to the projects list (not a nonexistent project-detail route)', async () => {
-    render(<DedupRulesPage />, { wrapper });
+    render(<DedupRulesPage />, { wrapper: createWrapper() });
 
     const backButton = await screen.findByRole('button', {
       name: /dedupRules\.backToProject/i,


### PR DESCRIPTION
The back arrow on the deduplication-rules page navigated to `/projects/:projectId`, which has no route (there's no project-detail page), so clicking it did nothing. Navigate to `/projects` instead, matching the sibling pages (`project-members`, `project-integrations`). Adds a regression test. Reported from prod (the circled back arrow was a no-op).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed back button navigation on the dedup rules page to always return users to the general projects list (instead of navigating to a project-specific URL).

* **Tests**
  * Added a regression test to verify the back navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->