### PR TITLE
fix(impl-agent): raise max_tokens to 16384, guard truncated response

### DIFF
--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -146,7 +146,7 @@ const res = await fetch('https://api.anthropic.com/v1/messages', {
   },
   body: JSON.stringify({
     model: MODEL,
-    max_tokens: 8192,
+    max_tokens: 16384,
     messages,
   }),
 });
@@ -171,6 +171,12 @@ if (usage.cache_creation_input_tokens || usage.cache_read_input_tokens) {
   console.log(
     `Cache: created=${usage.cache_creation_input_tokens ?? 0} read=${usage.cache_read_input_tokens ?? 0} uncached=${usage.input_tokens ?? 0}`,
   );
+}
+
+// Fail fast if truncated — a partial JSON response will always cause a parse error downstream
+if (data.stop_reason === 'max_tokens') {
+  console.error(`Claude response truncated (stop_reason=max_tokens). Raise max_tokens in generate-impl.mjs.`);
+  process.exit(1);
 }
 
 // Parse JSON response


### PR DESCRIPTION
Scaffold for issue #226 hit the 8192-token ceiling mid-JSON (`Unterminated string at position 26591`). Sonnet 4.6 supports up to 64K output tokens; 16384 gives comfortable headroom for up to 6 real files.

Also adds an explicit `stop_reason === 'max_tokens'` check immediately after the API call so truncation surfaces as a clear diagnostic error instead of a confusing downstream JSON parse failure.

Refs #226

Assisted-by: claude-sonnet-4-6 (agent)