### PR TITLE
fix(spec-agent): strip ANTHROPIC_API_KEY from claude CLI subprocess env

### DIFF
--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -8,6 +8,9 @@
 //   Team/Enterprise). Tools are disabled (--allowedTools "") so the call is a
 //   plain text completion, matching the API path's behavior — without this,
 //   Claude Code's normal agentic tool loop would try to explore/edit files.
+//   ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN are deliberately stripped from the
+//   CLI subprocess env (see callViaCli) since they outrank the OAuth token
+//   in Claude Code's auth precedence and would otherwise silently shadow it.
 
 import { spawn } from 'node:child_process';
 

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -75,9 +75,17 @@ async function callViaCli({ prompt, timeoutMs }) {
     // anywhere in the parent environment silently overrides
     // CLAUDE_CODE_OAUTH_TOKEN. Strip both from the child's env so the OAuth
     // token is what actually authenticates this call.
+    // { ...process.env } yields a plain object with whatever key casing the
+    // OS reported; on Windows that copy is case-sensitive even though
+    // process.env itself is not, so an exact-case delete can miss a
+    // variable set with different casing. Strip case-insensitively.
     const childEnv = { ...process.env };
-    delete childEnv.ANTHROPIC_API_KEY;
-    delete childEnv.ANTHROPIC_AUTH_TOKEN;
+    for (const key of Object.keys(childEnv)) {
+      const upperKey = key.toUpperCase();
+      if (upperKey === 'ANTHROPIC_API_KEY' || upperKey === 'ANTHROPIC_AUTH_TOKEN') {
+        delete childEnv[key];
+      }
+    }
 
     const child = spawn(
       'claude',

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -123,7 +123,7 @@ async function callViaCli({ prompt, timeoutMs }) {
         // The claude CLI's error detail (e.g. a billing/auth failure) lands
         // in the JSON on stdout, not stderr — include both.
         const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n');
-        reject(new Error(`claude CLI exited with ${reason}: ${detail}`));
+        reject(new Error(`claude CLI exited with ${reason}${detail ? `: ${detail}` : ''}`));
         return;
       }
       let data;

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -111,7 +111,7 @@ async function callViaCli({ prompt, timeoutMs }) {
         const reason = code !== null ? `code ${code}` : `signal ${signal}`;
         // The claude CLI's error detail (e.g. a billing/auth failure) lands
         // in the JSON on stdout, not stderr — include both.
-        const detail = [stderr, stdout].filter(Boolean).join('\n');
+        const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n');
         reject(new Error(`claude CLI exited with ${reason}: ${detail}`));
         return;
       }

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -67,6 +67,15 @@ async function callViaApi({ prompt, maxTokens, timeoutMs }) {
 
 async function callViaCli({ prompt, timeoutMs }) {
   return new Promise((resolve, reject) => {
+    // ANTHROPIC_API_KEY (and ANTHROPIC_AUTH_TOKEN) outrank the OAuth token in
+    // Claude Code's own auth precedence, so a stale/low-balance key set
+    // anywhere in the parent environment silently overrides
+    // CLAUDE_CODE_OAUTH_TOKEN. Strip both from the child's env so the OAuth
+    // token is what actually authenticates this call.
+    const childEnv = { ...process.env };
+    delete childEnv.ANTHROPIC_API_KEY;
+    delete childEnv.ANTHROPIC_AUTH_TOKEN;
+
     const child = spawn(
       'claude',
       ['-p', '--output-format', 'json', '--model', CLI_MODEL, '--allowedTools='],
@@ -74,7 +83,7 @@ async function callViaCli({ prompt, timeoutMs }) {
       // can't exec directly. On POSIX (CI runs on ubuntu-latest) spawning
       // claude directly means SIGKILL on timeout kills the actual process
       // instead of orphaning it under an intermediate shell.
-      { stdio: ['pipe', 'pipe', 'pipe'], shell: process.platform === 'win32' }
+      { stdio: ['pipe', 'pipe', 'pipe'], shell: process.platform === 'win32', env: childEnv }
     );
 
     let stdout = '';
@@ -100,7 +109,10 @@ async function callViaCli({ prompt, timeoutMs }) {
       clearTimeout(timer);
       if (code !== 0 || signal) {
         const reason = code !== null ? `code ${code}` : `signal ${signal}`;
-        reject(new Error(`claude CLI exited with ${reason}: ${stderr}`));
+        // The claude CLI's error detail (e.g. a billing/auth failure) lands
+        // in the JSON on stdout, not stderr — include both.
+        const detail = [stderr, stdout].filter(Boolean).join('\n');
+        reject(new Error(`claude CLI exited with ${reason}: ${detail}`));
         return;
       }
       let data;

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -94,6 +94,38 @@ test('callViaCli strips ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN from the spawned 
   }
 });
 
+test('callViaCli strips differently-cased ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN keys too', async () => {
+  // { ...process.env } copies keys with whatever casing they happen to
+  // have; an exact-case delete would miss a variable set under different
+  // casing (e.g. inherited from a case-insensitive OS environment on
+  // Windows). Prove the strip is case-insensitive by planting lowercase
+  // variants and checking neither casing reaches the child.
+  process.env.anthropic_api_key = 'sk-ant-leaked-lowercase-key';
+  process.env.Anthropic_Auth_Token = 'leaked-mixed-case-token';
+  process.env.FAKE_CLAUDE_MODE = 'success';
+  process.env.FAKE_CLAUDE_ENV_DUMP = ENV_DUMP;
+
+  try {
+    await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
+
+    const childEnv = JSON.parse(readFileSync(ENV_DUMP, 'utf8'));
+    assert.equal(
+      childEnv.anthropic_api_key,
+      undefined,
+      'lowercase anthropic_api_key must not reach the child'
+    );
+    assert.equal(
+      childEnv.Anthropic_Auth_Token,
+      undefined,
+      'mixed-case Anthropic_Auth_Token must not reach the child'
+    );
+    assert.equal(childEnv.CLAUDE_CODE_OAUTH_TOKEN, 'test-oauth-token');
+  } finally {
+    delete process.env.anthropic_api_key;
+    delete process.env.Anthropic_Auth_Token;
+  }
+});
+
 test('callViaCli error path includes stdout content (not just stderr) in the thrown error', async () => {
   process.env.FAKE_CLAUDE_MODE = 'error';
   process.env.FAKE_CLAUDE_ENV_DUMP = '';

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -1,0 +1,105 @@
+// Tests for llm-client.mjs's CLI backend (callViaCli, via callClaude).
+// Zero-dependency: run with `node --test`.
+//
+// Rather than mocking node:child_process.spawn, this puts a fake `claude`
+// executable ahead of everything else on PATH, so callViaCli's real spawn()
+// call resolves to it. That exercises the actual code path end to end:
+// - proves ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN are genuinely absent
+//   from the *actual* child process env (the fake binary dumps its own
+//   process.env to a file — not an env object we merely inspect on the
+//   parent side), while other vars (e.g. CLAUDE_CODE_OAUTH_TOKEN) survive.
+// - proves a non-zero exit's stdout content lands in the thrown Error
+//   message, not just stderr.
+//
+// Two entrypoints are written because callViaCli spawns with
+// shell: process.platform === 'win32' (see llm-client.mjs): POSIX execs
+// `claude` directly via its shebang, Windows resolves `claude.cmd` through
+// cmd.exe's PATHEXT search. Both delegate to the same CommonJS impl file
+// (the temp dir has no package.json, so a bare `claude` script defaults to
+// CommonJS as Node's entry-point module system).
+
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdtempSync, rmSync, chmodSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const DIR = mkdtempSync(join(tmpdir(), 'llm-client-test-'));
+const IMPL = join(DIR, 'fake-claude-impl.cjs');
+const ENV_DUMP = join(DIR, 'env-dump.json');
+
+writeFileSync(
+  IMPL,
+  [
+    "const fs = require('node:fs');",
+    'const dumpPath = process.env.FAKE_CLAUDE_ENV_DUMP;',
+    'if (dumpPath) fs.writeFileSync(dumpPath, JSON.stringify(process.env));',
+    "const mode = process.env.FAKE_CLAUDE_MODE || 'success';",
+    "if (mode === 'error') {",
+    "  process.stdout.write('FAKE_STDOUT_MARKER: upstream billing failure detail');",
+    '  process.exit(2);',
+    '}',
+    "process.stdout.write(JSON.stringify({ result: 'fake cli response', stop_reason: 'end_turn' }));",
+    'process.exit(0);',
+    '',
+  ].join('\n')
+);
+
+const POSIX_BIN = join(DIR, 'claude');
+writeFileSync(POSIX_BIN, `#!/usr/bin/env node\nrequire(${JSON.stringify(IMPL)});\n`);
+chmodSync(POSIX_BIN, 0o755);
+
+const WIN_BIN = join(DIR, 'claude.cmd');
+writeFileSync(WIN_BIN, `@echo off\r\nnode "${IMPL}" %*\r\n`);
+
+after(() => rmSync(DIR, { recursive: true, force: true }));
+
+// LLM_BACKEND is read at module-load time in llm-client.mjs, so it must be
+// set before the dynamic import below.
+process.env.LLM_BACKEND = 'cli';
+process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
+process.env.PATH = `${DIR}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`;
+
+const { callClaude } = await import('./llm-client.mjs');
+
+test('callViaCli strips ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN from the spawned child env, keeps other vars', async () => {
+  process.env.ANTHROPIC_API_KEY = 'sk-ant-leaked-key';
+  process.env.ANTHROPIC_AUTH_TOKEN = 'leaked-auth-token';
+  process.env.FAKE_CLAUDE_MODE = 'success';
+  process.env.FAKE_CLAUDE_ENV_DUMP = ENV_DUMP;
+
+  try {
+    const result = await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
+    assert.equal(result.text, 'fake cli response');
+    assert.equal(result.stopReason, 'end_turn');
+
+    const childEnv = JSON.parse(readFileSync(ENV_DUMP, 'utf8'));
+    assert.equal(
+      childEnv.ANTHROPIC_API_KEY,
+      undefined,
+      'ANTHROPIC_API_KEY must not reach the child'
+    );
+    assert.equal(
+      childEnv.ANTHROPIC_AUTH_TOKEN,
+      undefined,
+      'ANTHROPIC_AUTH_TOKEN must not reach the child'
+    );
+    // Not vacuous: other env vars, including the OAuth token the CLI
+    // actually needs, must still be passed through.
+    assert.equal(childEnv.CLAUDE_CODE_OAUTH_TOKEN, 'test-oauth-token');
+    assert.equal(childEnv.FAKE_CLAUDE_MODE, 'success');
+  } finally {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+  }
+});
+
+test('callViaCli error path includes stdout content (not just stderr) in the thrown error', async () => {
+  process.env.FAKE_CLAUDE_MODE = 'error';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+
+  await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 }), (err) => {
+    assert.match(err.message, /FAKE_STDOUT_MARKER: upstream billing failure detail/);
+    return true;
+  });
+});


### PR DESCRIPTION
## Summary
- Re-labeling issue #238 `needs-spec` after merging #241 and switching `LLM_BACKEND=cli` still failed (run 29696047088). Root cause: `ANTHROPIC_API_KEY` outranks `CLAUDE_CODE_OAUTH_TOKEN` in Claude Code's own auth precedence, and the workflow passes both into the subprocess's env unconditionally - the low-balance API key silently shadowed the OAuth token. Fixes #243.
- `callViaCli()` in `scripts/ai-sdlc/llm-client.mjs` now strips `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` from the child process's env before spawning `claude`, so the CLI backend is immune to this regardless of the caller's environment.
- Also surfaces `stdout` (where the CLI's JSON error body actually lands) on non-zero exit, instead of only the empty `stderr` - the previous failure log showed a blank `claude CLI exited with code 1: ` with no detail.

## Testing
- [x] `node --check` on the changed file
- [x] `prettier --check` clean
- [x] Reproduced the exact bug locally: `ANTHROPIC_API_KEY` set (inherited) + `LLM_BACKEND=cli` → confirmed the old code path fails with the same "Credit balance is too low" error the CLI backend exists to avoid
- [x] Confirmed the fix resolves it: same env, same call, now returns `{"text":"PONG","stopReason":"end_turn"}`
- [ ] First live `needs-spec` run in CI after merge

Assisted-by: claude-sonnet-5 (agent)
