### PR TITLE
feat: add .gitleaks.toml (bootstrap for secret-scan workflow)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,9 +8,9 @@ title = "BugSpotter gitleaks config"
 [extend]
 useDefault = true
 
-[allowlist]
+[[allowlists]]
 description = "Known non-secret CI/test placeholders"
 regexes = [
   '''^(ci_jwt_secret_key_for_testing_only_not_production|ci_encryption_key_for_testing_only_32bytes)$''',
-  '''bugspotter_ci_password''',
+  '''^bugspotter_ci_password$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# Config for the fail-closed secret-scan guard (#201): the "Secret Scan" CI
+# workflow and the pre-commit mirror. Extends gitleaks' built-in ruleset and
+# allowlists known test/CI placeholder secrets so the gate flags real leaks,
+# not fixtures. Tune the allowlist as false positives surface.
+
+title = "BugSpotter gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known non-secret CI/test placeholders"
+regexes = [
+  '''^(ci_jwt_secret_key_for_testing_only_not_production|ci_encryption_key_for_testing_only_32bytes)$''',
+  '''bugspotter_ci_password''',
+]


### PR DESCRIPTION
## Summary

Lands `.gitleaks.toml` on `main` before the secret-scan workflow so PR #206 can pin config to the base branch without a PR-controlled fallback.

## Testing

- Verified allowlist regexes are anchored to exact fixture values from `ci.yml`
- No production secrets in allowlist; entries cover only CI test fixtures
- Merge before #206; #206 will then replace its `cp` fallback with a hard-fail