### PR TITLE
ci: auto-add issues and PRs to project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add to Project Board
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/apex-bridge/projects/1
+          github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,19 @@ Thank you for your interest in contributing to BugSpotter! This document provide
 
 ## 🤝 How to Contribute
 
+## 📋 Task Tracking
+
+All work is tracked in the [BugSpotter Tasks](https://github.com/orgs/apex-bridge/projects/1) project board.
+
+New issues and PRs opened in any of the active repos are **automatically added** to the board via the `add-to-project.yml` workflow. Set the **Status** field to track progress:
+
+| Status | Meaning |
+|--------|---------|
+| Todo | Not started yet |
+| In Progress | Actively being worked on |
+| Done | Merged / closed |
+
+
 ### Reporting Bugs
 
 If you find a bug, please create an issue with:
@@ -309,6 +322,8 @@ Our GitHub Actions workflow (`ci.yml`) verifies:
 5. **Coverage** - Generates coverage reports for SDK and API
 
 **Important:** The CI workflow expects the standard pnpm workspace structure. If you change directory structure, update `.github/workflows/ci.yml` accordingly.
+
+New issues and PRs are also automatically added to the project board by `.github/workflows/add-to-project.yml`.
 
 ## 🎯 Development Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,6 @@ We love pull requests! Here's how to contribute code:
    ```
 
 4. **Make your changes**
-
    - Write clean, readable code
    - Follow existing code style
    - Add tests for new features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ We love pull requests! Here's how to contribute code:
    ```
 
 4. **Make your changes**
+
    - Write clean, readable code
    - Follow existing code style
    - Add tests for new features
@@ -173,18 +174,18 @@ pnpm test --coverage
 All new features should include tests:
 
 ```typescript
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from 'vitest';
 
-describe("MyFeature", () => {
-  it("should do something", () => {
+describe('MyFeature', () => {
+  it('should do something', () => {
     // Arrange
-    const input = "test";
+    const input = 'test';
 
     // Act
     const result = myFunction(input);
 
     // Assert
-    expect(result).toBe("expected");
+    expect(result).toBe('expected');
   });
 });
 ```
@@ -384,18 +385,18 @@ const bugSpotter = BugSpotter.init({
 
 // Check captured data
 const report = await bugSpotter.capture();
-console.log("Screenshot:", report.screenshot.substring(0, 50));
-console.log("Console logs:", report.console);
-console.log("Network:", report.network);
-console.log("Metadata:", report.metadata);
+console.log('Screenshot:', report.screenshot.substring(0, 50));
+console.log('Console logs:', report.console);
+console.log('Network:', report.network);
+console.log('Metadata:', report.metadata);
 ```
 
 ### Test Debugging
 
 ```typescript
 // Use .only to focus on one test
-it.only("should debug this test", () => {
-  console.log("Debug output");
+it.only('should debug this test', () => {
+  console.log('Debug output');
   expect(true).toBe(true);
 });
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,11 @@ All work is tracked in the [BugSpotter Tasks](https://github.com/orgs/apex-bridg
 
 New issues and PRs opened in any of the active repos are **automatically added** to the board via the `add-to-project.yml` workflow. Set the **Status** field to track progress:
 
-| Status | Meaning |
-|--------|---------|
-| Todo | Not started yet |
+| Status      | Meaning                  |
+| ----------- | ------------------------ |
+| Todo        | Not started yet          |
 | In Progress | Actively being worked on |
-| Done | Merged / closed |
-
+| Done        | Merged / closed          |
 
 ### Reporting Bugs
 
@@ -174,18 +173,18 @@ pnpm test --coverage
 All new features should include tests:
 
 ```typescript
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 
-describe('MyFeature', () => {
-  it('should do something', () => {
+describe("MyFeature", () => {
+  it("should do something", () => {
     // Arrange
-    const input = 'test';
+    const input = "test";
 
     // Act
     const result = myFunction(input);
 
     // Assert
-    expect(result).toBe('expected');
+    expect(result).toBe("expected");
   });
 });
 ```
@@ -385,18 +384,18 @@ const bugSpotter = BugSpotter.init({
 
 // Check captured data
 const report = await bugSpotter.capture();
-console.log('Screenshot:', report.screenshot.substring(0, 50));
-console.log('Console logs:', report.console);
-console.log('Network:', report.network);
-console.log('Metadata:', report.metadata);
+console.log("Screenshot:", report.screenshot.substring(0, 50));
+console.log("Console logs:", report.console);
+console.log("Network:", report.network);
+console.log("Metadata:", report.metadata);
 ```
 
 ### Test Debugging
 
 ```typescript
 // Use .only to focus on one test
-it.only('should debug this test', () => {
-  console.log('Debug output');
+it.only("should debug this test", () => {
+  console.log("Debug output");
   expect(true).toBe(true);
 });
 ```


### PR DESCRIPTION
Adds `.github/workflows/add-to-project.yml` — uses `actions/add-to-project` to automatically add new issues and PRs to the [BugSpotter Tasks](https://github.com/orgs/apex-bridge/projects/1) project board. Requires the org-level `PROJECT_TOKEN` secret (already set).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automation to automatically add newly opened issues and pull requests to the project tracking board.
* **Documentation**
  * Updated contribution guidance with a clearer task-tracking status table.
  * Refreshed test-writing and CI/CD examples for consistency, including notes about project board updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->