### PR TITLE
SDLC 0.2: agent-commit attribution trailer + guard

### DIFF
--- a/.github/workflows/commit-trailers.yml
+++ b/.github/workflows/commit-trailers.yml
@@ -1,0 +1,38 @@
+name: Commit Trailers
+
+# Deterministic (Tier-1) guard: validates the agent-attribution commit
+# trailer FORMAT on every commit in a PR. The convention lives in
+# CONTRIBUTING.md ("Commit attribution trailer").
+#
+# Presence of the trailer is convention-driven (agents add it) - this job
+# only enforces that a present trailer is well-formed, so the code-metrics
+# attribution layer can parse it reliably. Fail-closed.
+#
+# This is intentionally a standalone required-check candidate, separate
+# from the main `CI` aggregator. To make it a merge gate, add the
+# "Commit Trailers" status check to branch protection on `main`
+# (rides on the gate armed in #199). Tracks #200.
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  commit-trailers:
+    name: Commit Trailers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for the range)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate attribution trailers
+        run: >
+          node scripts/check-commit-trailers.mjs
+          --range "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/commit-trailers.yml
+++ b/.github/workflows/commit-trailers.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Test the trailer checker
+        run: node --test scripts/check-commit-trailers.test.mjs
+
       - name: Validate attribution trailers
         run: >
           node scripts/check-commit-trailers.mjs

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+node scripts/check-commit-trailers.mjs --message "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,6 +415,34 @@ it.only('should debug this test', () => {
 - [Conventional Commits](https://www.conventionalcommits.org/)
 - [Semantic Versioning](https://semver.org/)
 
+## 🏷️ Commit attribution trailer
+
+Agent-assisted commits carry a git trailer so we can measure agent-vs-human
+code outcomes honestly. When a commit's code was generated with an AI agent,
+add a trailer line:
+
+```
+Assisted-by: <tool-or-model> (agent)
+```
+
+For example: `Assisted-by: claude-opus-4-8 (agent)`. A human may optionally
+mark their own work with `(human)`; that is not required.
+
+Rules:
+
+- The trailer goes in the commit **message body** (a trailer line, like
+  `Co-Authored-By:`), not the code diff.
+- It is validated by format only. The `commit-msg` hook and the
+  **Commit Trailers** CI check reject a malformed trailer, but they do
+  **not** force a trailer onto every commit - there is no deterministic
+  human-vs-agent signal to key on, so presence is a convention agents
+  follow, not a machine-enforced gate. That honest limit is the point: the
+  check guarantees the attribution data is _parseable_, not that it is
+  _complete_.
+- This trailer is the attribution key for the code-metrics layer
+  (agent-vs-human change-failure rate). It cannot be backfilled onto old
+  history, so start using it now.
+
 ## ❓ Questions?
 
 - Create a [GitHub Discussion](https://github.com/apex-bridge/bugspotter/discussions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -430,8 +430,11 @@ mark their own work with `(human)`; that is not required.
 
 Rules:
 
-- The trailer goes in the commit **message body** (a trailer line, like
-  `Co-Authored-By:`), not the code diff.
+- The trailer goes at the very end of the commit **message body**, as a
+  standard git trailer line (like `Co-Authored-By:`), separated from the
+  rest of the body by a blank line - not in the code diff. Trailers placed
+  anywhere but the final block are invisible to `git interpret-trailers`
+  and to the metrics parser.
 - It is validated by format only. The `commit-msg` hook and the
   **Commit Trailers** CI check reject a malformed trailer, but they do
   **not** force a trailer onto every commit - there is no deterministic

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -91,7 +91,7 @@ function main() {
     // execFileSync (no shell) - avoids any command-injection surface.
     const shas = execFileSync('git', ['rev-list', range], { encoding: 'utf8' })
       .trim()
-      .split('\n')
+      .split(/\r?\n/)
       .filter(Boolean);
     for (const sha of shas) {
       const body = execFileSync('git', ['show', '-s', '--format=%B', sha], { encoding: 'utf8' });

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -18,7 +18,7 @@
 //   node scripts/check-commit-trailers.mjs --range <base>..<head>  # a commit range (CI)
 
 import { readFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const IS_TRAILER = /^Assisted-by:/i;
 const IS_VALID = /^Assisted-by: .+ \((agent|human)\)$/;
@@ -41,15 +41,25 @@ function main() {
   const problems = [];
 
   if (mi !== -1) {
-    problems.push(...validate('(staged)', readFileSync(args[mi + 1], 'utf8')));
+    const file = args[mi + 1];
+    if (!file) {
+      console.error('usage: --message <file>');
+      process.exit(2);
+    }
+    problems.push(...validate('(staged)', readFileSync(file, 'utf8')));
   } else if (ri !== -1) {
     const range = args[ri + 1];
-    const shas = execSync(`git rev-list ${range}`, { encoding: 'utf8' })
+    if (!range) {
+      console.error('usage: --range <base>..<head>');
+      process.exit(2);
+    }
+    // execFileSync (no shell) - avoids any command-injection surface.
+    const shas = execFileSync('git', ['rev-list', range], { encoding: 'utf8' })
       .trim()
       .split('\n')
       .filter(Boolean);
     for (const sha of shas) {
-      const body = execSync(`git show -s --format=%B ${sha}`, { encoding: 'utf8' });
+      const body = execFileSync('git', ['show', '-s', '--format=%B', sha], { encoding: 'utf8' });
       problems.push(...validate(sha.slice(0, 8), body));
     }
   } else {

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -86,7 +86,14 @@ function main() {
       console.error('usage: --message <file>');
       process.exit(2);
     }
-    problems.push(...validate('(staged)', readFileSync(file, 'utf8')));
+    let content;
+    try {
+      content = readFileSync(file, 'utf8');
+    } catch (e) {
+      console.error(`Error: cannot read commit message file "${file}": ${e.message}`);
+      process.exit(1);
+    }
+    problems.push(...validate('(staged)', content));
   } else if (ri !== -1) {
     const range = args[ri + 1];
     if (!range) {

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -21,7 +21,7 @@ import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
 const IS_TRAILER = /^Assisted-by:/i;
-const IS_VALID = /^Assisted-by: .+ \((agent|human)\)$/;
+const IS_VALID = /^Assisted-by: \S.* \((agent|human)\)$/;
 const IS_COMMENT = /^\s*#/;
 
 // Drop comment lines so the local commit-msg path (editor template comments)
@@ -89,10 +89,16 @@ function main() {
       process.exit(2);
     }
     // execFileSync (no shell) - avoids any command-injection surface.
-    const shas = execFileSync('git', ['rev-list', range], { encoding: 'utf8' })
-      .trim()
-      .split(/\r?\n/)
-      .filter(Boolean);
+    let shas;
+    try {
+      shas = execFileSync('git', ['rev-list', range], { encoding: 'utf8' })
+        .trim()
+        .split(/\r?\n/)
+        .filter(Boolean);
+    } catch (e) {
+      console.error(`Error: cannot resolve commit range "${range}": ${e.message}`);
+      process.exit(1);
+    }
     for (const sha of shas) {
       const body = execFileSync('git', ['show', '-s', '--format=%B', sha], { encoding: 'utf8' });
       problems.push(...validate(sha.slice(0, 8), body));

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -22,13 +22,48 @@ import { execFileSync } from 'node:child_process';
 
 const IS_TRAILER = /^Assisted-by:/i;
 const IS_VALID = /^Assisted-by: .+ \((agent|human)\)$/;
+const IS_COMMENT = /^\s*#/;
 
-function validate(sha, body) {
+// Drop comment lines so the local commit-msg path (editor template comments)
+// matches git's own cleanup before it looks for trailers.
+function stripComments(body) {
+  return body
+    .split(/\r?\n/)
+    .filter((l) => !IS_COMMENT.test(l))
+    .join('\n');
+}
+
+// Git's own view of the trailer block - authoritative for "will this be
+// recognized as a trailer at all?" (i.e. is it in the final, blank-line-
+// separated block). Returns null if git is unavailable, so we degrade to a
+// format-only scan rather than failing open.
+function gitTrailers(body) {
+  try {
+    return execFileSync('git', ['interpret-trailers', '--parse'], {
+      input: body,
+      encoding: 'utf8',
+    })
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function validate(sha, rawBody) {
+  const body = stripComments(rawBody);
+  const parsed = gitTrailers(body);
   const problems = [];
   for (const raw of body.split(/\r?\n/)) {
     const line = raw.trim();
-    if (IS_TRAILER.test(line) && !IS_VALID.test(line)) {
-      problems.push({ sha, line });
+    if (!IS_TRAILER.test(line)) continue;
+    const recognized =
+      parsed === null || parsed.some((p) => p.toLowerCase() === line.toLowerCase());
+    if (!recognized) {
+      problems.push({ sha, line, reason: 'misplaced - must be in the final block, separated by a blank line' });
+    } else if (!IS_VALID.test(line)) {
+      problems.push({ sha, line, reason: 'malformed - expected "Assisted-by: <tool-or-model> (agent)"' });
     }
   }
   return problems;
@@ -68,8 +103,8 @@ function main() {
   }
 
   if (problems.length) {
-    console.error('Malformed attribution trailer(s). Expected: "Assisted-by: <tool-or-model> (agent)"');
-    for (const p of problems) console.error(`  ${p.sha}: ${p.line}`);
+    console.error('Invalid commit attribution trailer(s):');
+    for (const p of problems) console.error(`  ${p.sha}: "${p.line}" -> ${p.reason}`);
     process.exit(1);
   }
   console.log('Commit attribution trailers OK.');

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -93,20 +93,21 @@ function main() {
       console.error('usage: --range <base>..<head>');
       process.exit(2);
     }
-    // execFileSync (no shell) - avoids any command-injection surface.
-    let shas;
+    // One `git log` call (execFileSync, no shell) instead of a `git show`
+    // per commit: full hash + raw body per commit, NUL-delimited. git ends
+    // each commit's output with a newline, so hash entries after a split on
+    // NUL carry a leading newline - the sha.trim() below absorbs it.
+    let out;
     try {
-      shas = execFileSync('git', ['rev-list', range], { encoding: 'utf8' })
-        .trim()
-        .split(/\r?\n/)
-        .filter(Boolean);
+      out = execFileSync('git', ['log', '--format=%H%x00%B%x00', range], { encoding: 'utf8' });
     } catch (e) {
       console.error(`Error: cannot resolve commit range "${range}": ${e.message}`);
       process.exit(1);
     }
-    for (const sha of shas) {
-      const body = execFileSync('git', ['show', '-s', '--format=%B', sha], { encoding: 'utf8' });
-      problems.push(...validate(sha.slice(0, 8), body));
+    const parts = out.split('\0');
+    for (let i = 0; i + 1 < parts.length; i += 2) {
+      const sha = parts[i].trim();
+      if (sha) problems.push(...validate(sha.slice(0, 8), parts[i + 1]));
     }
   } else {
     console.error('usage: --message <file> | --range <base>..<head>');

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -58,12 +58,17 @@ function validate(sha, rawBody) {
   for (const raw of body.split(/\r?\n/)) {
     const line = raw.trim();
     if (!IS_TRAILER.test(line)) continue;
+    // Format first: a malformed trailer (e.g. double-spaced) must not be
+    // mislabeled "misplaced" just because git's normalized parse won't match
+    // it. Only a well-formed trailer is then checked for placement.
+    if (!IS_VALID.test(line)) {
+      problems.push({ sha, line, reason: 'malformed - expected "Assisted-by: <tool-or-model> (agent)"' });
+      continue;
+    }
     const recognized =
       parsed === null || parsed.some((p) => p.toLowerCase() === line.toLowerCase());
     if (!recognized) {
       problems.push({ sha, line, reason: 'misplaced - must be in the final block, separated by a blank line' });
-    } else if (!IS_VALID.test(line)) {
-      problems.push({ sha, line, reason: 'malformed - expected "Assisted-by: <tool-or-model> (agent)"' });
     }
   }
   return problems;

--- a/scripts/check-commit-trailers.mjs
+++ b/scripts/check-commit-trailers.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Validate the agent-attribution commit trailer FORMAT.
+//
+// Convention (see CONTRIBUTING.md "Commit attribution trailer"): an
+// agent-assisted commit carries a git trailer
+//
+//     Assisted-by: <tool-or-model> (agent)
+//
+// A human may optionally mark their own with `(human)`. Presence is
+// convention-driven - agents add it; this check does NOT force it onto
+// every commit (there is no deterministic human-vs-agent signal to key
+// on). It only validates that a trailer, WHEN present, is well-formed, so
+// the code-metrics attribution layer can parse it reliably. Deterministic,
+// fail-closed (Tier-1). See sdlc-migration-plan.md 0.2.
+//
+// Usage:
+//   node scripts/check-commit-trailers.mjs --message <path>        # one commit-msg file (commit-msg hook)
+//   node scripts/check-commit-trailers.mjs --range <base>..<head>  # a commit range (CI)
+
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const IS_TRAILER = /^Assisted-by:/i;
+const IS_VALID = /^Assisted-by: .+ \((agent|human)\)$/;
+
+function validate(sha, body) {
+  const problems = [];
+  for (const raw of body.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (IS_TRAILER.test(line) && !IS_VALID.test(line)) {
+      problems.push({ sha, line });
+    }
+  }
+  return problems;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const mi = args.indexOf('--message');
+  const ri = args.indexOf('--range');
+  const problems = [];
+
+  if (mi !== -1) {
+    problems.push(...validate('(staged)', readFileSync(args[mi + 1], 'utf8')));
+  } else if (ri !== -1) {
+    const range = args[ri + 1];
+    const shas = execSync(`git rev-list ${range}`, { encoding: 'utf8' })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    for (const sha of shas) {
+      const body = execSync(`git show -s --format=%B ${sha}`, { encoding: 'utf8' });
+      problems.push(...validate(sha.slice(0, 8), body));
+    }
+  } else {
+    console.error('usage: --message <file> | --range <base>..<head>');
+    process.exit(2);
+  }
+
+  if (problems.length) {
+    console.error('Malformed attribution trailer(s). Expected: "Assisted-by: <tool-or-model> (agent)"');
+    for (const p of problems) console.error(`  ${p.sha}: ${p.line}`);
+    process.exit(1);
+  }
+  console.log('Commit attribution trailers OK.');
+}
+
+main();

--- a/scripts/check-commit-trailers.test.mjs
+++ b/scripts/check-commit-trailers.test.mjs
@@ -1,0 +1,60 @@
+// Tests for check-commit-trailers.mjs. Zero-dependency: run with `node --test`.
+// Wired into .github/workflows/commit-trailers.yml so the guard cannot silently
+// rot. The `misplaced` case relies on `git interpret-trailers` being available
+// (it is on CI runners and dev machines).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('./check-commit-trailers.mjs', import.meta.url));
+const DIR = mkdtempSync(join(tmpdir(), 'trailer-test-'));
+
+// Run the checker against a commit-message body; return { code, out }.
+function run(body) {
+  const file = join(DIR, `msg-${Math.random().toString(36).slice(2)}.txt`);
+  writeFileSync(file, body);
+  try {
+    const out = execFileSync('node', [SCRIPT, '--message', file], { encoding: 'utf8' });
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status, out: `${e.stdout || ''}${e.stderr || ''}` };
+  }
+}
+
+test('valid, well-placed trailer passes', () => {
+  assert.equal(run('feat: x\n\nAssisted-by: claude-opus-4-8 (agent)\n').code, 0);
+});
+
+test('malformed trailer fails with reason', () => {
+  const r = run('feat: x\n\nAssisted-by: claude-opus-4-8\n');
+  assert.equal(r.code, 1);
+  assert.match(r.out, /malformed/);
+});
+
+test('misplaced trailer (not final block) fails with reason', () => {
+  const r = run('feat: x\n\nAssisted-by: claude-opus-4-8 (agent)\n\nmore body after it\n');
+  assert.equal(r.code, 1);
+  assert.match(r.out, /misplaced/);
+});
+
+test('editor comment lines are ignored', () => {
+  assert.equal(run('feat: x\n\nAssisted-by: claude-opus-4-8 (agent)\n# a comment\n').code, 0);
+});
+
+test('no trailer passes (presence is not forced)', () => {
+  assert.equal(run('feat: x\n\njust a human commit\n').code, 0);
+});
+
+test('missing --message argument exits 2', () => {
+  try {
+    execFileSync('node', [SCRIPT, '--message'], { encoding: 'utf8' });
+    assert.fail('expected non-zero exit');
+  } catch (e) {
+    assert.equal(e.status, 2);
+  }
+});

--- a/scripts/check-commit-trailers.test.mjs
+++ b/scripts/check-commit-trailers.test.mjs
@@ -3,16 +3,18 @@
 // rot. The `misplaced` case relies on `git interpret-trailers` being available
 // (it is on CI runners and dev machines).
 
-import { test } from 'node:test';
+import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { writeFileSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SCRIPT = fileURLToPath(new URL('./check-commit-trailers.mjs', import.meta.url));
 const DIR = mkdtempSync(join(tmpdir(), 'trailer-test-'));
+
+after(() => rmSync(DIR, { recursive: true, force: true }));
 
 // Run the checker against a commit-message body; return { code, out }.
 function run(body) {

--- a/scripts/check-commit-trailers.test.mjs
+++ b/scripts/check-commit-trailers.test.mjs
@@ -44,6 +44,13 @@ test('misplaced trailer (not final block) fails with reason', () => {
   assert.match(r.out, /misplaced/);
 });
 
+test('double-spaced trailer reports malformed, not misplaced', () => {
+  const r = run('feat: x\n\nAssisted-by:  claude-opus-4-8 (agent)\n');
+  assert.equal(r.code, 1);
+  assert.match(r.out, /malformed/);
+  assert.doesNotMatch(r.out, /misplaced/);
+});
+
 test('editor comment lines are ignored', () => {
   assert.equal(run('feat: x\n\nAssisted-by: claude-opus-4-8 (agent)\n# a comment\n').code, 0);
 });

--- a/scripts/check-commit-trailers.test.mjs
+++ b/scripts/check-commit-trailers.test.mjs
@@ -67,3 +67,33 @@ test('missing --message argument exits 2', () => {
     assert.equal(e.status, 2);
   }
 });
+
+// Integration test for the --range path (the CI gate). Builds a throwaway
+// repo with a good commit and a malformed one, then checks the range.
+test('range mode catches a malformed trailer across commits', () => {
+  const repo = mkdtempSync(join(tmpdir(), 'trailer-repo-'));
+  const git = (...a) => execFileSync('git', a, { cwd: repo, encoding: 'utf8' });
+  try {
+    git('init', '-q');
+    git('config', 'user.email', 't@example.com');
+    git('config', 'user.name', 'Test');
+    git('config', 'commit.gpgsign', 'false');
+    writeFileSync(join(repo, 'a.txt'), '1');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'good\n\nAssisted-by: claude-opus-4-8 (agent)');
+    const base = git('rev-parse', 'HEAD').trim();
+    writeFileSync(join(repo, 'b.txt'), '2');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'bad\n\nAssisted-by: claude-opus-4-8'); // no (agent)
+    const head = git('rev-parse', 'HEAD').trim();
+    try {
+      execFileSync('node', [SCRIPT, '--range', `${base}..${head}`], { cwd: repo, encoding: 'utf8' });
+      assert.fail('expected non-zero exit');
+    } catch (e) {
+      assert.equal(e.status, 1);
+      assert.match(`${e.stdout || ''}${e.stderr || ''}`, /malformed/);
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-commit-trailers.test.mjs
+++ b/scripts/check-commit-trailers.test.mjs
@@ -68,6 +68,16 @@ test('missing --message argument exits 2', () => {
   }
 });
 
+test('unreadable --message file exits 1 with a clean error', () => {
+  try {
+    execFileSync('node', [SCRIPT, '--message', join(DIR, 'does-not-exist.txt')], { encoding: 'utf8' });
+    assert.fail('expected non-zero exit');
+  } catch (e) {
+    assert.equal(e.status, 1);
+    assert.match(`${e.stdout || ''}${e.stderr || ''}`, /cannot read/);
+  }
+});
+
 // Integration test for the --range path (the CI gate). Builds a throwaway
 // repo with a good commit and a malformed one, then checks the range.
 test('range mode catches a malformed trailer across commits', () => {


### PR DESCRIPTION
Deterministic Tier-1 guard for the code-metrics attribution key: a `commit-msg` hook plus a standalone `Commit Trailers` CI check that validate the `Assisted-by: <model> (agent)` trailer format, with the convention documented in CONTRIBUTING.md. Presence stays convention-driven (there is no reliable human-vs-agent signal), so the check only guarantees a present trailer is parseable, not that attribution is complete. Uses `commit-msg` rather than a pre-commit mirror because trailers live in the message, not the staged diff. To make it a merge gate, add the `Commit Trailers` status check to branch protection (rides on #199).

Closes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for commit attribution trailers in pull requests and during commit creation.
  * Expanded contributor guidance with the expected trailer format and placement in commit messages.

* **Bug Fixes**
  * Commit messages with malformed or misplaced attribution trailers now fail validation with clearer feedback.
  * Comment lines in commit messages are ignored during trailer checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->