### PR TITLE
fix(ci): add synchronize trigger to pr-link workflow

### DIFF
--- a/.github/workflows/pr-link.yml
+++ b/.github/workflows/pr-link.yml
@@ -10,7 +10,7 @@ name: PR Link
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, synchronize, reopened]
     branches: [main, develop]
 
 concurrency:


### PR DESCRIPTION
Without `synchronize` in the trigger types, a push to a PR branch resets the `PR Link` check to "Expected" and it never re-runs — blocking merge. Surfaced by PR #210 after the bot-fix push landed.

Same pattern as the `edited` fix applied to `commit-trailers.yml` in #205.

Closes #202.

Assisted-by: claude-sonnet-4-6 (agent)