### PR TITLE
improvement(spec-agent): structured template, source-tree context, adversarial verifier

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec.yml
+++ b/.github/ISSUE_TEMPLATE/spec.yml
@@ -1,6 +1,9 @@
 name: Spec
 description: Technical spec for an SDLC work item (AI-SDLC pipeline)
-labels: ["needs-spec", "ai-sdlc"]
+# Note: this form collects the human's high-level intent. The AI-generated
+# spec document (docs/specs/TEMPLATE.md) has a different, more detailed
+# structure — the two intentionally differ.
+labels: ['needs-spec', 'ai-sdlc']
 body:
   - type: textarea
     id: problem
@@ -41,7 +44,23 @@ body:
     id: adr
     attributes:
       label: ADR
-      description: "Path or number if an ADR governs this decision (e.g. docs/adr/0042-agent-identity.md). Leave blank if not yet written."
-      placeholder: "docs/adr/NNNN-slug.md"
+      description: 'Path or number if an ADR governs this decision (e.g. docs/adr/0042-agent-identity.md). Leave blank if not yet written.'
+      placeholder: 'docs/adr/NNNN-slug.md'
+    validations:
+      required: false
+
+  - type: textarea
+    id: files_touched
+    attributes:
+      label: Files touched (optional)
+      description: 'List any files you expect this change to affect. The spec agent will use this as a hint — leave blank to let it infer.'
+    validations:
+      required: false
+
+  - type: textarea
+    id: blocking_prerequisites
+    attributes:
+      label: Blocking prerequisites (optional)
+      description: 'Any issues or PRs that must land before this work can be implemented (e.g. #238). Leave blank if none.'
     validations:
       required: false

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -42,6 +42,12 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: node scripts/ai-sdlc/generate-spec.mjs
 
+      - name: Verify and patch spec (adversarial factual check)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
+        run: node scripts/ai-sdlc/verify-spec.mjs
+
       - name: Format generated files
         env:
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,5 +1,8 @@
 # Spec: <title>
 
+<!-- This is the AI-generated spec document. .github/ISSUE_TEMPLATE/spec.yml is
+     the human issue-filing form — different structure, different purpose. -->
+
 Linked issue: Refs #NNN
 ADR: pending / docs/adr/NNNN-slug.md / n/a
 

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,7 +1,5 @@
 # Spec: <title>
 
-<!-- Keep in sync with .github/ISSUE_TEMPLATE/spec.yml — that template is the canonical source. -->
-
 Linked issue: Refs #NNN
 ADR: pending / docs/adr/NNNN-slug.md / n/a
 

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -2,33 +2,79 @@
 
 <!-- Keep in sync with .github/ISSUE_TEMPLATE/spec.yml — that template is the canonical source. -->
 
-Linked issue: Closes #NNN
-ADR: docs/adr/NNNN-slug.md (or "pending")
+Linked issue: Refs #NNN
+ADR: pending / docs/adr/NNNN-slug.md / n/a
 
-## Problem / motivation
+**Files touched:** <!-- list every file this change edits or creates, e.g. `packages/backend/src/api/routes/foo.ts` -->
+**Blocking prerequisites:** <!-- #NNN — one-line reason, or "none" -->
 
-## Scope and constraints
+## Problem
 
-In scope:
+<!-- One paragraph. What breaks, who is affected, why it matters. -->
 
-- <!-- item -->
+## Out of scope
 
-Out of scope:
+- <!-- explicit exclusion to prevent scope creep during review -->
 
-- <!-- item -->
+## Constraints
 
-Constraints:
+<!-- Hard requirements the implementation must satisfy: type-safety gotchas, backward-compat
+     rules, test-infrastructure gaps, schema interactions, etc. Number them so ACs can reference them. -->
 
-- <!-- item -->
+1. <!-- constraint -->
 
 ## Acceptance criteria
 
-- [ ] <!-- condition -->
+<!-- Specific, testable, written from the caller's perspective.
+     Each bullet should map to a named test case in the Tests section. -->
 
-## How (runnable steps)
+- [ ] <!-- condition — verified by test case X -->
 
-```bash
-# implementation steps
+## Changes
+
+<!-- One subsection per file. Show only new/changed lines in ```ts blocks.
+     Always indicate the insertion point ("Append after X", "Replace Y with Z").
+     Never show the full existing file as if it were new code to write. -->
+
+### `packages/…/file.ts`
+
+<!-- What changes and why (one sentence). -->
+
+```ts
+// Append after <existing line or function name>:
 ```
 
-Rollback: <!-- describe rollback for any irreversible action -->
+## Tests
+
+<!-- One subsection per test file. Separate mock/fixture updates from new test cases. -->
+
+### `packages/…/tests/file.test.ts`
+
+**Mock/fixture updates required:**
+
+<!-- List any changes to test helpers or mocks needed before new test cases can pass.
+     If a helper is missing a key (e.g. db.organizations), call it out explicitly here
+     rather than discovering it at CI runtime. -->
+
+```ts
+// example: add to createMockX():
+```
+
+**Test case A — description (AC #N):**
+
+<!-- Show the concrete vitest/jest setup and assertion, not pseudocode.
+     For ES-module mocks: vi.mock() must be at top level; use vi.mocked() to configure return values. -->
+
+```ts
+```
+
+## Verification
+
+<!-- Only runnable shell commands here — no pseudocode, no file edits. -->
+
+```bash
+pnpm --filter <package> build
+pnpm --filter <package> test:unit
+```
+
+Rollback: <!-- describe rollback for any irreversible action, or "n/a" if all steps are additive -->

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -66,6 +66,7 @@ ADR: pending / docs/adr/NNNN-slug.md / n/a
      For ES-module mocks: vi.mock() must be at top level; use vi.mocked() to configure return values. -->
 
 ```ts
+
 ```
 
 ## Verification

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -43,8 +43,8 @@ const specFile = `docs/specs/${padded}-${slug}.md`;
 
 // Build a source-file tree so the agent can reference accurate paths and
 // spot which files exist before writing the spec. Each root gets its own
-// 60-entry budget so no single large package starves the others.
-const BUDGET_PER_ROOT = 60;
+// 80-entry budget so no single large package starves the others.
+const BUDGET_PER_ROOT = 80;
 
 function scanDir(dir, depth = 0, acc = []) {
   if (depth > 3 || acc.length >= BUDGET_PER_ROOT) return acc;
@@ -73,6 +73,11 @@ const sourceTree = [
   'packages/backend/tests',
   'packages/bugspotter-intelligence/src',
   'packages/bugspotter-intelligence/tests',
+  'packages/billing',
+  'packages/message-broker',
+  'packages/payment-service',
+  'packages/types',
+  'packages/utils',
   'apps',
 ]
   .flatMap((dir) => scanDir(dir))
@@ -95,7 +100,7 @@ ${ISSUE_BODY?.trim() || '(no description provided)'}
 
 Rules:
 - "Linked issue:" line must say "Refs #${ISSUE_NUMBER}"
-- "ADR:" line: write "pending" unless the issue text names a specific ADR
+- "ADR:" line: write "pending" if an ADR will be needed, "docs/adr/NNNN-slug.md" if the issue names one, or "n/a" if the change is purely additive with no architectural decision
 - "Files touched:" must list every file the spec edits or creates, using exact paths from the source tree above
 - In the Changes section, show ONLY new or changed lines — never reproduce the full existing file as if it were new code
 - Indicate insertion points precisely ("Append after <function/line>", "Replace <old> with <new>")

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -58,6 +58,9 @@ function scanDir(rootDir) {
   while (currentLevel.length > 0 && results.length < BUDGET_PER_ROOT * 5) {
     const nextLevel = [];
     for (const dir of currentLevel) {
+      if (results.length >= BUDGET_PER_ROOT * 5) {
+        break;
+      }
       let entries;
       try {
         entries = readdirSync(dir);
@@ -65,11 +68,18 @@ function scanDir(rootDir) {
         continue;
       }
       for (const name of entries) {
-        if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
+        if (results.length >= BUDGET_PER_ROOT * 5) {
+          break;
+        }
+        if (name.startsWith('.') || name === 'node_modules' || name === 'dist') {
+          continue;
+        }
         const full = join(dir, name).replace(/\\/g, '/');
         results.push(full);
         try {
-          if (statSync(full).isDirectory()) nextLevel.push(full);
+          if (statSync(full).isDirectory()) {
+            nextLevel.push(full);
+          }
         } catch {
           /* skip unreadable */
         }

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -42,10 +42,12 @@ const padded = String(ISSUE_NUMBER).padStart(4, '0');
 const specFile = `docs/specs/${padded}-${slug}.md`;
 
 // Build a source-file tree so the agent can reference accurate paths and
-// spot which files exist before writing the spec. Capped at 300 entries to
-// keep prompt size bounded.
+// spot which files exist before writing the spec. Each root gets its own
+// 60-entry budget so no single large package starves the others.
+const BUDGET_PER_ROOT = 60;
+
 function scanDir(dir, depth = 0, acc = []) {
-  if (depth > 3 || acc.length >= 300) return acc;
+  if (depth > 3 || acc.length >= BUDGET_PER_ROOT) return acc;
   let entries;
   try {
     entries = readdirSync(dir);
@@ -53,7 +55,7 @@ function scanDir(dir, depth = 0, acc = []) {
     return acc;
   }
   for (const name of entries) {
-    if (acc.length >= 300) break;
+    if (acc.length >= BUDGET_PER_ROOT) break;
     if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
     const full = join(dir, name).replace(/\\/g, '/');
     acc.push(full);
@@ -66,13 +68,15 @@ function scanDir(dir, depth = 0, acc = []) {
   return acc;
 }
 
-const sourceTreeAcc = [];
-scanDir('packages/backend/src', 0, sourceTreeAcc);
-scanDir('packages/backend/tests', 0, sourceTreeAcc);
-scanDir('packages/bugspotter-intelligence/src', 0, sourceTreeAcc);
-scanDir('packages/bugspotter-intelligence/tests', 0, sourceTreeAcc);
-scanDir('apps', 0, sourceTreeAcc);
-const sourceTree = sourceTreeAcc.join('\n');
+const sourceTree = [
+  'packages/backend/src',
+  'packages/backend/tests',
+  'packages/bugspotter-intelligence/src',
+  'packages/bugspotter-intelligence/tests',
+  'apps',
+]
+  .flatMap((dir) => scanDir(dir))
+  .join('\n');
 
 const prompt = `\
 You are a spec writer for BugSpotter, a SaaS bug-reporting platform (Fastify + TypeScript + Postgres + Redis; pnpm monorepo; Docker Compose on VMs).

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -46,8 +46,10 @@ const specFile = `docs/specs/${padded}-${slug}.md`;
 // 80-entry budget using true level-order BFS: all entries at depth N are
 // collected before any entry at depth N+1 is visited, so a wide directory
 // (e.g. src/api with 137 entries) cannot exhaust the budget before
-// src/services/intelligence is ever reached. A 5x safety cap bounds total
-// fs work; the final slice(0, BUDGET_PER_ROOT) trims to the budget.
+// src/services/intelligence is ever reached. The while condition prevents
+// new levels from starting once results exceed 5× budget, but a wide final
+// level may push beyond that before the check runs — slice(0, BUDGET_PER_ROOT)
+// trims the result to the budget regardless.
 const BUDGET_PER_ROOT = 80;
 
 function scanDir(rootDir) {

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -6,7 +6,8 @@
 // Required env vars: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY
 // Optional:          GITHUB_OUTPUT (set by Actions; falls back to stdout print)
 
-import { readFileSync, writeFileSync, mkdirSync, appendFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, appendFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 
 const { ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, GITHUB_OUTPUT } = process.env;
 
@@ -25,13 +26,42 @@ const slug = ISSUE_TITLE
 const padded = String(ISSUE_NUMBER).padStart(4, '0');
 const specFile = `docs/specs/${padded}-${slug}.md`;
 
+// Build a source-file tree so the agent can reference accurate paths and
+// spot which files exist before writing the spec. Capped at 300 entries to
+// keep prompt size bounded.
+function scanDir(dir, depth = 0, acc = []) {
+  if (depth > 3 || acc.length > 300) return acc;
+  let entries;
+  try { entries = readdirSync(dir); } catch { return acc; }
+  for (const name of entries) {
+    if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
+    const full = join(dir, name).replace(/\\/g, '/');
+    acc.push(full);
+    try {
+      if (statSync(full).isDirectory()) scanDir(full, depth + 1, acc);
+    } catch { /* skip unreadable */ }
+  }
+  return acc;
+}
+
+const sourceTree = [
+  ...scanDir('packages/backend/src'),
+  ...scanDir('packages/backend/tests'),
+  ...scanDir('packages/bugspotter-intelligence/src'),
+  ...scanDir('packages/bugspotter-intelligence/tests'),
+  ...scanDir('apps'),
+].join('\n');
+
 const prompt = `\
 You are a spec writer for BugSpotter, a SaaS bug-reporting platform (Fastify + TypeScript + Postgres + Redis; pnpm monorepo; Docker Compose on VMs).
 
-Draft a spec document for GitHub issue #${ISSUE_NUMBER}. Follow the template below exactly — fill every section, keep the comment markers removed, replace placeholder text with concrete content.
+Draft a spec document for GitHub issue #${ISSUE_NUMBER}. Follow the template below exactly — fill every section, remove comment markers, replace placeholder text with concrete content.
 
 TEMPLATE:
 ${template}
+
+SOURCE FILE TREE (use this to write accurate file paths and verify files exist):
+${sourceTree}
 
 ISSUE #${ISSUE_NUMBER}: ${ISSUE_TITLE}
 
@@ -40,8 +70,13 @@ ${ISSUE_BODY?.trim() || '(no description provided)'}
 Rules:
 - "Linked issue:" line must say "Refs #${ISSUE_NUMBER}"
 - "ADR:" line: write "pending" unless the issue text names a specific ADR
+- "Files touched:" must list every file the spec edits or creates, using exact paths from the source tree above
+- In the Changes section, show ONLY new or changed lines — never reproduce the full existing file as if it were new code
+- Indicate insertion points precisely ("Append after <function/line>", "Replace <old> with <new>")
+- Method names, function signatures, and type names must exist in the source tree above — do not invent them
 - Acceptance criteria must be testable conditions, not vague goals
-- "How (runnable steps)" must be concrete bash/TypeScript snippets an implementor can run
+- In the Tests section, list any mock/fixture helper changes required BEFORE the new test cases (missing keys on mocks cause TypeErrors at runtime, not type errors at compile time)
+- Verification section must contain only runnable shell commands, no pseudocode
 - "Rollback:" must describe a concrete undo action for any irreversible step, or "n/a" if all steps are additive
 - Return ONLY the filled spec document — no preamble, no explanation, no markdown fences`;
 
@@ -52,10 +87,10 @@ const res = await fetch('https://api.anthropic.com/v1/messages', {
     'x-api-key': ANTHROPIC_API_KEY,
     'anthropic-version': '2023-06-01',
   },
-  signal: AbortSignal.timeout(60_000),
+  signal: AbortSignal.timeout(90_000),
   body: JSON.stringify({
     model: 'claude-sonnet-4-6',
-    max_tokens: 2048,
+    max_tokens: 4096,
     messages: [{ role: 'user', content: prompt }],
   }),
 });

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -43,36 +43,39 @@ const specFile = `docs/specs/${padded}-${slug}.md`;
 
 // Build a source-file tree so the agent can reference accurate paths and
 // spot which files exist before writing the spec. Each root gets its own
-// 80-entry BFS budget so the scan spreads across the breadth of the tree
-// rather than exhausting the budget inside one deep subdirectory (e.g.
-// packages/backend/src/api has 137 entries — DFS would never reach
-// src/services with a per-root cap).
+// 80-entry budget using true level-order BFS: all entries at depth N are
+// collected before any entry at depth N+1 is visited, so a wide directory
+// (e.g. src/api with 137 entries) cannot exhaust the budget before
+// src/services/intelligence is ever reached. A 5x safety cap bounds total
+// fs work; the final slice(0, BUDGET_PER_ROOT) trims to the budget.
 const BUDGET_PER_ROOT = 80;
 
 function scanDir(rootDir) {
   const results = [];
-  const queue = [rootDir];
-  while (queue.length > 0 && results.length < BUDGET_PER_ROOT) {
-    const dir = queue.shift();
-    let entries;
-    try {
-      entries = readdirSync(dir);
-    } catch {
-      continue;
-    }
-    for (const name of entries) {
-      if (results.length >= BUDGET_PER_ROOT) break;
-      if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
-      const full = join(dir, name).replace(/\\/g, '/');
-      results.push(full);
+  let currentLevel = [rootDir];
+  while (currentLevel.length > 0 && results.length < BUDGET_PER_ROOT * 5) {
+    const nextLevel = [];
+    for (const dir of currentLevel) {
+      let entries;
       try {
-        if (statSync(full).isDirectory()) queue.push(full);
+        entries = readdirSync(dir);
       } catch {
-        /* skip unreadable */
+        continue;
+      }
+      for (const name of entries) {
+        if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
+        const full = join(dir, name).replace(/\\/g, '/');
+        results.push(full);
+        try {
+          if (statSync(full).isDirectory()) nextLevel.push(full);
+        } catch {
+          /* skip unreadable */
+        }
       }
     }
+    currentLevel = nextLevel;
   }
-  return results;
+  return results.slice(0, BUDGET_PER_ROOT);
 }
 
 const sourceTree = [
@@ -80,11 +83,14 @@ const sourceTree = [
   'packages/backend/tests',
   'packages/bugspotter-intelligence/src',
   'packages/bugspotter-intelligence/tests',
-  'packages/billing',
-  'packages/message-broker',
-  'packages/payment-service',
-  'packages/types',
-  'packages/utils',
+  'packages/billing/src',
+  'packages/billing/tests',
+  'packages/message-broker/src',
+  'packages/message-broker/tests',
+  'packages/payment-service/src',
+  'packages/payment-service/tests',
+  'packages/types/src',
+  'packages/utils/src',
   'apps',
 ]
   .flatMap((dir) => scanDir(dir))

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -6,19 +6,34 @@
 // Required env vars: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY
 // Optional:          GITHUB_OUTPUT (set by Actions; falls back to stdout print)
 
-import { readFileSync, writeFileSync, mkdirSync, appendFileSync, readdirSync, statSync } from 'node:fs';
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  appendFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 const { ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, GITHUB_OUTPUT } = process.env;
 
-if (!ANTHROPIC_API_KEY) { console.error('Missing ANTHROPIC_API_KEY'); process.exit(1); }
-if (!ISSUE_NUMBER)      { console.error('Missing ISSUE_NUMBER');      process.exit(1); }
-if (!ISSUE_TITLE)       { console.error('Missing ISSUE_TITLE');       process.exit(1); }
+if (!ANTHROPIC_API_KEY) {
+  console.error('Missing ANTHROPIC_API_KEY');
+  process.exit(1);
+}
+if (!ISSUE_NUMBER) {
+  console.error('Missing ISSUE_NUMBER');
+  process.exit(1);
+}
+if (!ISSUE_TITLE) {
+  console.error('Missing ISSUE_TITLE');
+  process.exit(1);
+}
 
 const template = readFileSync('docs/specs/TEMPLATE.md', 'utf8');
 
-const slug = ISSUE_TITLE
-  .toLowerCase()
+const slug = ISSUE_TITLE.toLowerCase()
   .replace(/[^a-z0-9]+/g, '-')
   .replace(/^-+|-+$/g, '')
   .slice(0, 40);
@@ -30,27 +45,34 @@ const specFile = `docs/specs/${padded}-${slug}.md`;
 // spot which files exist before writing the spec. Capped at 300 entries to
 // keep prompt size bounded.
 function scanDir(dir, depth = 0, acc = []) {
-  if (depth > 3 || acc.length > 300) return acc;
+  if (depth > 3 || acc.length >= 300) return acc;
   let entries;
-  try { entries = readdirSync(dir); } catch { return acc; }
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return acc;
+  }
   for (const name of entries) {
+    if (acc.length >= 300) break;
     if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
     const full = join(dir, name).replace(/\\/g, '/');
     acc.push(full);
     try {
       if (statSync(full).isDirectory()) scanDir(full, depth + 1, acc);
-    } catch { /* skip unreadable */ }
+    } catch {
+      /* skip unreadable */
+    }
   }
   return acc;
 }
 
-const sourceTree = [
-  ...scanDir('packages/backend/src'),
-  ...scanDir('packages/backend/tests'),
-  ...scanDir('packages/bugspotter-intelligence/src'),
-  ...scanDir('packages/bugspotter-intelligence/tests'),
-  ...scanDir('apps'),
-].join('\n');
+const sourceTreeAcc = [];
+scanDir('packages/backend/src', 0, sourceTreeAcc);
+scanDir('packages/backend/tests', 0, sourceTreeAcc);
+scanDir('packages/bugspotter-intelligence/src', 0, sourceTreeAcc);
+scanDir('packages/bugspotter-intelligence/tests', 0, sourceTreeAcc);
+scanDir('apps', 0, sourceTreeAcc);
+const sourceTree = sourceTreeAcc.join('\n');
 
 const prompt = `\
 You are a spec writer for BugSpotter, a SaaS bug-reporting platform (Fastify + TypeScript + Postgres + Redis; pnpm monorepo; Docker Compose on VMs).
@@ -99,8 +121,14 @@ if (!res.ok) {
   let detail = '';
   try {
     const raw = await res.text();
-    try { detail = JSON.stringify(JSON.parse(raw), null, 2); } catch { detail = raw; }
-  } catch { /* body unreadable */ }
+    try {
+      detail = JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      detail = raw;
+    }
+  } catch {
+    /* body unreadable */
+  }
   console.error(`Claude API error (${res.status}):`, detail);
   process.exit(1);
 }

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -43,29 +43,36 @@ const specFile = `docs/specs/${padded}-${slug}.md`;
 
 // Build a source-file tree so the agent can reference accurate paths and
 // spot which files exist before writing the spec. Each root gets its own
-// 80-entry budget so no single large package starves the others.
+// 80-entry BFS budget so the scan spreads across the breadth of the tree
+// rather than exhausting the budget inside one deep subdirectory (e.g.
+// packages/backend/src/api has 137 entries — DFS would never reach
+// src/services with a per-root cap).
 const BUDGET_PER_ROOT = 80;
 
-function scanDir(dir, depth = 0, acc = []) {
-  if (depth > 3 || acc.length >= BUDGET_PER_ROOT) return acc;
-  let entries;
-  try {
-    entries = readdirSync(dir);
-  } catch {
-    return acc;
-  }
-  for (const name of entries) {
-    if (acc.length >= BUDGET_PER_ROOT) break;
-    if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
-    const full = join(dir, name).replace(/\\/g, '/');
-    acc.push(full);
+function scanDir(rootDir) {
+  const results = [];
+  const queue = [rootDir];
+  while (queue.length > 0 && results.length < BUDGET_PER_ROOT) {
+    const dir = queue.shift();
+    let entries;
     try {
-      if (statSync(full).isDirectory()) scanDir(full, depth + 1, acc);
+      entries = readdirSync(dir);
     } catch {
-      /* skip unreadable */
+      continue;
+    }
+    for (const name of entries) {
+      if (results.length >= BUDGET_PER_ROOT) break;
+      if (name.startsWith('.') || name === 'node_modules' || name === 'dist') continue;
+      const full = join(dir, name).replace(/\\/g, '/');
+      results.push(full);
+      try {
+        if (statSync(full).isDirectory()) queue.push(full);
+      } catch {
+        /* skip unreadable */
+      }
     }
   }
-  return acc;
+  return results;
 }
 
 const sourceTree = [
@@ -102,6 +109,7 @@ Rules:
 - "Linked issue:" line must say "Refs #${ISSUE_NUMBER}"
 - "ADR:" line: write "pending" if an ADR will be needed, "docs/adr/NNNN-slug.md" if the issue names one, or "n/a" if the change is purely additive with no architectural decision
 - "Files touched:" must list every file the spec edits or creates, using exact paths from the source tree above
+- "Blocking prerequisites:" must list any issue or PR number that must land before this work can be implemented (e.g. "#238 — adds the foo table"), or "none" if there are no dependencies
 - In the Changes section, show ONLY new or changed lines — never reproduce the full existing file as if it were new code
 - Indicate insertion points precisely ("Append after <function/line>", "Replace <old> with <new>")
 - Method names, function signatures, and type names must exist in the source tree above — do not invent them

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -44,13 +44,12 @@ const specFile = `docs/specs/${padded}-${slug}.md`;
 // Build a source-file tree so the agent can reference accurate paths and
 // spot which files exist before writing the spec. Each root gets its own
 // 80-entry budget using true level-order BFS: all entries at depth N are
-// collected before any entry at depth N+1 is visited, so a wide directory
-// (e.g. src/api with 137 entries) cannot exhaust the budget before
-// src/services/intelligence is ever reached. The while condition prevents
-// new levels from starting once results exceed 5× budget, but a wide final
-// level may push beyond that before the check runs — slice(0, BUDGET_PER_ROOT)
-// trims the result to the budget regardless.
+// collected before any entry at depth N+1 is visited. To prevent a wide
+// directory from crowding out peer directories within the same BFS level,
+// at most 15 entries per directory are added to results; directories are
+// still queued for BFS traversal regardless of the per-dir cap.
 const BUDGET_PER_ROOT = 80;
+const MAX_ENTRIES_PER_DIR = 15;
 
 function scanDir(rootDir) {
   const results = [];
@@ -67,6 +66,7 @@ function scanDir(rootDir) {
       } catch {
         continue;
       }
+      let addedFromDir = 0;
       for (const name of entries) {
         if (results.length >= BUDGET_PER_ROOT * 5) {
           break;
@@ -75,13 +75,18 @@ function scanDir(rootDir) {
           continue;
         }
         const full = join(dir, name).replace(/\\/g, '/');
-        results.push(full);
+        let isDir = false;
         try {
-          if (statSync(full).isDirectory()) {
-            nextLevel.push(full);
-          }
+          isDir = statSync(full).isDirectory();
         } catch {
-          /* skip unreadable */
+          continue;
+        }
+        if (isDir) {
+          nextLevel.push(full);
+        }
+        if (addedFromDir < MAX_ENTRIES_PER_DIR) {
+          results.push(full);
+          addedFromDir++;
         }
       }
     }

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -22,7 +22,7 @@ if (!SPEC_FILE) {
 const spec = readFileSync(SPEC_FILE, 'utf8');
 
 // Extract every packages/… or apps/… path mentioned in the spec.
-const pathPattern = /(?:packages|apps)\/[\w\-./@]+\.(?:ts|mjs|js|json|yml|yaml)/g;
+const pathPattern = /(?:packages|apps)\/[\w\-./@]+\.(?:ts|mjs|js|json|yml|yaml)(?![\w\-./@])/g;
 const mentioned = [...new Set(spec.match(pathPattern) ?? [])];
 
 // Read files that actually exist (new files won't exist yet — skip them).
@@ -133,6 +133,9 @@ function sanitize(raw) {
       .replace(/\n?```$/, '')
       .trim();
   }
+  // Trim any leading preamble before the first section header.
+  const headerIdx = text.indexOf('## ');
+  if (headerIdx > 0) text = text.slice(headerIdx);
   const required = ['## Problem', '## Changes', '## Tests'];
   if (!required.every((h) => text.includes(h))) return null;
   return text;

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -26,8 +26,11 @@ const pathPattern = /(?:packages|apps)\/[\w\-./@]+\.(?:ts|mjs|js|json|yml|yaml)/
 const mentioned = [...new Set(spec.match(pathPattern) ?? [])];
 
 // Read files that actually exist (new files won't exist yet — skip them).
+// Cap at 15 files to keep the verify prompt bounded.
+const MAX_VERIFY_FILES = 15;
 const fileSections = mentioned
   .filter((p) => !p.includes('..') && existsSync(p))
+  .slice(0, MAX_VERIFY_FILES)
   .map((p) => {
     const content = readFileSync(p, 'utf8');
     // Cap at 300 lines to keep prompt size bounded.
@@ -120,11 +123,31 @@ try {
 }
 const result = data?.content?.[0]?.text?.trim() ?? '';
 
+// Strip outer markdown fences the model sometimes adds, then confirm the
+// required section headers survived before overwriting the spec.
+function sanitize(raw) {
+  let text = raw.trim();
+  if (text.startsWith('```')) {
+    text = text
+      .replace(/^```[a-z]*\n?/, '')
+      .replace(/\n?```$/, '')
+      .trim();
+  }
+  const required = ['## Problem', '## Changes', '## Tests'];
+  if (!required.every((h) => text.includes(h))) return null;
+  return text;
+}
+
 if (result === 'NO_CHANGES_NEEDED') {
   console.log('Spec verification passed — no factual errors found.');
 } else if (result) {
-  writeFileSync(SPEC_FILE, result, 'utf8');
-  console.log('Spec patched by verifier — factual errors corrected.');
+  const patched = sanitize(result);
+  if (patched) {
+    writeFileSync(SPEC_FILE, patched, 'utf8');
+    console.log('Spec patched by verifier — factual errors corrected.');
+  } else {
+    console.warn('Spec verifier response failed sanity check — skipping patch.');
+  }
 } else {
   console.warn('Spec verifier returned empty response — skipping patch.');
 }

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -4,7 +4,9 @@
 // the PR is opened.
 //
 // Required env vars: ANTHROPIC_API_KEY, SPEC_FILE
-// Exits 0 always — verification failure patches the spec, not blocks the run.
+// Configuration errors (missing env vars) exit 1. All other failures
+// (missing spec file, API errors, bad model response) exit 0 so a
+// verification hiccup never blocks the CI run.
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
@@ -19,7 +21,13 @@ if (!SPEC_FILE) {
   process.exit(1);
 }
 
-const spec = readFileSync(SPEC_FILE, 'utf8');
+let spec;
+try {
+  spec = readFileSync(SPEC_FILE, 'utf8');
+} catch (err) {
+  console.warn(`Spec verifier: could not read spec file: ${err.message}`);
+  process.exit(0);
+}
 
 // Extract every packages/… or apps/… path mentioned in the spec.
 const pathPattern = /(?:packages|apps)\/[\w\-./@]+\.(?:ts|mjs|js|json|yml|yaml)(?![\w\-./@])/g;
@@ -133,10 +141,11 @@ function sanitize(raw) {
       .replace(/\n?```$/, '')
       .trim();
   }
-  // Trim any leading preamble before the spec title line.
-  // Anchor to "# Spec:" so frontmatter (Linked issue, ADR, Files touched)
-  // is not stripped along with the preamble.
+  // Require the spec title line — if the model dropped it entirely, reject.
+  // Trim any preamble that precedes it so frontmatter (Linked issue, ADR,
+  // Files touched) is not stripped along with stray prose.
   const titleIdx = text.indexOf('# Spec:');
+  if (titleIdx === -1) return null;
   if (titleIdx > 0) text = text.slice(titleIdx);
   const required = ['## Problem', '## Changes', '## Tests'];
   if (!required.every((h) => text.includes(h))) return null;

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -46,9 +46,10 @@ const fileSections = mentioned
     } catch {
       return null;
     }
-    // Cap at 300 lines to keep prompt size bounded.
-    const lines = content.split('\n').slice(0, 300).join('\n');
-    const truncated = content.split('\n').length > 300 ? '\n[… truncated at 300 lines]' : '';
+    // Cap at 1000 lines — 300 caused false positives when a referenced method
+    // appeared past the cutoff in a larger source file.
+    const lines = content.split('\n').slice(0, 1000).join('\n');
+    const truncated = content.split('\n').length > 1000 ? '\n[… truncated at 1000 lines]' : '';
     return `### ${p}\n\`\`\`ts\n${lines}${truncated}\n\`\`\``;
   })
   .filter(Boolean)

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -40,12 +40,18 @@ const fileSections = mentioned
   .filter((p) => !p.includes('..') && existsSync(p))
   .slice(0, MAX_VERIFY_FILES)
   .map((p) => {
-    const content = readFileSync(p, 'utf8');
+    let content;
+    try {
+      content = readFileSync(p, 'utf8');
+    } catch {
+      return null;
+    }
     // Cap at 300 lines to keep prompt size bounded.
     const lines = content.split('\n').slice(0, 300).join('\n');
     const truncated = content.split('\n').length > 300 ? '\n[… truncated at 300 lines]' : '';
     return `### ${p}\n\`\`\`ts\n${lines}${truncated}\n\`\`\``;
   })
+  .filter(Boolean)
   .join('\n\n');
 
 if (!fileSections) {

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Adversarial spec verifier: reads the generated spec, reads every file it
+// claims to touch, then calls Claude to find and fix factual errors before
+// the PR is opened.
+//
+// Required env vars: ANTHROPIC_API_KEY, SPEC_FILE
+// Exits 0 always — verification failure patches the spec, not blocks the run.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+const { ANTHROPIC_API_KEY, SPEC_FILE } = process.env;
+
+if (!ANTHROPIC_API_KEY) { console.error('Missing ANTHROPIC_API_KEY'); process.exit(1); }
+if (!SPEC_FILE)         { console.error('Missing SPEC_FILE');         process.exit(1); }
+
+const spec = readFileSync(SPEC_FILE, 'utf8');
+
+// Extract every packages/… or apps/… path mentioned in the spec.
+const pathPattern = /(?:packages|apps)\/[\w\-./]+\.(?:ts|mjs|js|json|yml|yaml)/g;
+const mentioned = [...new Set(spec.match(pathPattern) ?? [])];
+
+// Read files that actually exist (new files won't exist yet — skip them).
+const fileSections = mentioned
+  .filter(p => existsSync(p))
+  .map(p => {
+    const content = readFileSync(p, 'utf8');
+    // Cap at 300 lines to keep prompt size bounded.
+    const lines = content.split('\n').slice(0, 300).join('\n');
+    const truncated = content.split('\n').length > 300 ? '\n[… truncated at 300 lines]' : '';
+    return `### ${p}\n\`\`\`ts\n${lines}${truncated}\n\`\`\``;
+  })
+  .join('\n\n');
+
+if (!fileSections) {
+  console.log('No existing source files referenced in spec — skipping verification.');
+  process.exit(0);
+}
+
+const prompt = `\
+You are an adversarial reviewer for a spec document. Your job is to find and fix ONLY factual errors before the spec reaches an impl-agent.
+
+SPEC TO VERIFY:
+${spec}
+
+SOURCE FILES REFERENCED BY THE SPEC:
+${fileSections}
+
+Check for:
+1. Method or function names called in the spec that don't exist in the source files
+2. File paths in the spec that don't match actual paths
+3. TypeScript type errors — e.g. accessing a property typed as non-optional with optional chaining, or vice versa
+4. Test mock/helper shapes — if the spec proposes calling db.X.findById() but the test helper has no X key, flag it
+5. TypeScript closure narrowing — optional function parameters are not narrowed by early-return guards inside nested async closures; a const binding is required
+6. Schema constraints that would produce wrong HTTP status codes (e.g. minimum on a schema field that causes Fastify to reject values the caller legally sends, mapped to a worse error code downstream)
+7. Code shown as "new code to write" that is actually already present in the source file verbatim (impl-agent would duplicate it)
+
+Do NOT change:
+- The spec's intent, scope, or architectural decisions
+- Wording or style unless it contains a factual error
+- Anything not in the check list above
+
+If you find no factual errors, respond with exactly the word: NO_CHANGES_NEEDED
+
+Otherwise respond with the complete corrected spec document — no preamble, no explanation, no markdown fences around the whole document.`;
+
+console.log(`Verifying spec against ${mentioned.filter(p => existsSync(p)).length} source file(s)…`);
+
+const res = await fetch('https://api.anthropic.com/v1/messages', {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'x-api-key': ANTHROPIC_API_KEY,
+    'anthropic-version': '2023-06-01',
+  },
+  signal: AbortSignal.timeout(120_000),
+  body: JSON.stringify({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 4096,
+    messages: [{ role: 'user', content: prompt }],
+  }),
+});
+
+if (!res.ok) {
+  let detail = '';
+  try {
+    const raw = await res.text();
+    try { detail = JSON.stringify(JSON.parse(raw), null, 2); } catch { detail = raw; }
+  } catch { /* body unreadable */ }
+  // Verification failure is non-fatal — log and continue with unpatched spec.
+  console.warn(`Spec verifier API error (${res.status}): ${detail}`);
+  process.exit(0);
+}
+
+const data = await res.json();
+const result = data?.content?.[0]?.text?.trim() ?? '';
+
+if (result === 'NO_CHANGES_NEEDED') {
+  console.log('Spec verification passed — no factual errors found.');
+} else if (result) {
+  writeFileSync(SPEC_FILE, result, 'utf8');
+  console.log('Spec patched by verifier — factual errors corrected.');
+} else {
+  console.warn('Spec verifier returned empty response — skipping patch.');
+}

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -103,7 +103,7 @@ try {
     signal: AbortSignal.timeout(120_000),
     body: JSON.stringify({
       model: 'claude-sonnet-4-6',
-      max_tokens: 4096,
+      max_tokens: 8192,
       messages: [{ role: 'user', content: prompt }],
     }),
   });
@@ -136,10 +136,18 @@ try {
   console.warn(`Failed to parse spec verifier response: ${err.message}`);
   process.exit(0);
 }
+// Truncated responses pass header checks because the missing content is at
+// the tail — stop_reason is the authoritative signal (mirrors generate-impl.mjs).
+if (data.stop_reason === 'max_tokens') {
+  console.warn('Spec verifier response truncated (stop_reason=max_tokens) — skipping patch.');
+  process.exit(0);
+}
+
 const result = data?.content?.[0]?.text?.trim() ?? '';
 
-// Strip outer markdown fences the model sometimes adds, then confirm the
-// required section headers survived before overwriting the spec.
+// Strip outer markdown fences the model sometimes adds, then confirm all
+// required section headers survived — tail sections (Verification, Rollback)
+// are what truncation cuts first.
 function sanitize(raw) {
   let text = raw.trim();
   if (text.startsWith('```')) {
@@ -154,7 +162,15 @@ function sanitize(raw) {
   const titleIdx = text.indexOf('# Spec:');
   if (titleIdx === -1) return null;
   if (titleIdx > 0) text = text.slice(titleIdx);
-  const required = ['## Problem', '## Changes', '## Tests'];
+  const required = [
+    '## Problem',
+    '## Out of scope',
+    '## Constraints',
+    '## Acceptance criteria',
+    '## Changes',
+    '## Tests',
+    '## Verification',
+  ];
   if (!required.every((h) => text.includes(h))) return null;
   return text;
 }

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -22,7 +22,7 @@ if (!SPEC_FILE) {
 const spec = readFileSync(SPEC_FILE, 'utf8');
 
 // Extract every packages/… or apps/… path mentioned in the spec.
-const pathPattern = /(?:packages|apps)\/[\w\-./]+\.(?:ts|mjs|js|json|yml|yaml)/g;
+const pathPattern = /(?:packages|apps)\/[\w\-./@]+\.(?:ts|mjs|js|json|yml|yaml)/g;
 const mentioned = [...new Set(spec.match(pathPattern) ?? [])];
 
 // Read files that actually exist (new files won't exist yet — skip them).
@@ -111,7 +111,13 @@ if (!res.ok) {
   process.exit(0);
 }
 
-const data = await res.json();
+let data;
+try {
+  data = await res.json();
+} catch (err) {
+  console.warn(`Failed to parse spec verifier response: ${err.message}`);
+  process.exit(0);
+}
 const result = data?.content?.[0]?.text?.trim() ?? '';
 
 if (result === 'NO_CHANGES_NEEDED') {

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -150,6 +150,13 @@ const result = data?.content?.[0]?.text?.trim() ?? '';
 // are what truncation cuts first.
 function sanitize(raw) {
   let text = raw.trim();
+  // Discard conversational preamble preceding an opening code fence so that
+  // startsWith('```') fires correctly and the closing fence is also stripped.
+  const tickIdx = text.indexOf('```');
+  const titleIdxEarly = text.indexOf('# Spec:');
+  if (tickIdx !== -1 && (titleIdxEarly === -1 || tickIdx < titleIdxEarly)) {
+    text = text.slice(tickIdx);
+  }
   if (text.startsWith('```')) {
     text = text
       .replace(/^```[a-z]*\n?/, '')

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -133,9 +133,11 @@ function sanitize(raw) {
       .replace(/\n?```$/, '')
       .trim();
   }
-  // Trim any leading preamble before the first section header.
-  const headerIdx = text.indexOf('## ');
-  if (headerIdx > 0) text = text.slice(headerIdx);
+  // Trim any leading preamble before the spec title line.
+  // Anchor to "# Spec:" so frontmatter (Linked issue, ADR, Files touched)
+  // is not stripped along with the preamble.
+  const titleIdx = text.indexOf('# Spec:');
+  if (titleIdx > 0) text = text.slice(titleIdx);
   const required = ['## Problem', '## Changes', '## Tests'];
   if (!required.every((h) => text.includes(h))) return null;
   return text;

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -10,8 +10,14 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
 const { ANTHROPIC_API_KEY, SPEC_FILE } = process.env;
 
-if (!ANTHROPIC_API_KEY) { console.error('Missing ANTHROPIC_API_KEY'); process.exit(1); }
-if (!SPEC_FILE)         { console.error('Missing SPEC_FILE');         process.exit(1); }
+if (!ANTHROPIC_API_KEY) {
+  console.error('Missing ANTHROPIC_API_KEY');
+  process.exit(1);
+}
+if (!SPEC_FILE) {
+  console.error('Missing SPEC_FILE');
+  process.exit(1);
+}
 
 const spec = readFileSync(SPEC_FILE, 'utf8');
 
@@ -21,8 +27,8 @@ const mentioned = [...new Set(spec.match(pathPattern) ?? [])];
 
 // Read files that actually exist (new files won't exist yet — skip them).
 const fileSections = mentioned
-  .filter(p => existsSync(p))
-  .map(p => {
+  .filter((p) => !p.includes('..') && existsSync(p))
+  .map((p) => {
     const content = readFileSync(p, 'utf8');
     // Cap at 300 lines to keep prompt size bounded.
     const lines = content.split('\n').slice(0, 300).join('\n');
@@ -63,29 +69,43 @@ If you find no factual errors, respond with exactly the word: NO_CHANGES_NEEDED
 
 Otherwise respond with the complete corrected spec document — no preamble, no explanation, no markdown fences around the whole document.`;
 
-console.log(`Verifying spec against ${mentioned.filter(p => existsSync(p)).length} source file(s)…`);
+console.log(
+  `Verifying spec against ${mentioned.filter((p) => existsSync(p)).length} source file(s)…`
+);
 
-const res = await fetch('https://api.anthropic.com/v1/messages', {
-  method: 'POST',
-  headers: {
-    'content-type': 'application/json',
-    'x-api-key': ANTHROPIC_API_KEY,
-    'anthropic-version': '2023-06-01',
-  },
-  signal: AbortSignal.timeout(120_000),
-  body: JSON.stringify({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 4096,
-    messages: [{ role: 'user', content: prompt }],
-  }),
-});
+let res;
+try {
+  res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    signal: AbortSignal.timeout(120_000),
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+} catch (err) {
+  console.warn(`Spec verifier fetch error: ${err.message}`);
+  process.exit(0);
+}
 
 if (!res.ok) {
   let detail = '';
   try {
     const raw = await res.text();
-    try { detail = JSON.stringify(JSON.parse(raw), null, 2); } catch { detail = raw; }
-  } catch { /* body unreadable */ }
+    try {
+      detail = JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      detail = raw;
+    }
+  } catch {
+    /* body unreadable */
+  }
   // Verification failure is non-fatal — log and continue with unpatched spec.
   console.warn(`Spec verifier API error (${res.status}): ${detail}`);
   process.exit(0);


### PR DESCRIPTION
## What and why

7 fix-commits on the #239 spec (issue #237) traced to five error categories:

| Category | Example | Root cause |
|---|---|---|
| Hallucinated method names | `clientFactory.getOrgSettings` | Agent had no codebase context |
| Wrong file paths | `src/clients/` vs `src/services/intelligence/` | Same |
| Architectural misunderstanding | `getOrgIntelligenceSettings` always fills default | Agent didn't read the function |
| TS closure narrowing | `db` not narrowed inside async closure | Not caught by 3 bot review rounds |
| Schema → wrong status code | `minimum:0.5` causing 400→502 | Cross-file interaction, bots missed it |

## Changes

**`docs/specs/TEMPLATE.md`** — restructured into `## Changes` / `## Tests` / `## Verification` sections with real ` ```ts ``` ` blocks. Adds `Files touched` and `Blocking prerequisites` frontmatter. Mock/fixture updates get their own explicit callout before test cases.

**`scripts/ai-sdlc/generate-spec.mjs`** — scans `packages/backend/src`, `packages/bugspotter-intelligence/src`, and test directories and passes the file tree as prompt context. Agent can reference accurate paths before writing. `max_tokens` raised 2048→4096. Prompt rules updated to enforce append-only Change instructions and explicit mock gaps.

**`scripts/ai-sdlc/verify-spec.mjs`** (new) — reads every source file the spec references, then runs an adversarial Claude pass checking for: non-existent methods, wrong file paths, wrong TypeScript types, missing test mock keys, TS closure narrowing issues, schema constraints that produce wrong downstream status codes, and code shown as new that already exists. Patches the spec in-place; non-fatal on API error.

**`.github/workflows/spec-agent.yml`** — adds verify step between generate and prettier.

## Expected outcome

The issues caught across 7 commits on #239 would be caught in the verify step before the PR opens, reducing bot review rounds from 3+ to 1.

Refs #237

Assisted-by: claude-sonnet-4-6 (agent)