### PR TITLE
fix(ci): run prettier before commit in all agent workflows

### DIFF
--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -79,9 +79,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
-          git add "$ADR_FILE"
+          git add -- "$ADR_FILE"
           MSG="$(printf 'docs(adr): ADR-%s draft (%s)\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ADR_NUMBER" "$ADR_SLUG")"
           git commit -m "$MSG"
+          git fetch origin "$BRANCH" 2>/dev/null || true
           git push --force-with-lease origin "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -62,6 +62,11 @@ jobs:
           SPEC_CONTENT: ${{ steps.spec.outputs.spec_content }}
         run: node scripts/ai-sdlc/generate-adr.mjs
 
+      - name: Format generated files
+        env:
+          ADR_FILE: ${{ steps.gen.outputs.adr_file }}
+        run: npx prettier@3.6.2 --write "$ADR_FILE"
+
       - name: Commit ADR to branch
         id: push
         env:
@@ -73,11 +78,11 @@ jobs:
           BRANCH="adr/${ADR_NUMBER}-${ADR_SLUG}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add "$ADR_FILE"
           MSG="$(printf 'docs(adr): ADR-%s draft (%s)\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ADR_NUMBER" "$ADR_SLUG")"
           git commit -m "$MSG"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Open draft PR
@@ -89,7 +94,7 @@ jobs:
           BRANCH: ${{ steps.push.outputs.branch }}
           ADR_NUMBER: ${{ steps.gen.outputs.adr_number }}
         run: |
-          PR_BODY="$(printf 'Agent-drafted ADR-%s for issue #%s.\n\nReview, promote Status to Accepted if correct, and merge to advance this issue to `agent-working`.\n\nRefs #%s\nAssisted-by: claude-sonnet-4-6 (agent)' "$ADR_NUMBER" "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
+          PR_BODY="$(printf 'Agent-drafted ADR-%s for issue #%s.\n\nReview, promote Status to Accepted if correct, and merge to advance this issue to `agent-working`.\n\nRefs #%s\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ADR_NUMBER" "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
 
           PR_URL=$(gh pr create \
             --title "docs(adr): ADR-${ADR_NUMBER} ${ISSUE_TITLE}" \

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -85,6 +85,14 @@ jobs:
           IMPL_MODEL_LOW: ${{ vars.IMPL_MODEL_LOW }}
         run: node scripts/ai-sdlc/generate-impl.mjs
 
+      - name: Format generated files
+        env:
+          FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
+        run: |
+          printf '%s' "$FILES_WRITTEN" | tr ',' '\n' | while IFS= read -r f; do
+            [ -n "$f" ] && npx prettier@3.6.2 --write --ignore-unknown "$f"
+          done
+
       - name: Commit scaffold to branch
         id: push
         env:
@@ -97,14 +105,14 @@ jobs:
           BRANCH="impl/issue-${ISSUE_NUMBER}-${SLUG}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           # stage only generated files — use -- to prevent path-as-option injection
           while IFS= read -r f; do
             [ -n "$f" ] && git add -- "$f"
           done < <(printf '%s' "$FILES_WRITTEN" | tr ',' '\n')
           MSG="$(printf 'impl(#%s): scaffold\n\nAssisted-by: %s (agent)' "$ISSUE_NUMBER" "$MODEL_USED")"
           git commit -m "$MSG"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Open draft PR

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -112,6 +112,7 @@ jobs:
           done < <(printf '%s' "$FILES_WRITTEN" | tr ',' '\n')
           MSG="$(printf 'impl(#%s): scaffold\n\nAssisted-by: %s (agent)' "$ISSUE_NUMBER" "$MODEL_USED")"
           git commit -m "$MSG"
+          git fetch origin "$BRANCH" 2>/dev/null || true
           git push --force-with-lease origin "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -61,6 +61,7 @@ jobs:
           git add "$SPEC_FILE"
           MSG="$(printf 'spec(#%s): draft spec\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ISSUE_NUMBER")"
           git commit -m "$MSG"
+          git fetch origin "$BRANCH" 2>/dev/null || true
           git push --force-with-lease origin "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -42,6 +42,11 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: node scripts/ai-sdlc/generate-spec.mjs
 
+      - name: Format generated files
+        env:
+          SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
+        run: npx prettier@3.6.2 --write "$SPEC_FILE"
+
       - name: Commit spec to branch
         id: push
         env:
@@ -52,11 +57,11 @@ jobs:
           BRANCH="spec/issue-${ISSUE_NUMBER}-${SPEC_SLUG}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add "$SPEC_FILE"
           MSG="$(printf 'spec(#%s): draft spec\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ISSUE_NUMBER")"
           git commit -m "$MSG"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Open draft PR
@@ -68,7 +73,7 @@ jobs:
           BRANCH: ${{ steps.push.outputs.branch }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
         run: |
-          PR_BODY="$(printf 'Agent-drafted spec for issue #%s.\n\nReview, fill gaps, and merge to advance this issue to `needs-adr` (if an ADR is warranted) or `agent-working` (if no ADR is needed).\n\nRefs #%s\nAssisted-by: claude-sonnet-4-6 (agent)' "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
+          PR_BODY="$(printf 'Agent-drafted spec for issue #%s.\n\nReview, fill gaps, and merge to advance this issue to `needs-adr` (if an ADR is warranted) or `agent-working` (if no ADR is needed).\n\nRefs #%s\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
 
           PR_URL=$(gh pr create \
             --title "spec(#${ISSUE_NUMBER}): ${ISSUE_TITLE}" \


### PR DESCRIPTION
Adds \`npx prettier@3.6.2 --write\` before the git commit step in all three agent workflows so generated files are always lint-clean on push.

Also fixes:
- Missing blank line before \`Assisted-by:\` in spec-agent and adr-agent PR bodies (Commit Trailers guard requires it)
- \`git checkout -b\` -> \`-B\` and \`git push\` -> \`--force-with-lease\` so re-triggered runs do not fail on an existing branch

Refs #226

Assisted-by: claude-sonnet-4-6 (agent)