### PR TITLE
SDLC 0.3: fail-closed secret scan on PR diffs (gitleaks, #201)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,44 @@
+name: Secret Scan
+
+# Fail-closed (Tier-1) secret scan on PR diffs, using the gitleaks CLI binary
+# directly - the gitleaks GitHub Action requires a paid license for org
+# accounts, but the CLI is free (MIT). Deterministic and offline (no
+# third-party verification calls), which fits the residency/portability
+# constraints. Config in .gitleaks.toml. Mirrored locally by .husky/pre-commit
+# (convenience). Complements GitHub-native push protection (known-provider
+# patterns only). To gate merges, add "Secret Scan" to branch protection on
+# main (rides on #199). Tracks #201.
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for the diff range)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks (CLI binary, no org license needed)
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          mkdir -p "$HOME/bin"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "$HOME/bin" gitleaks
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Scan PR commits for secrets (fail-closed)
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gitleaks version
+          gitleaks git -c .gitleaks.toml --log-opts="$BASE..$HEAD" --redact .

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -40,10 +40,14 @@ jobs:
           tar -xz -C "$HOME/bin" -f "/tmp/${TARBALL}" gitleaks
           echo "$HOME/bin" >> "$GITHUB_PATH"
 
+      - name: Export gitleaks config from base branch (prevents PR bypass)
+        run: |
+          git show "origin/${{ github.base_ref }}:.gitleaks.toml" > /tmp/gitleaks-base.toml 2>/dev/null || cp .gitleaks.toml /tmp/gitleaks-base.toml
+
       - name: Scan PR commits for secrets (fail-closed)
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           gitleaks version
-          gitleaks git -c .gitleaks.toml --log-opts="$BASE..$HEAD" --redact .
+          gitleaks git -c /tmp/gitleaks-base.toml --log-opts="$BASE..$HEAD" --redact .

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -25,14 +25,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install gitleaks (CLI binary, no org license needed)
         env:
           GITLEAKS_VERSION: 8.30.1
         run: |
           mkdir -p "$HOME/bin"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C "$HOME/bin" gitleaks
+          BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "${BASE_URL}/${TARBALL}" -o "/tmp/${TARBALL}"
+          curl -sSfL "${BASE_URL}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o /tmp/checksums.txt
+          (cd /tmp && sha256sum -c --ignore-missing checksums.txt)
+          tar -xz -C "$HOME/bin" -f "/tmp/${TARBALL}" gitleaks
           echo "$HOME/bin" >> "$GITHUB_PATH"
 
       - name: Scan PR commits for secrets (fail-closed)

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -42,7 +42,10 @@ jobs:
 
       - name: Export gitleaks config from base branch (prevents PR bypass)
         run: |
-          git show "origin/${{ github.base_ref }}:.gitleaks.toml" > /tmp/gitleaks-base.toml 2>/dev/null || cp .gitleaks.toml /tmp/gitleaks-base.toml
+          if ! git show "origin/${{ github.base_ref }}:.gitleaks.toml" > /tmp/gitleaks-base.toml 2>/dev/null; then
+            echo "::error::.gitleaks.toml missing on base branch — refusing to fall back to PR-controlled config" >&2
+            exit 1
+          fi
 
       - name: Scan PR commits for secrets (fail-closed)
         env:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,9 +8,9 @@ title = "BugSpotter gitleaks config"
 [extend]
 useDefault = true
 
-[allowlist]
+[[allowlists]]
 description = "Known non-secret CI/test placeholders"
 regexes = [
   '''^(ci_jwt_secret_key_for_testing_only_not_production|ci_encryption_key_for_testing_only_32bytes)$''',
-  '''bugspotter_ci_password''',
+  '''^bugspotter_ci_password$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,6 +11,6 @@ useDefault = true
 [allowlist]
 description = "Known non-secret CI/test placeholders"
 regexes = [
-  '''.*_for_testing_only.*''',
+  '''^(ci_jwt_secret_key_for_testing_only_not_production|ci_encryption_key_for_testing_only_32bytes)$''',
   '''bugspotter_ci_password''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,9 +8,9 @@ title = "BugSpotter gitleaks config"
 [extend]
 useDefault = true
 
-[[allowlists]]
+[allowlist]
 description = "Known non-secret CI/test placeholders"
 regexes = [
-  '''^(ci_jwt_secret_key_for_testing_only_not_production|ci_encryption_key_for_testing_only_32bytes)$''',
-  '''^bugspotter_ci_password$''',
+  '''.*_for_testing_only.*''',
+  '''bugspotter_ci_password''',
 ]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,9 @@ npx lint-staged || exit 1
 # Secret-scan mirror (convenience; the CI "Secret Scan" job is the gate).
 # Skipped when gitleaks isn't installed locally - fresh worktrees won't have it.
 if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks git -c .gitleaks.toml --pre-commit --staged --redact --verbose || exit 1
+  if gitleaks git --help >/dev/null 2>&1; then
+    gitleaks git -c .gitleaks.toml --pre-commit --staged --redact --verbose --no-banner || exit 1
+  else
+    gitleaks protect -c .gitleaks.toml --staged --redact --verbose --no-banner || exit 1
+  fi
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
-npx lint-staged
+npx lint-staged || exit 1
 
 # Secret-scan mirror (convenience; the CI "Secret Scan" job is the gate).
 # Skipped when gitleaks isn't installed locally - fresh worktrees won't have it.
 if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks protect --staged --redact
+  gitleaks git -c .gitleaks.toml --staged --redact
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,8 @@
 #!/usr/bin/env sh
 npx lint-staged
+
+# Secret-scan mirror (convenience; the CI "Secret Scan" job is the gate).
+# Skipped when gitleaks isn't installed locally - fresh worktrees won't have it.
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --redact
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,5 @@ npx lint-staged || exit 1
 # Secret-scan mirror (convenience; the CI "Secret Scan" job is the gate).
 # Skipped when gitleaks isn't installed locally - fresh worktrees won't have it.
 if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks git -c .gitleaks.toml --staged --redact
+  gitleaks git -c .gitleaks.toml --staged --redact --verbose
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,5 @@ npx lint-staged || exit 1
 # Secret-scan mirror (convenience; the CI "Secret Scan" job is the gate).
 # Skipped when gitleaks isn't installed locally - fresh worktrees won't have it.
 if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks git -c .gitleaks.toml --pre-commit --staged --redact --verbose
+  gitleaks git -c .gitleaks.toml --pre-commit --staged --redact --verbose || exit 1
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,5 @@ npx lint-staged || exit 1
 # Secret-scan mirror (convenience; the CI "Secret Scan" job is the gate).
 # Skipped when gitleaks isn't installed locally - fresh worktrees won't have it.
 if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks git -c .gitleaks.toml --staged --redact --verbose
+  gitleaks git -c .gitleaks.toml --pre-commit --staged --redact --verbose
 fi


### PR DESCRIPTION
Implements #201: a fail-closed **Secret Scan** CI check on PR diffs, plus a pre-commit mirror.

- Uses the gitleaks CLI binary directly (the gitleaks Action requires a paid license for org accounts; the CLI is free/MIT). Deterministic and offline - no third-party verification calls - which fits the residency/portability constraints (chosen over trufflehog for that reason).
- `.gitleaks.toml` extends the default ruleset with a minimal placeholder allowlist; tune as false positives surface.
- `.husky/pre-commit` gets a guarded gitleaks mirror (skipped if gitleaks isn't installed locally).
- Complements GitHub-native push protection (known-provider patterns only).

To make it a merge gate, add the `Secret Scan` status check to branch protection (rides on #199). The exact gitleaks invocation is validated by this PR's own CI run. This is also the first PR under option B, so the trailer below should survive to `main` parseable - the live confirmation B works.

Refs #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: claude-opus-4-8 (agent)
