### PR TITLE
improvement(spec-agent): switchable LLM backend (API key or Claude subscription)

### DIFF
--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -1,10 +1,18 @@
 name: Spec Agent
 
 # Phase 1 agent: fires when a human applies the `needs-spec` label.
-# Calls Claude API to draft a spec from TEMPLATE.md and opens a DRAFT PR.
+# Calls Claude to draft a spec from TEMPLATE.md and opens a DRAFT PR.
 # Gate 1 (spec approval) is human-held: the agent cannot merge.
 #
-# Required secrets: ANTHROPIC_API_KEY
+# LLM backend is switchable via the LLM_BACKEND repo variable:
+#   unset/"api" (default) — Messages API, billed per-token, needs
+#     secrets.ANTHROPIC_API_KEY
+#   "cli" — routes through the Claude Code CLI so usage draws from a Claude
+#     subscription instead, needs secrets.CLAUDE_CODE_OAUTH_TOKEN (generate
+#     with `claude setup-token`, requires Pro/Max/Team/Enterprise)
+# Set with: gh variable set LLM_BACKEND --body cli   (or "api" to switch back)
+#
+# Required secrets: ANTHROPIC_API_KEY and/or CLAUDE_CODE_OAUTH_TOKEN
 # ADR: docs/adr/0042-agent-identity-scoped-app.md
 
 on:
@@ -33,10 +41,16 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install Claude Code CLI
+        if: vars.LLM_BACKEND == 'cli'
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Generate spec
         id: gen
         env:
+          LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -44,7 +58,9 @@ jobs:
 
       - name: Verify and patch spec (adversarial factual check)
         env:
+          LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
         run: node scripts/ai-sdlc/verify-spec.mjs
 

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// Calls Claude API to draft a spec document for a GitHub issue.
+// Calls Claude to draft a spec document for a GitHub issue.
 // Run from the repo root. Reads TEMPLATE.md; writes docs/specs/<file>.
 // Outputs spec_file and spec_slug to GITHUB_OUTPUT.
 //
-// Required env vars: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY
+// Required env vars: ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, plus either
+//   ANTHROPIC_API_KEY (default) or CLAUDE_CODE_OAUTH_TOKEN (LLM_BACKEND=cli)
 // Optional:          GITHUB_OUTPUT (set by Actions; falls back to stdout print)
 
 import {
@@ -15,13 +16,11 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { callClaude, requireLlmCredentials } from './llm-client.mjs';
 
-const { ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, GITHUB_OUTPUT } = process.env;
+const { ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, GITHUB_OUTPUT } = process.env;
 
-if (!ANTHROPIC_API_KEY) {
-  console.error('Missing ANTHROPIC_API_KEY');
-  process.exit(1);
-}
+requireLlmCredentials();
 if (!ISSUE_NUMBER) {
   console.error('Missing ISSUE_NUMBER');
   process.exit(1);
@@ -142,42 +141,13 @@ Rules:
 - "Rollback:" must describe a concrete undo action for any irreversible step, or "n/a" if all steps are additive
 - Return ONLY the filled spec document — no preamble, no explanation, no markdown fences`;
 
-const res = await fetch('https://api.anthropic.com/v1/messages', {
-  method: 'POST',
-  headers: {
-    'content-type': 'application/json',
-    'x-api-key': ANTHROPIC_API_KEY,
-    'anthropic-version': '2023-06-01',
-  },
-  signal: AbortSignal.timeout(90_000),
-  body: JSON.stringify({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 4096,
-    messages: [{ role: 'user', content: prompt }],
-  }),
-});
-
-if (!res.ok) {
-  let detail = '';
-  try {
-    const raw = await res.text();
-    try {
-      detail = JSON.stringify(JSON.parse(raw), null, 2);
-    } catch {
-      detail = raw;
-    }
-  } catch {
-    /* body unreadable */
-  }
-  console.error(`Claude API error (${res.status}):`, detail);
+let specContent;
+try {
+  ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 90_000 }));
+} catch (err) {
+  console.error(err.message);
   process.exit(1);
 }
-const data = await res.json();
-if (data?.content?.[0]?.type !== 'text') {
-  console.error('Unexpected API response shape:', JSON.stringify(data, null, 2));
-  process.exit(1);
-}
-const specContent = data.content[0].text;
 
 mkdirSync('docs/specs', { recursive: true });
 writeFileSync(specFile, specContent, 'utf8');

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -110,6 +110,10 @@ async function callViaCli({ prompt, timeoutMs }) {
         reject(new Error(`Failed to parse claude CLI JSON output: ${err.message}\n${stdout}`));
         return;
       }
+      if (!data || typeof data !== 'object') {
+        reject(new Error(`Unexpected claude CLI JSON output (not an object): ${stdout}`));
+        return;
+      }
       if (data.is_error) {
         reject(new Error(`claude CLI reported an error: ${JSON.stringify(data)}`));
         return;

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -70,7 +70,11 @@ async function callViaCli({ prompt, timeoutMs }) {
     const child = spawn(
       'claude',
       ['-p', '--output-format', 'json', '--model', CLI_MODEL, '--allowedTools='],
-      { stdio: ['pipe', 'pipe', 'pipe'], shell: true }
+      // shell only on Windows, where npm's global bin is a .cmd shim spawn()
+      // can't exec directly. On POSIX (CI runs on ubuntu-latest) spawning
+      // claude directly means SIGKILL on timeout kills the actual process
+      // instead of orphaning it under an intermediate shell.
+      { stdio: ['pipe', 'pipe', 'pipe'], shell: process.platform === 'win32' }
     );
 
     let stdout = '';
@@ -80,6 +84,8 @@ async function callViaCli({ prompt, timeoutMs }) {
       reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
     }, timeoutMs);
 
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
     child.stdout.on('data', (d) => {
       stdout += d;
     });
@@ -114,6 +120,7 @@ async function callViaCli({ prompt, timeoutMs }) {
       resolve({ text: data.result, stopReason: data.stop_reason });
     });
 
+    child.stdin.on('error', () => {});
     child.stdin.write(prompt);
     child.stdin.end();
   });

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -96,10 +96,11 @@ async function callViaCli({ prompt, timeoutMs }) {
       clearTimeout(timer);
       reject(err);
     });
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
       clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(`claude CLI exited with code ${code}: ${stderr}`));
+      if (code !== 0 || signal) {
+        const reason = code !== null ? `code ${code}` : `signal ${signal}`;
+        reject(new Error(`claude CLI exited with ${reason}: ${stderr}`));
         return;
       }
       let data;

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -1,0 +1,128 @@
+// Shared Claude call for ai-sdlc scripts (generate-spec.mjs, verify-spec.mjs).
+//
+// LLM_BACKEND=api (default) — raw Messages API call, billed per-token,
+//   needs ANTHROPIC_API_KEY.
+// LLM_BACKEND=cli — routes through the Claude Code CLI so usage draws from a
+//   Claude subscription instead of metered API billing, needs
+//   CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`, requires Pro/Max/
+//   Team/Enterprise). Tools are disabled (--allowedTools "") so the call is a
+//   plain text completion, matching the API path's behavior — without this,
+//   Claude Code's normal agentic tool loop would try to explore/edit files.
+
+import { spawn } from 'node:child_process';
+
+const LLM_BACKEND = process.env.LLM_BACKEND || 'api';
+
+const CLI_MODEL = 'claude-sonnet-4-6';
+
+export function requireLlmCredentials() {
+  if (LLM_BACKEND === 'cli') {
+    if (!process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+      console.error('Missing CLAUDE_CODE_OAUTH_TOKEN (required when LLM_BACKEND=cli)');
+      process.exit(1);
+    }
+  } else if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('Missing ANTHROPIC_API_KEY');
+    process.exit(1);
+  }
+}
+
+async function callViaApi({ prompt, maxTokens, timeoutMs }) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': process.env.ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      max_tokens: maxTokens,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    let detail = '';
+    try {
+      const raw = await res.text();
+      try {
+        detail = JSON.stringify(JSON.parse(raw), null, 2);
+      } catch {
+        detail = raw;
+      }
+    } catch {
+      /* body unreadable */
+    }
+    throw new Error(`Claude API error (${res.status}): ${detail}`);
+  }
+
+  const data = await res.json();
+  if (data?.content?.[0]?.type !== 'text') {
+    throw new Error(`Unexpected API response shape: ${JSON.stringify(data, null, 2)}`);
+  }
+  return { text: data.content[0].text, stopReason: data.stop_reason };
+}
+
+async function callViaCli({ prompt, timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'claude',
+      ['-p', '--output-format', 'json', '--model', CLI_MODEL, '--allowedTools='],
+      { stdio: ['pipe', 'pipe', 'pipe'], shell: true }
+    );
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout.on('data', (d) => {
+      stdout += d;
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`claude CLI exited with code ${code}: ${stderr}`));
+        return;
+      }
+      let data;
+      try {
+        data = JSON.parse(stdout);
+      } catch (err) {
+        reject(new Error(`Failed to parse claude CLI JSON output: ${err.message}\n${stdout}`));
+        return;
+      }
+      if (data.is_error) {
+        reject(new Error(`claude CLI reported an error: ${JSON.stringify(data)}`));
+        return;
+      }
+      if (typeof data.result !== 'string') {
+        reject(new Error(`Unexpected claude CLI response shape: ${JSON.stringify(data)}`));
+        return;
+      }
+      resolve({ text: data.result, stopReason: data.stop_reason });
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}
+
+// Returns { text, stopReason }, e.g. stopReason 'end_turn' | 'max_tokens'.
+export async function callClaude({ prompt, maxTokens, timeoutMs }) {
+  if (LLM_BACKEND === 'cli') {
+    return callViaCli({ prompt, timeoutMs });
+  }
+  return callViaApi({ prompt, maxTokens, timeoutMs });
+}

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -3,19 +3,18 @@
 // claims to touch, then calls Claude to find and fix factual errors before
 // the PR is opened.
 //
-// Required env vars: ANTHROPIC_API_KEY, SPEC_FILE
+// Required env vars: SPEC_FILE, plus either ANTHROPIC_API_KEY (default) or
+//   CLAUDE_CODE_OAUTH_TOKEN (LLM_BACKEND=cli)
 // Configuration errors (missing env vars) exit 1. All other failures
 // (missing spec file, API errors, bad model response) exit 0 so a
 // verification hiccup never blocks the CI run.
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { callClaude, requireLlmCredentials } from './llm-client.mjs';
 
-const { ANTHROPIC_API_KEY, SPEC_FILE } = process.env;
+const { SPEC_FILE } = process.env;
 
-if (!ANTHROPIC_API_KEY) {
-  console.error('Missing ANTHROPIC_API_KEY');
-  process.exit(1);
-}
+requireLlmCredentials();
 if (!SPEC_FILE) {
   console.error('Missing SPEC_FILE');
   process.exit(1);
@@ -91,59 +90,22 @@ console.log(
   `Verifying spec against ${mentioned.filter((p) => existsSync(p)).length} source file(s)…`
 );
 
-let res;
+let text, stopReason;
 try {
-  res = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-api-key': ANTHROPIC_API_KEY,
-      'anthropic-version': '2023-06-01',
-    },
-    signal: AbortSignal.timeout(120_000),
-    body: JSON.stringify({
-      model: 'claude-sonnet-4-6',
-      max_tokens: 8192,
-      messages: [{ role: 'user', content: prompt }],
-    }),
-  });
+  ({ text, stopReason } = await callClaude({ prompt, maxTokens: 8192, timeoutMs: 120_000 }));
 } catch (err) {
-  console.warn(`Spec verifier fetch error: ${err.message}`);
-  process.exit(0);
-}
-
-if (!res.ok) {
-  let detail = '';
-  try {
-    const raw = await res.text();
-    try {
-      detail = JSON.stringify(JSON.parse(raw), null, 2);
-    } catch {
-      detail = raw;
-    }
-  } catch {
-    /* body unreadable */
-  }
   // Verification failure is non-fatal — log and continue with unpatched spec.
-  console.warn(`Spec verifier API error (${res.status}): ${detail}`);
-  process.exit(0);
-}
-
-let data;
-try {
-  data = await res.json();
-} catch (err) {
-  console.warn(`Failed to parse spec verifier response: ${err.message}`);
+  console.warn(`Spec verifier error: ${err.message}`);
   process.exit(0);
 }
 // Truncated responses pass header checks because the missing content is at
 // the tail — stop_reason is the authoritative signal (mirrors generate-impl.mjs).
-if (data.stop_reason === 'max_tokens') {
+if (stopReason === 'max_tokens') {
   console.warn('Spec verifier response truncated (stop_reason=max_tokens) — skipping patch.');
   process.exit(0);
 }
 
-const result = data?.content?.[0]?.text?.trim() ?? '';
+const result = text?.trim() ?? '';
 
 // Strip outer markdown fences the model sometimes adds, then confirm all
 // required section headers survived — tail sections (Verification, Rollback)


### PR DESCRIPTION
## Summary
- `ANTHROPIC_API_KEY` ran out of credit and blocked the spec-agent workflow (issue #238's `needs-spec` run failed with a 400 billing error). Fixes #242.
- Extracts the Claude call from `generate-spec.mjs` / `verify-spec.mjs` into a shared `scripts/ai-sdlc/llm-client.mjs` with two backends: the raw Messages API (default, `ANTHROPIC_API_KEY`) or the Claude Code CLI (`LLM_BACKEND=cli`, `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`, draws from a Claude subscription instead of metered billing).
- Switch with `gh variable set LLM_BACKEND --body cli` (or `api` to revert) — no code changes needed to toggle.

## Test plan
- [x] `node --check` on all three scripts
- [x] `actionlint` on the updated workflow
- [x] `prettier --check` clean
- [x] Live round-trip on the CLI backend (`LLM_BACKEND=cli`, real subscription auth) — confirmed working response + `stop_reason`
- [x] API backend confirmed to fail with the same original low-balance error (behavior-preserving refactor, not a regression)
- [ ] First live `needs-spec` run in CI on whichever backend is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)