### PR TITLE
ci: record per-PR metrics to bugspotter-metrics on merge

### DIFF
--- a/.github/workflows/record-metrics.yml
+++ b/.github/workflows/record-metrics.yml
@@ -1,0 +1,64 @@
+name: Record PR Metrics
+
+# Appends one JSONL row to bugspotter-metrics/data/prs.jsonl on every
+# squash-merge to main. Uses METRICS_REPO_TOKEN (PAT with repo scope on
+# apex-bridge/bugspotter-metrics) for checkout and push; the default
+# GITHUB_TOKEN is used to read PR details from this repo. Runs after
+# merge - not a gate, never blocks the PR. Tracks the metrics design in
+# core-intelligence-features/metrics-design.md.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: metrics-record-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  record:
+    if: github.event.pull_request.merged == true
+    name: Record PR Metrics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout metrics repo (data/main)
+        uses: actions/checkout@v4
+        with:
+          repository: apex-bridge/bugspotter-metrics
+          ref: data/main
+          token: ${{ secrets.METRICS_REPO_TOKEN }}
+          path: metrics
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Record PR row
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          cd metrics
+          node scripts/record-pr.mjs \
+            --pr "$PR_NUMBER" \
+            --sha "$MERGE_SHA" \
+            --repo "$REPO"
+
+      - name: Commit and push metrics row
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cd metrics
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/prs.jsonl
+          git diff --cached --quiet || \
+            git commit -m "[metrics] record PR #${PR_NUMBER}" && \
+            git push

--- a/.github/workflows/record-metrics.yml
+++ b/.github/workflows/record-metrics.yml
@@ -13,7 +13,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: metrics-record-${{ github.event.pull_request.number }}
+  group: metrics-record
   cancel-in-progress: false
 
 permissions:
@@ -60,5 +60,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/prs.jsonl
           git diff --cached --quiet || \
-            git commit -m "[metrics] record PR #${PR_NUMBER}" && \
-            git push
+            { git commit -m "[metrics] record PR #${PR_NUMBER}" && \
+              git push; }


### PR DESCRIPTION
Wires the AI-SDLC metrics layer. On every squash-merge to \`main\`, the \`Record PR Metrics\` workflow checks out \`apex-bridge/bugspotter-metrics\` (\`data/main\`), runs \`scripts/record-pr.mjs\`, and appends one JSONL row. Not a gate - runs after merge.

## What

- \`.github/workflows/record-metrics.yml\` - triggers on \`pull_request\` closed+merged; uses \`METRICS_REPO_TOKEN\` for cross-repo write, default \`GITHUB_TOKEN\` for read-only PR API calls; \`cancel-in-progress: false\` so concurrent merges all get recorded.

## Required: set up METRICS_REPO_TOKEN before merging

The workflow needs a PAT with write access to \`apex-bridge/bugspotter-metrics\`.

Step 1 - Create a fine-grained PAT in GitHub Settings > Developer settings > Fine-grained tokens: name \`bugspotter-metrics-writer\`, repo \`apex-bridge/bugspotter-metrics\`, permission \`Contents: Read and write\`.

Step 2 - Store as a repo secret:

    gh secret set METRICS_REPO_TOKEN --repo apex-bridge/bugspotter --body "$YOUR_TOKEN"

## Design notes

- Attribution extracted via grep-body, not %(trailers) - see criteria.md in bugspotter-metrics
- reverted_within_30d and incident are null on append; back-filled by human writer monthly
- concurrency cancel-in-progress: false - never drop a row if two PRs merge close together

Closes #211.

Assisted-by: claude-sonnet-4-6 (agent)