### PR TITLE
feat(ai-sdlc): Phase 2 impl agent - scaffold from spec

### DIFF
--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -49,9 +49,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          # Look for a merged spec PR that references this issue
-          SPEC_PR=$(gh pr list --state merged --search "spec(#${ISSUE_NUMBER})" --json number,files --jq \
-            '[.[] | select(.files[].path | startswith("docs/specs/")) | .number] | first // empty')
+          # Look for a merged spec PR that closes this issue (exact match via closingIssuesReferences)
+          SPEC_PR=$(gh pr list --state merged --json number,files,closingIssuesReferences --jq \
+            --argjson issue "$ISSUE_NUMBER" \
+            '[.[] | select(.closingIssuesReferences[]? | .number == $issue) | select(.files[]?.path | startswith("docs/specs/")) | .number] | first // empty')
           if [ -z "$SPEC_PR" ]; then
             echo "::error::No merged spec PR found for issue #${ISSUE_NUMBER}. Ratify a spec (Gate 1) before running the impl agent."
             exit 1
@@ -62,9 +63,10 @@ jobs:
             echo "::error::Spec file not found on disk for PR #${SPEC_PR}. Ensure the checkout includes the spec."
             exit 1
           fi
-          echo "spec_content<<EOF_SPEC" >> "$GITHUB_OUTPUT"
+          DELIM="EOF_SPEC_$(openssl rand -hex 8)"
+          echo "spec_content<<${DELIM}" >> "$GITHUB_OUTPUT"
           cat "$SPEC_FILE" >> "$GITHUB_OUTPUT"
-          echo "EOF_SPEC" >> "$GITHUB_OUTPUT"
+          echo "${DELIM}" >> "$GITHUB_OUTPUT"
           echo "spec_file=$SPEC_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Generate scaffold

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -76,6 +76,11 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
           SPEC_CONTENT: ${{ steps.spec.outputs.spec_content }}
+          # Model router overrides — set via GitHub repo variables (no code change needed).
+          # Unset = fall back to hardcoded defaults in generate-impl.mjs.
+          IMPL_MODEL_HIGH: ${{ vars.IMPL_MODEL_HIGH }}
+          IMPL_MODEL_DEFAULT: ${{ vars.IMPL_MODEL_DEFAULT }}
+          IMPL_MODEL_LOW: ${{ vars.IMPL_MODEL_LOW }}
         run: node scripts/ai-sdlc/generate-impl.mjs
 
       - name: Commit scaffold to branch

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -110,7 +110,7 @@ jobs:
           MODEL_USED: ${{ steps.gen.outputs.model_used }}
           IMPL_SUMMARY: ${{ steps.gen.outputs.impl_summary }}
         run: |
-          PR_BODY="$(printf 'Agent-generated scaffold for issue #%s (model: %s).\n\n%s\n\nReview, fill in TODO sections, run tests, and merge when ready (Gate 3).\n\nRefs #%s\nAssisted-by: %s (agent)' \
+          PR_BODY="$(printf 'Agent-generated scaffold for issue #%s (model: %s).\n\n%s\n\nReview, fill in TODO sections, run tests, and merge when ready (Gate 3).\n\nRefs #%s\n\nAssisted-by: %s (agent)' \
             "$ISSUE_NUMBER" "$MODEL_USED" "$IMPL_SUMMARY" "$ISSUE_NUMBER" "$MODEL_USED")"
 
           PR_URL=$(gh pr create \

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Fetch linked spec (if any)
+      - name: Fetch linked spec (required)
         id: spec
         env:
           GH_TOKEN: ${{ github.token }}
@@ -52,16 +52,20 @@ jobs:
           # Look for a merged spec PR that references this issue
           SPEC_PR=$(gh pr list --state merged --search "spec(#${ISSUE_NUMBER})" --json number,files --jq \
             '[.[] | select(.files[].path | startswith("docs/specs/")) | .number] | first // empty')
-          if [ -n "$SPEC_PR" ]; then
-            SPEC_FILE=$(gh pr view "$SPEC_PR" --json files --jq \
-              '.files[] | select(.path | startswith("docs/specs/")) | .path' | head -1)
-            if [ -n "$SPEC_FILE" ] && [ -f "$SPEC_FILE" ]; then
-              echo "spec_content<<EOF_SPEC" >> "$GITHUB_OUTPUT"
-              cat "$SPEC_FILE" >> "$GITHUB_OUTPUT"
-              echo "EOF_SPEC" >> "$GITHUB_OUTPUT"
-              echo "spec_file=$SPEC_FILE" >> "$GITHUB_OUTPUT"
-            fi
+          if [ -z "$SPEC_PR" ]; then
+            echo "::error::No merged spec PR found for issue #${ISSUE_NUMBER}. Ratify a spec (Gate 1) before running the impl agent."
+            exit 1
           fi
+          SPEC_FILE=$(gh pr view "$SPEC_PR" --json files --jq \
+            '.files[] | select(.path | startswith("docs/specs/")) | .path' | head -1)
+          if [ -z "$SPEC_FILE" ] || [ ! -f "$SPEC_FILE" ]; then
+            echo "::error::Spec file not found on disk for PR #${SPEC_PR}. Ensure the checkout includes the spec."
+            exit 1
+          fi
+          echo "spec_content<<EOF_SPEC" >> "$GITHUB_OUTPUT"
+          cat "$SPEC_FILE" >> "$GITHUB_OUTPUT"
+          echo "EOF_SPEC" >> "$GITHUB_OUTPUT"
+          echo "spec_file=$SPEC_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Generate scaffold
         id: gen
@@ -70,7 +74,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
           SPEC_CONTENT: ${{ steps.spec.outputs.spec_content }}
         run: node scripts/ai-sdlc/generate-impl.mjs
@@ -79,16 +82,19 @@ jobs:
         id: push
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
           FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
           MODEL_USED: ${{ steps.gen.outputs.model_used }}
         run: |
-          SLUG=$(echo "${{ github.event.issue.title }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
+          SLUG=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
           BRANCH="impl/issue-${ISSUE_NUMBER}-${SLUG}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          # stage only generated files
-          echo "$FILES_WRITTEN" | tr ',' '\n' | xargs git add
+          # stage only generated files — use -- to prevent path-as-option injection
+          while IFS= read -r f; do
+            [ -n "$f" ] && git add -- "$f"
+          done < <(printf '%s' "$FILES_WRITTEN" | tr ',' '\n')
           MSG="$(printf 'impl(#%s): scaffold\n\nAssisted-by: %s (agent)' "$ISSUE_NUMBER" "$MODEL_USED")"
           git commit -m "$MSG"
           git push origin "$BRANCH"

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -1,0 +1,127 @@
+name: Impl Agent
+
+# Phase 2 agent: fires when a human applies the `agent-working` label after
+# ratifying the spec (Gate 1) and optionally an ADR (Gate 2).
+# Reads the linked spec, calls Claude API, opens a DRAFT PR with a scaffold.
+# Gate 3 (merge) is human-held: the agent cannot merge.
+#
+# Model router (label-based):
+#   complexity:high  -> claude-opus-4-8
+#   pii-sensitive    -> claude-haiku-4-5-20251001
+#   default          -> claude-sonnet-4-6
+#
+# Prompt caching: static context (CLAUDE.md + style examples) is marked
+# cache_control=ephemeral; repeated runs on the same day skip re-sending it.
+#
+# Required secrets: ANTHROPIC_API_KEY
+# ADR: docs/adr/0042-agent-identity-scoped-app.md
+
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: impl-agent-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  scaffold:
+    name: Generate implementation scaffold
+    if: github.event.label.name == 'agent-working'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Fetch linked spec (if any)
+        id: spec
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Look for a merged spec PR that references this issue
+          SPEC_PR=$(gh pr list --state merged --search "spec(#${ISSUE_NUMBER})" --json number,files --jq \
+            '[.[] | select(.files[].path | startswith("docs/specs/")) | .number] | first // empty')
+          if [ -n "$SPEC_PR" ]; then
+            SPEC_FILE=$(gh pr view "$SPEC_PR" --json files --jq \
+              '.files[] | select(.path | startswith("docs/specs/")) | .path' | head -1)
+            if [ -n "$SPEC_FILE" ] && [ -f "$SPEC_FILE" ]; then
+              echo "spec_content<<EOF_SPEC" >> "$GITHUB_OUTPUT"
+              cat "$SPEC_FILE" >> "$GITHUB_OUTPUT"
+              echo "EOF_SPEC" >> "$GITHUB_OUTPUT"
+              echo "spec_file=$SPEC_FILE" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Generate scaffold
+        id: gen
+        timeout-minutes: 15
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          SPEC_CONTENT: ${{ steps.spec.outputs.spec_content }}
+        run: node scripts/ai-sdlc/generate-impl.mjs
+
+      - name: Commit scaffold to branch
+        id: push
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
+          MODEL_USED: ${{ steps.gen.outputs.model_used }}
+        run: |
+          SLUG=$(echo "${{ github.event.issue.title }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
+          BRANCH="impl/issue-${ISSUE_NUMBER}-${SLUG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          # stage only generated files
+          echo "$FILES_WRITTEN" | tr ',' '\n' | xargs git add
+          MSG="$(printf 'impl(#%s): scaffold\n\nAssisted-by: %s (agent)' "$ISSUE_NUMBER" "$MODEL_USED")"
+          git commit -m "$MSG"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          BRANCH: ${{ steps.push.outputs.branch }}
+          MODEL_USED: ${{ steps.gen.outputs.model_used }}
+          IMPL_SUMMARY: ${{ steps.gen.outputs.impl_summary }}
+        run: |
+          PR_BODY="$(printf 'Agent-generated scaffold for issue #%s (model: %s).\n\n%s\n\nReview, fill in TODO sections, run tests, and merge when ready (Gate 3).\n\nRefs #%s\nAssisted-by: %s (agent)' \
+            "$ISSUE_NUMBER" "$MODEL_USED" "$IMPL_SUMMARY" "$ISSUE_NUMBER" "$MODEL_USED")"
+
+          PR_URL=$(gh pr create \
+            --title "impl(#${ISSUE_NUMBER}): ${ISSUE_TITLE}" \
+            --body "$PR_BODY" \
+            --draft \
+            --head "$BRANCH" \
+            --base main)
+
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          MODEL_USED: ${{ steps.gen.outputs.model_used }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body \
+            "Scaffold drafted (${MODEL_USED}): ${PR_URL}. Review TODO sections, run tests, and merge when ready."

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -128,6 +128,7 @@ export default tseslint.config(
         clearTimeout: 'readonly',
         setInterval: 'readonly',
         clearInterval: 'readonly',
+        AbortSignal: 'readonly',
       },
     },
     rules: {

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -15,8 +15,8 @@
 // Required env: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY
 // Optional:     ISSUE_LABELS (comma-separated), SPEC_CONTENT, GITHUB_OUTPUT
 
-import { readFileSync, writeFileSync, mkdirSync, appendFileSync, existsSync, readdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { readFileSync, writeFileSync, mkdirSync, appendFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve, relative, isAbsolute } from 'node:path';
 
 const {
   ANTHROPIC_API_KEY,
@@ -131,8 +131,9 @@ const res = await fetch('https://api.anthropic.com/v1/messages', {
 });
 
 if (!res.ok) {
-  let detail = '';
-  try { detail = JSON.stringify(await res.json(), null, 2); } catch { detail = await res.text().catch(() => ''); }
+  const text = await res.text().catch(() => '');
+  let detail = text;
+  try { detail = JSON.stringify(JSON.parse(text), null, 2); } catch { /* use raw text */ }
   console.error(`Claude API error (${res.status}):`, detail);
   process.exit(1);
 }
@@ -163,25 +164,33 @@ try {
   process.exit(1);
 }
 
-if (!Array.isArray(parsed.files) || parsed.files.length === 0) {
+if (!parsed || !Array.isArray(parsed.files) || parsed.files.length === 0) {
   console.error('No files in response:', JSON.stringify(parsed, null, 2));
   process.exit(1);
 }
 
 // Write files
 const writtenPaths = [];
+const repoRoot = process.cwd();
 for (const { path, content } of parsed.files) {
   if (!path || !content) continue;
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, content, 'utf8');
-  console.log(`Wrote ${path}`);
-  writtenPaths.push(path);
+  const resolvedPath = resolve(repoRoot, path);
+  const relPath = relative(repoRoot, resolvedPath);
+  if (relPath.startsWith('..') || isAbsolute(relPath)) {
+    console.error(`Path traversal detected and blocked: ${path}`);
+    continue;
+  }
+  mkdirSync(dirname(resolvedPath), { recursive: true });
+  writeFileSync(resolvedPath, content, 'utf8');
+  console.log(`Wrote ${relPath}`);
+  writtenPaths.push(relPath);
 }
 
 console.log(`\nSummary: ${parsed.summary}`);
 
 if (GITHUB_OUTPUT) {
+  const sanitizedSummary = (parsed.summary || '').replace(/[\r\n]+/g, ' ').trim();
   appendFileSync(GITHUB_OUTPUT, `files_written=${writtenPaths.join(',')}\n`);
   appendFileSync(GITHUB_OUTPUT, `model_used=${MODEL}\n`);
-  appendFileSync(GITHUB_OUTPUT, `impl_summary=${parsed.summary}\n`);
+  appendFileSync(GITHUB_OUTPUT, `impl_summary=${sanitizedSummary}\n`);
 }

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// Phase 2 impl agent: reads a ratified spec + codebase context, calls Claude API,
+// writes a multi-file implementation scaffold.
+//
+// Model router (label-based via ISSUE_LABELS env):
+//   complexity:high  -> claude-opus-4-8   (deep architecture, cross-cutting changes)
+//   pii-sensitive    -> claude-haiku-4-5-20251001  (local-floor stand-in; cheapest hosted)
+//   default          -> claude-sonnet-4-6
+//
+// Prompt caching: static context (CLAUDE.md files + pattern examples) marked with
+// cache_control so repeated runs on the same day skip re-sending that payload.
+//
+// Output: writes files listed in Claude's JSON response; outputs file list to GITHUB_OUTPUT.
+//
+// Required env: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY
+// Optional:     ISSUE_LABELS (comma-separated), SPEC_CONTENT, GITHUB_OUTPUT
+
+import { readFileSync, writeFileSync, mkdirSync, appendFileSync, existsSync, readdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const {
+  ANTHROPIC_API_KEY,
+  ISSUE_NUMBER,
+  ISSUE_TITLE,
+  ISSUE_BODY,
+  ISSUE_LABELS = '',
+  SPEC_CONTENT,
+  GITHUB_OUTPUT,
+} = process.env;
+
+if (!ANTHROPIC_API_KEY) { console.error('Missing ANTHROPIC_API_KEY'); process.exit(1); }
+if (!ISSUE_NUMBER)      { console.error('Missing ISSUE_NUMBER');       process.exit(1); }
+if (!ISSUE_TITLE)       { console.error('Missing ISSUE_TITLE');        process.exit(1); }
+
+// Model router
+function selectModel(labels) {
+  const set = new Set(labels.split(',').map((l) => l.trim().toLowerCase()));
+  if (set.has('complexity:high')) return 'claude-opus-4-8';
+  if (set.has('pii-sensitive'))   return 'claude-haiku-4-5-20251001';
+  return 'claude-sonnet-4-6';
+}
+const MODEL = selectModel(ISSUE_LABELS);
+console.log(`Model router selected: ${MODEL} (labels: "${ISSUE_LABELS || 'none'}")`);
+
+// Read static context for prompt caching
+function safeRead(path) {
+  try { return readFileSync(path, 'utf8'); } catch { return ''; }
+}
+
+const rootClaudeMd    = safeRead('CLAUDE.md');
+const backendClaudeMd = safeRead('packages/backend/CLAUDE.md');
+const contributing    = safeRead('CONTRIBUTING.md');
+
+// Read one existing route + test as style examples
+function findExample(dir, ext) {
+  try {
+    const files = readdirSync(dir).filter((f) => f.endsWith(ext));
+    return files.length ? safeRead(`${dir}/${files[0]}`) : '';
+  } catch { return ''; }
+}
+const routeExample = findExample('packages/backend/src/api/routes', '.ts').slice(0, 1500);
+const testExample  = findExample('packages/backend/tests/api', '.test.ts').slice(0, 1500);
+
+// Static context block (cached)
+const staticContext = [
+  rootClaudeMd    ? `# CLAUDE.md (root)\n${rootClaudeMd}`    : '',
+  backendClaudeMd ? `# CLAUDE.md (backend)\n${backendClaudeMd}` : '',
+  contributing    ? `# CONTRIBUTING.md\n${contributing}`     : '',
+  routeExample    ? `# Example route (style reference)\n\`\`\`typescript\n${routeExample}\n\`\`\`` : '',
+  testExample     ? `# Example test (style reference)\n\`\`\`typescript\n${testExample}\n\`\`\`` : '',
+].filter(Boolean).join('\n\n---\n\n');
+
+const specSection = SPEC_CONTENT
+  ? `# Ratified spec\n${SPEC_CONTENT}`
+  : `# Issue body (no spec linked)\n${ISSUE_BODY || '(empty)'}`;
+
+const userPrompt = `\
+You are an implementation agent for BugSpotter, a SaaS bug-reporting platform (Fastify + TypeScript + Postgres + Redis; pnpm monorepo; Docker Compose on VMs).
+
+Generate a **minimal, compilable implementation scaffold** for GitHub issue #${ISSUE_NUMBER}: "${ISSUE_TITLE}".
+
+Read the spec and acceptance criteria carefully. Generate exactly the files needed — no more.
+Match the style of the examples in the static context above exactly (same import style, error classes, Fastify plugin pattern, test helpers).
+
+${specSection}
+
+RULES:
+1. Return ONLY valid JSON — no prose, no markdown fences around the JSON itself.
+2. Schema: { "files": [ { "path": "...", "content": "..." } ], "summary": "one sentence" }
+3. Paths are relative to the repo root (e.g. "packages/backend/src/api/routes/foo.ts").
+4. Include a route file AND a test file at minimum if the spec mentions an API endpoint.
+5. Include a migration file if the spec mentions a DB schema change.
+6. Leave TODO comments for logic that requires business context only a human can supply.
+7. Do NOT generate package.json, pnpm-lock.yaml, or any config file changes.
+8. Do NOT generate more than 6 files total.
+9. Scaffold tests must use the same test helpers as the example (do not invent new ones).
+10. Every generated file must compile without errors given reasonable stub imports.`;
+
+// Build messages with prompt caching on static context
+const messages = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: staticContext,
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: userPrompt,
+      },
+    ],
+  },
+];
+
+const res = await fetch('https://api.anthropic.com/v1/messages', {
+  method: 'POST',
+  signal: AbortSignal.timeout(120_000),
+  headers: {
+    'content-type': 'application/json',
+    'x-api-key': ANTHROPIC_API_KEY,
+    'anthropic-version': '2023-06-01',
+    'anthropic-beta': 'prompt-caching-2024-07-31',
+  },
+  body: JSON.stringify({
+    model: MODEL,
+    max_tokens: 8192,
+    messages,
+  }),
+});
+
+if (!res.ok) {
+  let detail = '';
+  try { detail = JSON.stringify(await res.json(), null, 2); } catch { detail = await res.text().catch(() => ''); }
+  console.error(`Claude API error (${res.status}):`, detail);
+  process.exit(1);
+}
+
+const data = await res.json();
+if (data?.content?.[0]?.type !== 'text') {
+  console.error('Unexpected API response shape:', JSON.stringify(data, null, 2));
+  process.exit(1);
+}
+
+// Log cache stats if available
+const usage = data.usage ?? {};
+if (usage.cache_creation_input_tokens || usage.cache_read_input_tokens) {
+  console.log(
+    `Cache: created=${usage.cache_creation_input_tokens ?? 0} read=${usage.cache_read_input_tokens ?? 0} uncached=${usage.input_tokens ?? 0}`,
+  );
+}
+
+// Parse JSON response
+let parsed;
+try {
+  // Strip accidental fences if the model wraps in ```json ... ```
+  const raw = data.content[0].text.replace(/^```json\s*/i, '').replace(/\s*```$/, '').trim();
+  parsed = JSON.parse(raw);
+} catch (e) {
+  console.error('Failed to parse JSON from Claude response:', e.message);
+  console.error('Raw response:', data.content[0].text.slice(0, 500));
+  process.exit(1);
+}
+
+if (!Array.isArray(parsed.files) || parsed.files.length === 0) {
+  console.error('No files in response:', JSON.stringify(parsed, null, 2));
+  process.exit(1);
+}
+
+// Write files
+const writtenPaths = [];
+for (const { path, content } of parsed.files) {
+  if (!path || !content) continue;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, 'utf8');
+  console.log(`Wrote ${path}`);
+  writtenPaths.push(path);
+}
+
+console.log(`\nSummary: ${parsed.summary}`);
+
+if (GITHUB_OUTPUT) {
+  appendFileSync(GITHUB_OUTPUT, `files_written=${writtenPaths.join(',')}\n`);
+  appendFileSync(GITHUB_OUTPUT, `model_used=${MODEL}\n`);
+  appendFileSync(GITHUB_OUTPUT, `impl_summary=${parsed.summary}\n`);
+}

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -166,8 +166,9 @@ if (usage.cache_creation_input_tokens || usage.cache_read_input_tokens) {
 // Parse JSON response
 let parsed;
 try {
-  // Strip accidental fences if the model wraps in ```json ... ```
-  const raw = data.content[0].text.replace(/^```json\s*/i, '').replace(/\s*```$/, '').trim();
+  // Extract JSON — handle leading prose + fenced block, or bare JSON
+  const fenceMatch = data.content[0].text.match(/```json\s*([\s\S]*?)\s*```/i);
+  const raw = fenceMatch ? fenceMatch[1].trim() : data.content[0].text.trim();
   parsed = JSON.parse(raw);
 } catch (e) {
   console.error('Failed to parse JSON from Claude response:', e.message);

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -54,8 +54,12 @@ const MODEL_LOW     = process.env.IMPL_MODEL_LOW     || 'claude-haiku-4-5-202510
 
 function selectModel(labels) {
   const set = new Set(labels.split(',').map((l) => l.trim().toLowerCase()));
-  if (set.has('complexity:high')) return MODEL_HIGH;
-  if (set.has('pii-sensitive'))   return MODEL_LOW;
+  if (set.has('complexity:high')) {
+    return MODEL_HIGH;
+  }
+  if (set.has('pii-sensitive')) {
+    return MODEL_LOW;
+  }
   return MODEL_DEFAULT;
 }
 const MODEL = selectModel(ISSUE_LABELS);
@@ -190,18 +194,42 @@ if (!parsed || !Array.isArray(parsed.files) || parsed.files.length === 0) {
 // Write files
 const writtenPaths = [];
 const repoRoot = process.cwd();
+const FORBIDDEN_PATH_PATTERNS = [
+  /^\.git(\/|$)/,
+  /^\.github\/workflows\//,
+  /(^|\/)package(-lock)?\.json$/,
+  /(^|\/)(pnpm-lock\.yaml|yarn\.lock)$/,
+];
+
+const seenPaths = new Set();
 for (const { path, content } of parsed.files) {
-  if (!path || !content) continue;
+  if (typeof path !== 'string' || typeof content !== 'string' || !path || !content) {
+    continue;
+  }
+  if (/[\x00-\x1f]/.test(path)) {
+    console.error(`Rejected path with control characters: ${JSON.stringify(path)}`);
+    continue;
+  }
   const resolvedPath = resolve(repoRoot, path);
   const relPath = relative(repoRoot, resolvedPath);
   if (relPath.startsWith('..') || isAbsolute(relPath)) {
     console.error(`Path traversal detected and blocked: ${path}`);
     continue;
   }
+  if (FORBIDDEN_PATH_PATTERNS.some((re) => re.test(relPath)) || seenPaths.has(relPath)) {
+    console.error(`Rejected forbidden/duplicate target path: ${relPath}`);
+    continue;
+  }
+  seenPaths.add(relPath);
   mkdirSync(dirname(resolvedPath), { recursive: true });
   writeFileSync(resolvedPath, content, 'utf8');
   console.log(`Wrote ${relPath}`);
   writtenPaths.push(relPath);
+}
+
+if (writtenPaths.length === 0) {
+  console.error('No valid files were written after validation - aborting.');
+  process.exit(1);
 }
 
 console.log(`\nSummary: ${parsed.summary}`);

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -45,12 +45,18 @@ if (!SPEC_CONTENT) {
   process.exit(1);
 }
 
-// Model router
+// Model router — label-based with per-tier overrides via GitHub repo variables.
+// Change without a code edit: set IMPL_MODEL_HIGH / IMPL_MODEL_DEFAULT / IMPL_MODEL_LOW
+// in Settings > Secrets and variables > Actions > Variables.
+const MODEL_HIGH    = process.env.IMPL_MODEL_HIGH    || 'claude-opus-4-8';
+const MODEL_DEFAULT = process.env.IMPL_MODEL_DEFAULT || 'claude-sonnet-4-6';
+const MODEL_LOW     = process.env.IMPL_MODEL_LOW     || 'claude-haiku-4-5-20251001';
+
 function selectModel(labels) {
   const set = new Set(labels.split(',').map((l) => l.trim().toLowerCase()));
-  if (set.has('complexity:high')) return 'claude-opus-4-8';
-  if (set.has('pii-sensitive'))   return 'claude-haiku-4-5-20251001';
-  return 'claude-sonnet-4-6';
+  if (set.has('complexity:high')) return MODEL_HIGH;
+  if (set.has('pii-sensitive'))   return MODEL_LOW;
+  return MODEL_DEFAULT;
 }
 const MODEL = selectModel(ISSUE_LABELS);
 console.log(`Model router selected: ${MODEL} (labels: "${ISSUE_LABELS || 'none'}")`);

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -12,25 +12,38 @@
 //
 // Output: writes files listed in Claude's JSON response; outputs file list to GITHUB_OUTPUT.
 //
-// Required env: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY
-// Optional:     ISSUE_LABELS (comma-separated), SPEC_CONTENT, GITHUB_OUTPUT
+// Required env: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, SPEC_CONTENT
+// Optional:     ISSUE_LABELS (comma-separated), GITHUB_OUTPUT
 
 import { readFileSync, writeFileSync, mkdirSync, appendFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve, relative, isAbsolute } from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 const {
   ANTHROPIC_API_KEY,
   ISSUE_NUMBER,
   ISSUE_TITLE,
-  ISSUE_BODY,
   ISSUE_LABELS = '',
   SPEC_CONTENT,
   GITHUB_OUTPUT,
 } = process.env;
 
-if (!ANTHROPIC_API_KEY) { console.error('Missing ANTHROPIC_API_KEY'); process.exit(1); }
-if (!ISSUE_NUMBER)      { console.error('Missing ISSUE_NUMBER');       process.exit(1); }
-if (!ISSUE_TITLE)       { console.error('Missing ISSUE_TITLE');        process.exit(1); }
+if (!ANTHROPIC_API_KEY) {
+  console.error('Missing ANTHROPIC_API_KEY');
+  process.exit(1);
+}
+if (!ISSUE_NUMBER) {
+  console.error('Missing ISSUE_NUMBER');
+  process.exit(1);
+}
+if (!ISSUE_TITLE) {
+  console.error('Missing ISSUE_TITLE');
+  process.exit(1);
+}
+if (!SPEC_CONTENT) {
+  console.error('Missing SPEC_CONTENT — ratify a spec (Gate 1) before running the impl agent.');
+  process.exit(1);
+}
 
 // Model router
 function selectModel(labels) {
@@ -70,9 +83,7 @@ const staticContext = [
   testExample     ? `# Example test (style reference)\n\`\`\`typescript\n${testExample}\n\`\`\`` : '',
 ].filter(Boolean).join('\n\n---\n\n');
 
-const specSection = SPEC_CONTENT
-  ? `# Ratified spec\n${SPEC_CONTENT}`
-  : `# Issue body (no spec linked)\n${ISSUE_BODY || '(empty)'}`;
+const specSection = `# Ratified spec\n${SPEC_CONTENT}`;
 
 const userPrompt = `\
 You are an implementation agent for BugSpotter, a SaaS bug-reporting platform (Fastify + TypeScript + Postgres + Redis; pnpm monorepo; Docker Compose on VMs).
@@ -189,8 +200,11 @@ for (const { path, content } of parsed.files) {
 console.log(`\nSummary: ${parsed.summary}`);
 
 if (GITHUB_OUTPUT) {
-  const sanitizedSummary = (parsed.summary || '').replace(/[\r\n]+/g, ' ').trim();
+  const delimiter = `IMPL_SUMMARY_${randomUUID()}`;
   appendFileSync(GITHUB_OUTPUT, `files_written=${writtenPaths.join(',')}\n`);
   appendFileSync(GITHUB_OUTPUT, `model_used=${MODEL}\n`);
-  appendFileSync(GITHUB_OUTPUT, `impl_summary=${sanitizedSummary}\n`);
+  appendFileSync(
+    GITHUB_OUTPUT,
+    `impl_summary<<${delimiter}\n${String(parsed.summary ?? '')}\n${delimiter}\n`,
+  );
 }


### PR DESCRIPTION
Phase 2 of the AI-SDLC migration: an implementation agent that reads a ratified spec and opens a draft PR with a compilable code scaffold. Humans hold Gate 3 (merge) via branch protection — the agent cannot merge.

## What fires this

Applying the `agent-working` label to an issue (after the spec and optional ADR are ratified by the human).

## Model router

| Label on issue | Model |
| --- | --- |
| `complexity:high` | `claude-opus-4-8` |
| `pii-sensitive` | `claude-haiku-4-5-20251001` |
| (default) | `claude-sonnet-4-6` |

## Prompt caching

Static context (CLAUDE.md files + route/test style examples) is sent with `cache_control: ephemeral`. Repeated runs on the same day skip re-sending that payload, reducing cost and latency.

## Output shape

Claude returns structured JSON `{files: [{path, content}], summary}`. The workflow writes each file, commits with the correct `Assisted-by:` trailer (using the routed model slug), and opens a draft PR. A 6-file cap prevents runaway generation.

## Guards satisfied

- Commit Trailers: `Assisted-by: <model> (agent)` in commit + PR body (model slug from router)
- PR Link: `Refs #216` in this PR body; agent-opened PRs carry `Refs #NNN`
- Agent never holds merge rights (branch protection, ADR-0042)

Closes #216

Assisted-by: claude-sonnet-4-6 (agent)