### PR TITLE
fix(ci): stop passing ANTHROPIC_API_KEY to claude-review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -93,10 +93,14 @@ jobs:
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
         with:
-          # Pass both auth modes — the action picks whichever secret is set.
-          # ANTHROPIC_API_KEY is raw API billing; CLAUDE_CODE_OAUTH_TOKEN is
-          # what `/install-github-app` populates and uses App billing.
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Only pass the OAuth token. The action does NOT arbitrate between
+          # anthropic_api_key and claude_code_oauth_token when both are set -
+          # it maps both straight into env vars unconditionally, and the
+          # underlying `claude` CLI's own auth precedence (ANTHROPIC_API_KEY
+          # over the OAuth token) then silently picks whichever one is
+          # ANTHROPIC_API_KEY. If that secret is dead or out of credit, the
+          # review fails instantly with no visible error. Configure exactly
+          # one of the two secrets for this repo, never both.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Review PR #${{ github.event.pull_request.number || github.event.issue.number }}. Focus on real-impact issues:

--- a/scripts/.verify-247-throwaway.txt
+++ b/scripts/.verify-247-throwaway.txt
@@ -1,5 +1,0 @@
-Temporary file to defeat claude-review.yml's paths-ignore (which excludes .github/**)
-so this PR's own pull_request-triggered auto-review runs against this branch's fixed
-workflow file, as live verification for issue #247 / PR #248.
-
-Will be removed before merge.

--- a/scripts/.verify-247-throwaway.txt
+++ b/scripts/.verify-247-throwaway.txt
@@ -1,0 +1,5 @@
+Temporary file to defeat claude-review.yml's paths-ignore (which excludes .github/**)
+so this PR's own pull_request-triggered auto-review runs against this branch's fixed
+workflow file, as live verification for issue #247 / PR #248.
+
+Will be removed before merge.


### PR DESCRIPTION
Fixes #247

`claude-review.yml` passed both `anthropic_api_key` and `claude_code_oauth_token` to `anthropics/claude-code-action@v1`, with a comment claiming the action picks whichever secret is set. It doesn't - both inputs get mapped to env vars unconditionally, and the underlying `claude` CLI's own auth precedence then picks `ANTHROPIC_API_KEY` over the OAuth token. This repo's `ANTHROPIC_API_KEY` is out of credit, so every review run was failing near-instantly instead of using the working `CLAUDE_CODE_OAUTH_TOKEN`.

Same root failure mode as #242/#243/#245, here in `claude-review.yml` instead of `spec-agent.yml`.

## Changes

- Remove the `anthropic_api_key` input from the `Run Claude review` step.
- Keep `claude_code_oauth_token`.
- Replace the misleading comment with an accurate one explaining the shadowing mechanism.
- Verified no other `env:` block in this file sets `ANTHROPIC_API_KEY` (only step-level `env:` in the file sets `GH_TOKEN` for the checkout step) - nothing left that could resurrect the shadow via the action's `env.ANTHROPIC_API_KEY` fallback.

## Testing

This is a GitHub Actions auth-wiring change and can't be meaningfully tested locally. `packages/backend` unit tests (2961 tests) pass, unaffected since nothing in application code changed. The real test is the next live `claude-review.yml` run on this PR.

Assisted-by: claude-sonnet-5 (agent)
