### PR TITLE
fix(impl-agent): build workspace packages before push to fix pre-push hook failure

### DIFF
--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -98,6 +98,20 @@ jobs:
       - name: Install dependencies (required for ESLint)
         run: pnpm install --frozen-lockfile
 
+      # Installing deps activates Husky's prepare script, which wires up the
+      # pre-push hook — it fires on the `git push` in "Commit scaffold to
+      # branch" below and runs the backend test suite. That suite imports
+      # internal workspace packages (@bugspotter/types, /utils,
+      # /message-broker, ...) whose package.json points `main` at a `dist/`
+      # that doesn't exist until they're built; without this, the push step
+      # fails on an unrelated module-resolution error in the pre-push hook,
+      # after the scaffold itself was already generated successfully. Using
+      # the same root `build` script (`pnpm --filter "./packages/*" build`)
+      # as everywhere else keeps this from silently missing a package if one
+      # is added later.
+      - name: Build workspace packages (required by pre-push test hook)
+        run: pnpm build
+
       - name: Format generated files
         env:
           FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -101,8 +101,8 @@ jobs:
       # Installing deps activates Husky's prepare script, which wires up the
       # pre-push hook — it fires on the `git push` in "Commit scaffold to
       # branch" below and runs the backend test suite. That suite imports
-      # internal workspace packages (@bugspotter/types, /utils,
-      # /message-broker, ...) whose package.json points `main` at a `dist/`
+      # internal workspace packages (@bugspotter/types, @bugspotter/utils,
+      # @bugspotter/message-broker, ...) whose package.json points `main` at a `dist/`
       # that doesn't exist until they're built; without this, the push step
       # fails on an unrelated module-resolution error in the pre-push hook,
       # after the scaffold itself was already generated successfully. Using


### PR DESCRIPTION
impl-agent.yml's "Commit scaffold to branch" step runs `git push`, which fires Husky's pre-push hook (installed by the earlier `pnpm install` step). That hook runs the full backend test suite, which imports internal workspace packages (`@bugspotter/types`, `/utils`, `/message-broker`) whose `package.json` points `main` at a `dist/` the workflow never builds — so the push failed on an unrelated module-resolution error after the scaffold itself had already generated successfully.

Confirmed live on issue #238's first successful impl-agent run (run 30147723166): "Generate scaffold" succeeded for the first time ever (validates #251's LLM_BACKEND fix), but "Commit scaffold to branch" failed at the hook. Reproduced locally without the build (5 test files fail with "Failed to resolve entry"), fixed with `pnpm build` (all 116 files / 2961 tests pass) — same fix verified again live via this branch's own `git push`.

`adr-agent.yml` isn't exposed to this — it never runs `pnpm install`, so the hook is never installed there.

## Testing

- Reproduced the failure locally (removed the build, re-ran `pnpm --filter @bugspotter/backend test:unit`, saw the same "Failed to resolve entry" errors on 5 files)
- Applied `pnpm build`, re-ran the suite: 116/116 files, 2961/2961 tests pass
- `actionlint` clean, `prettier --check` clean
- This branch's own `git push` exercised the real pre-push hook end to end, same as the fix does in CI

Fixes #252

Assisted-by: claude-sonnet-5 (agent)