### PR TITLE
fix(spec-agent): use --tools= instead of --allowedTools= to actually disable CLI tools

### DIFF
--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -143,7 +143,7 @@ Rules:
 
 let specContent;
 try {
-  ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 90_000 }));
+  ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 180_000 }));
 } catch (err) {
   console.error(err.message);
   process.exit(1);

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -5,9 +5,19 @@
 // LLM_BACKEND=cli — routes through the Claude Code CLI so usage draws from a
 //   Claude subscription instead of metered API billing, needs
 //   CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`, requires Pro/Max/
-//   Team/Enterprise). Tools are disabled (--allowedTools "") so the call is a
-//   plain text completion, matching the API path's behavior — without this,
-//   Claude Code's normal agentic tool loop would try to explore/edit files.
+//   Team/Enterprise). Tools are disabled with --tools= (plus
+//   --strict-mcp-config to also block MCP tools) so the call is a plain text
+//   completion, matching the API path's behavior — without this, Claude
+//   Code's normal agentic tool loop would try to explore/edit files.
+//   --allowedTools "" does NOT achieve this: it only pre-approves which
+//   tools skip the permission prompt, it does not control tool
+//   *availability* — read-only tools (Read, Grep, Glob, read-only Bash)
+//   still run unprompted regardless of the allow-list, so a CLI call made
+//   with --allowedTools "" silently runs a full multi-turn exploration loop
+//   instead of a single-shot completion (confirmed empirically: 50 turns,
+//   5m30s, vs. 1-2 turns, well under a minute, with --tools=). See
+//   callViaCli below for why --tools= (one token) is used instead of the
+//   two-token ['--tools', ''] form the CLI's own --help implies.
 //   ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN are deliberately stripped from the
 //   CLI subprocess env (see callViaCli) since they outrank the OAuth token
 //   in Claude Code's auth precedence and would otherwise silently shadow it.
@@ -89,7 +99,18 @@ async function callViaCli({ prompt, timeoutMs }) {
 
     const child = spawn(
       'claude',
-      ['-p', '--output-format', 'json', '--model', CLI_MODEL, '--allowedTools='],
+      // --tools takes a following value ('claude -p --help': "--tools
+      // <tools...>"), so the natural form is a separate '' array element.
+      // But on Windows, spawn() with shell: true stringifies the args array
+      // into a single command line for cmd.exe, and a bare '' element gets
+      // silently elided from that command line (confirmed empirically) —
+      // the same class of bug that forced --allowedTools='' (a single
+      // token) instead of ['--allowedTools', ''] originally. '--tools='
+      // (one token, value baked in) sidesteps that: nothing to elide.
+      // Confirmed empirically on both Windows (shell: true) and POSIX
+      // (shell: false, tested under WSL) that '--tools=' parses correctly
+      // and disables tools, so one token form is used unconditionally.
+      ['-p', '--output-format', 'json', '--model', CLI_MODEL, '--tools=', '--strict-mcp-config'],
       // shell only on Windows, where npm's global bin is a .cmd shim spawn()
       // can't exec directly. On POSIX (CI runs on ubuntu-latest) spawning
       // claude directly means SIGKILL on timeout kills the actual process

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -36,9 +36,12 @@ writeFileSync(
     'const dumpPath = process.env.FAKE_CLAUDE_ENV_DUMP;',
     'if (dumpPath) fs.writeFileSync(dumpPath, JSON.stringify(process.env));',
     'const argvDumpPath = process.env.FAKE_CLAUDE_ARGV_DUMP;',
-    // process.argv[0] is the node executable, [1] is this script (IMPL) —
-    // slice those off so the dump holds only the args callViaCli passed to
-    // `claude` itself (['-p', '--output-format', ...]).
+    // process.argv[0] is the node executable, [1] is the entry script —
+    // IMPL on Windows (claude.cmd invokes `node IMPL`), but the POSIX_BIN
+    // wrapper on POSIX (its shebang makes it the entry; requiring IMPL from
+    // there doesn't change argv). Either way, slice off [0] and [1] so the
+    // dump holds only the args callViaCli passed to `claude` itself
+    // (['-p', '--output-format', ...]).
     'if (argvDumpPath) fs.writeFileSync(argvDumpPath, JSON.stringify(process.argv.slice(2)));',
     "const mode = process.env.FAKE_CLAUDE_MODE || 'success';",
     "if (mode === 'error') {",

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -27,6 +27,7 @@ import { join } from 'node:path';
 const DIR = mkdtempSync(join(tmpdir(), 'llm-client-test-'));
 const IMPL = join(DIR, 'fake-claude-impl.cjs');
 const ENV_DUMP = join(DIR, 'env-dump.json');
+const ARGV_DUMP = join(DIR, 'argv-dump.json');
 
 writeFileSync(
   IMPL,
@@ -34,6 +35,11 @@ writeFileSync(
     "const fs = require('node:fs');",
     'const dumpPath = process.env.FAKE_CLAUDE_ENV_DUMP;',
     'if (dumpPath) fs.writeFileSync(dumpPath, JSON.stringify(process.env));',
+    'const argvDumpPath = process.env.FAKE_CLAUDE_ARGV_DUMP;',
+    // process.argv[0] is the node executable, [1] is this script (IMPL) —
+    // slice those off so the dump holds only the args callViaCli passed to
+    // `claude` itself (['-p', '--output-format', ...]).
+    'if (argvDumpPath) fs.writeFileSync(argvDumpPath, JSON.stringify(process.argv.slice(2)));',
     "const mode = process.env.FAKE_CLAUDE_MODE || 'success';",
     "if (mode === 'error') {",
     "  process.stdout.write('FAKE_STDOUT_MARKER: upstream billing failure detail');",
@@ -124,6 +130,36 @@ test('callViaCli strips differently-cased ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN
     delete process.env.anthropic_api_key;
     delete process.env.Anthropic_Auth_Token;
   }
+});
+
+test('callViaCli invokes claude with --tools= and --strict-mcp-config, not --allowedTools=', async () => {
+  process.env.FAKE_CLAUDE_MODE = 'success';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+  process.env.FAKE_CLAUDE_ARGV_DUMP = ARGV_DUMP;
+
+  await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
+
+  const argv = JSON.parse(readFileSync(ARGV_DUMP, 'utf8'));
+  // Single-token '--tools=' (not a separate '' array element): on Windows,
+  // spawn() with shell: true stringifies argv into one command line and a
+  // bare '' element gets silently dropped from it (confirmed empirically),
+  // which would leave --tools swallowing --strict-mcp-config as its value
+  // instead of disabling tools. A single token has nothing to elide.
+  assert.deepEqual(argv, [
+    '-p',
+    '--output-format',
+    'json',
+    '--model',
+    'claude-sonnet-4-6',
+    '--tools=',
+    '--strict-mcp-config',
+  ]);
+  // The old, broken flag must be gone: --allowedTools only pre-approves
+  // tools for the permission prompt, it does not disable tool availability.
+  assert.ok(
+    !argv.some((a) => a.startsWith('--allowedTools')),
+    'must not pass --allowedTools (does not disable tool availability)'
+  );
 });
 
 test('callViaCli error path includes stdout content (not just stderr) in the thrown error', async () => {

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -137,29 +137,33 @@ test('callViaCli invokes claude with --tools= and --strict-mcp-config, not --all
   process.env.FAKE_CLAUDE_ENV_DUMP = '';
   process.env.FAKE_CLAUDE_ARGV_DUMP = ARGV_DUMP;
 
-  await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
+  try {
+    await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
 
-  const argv = JSON.parse(readFileSync(ARGV_DUMP, 'utf8'));
-  // Single-token '--tools=' (not a separate '' array element): on Windows,
-  // spawn() with shell: true stringifies argv into one command line and a
-  // bare '' element gets silently dropped from it (confirmed empirically),
-  // which would leave --tools swallowing --strict-mcp-config as its value
-  // instead of disabling tools. A single token has nothing to elide.
-  assert.deepEqual(argv, [
-    '-p',
-    '--output-format',
-    'json',
-    '--model',
-    'claude-sonnet-4-6',
-    '--tools=',
-    '--strict-mcp-config',
-  ]);
-  // The old, broken flag must be gone: --allowedTools only pre-approves
-  // tools for the permission prompt, it does not disable tool availability.
-  assert.ok(
-    !argv.some((a) => a.startsWith('--allowedTools')),
-    'must not pass --allowedTools (does not disable tool availability)'
-  );
+    const argv = JSON.parse(readFileSync(ARGV_DUMP, 'utf8'));
+    // Single-token '--tools=' (not a separate '' array element): on Windows,
+    // spawn() with shell: true stringifies argv into one command line and a
+    // bare '' element gets silently dropped from it (confirmed empirically),
+    // which would leave --tools swallowing --strict-mcp-config as its value
+    // instead of disabling tools. A single token has nothing to elide.
+    assert.deepEqual(argv, [
+      '-p',
+      '--output-format',
+      'json',
+      '--model',
+      'claude-sonnet-4-6',
+      '--tools=',
+      '--strict-mcp-config',
+    ]);
+    // The old, broken flag must be gone: --allowedTools only pre-approves
+    // tools for the permission prompt, it does not disable tool availability.
+    assert.ok(
+      !argv.some((a) => a.startsWith('--allowedTools')),
+      'must not pass --allowedTools (does not disable tool availability)'
+    );
+  } finally {
+    delete process.env.FAKE_CLAUDE_ARGV_DUMP;
+  }
 });
 
 test('callViaCli error path includes stdout content (not just stderr) in the thrown error', async () => {

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -92,7 +92,13 @@ console.log(
 
 let text, stopReason;
 try {
-  ({ text, stopReason } = await callClaude({ prompt, maxTokens: 8192, timeoutMs: 120_000 }));
+  // 420s: this prompt (spec + up to 15 source files) is larger than
+  // generate-spec's, so it needs more than generate-spec's 180s. Measured
+  // empirically on the CLI backend with a ~60K-char verify prompt (spec +
+  // 4 source files): 283.9s to complete via callClaude's fixed --tools=
+  // path (single turn, real corrected output, not a truncation). 420s
+  // keeps roughly 1.5x margin over that measurement rather than guessing.
+  ({ text, stopReason } = await callClaude({ prompt, maxTokens: 8192, timeoutMs: 420_000 }));
 } catch (err) {
   // Verification failure is non-fatal — log and continue with unpatched spec.
   console.warn(`Spec verifier error: ${err.message}`);
@@ -129,8 +135,12 @@ function sanitize(raw) {
   // Trim any preamble that precedes it so frontmatter (Linked issue, ADR,
   // Files touched) is not stripped along with stray prose.
   const titleIdx = text.indexOf('# Spec:');
-  if (titleIdx === -1) return null;
-  if (titleIdx > 0) text = text.slice(titleIdx);
+  if (titleIdx === -1) {
+    return null;
+  }
+  if (titleIdx > 0) {
+    text = text.slice(titleIdx);
+  }
   const required = [
     '## Problem',
     '## Out of scope',
@@ -140,7 +150,9 @@ function sanitize(raw) {
     '## Tests',
     '## Verification',
   ];
-  if (!required.every((h) => text.includes(h))) return null;
+  if (!required.every((h) => text.includes(h))) {
+    return null;
+  }
   return text;
 }
 


### PR DESCRIPTION
## Summary
- `callViaCli()` in `scripts/ai-sdlc/llm-client.mjs` spawned `claude -p ... --allowedTools=`, assuming an empty allow-list disables all tools. It does not: `--allowedTools` only pre-approves which tools skip the permission prompt, it does not control tool availability, so every CLI-backend call was running a full agentic exploration loop (confirmed: 50 turns, 5m30s on a real spec prompt), well past the 90s timeout `generate-spec.mjs` used. Fixes #245.
- Replaced with `--tools=` (single token, disables all tools) plus `--strict-mcp-config` (blocks MCP-provided tools too, since `--tools` alone doesn't affect those). Confirmed empirically the fix collapses turns to 1 and reduces latency from 5m30s to well under a minute on a comparable prompt.
- Used the single-token `--tools=` form, not the two-token `['--tools', '']` the CLI's own `--help` implies, because `spawn()` with `shell: true` on Windows silently elides a bare `''` array element from the stringified command line (confirmed with a fake `claude.cmd` dumping its received `argv`) - the same class of bug `--allowedTools=` was originally written to avoid. The single-token form has nothing to elide and was confirmed correct on both Windows (`shell: true`) and POSIX (`shell: false`, tested under WSL).
- Bumped `generate-spec.mjs`'s timeout from 90s to 180s and `verify-spec.mjs`'s from 120s to 420s - the CLI path has no output-length cap equivalent to the API path's `max_tokens: 4096`, so latency varies more, and verify-spec's prompt (spec + up to 15 source files) is larger than generate-spec's.
- Added a test asserting the exact `spawn()` argv includes `--tools=` and `--strict-mcp-config`, not `--allowedTools`.

## Testing
- [x] `node --check` on all changed files
- [x] `npx prettier@3.6.2 --check` on all changed files
- [x] `node --test scripts/ai-sdlc/llm-client.test.mjs` - all 4 tests pass, including the new argv-assertion test
- [x] Empirical: fake `claude.cmd`/`claude` binaries on PATH proved `['--tools', '']` gets mangled by `spawn(..., { shell: true })` on Windows (the `''` element vanishes) while `--tools=` survives intact, on both Windows (`shell: true`) and POSIX (`shell: false`, verified under WSL)
- [x] Empirical end-to-end: real generate-spec-sized prompt (~17.5K chars) through the fixed `callViaCli` returned `num_turns: 1`, completed in 49-87s, well inside the new 180s timeout (previously: 50 turns, 5m30s, would have timed out)
- [x] Empirical end-to-end: real verify-spec-sized prompt (~60.5K chars, spec + 4 source files) through the fixed `callViaCli` completed in 283.9s (single turn, found and correctly reported 2 real factual errors in the test spec, not truncated garbage) - drove the 420s timeout choice (~1.5x margin) instead of guessing 180s to match generate-spec

Fixes #245

Assisted-by: claude-sonnet-5 (agent)
