### PR TITLE
fix(impl-agent): run ESLint --fix on generated TS files before commit

### DIFF
--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -39,9 +39,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.14.4
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'pnpm'
 
       - name: Fetch linked spec (required)
         id: spec
@@ -78,6 +83,9 @@ jobs:
           IMPL_MODEL_LOW: ${{ vars.IMPL_MODEL_LOW }}
         run: node scripts/ai-sdlc/generate-impl.mjs
 
+      - name: Install dependencies (required for ESLint)
+        run: pnpm install --frozen-lockfile
+
       - name: Format generated files
         env:
           FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
@@ -85,6 +93,16 @@ jobs:
           printf '%s' "$FILES_WRITTEN" | tr ',' '\n' | while IFS= read -r f; do
             [ -n "$f" ] && npx prettier@3.6.2 --write --ignore-unknown "$f"
           done
+
+      - name: Lint-fix generated TypeScript files
+        env:
+          FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
+        run: |
+          TS_FILES=$(printf '%s' "$FILES_WRITTEN" | tr ',' '\n' | grep -E '\.(ts|tsx|js|mjs)$' | tr '\n' ' ')
+          if [ -n "$TS_FILES" ]; then
+            # shellcheck disable=SC2086
+            pnpm exec eslint --fix $TS_FILES || true
+          fi
 
       - name: Commit scaffold to branch
         id: push

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -98,11 +98,11 @@ jobs:
         env:
           FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
         run: |
-          TS_FILES=$(printf '%s' "$FILES_WRITTEN" | tr ',' '\n' | grep -E '\.(ts|tsx|js|mjs)$' | tr '\n' ' ')
-          if [ -n "$TS_FILES" ]; then
-            # shellcheck disable=SC2086
-            pnpm exec eslint --fix $TS_FILES || true
-          fi
+          printf '%s' "$FILES_WRITTEN" | tr ',' '\n' | while IFS= read -r f; do
+            if [[ "$f" =~ \.(ts|tsx|js|mjs)$ ]]; then
+              pnpm exec eslint --fix -- "$f" || true
+            fi
+          done
 
       - name: Commit scaffold to branch
         id: push


### PR DESCRIPTION
Agent-generated TypeScript hits auto-fixable ESLint errors on every run — unused params (`options` vs `_options`), etc. PR #235 needed a manual patch for exactly this.

Adds `pnpm/action-setup@v4 (9.14.4)` + `pnpm install --frozen-lockfile` + `pnpm exec eslint --fix` scoped to generated TS/JS files, running after prettier. ESLint exit code is swallowed with `|| true` so non-auto-fixable warnings don't block the commit — the PR CI will still catch them for human review.

Refs #226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated project setup by adding pnpm configuration and dependency caching.
  * Added automatic lint and formatting fixes for generated JavaScript and TypeScript files.
  * Preserved the existing scaffolding, pull request creation, and issue comment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Assisted-by: claude-sonnet-4-6 (agent)