### PR TITLE
fix(ai-sdlc): migrate generate-adr.mjs and generate-impl.mjs to LLM_BACKEND switch

### DIFF
--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -1,11 +1,20 @@
 name: ADR Agent
 
 # Phase 1 agent: fires when a human applies the `needs-adr` label.
-# Calls Claude API to draft an ADR in docs/adr/ and opens a DRAFT PR.
+# Calls Claude to draft an ADR in docs/adr/ and opens a DRAFT PR.
 # Gate 2 (ADR ratification) is human-held: the agent cannot merge.
 #
 # If a linked spec PR exists, its content is passed to the agent for context.
-# Required secrets: ANTHROPIC_API_KEY
+#
+# LLM backend is switchable via the LLM_BACKEND repo variable:
+#   unset/"api" (default) — Messages API, billed per-token, needs
+#     secrets.ANTHROPIC_API_KEY
+#   "cli" — routes through the Claude Code CLI so usage draws from a Claude
+#     subscription instead, needs secrets.CLAUDE_CODE_OAUTH_TOKEN (generate
+#     with `claude setup-token`, requires Pro/Max/Team/Enterprise)
+# Set with: gh variable set LLM_BACKEND --body cli   (or "api" to switch back)
+#
+# Required secrets: ANTHROPIC_API_KEY and/or CLAUDE_CODE_OAUTH_TOKEN
 # ADR: docs/adr/0042-agent-identity-scoped-app.md
 
 on:
@@ -34,6 +43,10 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install Claude Code CLI
+        if: vars.LLM_BACKEND == 'cli'
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Fetch linked spec (if any)
         id: spec
         env:
@@ -55,7 +68,9 @@ jobs:
       - name: Generate ADR
         id: gen
         env:
+          LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -2,18 +2,24 @@ name: Impl Agent
 
 # Phase 2 agent: fires when a human applies the `agent-working` label after
 # ratifying the spec (Gate 1) and optionally an ADR (Gate 2).
-# Reads the linked spec, calls Claude API, opens a DRAFT PR with a scaffold.
+# Reads the linked spec, calls Claude, opens a DRAFT PR with a scaffold.
 # Gate 3 (merge) is human-held: the agent cannot merge.
 #
 # Model router (label-based):
 #   complexity:high  -> claude-opus-4-8
 #   pii-sensitive    -> claude-haiku-4-5-20251001
 #   default          -> claude-sonnet-4-6
+# The selected model is used on whichever LLM backend is active below.
 #
-# Prompt caching: static context (CLAUDE.md + style examples) is marked
-# cache_control=ephemeral; repeated runs on the same day skip re-sending it.
+# LLM backend is switchable via the LLM_BACKEND repo variable:
+#   unset/"api" (default) — Messages API, billed per-token, needs
+#     secrets.ANTHROPIC_API_KEY
+#   "cli" — routes through the Claude Code CLI so usage draws from a Claude
+#     subscription instead, needs secrets.CLAUDE_CODE_OAUTH_TOKEN (generate
+#     with `claude setup-token`, requires Pro/Max/Team/Enterprise)
+# Set with: gh variable set LLM_BACKEND --body cli   (or "api" to switch back)
 #
-# Required secrets: ANTHROPIC_API_KEY
+# Required secrets: ANTHROPIC_API_KEY and/or CLAUDE_CODE_OAUTH_TOKEN
 # ADR: docs/adr/0042-agent-identity-scoped-app.md
 
 on:
@@ -48,6 +54,10 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Install Claude Code CLI
+        if: vars.LLM_BACKEND == 'cli'
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Fetch linked spec (required)
         id: spec
         env:
@@ -71,7 +81,9 @@ jobs:
         id: gen
         timeout-minutes: 15
         env:
+          LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}

--- a/scripts/ai-sdlc/generate-adr.mjs
+++ b/scripts/ai-sdlc/generate-adr.mjs
@@ -1,29 +1,39 @@
 #!/usr/bin/env node
-// Calls Claude API to draft an ADR for a GitHub issue.
+// Calls Claude to draft an ADR for a GitHub issue.
 // Run from the repo root. Reads existing ADRs for numbering + style.
 // Outputs adr_file, adr_number, adr_slug to GITHUB_OUTPUT.
 //
-// Required env vars: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY
+// Required env vars: ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, plus either
+//   ANTHROPIC_API_KEY (default) or CLAUDE_CODE_OAUTH_TOKEN (LLM_BACKEND=cli)
 // Optional:          SPEC_CONTENT (contents of a linked spec, if any)
 //                    GITHUB_OUTPUT (set by Actions; falls back to stdout print)
 
-import { readFileSync, writeFileSync, readdirSync, appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  appendFileSync,
+  mkdirSync,
+  existsSync,
+} from 'node:fs';
+import { callClaude, requireLlmCredentials } from './llm-client.mjs';
 
-const {
-  ANTHROPIC_API_KEY,
-  ISSUE_NUMBER,
-  ISSUE_TITLE,
-  ISSUE_BODY,
-  SPEC_CONTENT,
-  GITHUB_OUTPUT,
-} = process.env;
+const { ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, SPEC_CONTENT, GITHUB_OUTPUT } = process.env;
 
-if (!ANTHROPIC_API_KEY) { console.error('Missing ANTHROPIC_API_KEY'); process.exit(1); }
-if (!ISSUE_NUMBER)      { console.error('Missing ISSUE_NUMBER');       process.exit(1); }
-if (!ISSUE_TITLE)       { console.error('Missing ISSUE_TITLE');        process.exit(1); }
+requireLlmCredentials();
+if (!ISSUE_NUMBER) {
+  console.error('Missing ISSUE_NUMBER');
+  process.exit(1);
+}
+if (!ISSUE_TITLE) {
+  console.error('Missing ISSUE_TITLE');
+  process.exit(1);
+}
 
 // Find next ADR number
-if (!existsSync('docs/adr')) mkdirSync('docs/adr', { recursive: true });
+if (!existsSync('docs/adr')) {
+  mkdirSync('docs/adr', { recursive: true });
+}
 const existing = readdirSync('docs/adr').filter((f) => /^\d{4}-/.test(f));
 const maxNum = existing.reduce((m, f) => Math.max(m, parseInt(f.slice(0, 4), 10)), 0);
 const nextNum = maxNum + 1;
@@ -35,8 +45,7 @@ const exampleAdr = exampleFile
   ? readFileSync(`docs/adr/${exampleFile}`, 'utf8').slice(0, 1200)
   : '';
 
-const slug = ISSUE_TITLE
-  .toLowerCase()
+const slug = ISSUE_TITLE.toLowerCase()
   .replace(/[^a-z0-9]+/g, '-')
   .replace(/^-+|-+$/g, '')
   .slice(0, 40);
@@ -89,36 +98,19 @@ Rules:
 - Be concrete about consequences; call out residual risks explicitly
 - Return ONLY the ADR document — no preamble, no explanation, no markdown fences`;
 
-const res = await fetch('https://api.anthropic.com/v1/messages', {
-  method: 'POST',
-  headers: {
-    'content-type': 'application/json',
-    'x-api-key': ANTHROPIC_API_KEY,
-    'anthropic-version': '2023-06-01',
-  },
-  signal: AbortSignal.timeout(60_000),
-  body: JSON.stringify({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 2048,
-    messages: [{ role: 'user', content: prompt }],
-  }),
-});
-
-if (!res.ok) {
-  let detail = '';
-  try {
-    const raw = await res.text();
-    try { detail = JSON.stringify(JSON.parse(raw), null, 2); } catch { detail = raw; }
-  } catch { /* body unreadable */ }
-  console.error(`Claude API error (${res.status}):`, detail);
+let adrContent;
+try {
+  // 120s: this prompt is much smaller than generate-spec.mjs's (no
+  // TEMPLATE.md, no source-file tree — just one ~1200-char example ADR plus
+  // the issue body and an optional ~1500-char spec excerpt) and max_tokens
+  // (2048) is half of generate-spec's (4096), so it needs less time than
+  // generate-spec's 180s. It still needs more than the old API-only 60s
+  // budget to cover the CLI backend's subprocess startup overhead.
+  ({ text: adrContent } = await callClaude({ prompt, maxTokens: 2048, timeoutMs: 120_000 }));
+} catch (err) {
+  console.error(err.message);
   process.exit(1);
 }
-const data = await res.json();
-if (data?.content?.[0]?.type !== 'text') {
-  console.error('Unexpected API response shape:', JSON.stringify(data, null, 2));
-  process.exit(1);
-}
-const adrContent = data.content[0].text;
 
 writeFileSync(adrFile, adrContent, 'utf8');
 

--- a/scripts/ai-sdlc/generate-adr.mjs
+++ b/scripts/ai-sdlc/generate-adr.mjs
@@ -3,9 +3,10 @@
 // Run from the repo root. Reads existing ADRs for numbering + style.
 // Outputs adr_file, adr_number, adr_slug to GITHUB_OUTPUT.
 //
-// Required env vars: ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, plus either
+// Required env vars: ISSUE_NUMBER, ISSUE_TITLE, plus either
 //   ANTHROPIC_API_KEY (default) or CLAUDE_CODE_OAUTH_TOKEN (LLM_BACKEND=cli)
-// Optional:          SPEC_CONTENT (contents of a linked spec, if any)
+// Optional:          ISSUE_BODY (falls back to "(no description)" if unset)
+//                    SPEC_CONTENT (contents of a linked spec, if any)
 //                    GITHUB_OUTPUT (set by Actions; falls back to stdout print)
 
 import {
@@ -98,7 +99,7 @@ Rules:
 - Be concrete about consequences; call out residual risks explicitly
 - Return ONLY the ADR document — no preamble, no explanation, no markdown fences`;
 
-let adrContent;
+let adrContent, stopReason;
 try {
   // 120s: this prompt is much smaller than generate-spec.mjs's (no
   // TEMPLATE.md, no source-file tree — just one ~1200-char example ADR plus
@@ -106,9 +107,23 @@ try {
   // (2048) is half of generate-spec's (4096), so it needs less time than
   // generate-spec's 180s. It still needs more than the old API-only 60s
   // budget to cover the CLI backend's subprocess startup overhead.
-  ({ text: adrContent } = await callClaude({ prompt, maxTokens: 2048, timeoutMs: 120_000 }));
+  ({ text: adrContent, stopReason } = await callClaude({
+    prompt,
+    maxTokens: 2048,
+    timeoutMs: 120_000,
+  }));
 } catch (err) {
   console.error(err.message);
+  process.exit(1);
+}
+
+// Fail fast if truncated — matches the check in generate-impl.mjs. Without
+// it, a response cut short by the 2048 maxTokens cap would silently write a
+// truncated ADR to disk instead of erroring.
+if (stopReason === 'max_tokens') {
+  console.error(
+    'Claude response truncated (stop_reason=max_tokens). Raise maxTokens in generate-adr.mjs.'
+  );
   process.exit(1);
 }
 

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -1,37 +1,31 @@
 #!/usr/bin/env node
-// Phase 2 impl agent: reads a ratified spec + codebase context, calls Claude API,
+// Phase 2 impl agent: reads a ratified spec + codebase context, calls Claude,
 // writes a multi-file implementation scaffold.
 //
 // Model router (label-based via ISSUE_LABELS env):
 //   complexity:high  -> claude-opus-4-8   (deep architecture, cross-cutting changes)
 //   pii-sensitive    -> claude-haiku-4-5-20251001  (local-floor stand-in; cheapest hosted)
 //   default          -> claude-sonnet-4-6
+// The selected model is passed to callClaude's `model` override on either backend.
 //
-// Prompt caching: static context (CLAUDE.md files + pattern examples) marked with
-// cache_control so repeated runs on the same day skip re-sending that payload.
+// Static context (CLAUDE.md files + pattern examples) is prepended to the prompt.
+// (Anthropic-native prompt caching via cache_control no longer applies once routed
+// through llm-client.mjs's plain-string prompt — see llm-client.mjs.)
 //
 // Output: writes files listed in Claude's JSON response; outputs file list to GITHUB_OUTPUT.
 //
-// Required env: ANTHROPIC_API_KEY, ISSUE_NUMBER, ISSUE_TITLE, SPEC_CONTENT
+// Required env: ISSUE_NUMBER, ISSUE_TITLE, SPEC_CONTENT, plus either
+//   ANTHROPIC_API_KEY (default) or CLAUDE_CODE_OAUTH_TOKEN (LLM_BACKEND=cli)
 // Optional:     ISSUE_LABELS (comma-separated), GITHUB_OUTPUT
 
 import { readFileSync, writeFileSync, mkdirSync, appendFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve, relative, isAbsolute } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { callClaude, requireLlmCredentials } from './llm-client.mjs';
 
-const {
-  ANTHROPIC_API_KEY,
-  ISSUE_NUMBER,
-  ISSUE_TITLE,
-  ISSUE_LABELS = '',
-  SPEC_CONTENT,
-  GITHUB_OUTPUT,
-} = process.env;
+const { ISSUE_NUMBER, ISSUE_TITLE, ISSUE_LABELS = '', SPEC_CONTENT, GITHUB_OUTPUT } = process.env;
 
-if (!ANTHROPIC_API_KEY) {
-  console.error('Missing ANTHROPIC_API_KEY');
-  process.exit(1);
-}
+requireLlmCredentials();
 if (!ISSUE_NUMBER) {
   console.error('Missing ISSUE_NUMBER');
   process.exit(1);
@@ -48,9 +42,9 @@ if (!SPEC_CONTENT) {
 // Model router — label-based with per-tier overrides via GitHub repo variables.
 // Change without a code edit: set IMPL_MODEL_HIGH / IMPL_MODEL_DEFAULT / IMPL_MODEL_LOW
 // in Settings > Secrets and variables > Actions > Variables.
-const MODEL_HIGH    = process.env.IMPL_MODEL_HIGH    || 'claude-opus-4-8';
+const MODEL_HIGH = process.env.IMPL_MODEL_HIGH || 'claude-opus-4-8';
 const MODEL_DEFAULT = process.env.IMPL_MODEL_DEFAULT || 'claude-sonnet-4-6';
-const MODEL_LOW     = process.env.IMPL_MODEL_LOW     || 'claude-haiku-4-5-20251001';
+const MODEL_LOW = process.env.IMPL_MODEL_LOW || 'claude-haiku-4-5-20251001';
 
 function selectModel(labels) {
   const set = new Set(labels.split(',').map((l) => l.trim().toLowerCase()));
@@ -65,33 +59,43 @@ function selectModel(labels) {
 const MODEL = selectModel(ISSUE_LABELS);
 console.log(`Model router selected: ${MODEL} (labels: "${ISSUE_LABELS || 'none'}")`);
 
-// Read static context for prompt caching
+// Read static context (CLAUDE.md files + style examples) shared by every issue
 function safeRead(path) {
-  try { return readFileSync(path, 'utf8'); } catch { return ''; }
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
 }
 
-const rootClaudeMd    = safeRead('CLAUDE.md');
+const rootClaudeMd = safeRead('CLAUDE.md');
 const backendClaudeMd = safeRead('packages/backend/CLAUDE.md');
-const contributing    = safeRead('CONTRIBUTING.md');
+const contributing = safeRead('CONTRIBUTING.md');
 
 // Read one existing route + test as style examples
 function findExample(dir, ext) {
   try {
     const files = readdirSync(dir).filter((f) => f.endsWith(ext));
     return files.length ? safeRead(`${dir}/${files[0]}`) : '';
-  } catch { return ''; }
+  } catch {
+    return '';
+  }
 }
 const routeExample = findExample('packages/backend/src/api/routes', '.ts').slice(0, 1500);
-const testExample  = findExample('packages/backend/tests/api', '.test.ts').slice(0, 1500);
+const testExample = findExample('packages/backend/tests/api', '.test.ts').slice(0, 1500);
 
-// Static context block (cached)
+// Static context block (prepended to every generate-impl prompt)
 const staticContext = [
-  rootClaudeMd    ? `# CLAUDE.md (root)\n${rootClaudeMd}`    : '',
+  rootClaudeMd ? `# CLAUDE.md (root)\n${rootClaudeMd}` : '',
   backendClaudeMd ? `# CLAUDE.md (backend)\n${backendClaudeMd}` : '',
-  contributing    ? `# CONTRIBUTING.md\n${contributing}`     : '',
-  routeExample    ? `# Example route (style reference)\n\`\`\`typescript\n${routeExample}\n\`\`\`` : '',
-  testExample     ? `# Example test (style reference)\n\`\`\`typescript\n${testExample}\n\`\`\`` : '',
-].filter(Boolean).join('\n\n---\n\n');
+  contributing ? `# CONTRIBUTING.md\n${contributing}` : '',
+  routeExample
+    ? `# Example route (style reference)\n\`\`\`typescript\n${routeExample}\n\`\`\``
+    : '',
+  testExample ? `# Example test (style reference)\n\`\`\`typescript\n${testExample}\n\`\`\`` : '',
+]
+  .filter(Boolean)
+  .join('\n\n---\n\n');
 
 const specSection = `# Ratified spec\n${SPEC_CONTENT}`;
 
@@ -117,65 +121,41 @@ RULES:
 9. Scaffold tests must use the same test helpers as the example (do not invent new ones).
 10. Every generated file must compile without errors given reasonable stub imports.`;
 
-// Build messages with prompt caching on static context
-const messages = [
-  {
-    role: 'user',
-    content: [
-      {
-        type: 'text',
-        text: staticContext,
-        cache_control: { type: 'ephemeral' },
-      },
-      {
-        type: 'text',
-        text: userPrompt,
-      },
-    ],
-  },
-];
+// staticContext used to be sent as a separate cache_control-marked content
+// block so repeated same-day runs skipped re-sending it; llm-client.mjs's
+// callClaude takes a single plain-text prompt, so it's folded in as a plain
+// prefix here instead. This drops the token-cache cost saving but not
+// correctness — see the header comment above.
+const prompt = staticContext ? `${staticContext}\n\n${userPrompt}` : userPrompt;
 
-const res = await fetch('https://api.anthropic.com/v1/messages', {
-  method: 'POST',
-  signal: AbortSignal.timeout(120_000),
-  headers: {
-    'content-type': 'application/json',
-    'x-api-key': ANTHROPIC_API_KEY,
-    'anthropic-version': '2023-06-01',
-    'anthropic-beta': 'prompt-caching-2024-07-31',
-  },
-  body: JSON.stringify({
+let text, stopReason;
+try {
+  // 600s: this is the largest of the four ai-sdlc Claude calls — max_tokens
+  // (16384) is 2x verify-spec.mjs's (8192), and the prompt (static
+  // CLAUDE.md/CONTRIBUTING.md/style-example context plus the full ratified
+  // spec) is comparable in size to verify-spec's (spec + up to 15 source
+  // files). verify-spec.mjs measured 283.9s for its 8192-token generation
+  // via the CLI backend and set 420s (~1.5x margin). Scaling that budget for
+  // roughly double the output tokens suggests ~600-800s; 600_000ms keeps a
+  // comparable margin while staying under impl-agent.yml's 15-minute
+  // "Generate scaffold" step timeout (900s), leaving headroom for node
+  // startup and file I/O in the same step.
+  ({ text, stopReason } = await callClaude({
+    prompt,
+    maxTokens: 16384,
+    timeoutMs: 600_000,
     model: MODEL,
-    max_tokens: 16384,
-    messages,
-  }),
-});
-
-if (!res.ok) {
-  const text = await res.text().catch(() => '');
-  let detail = text;
-  try { detail = JSON.stringify(JSON.parse(text), null, 2); } catch { /* use raw text */ }
-  console.error(`Claude API error (${res.status}):`, detail);
+  }));
+} catch (err) {
+  console.error(err.message);
   process.exit(1);
-}
-
-const data = await res.json();
-if (data?.content?.[0]?.type !== 'text') {
-  console.error('Unexpected API response shape:', JSON.stringify(data, null, 2));
-  process.exit(1);
-}
-
-// Log cache stats if available
-const usage = data.usage ?? {};
-if (usage.cache_creation_input_tokens || usage.cache_read_input_tokens) {
-  console.log(
-    `Cache: created=${usage.cache_creation_input_tokens ?? 0} read=${usage.cache_read_input_tokens ?? 0} uncached=${usage.input_tokens ?? 0}`,
-  );
 }
 
 // Fail fast if truncated — a partial JSON response will always cause a parse error downstream
-if (data.stop_reason === 'max_tokens') {
-  console.error(`Claude response truncated (stop_reason=max_tokens). Raise max_tokens in generate-impl.mjs.`);
+if (stopReason === 'max_tokens') {
+  console.error(
+    `Claude response truncated (stop_reason=max_tokens). Raise max_tokens in generate-impl.mjs.`
+  );
   process.exit(1);
 }
 
@@ -183,12 +163,12 @@ if (data.stop_reason === 'max_tokens') {
 let parsed;
 try {
   // Extract JSON — handle leading prose + fenced block, or bare JSON
-  const fenceMatch = data.content[0].text.match(/```json\s*([\s\S]*?)\s*```/i);
-  const raw = fenceMatch ? fenceMatch[1].trim() : data.content[0].text.trim();
+  const fenceMatch = text.match(/```json\s*([\s\S]*?)\s*```/i);
+  const raw = fenceMatch ? fenceMatch[1].trim() : text.trim();
   parsed = JSON.parse(raw);
 } catch (e) {
   console.error('Failed to parse JSON from Claude response:', e.message);
-  console.error('Raw response:', data.content[0].text.slice(0, 500));
+  console.error('Raw response:', text.slice(0, 500));
   process.exit(1);
 }
 
@@ -212,6 +192,7 @@ for (const { path, content } of parsed.files) {
   if (typeof path !== 'string' || typeof content !== 'string' || !path || !content) {
     continue;
   }
+  // eslint-disable-next-line no-control-regex -- deliberate: rejects paths containing raw control characters
   if (/[\x00-\x1f]/.test(path)) {
     console.error(`Rejected path with control characters: ${JSON.stringify(path)}`);
     continue;
@@ -246,6 +227,6 @@ if (GITHUB_OUTPUT) {
   appendFileSync(GITHUB_OUTPUT, `model_used=${MODEL}\n`);
   appendFileSync(
     GITHUB_OUTPUT,
-    `impl_summary<<${delimiter}\n${String(parsed.summary ?? '')}\n${delimiter}\n`,
+    `impl_summary<<${delimiter}\n${String(parsed.summary ?? '')}\n${delimiter}\n`
   );
 }

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -27,6 +27,13 @@
 //   generate-impl.mjs's label-based model router (complexity:high ->
 //   claude-opus-4-8, pii-sensitive -> claude-haiku, default -> sonnet)
 //   pick a different model per call on either backend.
+//   `maxTokens` only takes effect on the API backend (becomes max_tokens in
+//   the request body). callViaCli ignores it — `claude --help` has no flag
+//   to cap output tokens per call (only --max-budget-usd, a dollar budget,
+//   not a token count) — so it cannot be forwarded to the CLI backend.
+//   Callers should not assume it bounds CLI-backend output length; both
+//   backends still return stopReason, so a truncated response is equally
+//   detectable via stopReason === 'max_tokens' regardless of backend.
 
 import { spawn } from 'node:child_process';
 
@@ -84,6 +91,8 @@ async function callViaApi({ prompt, maxTokens, timeoutMs, model }) {
   return { text: data.content[0].text, stopReason: data.stop_reason };
 }
 
+// No `maxTokens` param here (deliberately) — the CLI has no per-call
+// output-token cap to forward it to. See the module header comment.
 async function callViaCli({ prompt, timeoutMs, model }) {
   return new Promise((resolve, reject) => {
     // ANTHROPIC_API_KEY (and ANTHROPIC_AUTH_TOKEN) outrank the OAuth token in

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -21,6 +21,12 @@
 //   ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN are deliberately stripped from the
 //   CLI subprocess env (see callViaCli) since they outrank the OAuth token
 //   in Claude Code's auth precedence and would otherwise silently shadow it.
+//
+// callClaude({ prompt, maxTokens, timeoutMs, model }) — `model` is optional
+//   (defaults to claude-sonnet-4-6 on both backends) and lets a caller like
+//   generate-impl.mjs's label-based model router (complexity:high ->
+//   claude-opus-4-8, pii-sensitive -> claude-haiku, default -> sonnet)
+//   pick a different model per call on either backend.
 
 import { spawn } from 'node:child_process';
 
@@ -40,7 +46,7 @@ export function requireLlmCredentials() {
   }
 }
 
-async function callViaApi({ prompt, maxTokens, timeoutMs }) {
+async function callViaApi({ prompt, maxTokens, timeoutMs, model }) {
   const res = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
@@ -50,7 +56,7 @@ async function callViaApi({ prompt, maxTokens, timeoutMs }) {
     },
     signal: AbortSignal.timeout(timeoutMs),
     body: JSON.stringify({
-      model: 'claude-sonnet-4-6',
+      model: model || 'claude-sonnet-4-6',
       max_tokens: maxTokens,
       messages: [{ role: 'user', content: prompt }],
     }),
@@ -78,7 +84,7 @@ async function callViaApi({ prompt, maxTokens, timeoutMs }) {
   return { text: data.content[0].text, stopReason: data.stop_reason };
 }
 
-async function callViaCli({ prompt, timeoutMs }) {
+async function callViaCli({ prompt, timeoutMs, model }) {
   return new Promise((resolve, reject) => {
     // ANTHROPIC_API_KEY (and ANTHROPIC_AUTH_TOKEN) outrank the OAuth token in
     // Claude Code's own auth precedence, so a stale/low-balance key set
@@ -110,7 +116,15 @@ async function callViaCli({ prompt, timeoutMs }) {
       // Confirmed empirically on both Windows (shell: true) and POSIX
       // (shell: false, tested under WSL) that '--tools=' parses correctly
       // and disables tools, so one token form is used unconditionally.
-      ['-p', '--output-format', 'json', '--model', CLI_MODEL, '--tools=', '--strict-mcp-config'],
+      [
+        '-p',
+        '--output-format',
+        'json',
+        '--model',
+        model || CLI_MODEL,
+        '--tools=',
+        '--strict-mcp-config',
+      ],
       // shell only on Windows, where npm's global bin is a .cmd shim spawn()
       // can't exec directly. On POSIX (CI runs on ubuntu-latest) spawning
       // claude directly means SIGKILL on timeout kills the actual process
@@ -176,9 +190,13 @@ async function callViaCli({ prompt, timeoutMs }) {
 }
 
 // Returns { text, stopReason }, e.g. stopReason 'end_turn' | 'max_tokens'.
-export async function callClaude({ prompt, maxTokens, timeoutMs }) {
+// `model` is optional and overrides the hardcoded per-backend default —
+// used by generate-impl.mjs's label-based model router (complexity:high /
+// pii-sensitive / default). Callers that omit it get the same model as
+// before this option existed.
+export async function callClaude({ prompt, maxTokens, timeoutMs, model }) {
   if (LLM_BACKEND === 'cli') {
-    return callViaCli({ prompt, timeoutMs });
+    return callViaCli({ prompt, timeoutMs, model });
   }
-  return callViaApi({ prompt, maxTokens, timeoutMs });
+  return callViaApi({ prompt, maxTokens, timeoutMs, model });
 }

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -178,3 +178,88 @@ test('callViaCli error path includes stdout content (not just stderr) in the thr
     return true;
   });
 });
+
+test('callViaCli forwards a caller-supplied model into --model argv, overriding the CLI default', async () => {
+  process.env.FAKE_CLAUDE_MODE = 'success';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+  process.env.FAKE_CLAUDE_ARGV_DUMP = ARGV_DUMP;
+
+  try {
+    // generate-impl.mjs's label-based model router passes `model` through
+    // callClaude() to reach the CLI's --model flag on this backend — prove
+    // it actually lands there instead of silently falling back to CLI_MODEL.
+    await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000, model: 'claude-opus-4-8' });
+
+    const argv = JSON.parse(readFileSync(ARGV_DUMP, 'utf8'));
+    const modelIndex = argv.indexOf('--model');
+    assert.ok(modelIndex !== -1, '--model must be present in argv');
+    assert.equal(argv[modelIndex + 1], 'claude-opus-4-8');
+  } finally {
+    delete process.env.FAKE_CLAUDE_ARGV_DUMP;
+  }
+});
+
+// --- API backend: model propagation ---
+//
+// The tests above import llm-client.mjs once with LLM_BACKEND=cli fixed at
+// module-load time (LLM_BACKEND is read at import time, not per-call — see
+// the comment above the first import). Exercising the API backend in the
+// same process needs a second, independently-configured module instance, so
+// it's imported here under a cache-busting query string (Node treats
+// import specifiers with different query strings as distinct module
+// instances, each re-evaluating top-level code — including the
+// LLM_BACKEND const — under whatever process.env holds at that moment).
+process.env.LLM_BACKEND = 'api';
+process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+const { callClaude: callClaudeApi } = await import('./llm-client.mjs?backend=api');
+
+test("callViaApi forwards a caller-supplied model into the request body's model field", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (url, init) => {
+    requests.push({ url, body: JSON.parse(init.body) });
+    return new Response(
+      JSON.stringify({
+        content: [{ type: 'text', text: 'fake api response' }],
+        stop_reason: 'end_turn',
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+  };
+
+  try {
+    const result = await callClaudeApi({
+      prompt: 'hi',
+      maxTokens: 100,
+      timeoutMs: 10000,
+      model: 'claude-opus-4-8',
+    });
+    assert.equal(result.text, 'fake api response');
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].body.model, 'claude-opus-4-8');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('callViaApi falls back to the hardcoded default model when none is supplied', async () => {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (url, init) => {
+    requests.push({ url, body: JSON.parse(init.body) });
+    return new Response(
+      JSON.stringify({
+        content: [{ type: 'text', text: 'fake api response' }],
+        stop_reason: 'end_turn',
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+  };
+
+  try {
+    await callClaudeApi({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
+    assert.equal(requests[0].body.model, 'claude-sonnet-4-6');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- `generate-spec.mjs`/`verify-spec.mjs` were migrated to the shared `llm-client.mjs` abstraction in #241/#244/#246 so the AI-SDLC pipeline can run on `LLM_BACKEND=cli` when API credits run out. `generate-adr.mjs` and `generate-impl.mjs` never were - they still hit `fetch('https://api.anthropic.com/v1/messages', ...)` directly with a hardcoded `ANTHROPIC_API_KEY` requirement, which is exactly what failed impl-agent run 30100971190 on issue #238.
- Both scripts now call `requireLlmCredentials()` + `callClaude()`, mirroring the proven `generate-spec.mjs` pattern.
- `adr-agent.yml` and `impl-agent.yml` gained the `LLM_BACKEND`/`CLAUDE_CODE_OAUTH_TOKEN` env wiring and conditional Claude Code CLI install step already present in `spec-agent.yml`.
- `generate-impl.mjs`'s label-based model router (`complexity:high` -> opus, `pii-sensitive` -> haiku) fed a per-call `model` into the raw fetch body, which `callClaude`'s signature didn't expose. `llm-client.mjs` gained an additive, backward-compatible optional `model` param (falls back to the existing hardcoded default on both backends when omitted, so `generate-spec.mjs`/`verify-spec.mjs` and the existing `llm-client.test.mjs` suite are unaffected) so the router keeps working end to end, including the `MODEL_USED` value that flows into the commit trailer and PR body.
- `generate-impl.mjs`'s `cache_control`-marked static context (Anthropic prompt caching) is dropped, since `callClaude` only accepts a flat prompt string - a cost-efficiency loss, not a correctness one.

## Timeout choices

- `generate-adr.mjs`: 120s. Its prompt (one ~1200-char example ADR + issue body + optional spec excerpt) and `max_tokens` (2048) are both smaller than `generate-spec.mjs`'s (180s budget, 4096 tokens), but it needed more than the old API-only 60s to cover CLI-backend subprocess startup.
- `generate-impl.mjs`: 600s. Its `max_tokens` (16384) is 2x `verify-spec.mjs`'s (8192), and its prompt (static CLAUDE.md/CONTRIBUTING.md/style context + full ratified spec) is comparable in size to `verify-spec.mjs`'s. `verify-spec.mjs` measured 283.9s for its 8192-token generation and set 420s (~1.5x margin); scaling for double the output tokens lands around 600-800s. 600s keeps a comparable margin while staying under `impl-agent.yml`'s existing 15-minute step timeout.

## Testing

- `node --check` on all three changed `.mjs` files.
- `npx prettier@3.6.2 --check` on all 5 changed files (2 scripts, `llm-client.mjs`, 2 workflow YAML) - clean.
- `node --test scripts/ai-sdlc/llm-client.test.mjs` - all 4 existing tests pass unmodified, confirming the additive `model` param didn't change default behavior.
- `actionlint .github/workflows/adr-agent.yml .github/workflows/impl-agent.yml` - clean.
- `pnpm --filter @bugspotter/backend test:unit` - 2961/2961 passing (unrelated to this diff; these scripts aren't covered by the backend suite).
- No live-credentials end-to-end test is possible locally; verified by mirroring the already-proven `generate-spec.mjs`/`verify-spec.mjs` pattern exactly.

Fixes #250

Assisted-by: claude-sonnet-5 (agent)