### PR TITLE
fix(ci): pipe to standalone jq for --argjson in impl-agent spec lookup

### DIFF
--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -50,8 +50,9 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           # Look for a merged spec PR that closes this issue (exact match via closingIssuesReferences)
-          SPEC_PR=$(gh pr list --state merged --json number,files,closingIssuesReferences --jq \
-            --argjson issue "$ISSUE_NUMBER" \
+          # gh --jq does not accept extra jq flags; pipe to standalone jq with --argjson
+          SPEC_PR=$(gh pr list --state merged --json number,files,closingIssuesReferences | \
+            jq --raw-output --argjson issue "$ISSUE_NUMBER" \
             '[.[] | select(.closingIssuesReferences[]? | .number == $issue) | select(.files[]?.path | startswith("docs/specs/")) | .number] | first // empty')
           if [ -z "$SPEC_PR" ]; then
             echo "::error::No merged spec PR found for issue #${ISSUE_NUMBER}. Ratify a spec (Gate 1) before running the impl agent."


### PR DESCRIPTION
gh pr list --jq does not accept extra jq flags -- --argjson was parsed as an unknown argument to gh, causing the impl-agent spec lookup to fail with "unknown arguments" on every run.

Fix: pipe to standalone jq so --argjson works as intended.

Refs #226

Assisted-by: claude-sonnet-4-6 (agent)