### PR TITLE
fix(admin/nginx): re-apply security headers in every location (closes #258)

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -80,11 +80,12 @@ COPY apps/admin/nginx.conf.template /etc/nginx/conf.d/default.conf.template
 # Copy nginx snippets (DRY: reusable security headers)
 COPY apps/admin/nginx-snippets /etc/nginx/snippets
 
-# Verify template has unsafe-inline in CSP
-RUN echo "=== Verifying nginx template CSP ===" && \
-    grep "style-src.*unsafe-inline" /etc/nginx/conf.d/default.conf.template || \
-    (echo "ERROR: unsafe-inline missing from template!" && exit 1) && \
-    echo "✓ Template verified: unsafe-inline present in style-src"
+# Verify the security-headers snippet template has unsafe-inline in CSP
+# (the CSP lives in security-headers.conf.template, rendered by the entrypoint)
+RUN echo "=== Verifying nginx CSP snippet ===" && \
+    grep "style-src.*unsafe-inline" /etc/nginx/snippets/security-headers.conf.template || \
+    (echo "ERROR: unsafe-inline missing from security-headers snippet!" && exit 1) && \
+    echo "✓ Snippet verified: unsafe-inline present in style-src"
 
 # Create directory for scripts
 RUN mkdir -p /app/scripts/shared

--- a/apps/admin/docker-entrypoint.sh
+++ b/apps/admin/docker-entrypoint.sh
@@ -25,12 +25,18 @@ echo "Runtime config created with GIT_COMMIT=${GIT_COMMIT:-unknown}, API_URL=${A
 # Process nginx template for standalone deployment
 envsubst '${API_DOMAIN_CSP}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
-echo "=== Generated nginx configuration (standalone) ==="
-grep "Content-Security-Policy" /etc/nginx/conf.d/default.conf
+# Render the security-headers snippet (CSP needs ${API_DOMAIN_CSP} filled in).
+# The config includes /etc/nginx/snippets/security-headers.conf at server scope
+# AND inside every location that sets its own add_header, so the security headers
+# are not dropped from HTML documents, hashed assets, and config.js.
+envsubst '${API_DOMAIN_CSP}' < /etc/nginx/snippets/security-headers.conf.template > /etc/nginx/snippets/security-headers.conf
+
+echo "=== Generated nginx security headers ==="
+grep "Content-Security-Policy" /etc/nginx/snippets/security-headers.conf
 echo "====================================="
 
 # Verify unsafe-inline is present in style-src
-if grep -q "style-src.*'self'.*'unsafe-inline'" /etc/nginx/conf.d/default.conf; then
+if grep -q "style-src.*'self'.*'unsafe-inline'" /etc/nginx/snippets/security-headers.conf; then
     echo "✓ CSP verified: style-src includes 'unsafe-inline'"
 else
     echo "⚠️  WARNING: style-src missing 'unsafe-inline' - React inline styles will be blocked!"

--- a/apps/admin/nginx-snippets/security-headers-dev.conf
+++ b/apps/admin/nginx-snippets/security-headers-dev.conf
@@ -1,0 +1,12 @@
+# Development security-header set (relaxed CSP for Vite HMR, no HSTS since dev
+# runs on HTTP), consolidated so it can be applied at the server scope AND
+# re-applied inside every location that sets its own add_header - nginx drops
+# inherited add_header directives from any location that defines its own. Used by
+# nginx.dev.conf.
+include /etc/nginx/snippets/security-headers-common.conf;
+include /etc/nginx/snippets/security-headers-permissions.conf;
+
+# img-src includes https://*.r2.cloudflarestorage.com for screenshot/replay uploads.
+# img-src includes https://secure.gravatar.com and https://*.atl-paas.net for Jira avatars.
+# connect-src allows localhost / ws for Vite HMR.
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.r2.cloudflarestorage.com https://secure.gravatar.com https://*.atl-paas.net; font-src 'self' data:; connect-src 'self' https://*.r2.cloudflarestorage.com http://localhost:* http://api:* ws://localhost:*; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;

--- a/apps/admin/nginx-snippets/security-headers-prod.conf
+++ b/apps/admin/nginx-snippets/security-headers-prod.conf
@@ -1,0 +1,14 @@
+# Production security-header set (static CSP variant), consolidated so it can be
+# applied at the server scope AND re-applied inside every location that sets its
+# own add_header - nginx drops inherited add_header directives from any location
+# that defines its own, which would otherwise strip these from HTML, assets, and
+# config.js. Used by nginx.conf. (The deployed image uses nginx.conf.template +
+# security-headers.conf.template, which supports a dynamic ${API_DOMAIN_CSP}.)
+include /etc/nginx/snippets/security-headers-common.conf;
+include /etc/nginx/snippets/security-headers-hsts.conf;
+include /etc/nginx/snippets/security-headers-permissions.conf;
+
+# img-src includes https://*.r2.cloudflarestorage.com for screenshot/replay uploads.
+# img-src includes https://secure.gravatar.com + https://*.atl-paas.net for Jira avatars.
+# font-src / connect-src include https://*.demo.bugspotter.io for Next.js fonts / app data.
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io https://secure.gravatar.com https://*.atl-paas.net; font-src 'self' data: https://*.demo.bugspotter.io; connect-src 'self' https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none';" always;

--- a/apps/admin/nginx-snippets/security-headers.conf.template
+++ b/apps/admin/nginx-snippets/security-headers.conf.template
@@ -1,0 +1,21 @@
+# All admin security headers in ONE place, so the exact same set can be applied
+# at the server scope AND re-applied inside every location that sets its own
+# add_header. nginx does not inherit add_header directives into a location that
+# defines any add_header of its own (the cache-control / CORS blocks below do),
+# so without re-including this, CSP + HSTS + framing/sniffing/referrer/permissions
+# silently vanish from HTML documents, hashed assets, and config.js.
+#
+# Rendered by docker-entrypoint.sh (envsubst fills ${API_DOMAIN_CSP}) to
+# /etc/nginx/snippets/security-headers.conf, which nginx.conf.template includes.
+include /etc/nginx/snippets/security-headers-common.conf;
+include /etc/nginx/snippets/security-headers-hsts.conf;
+include /etc/nginx/snippets/security-headers-permissions.conf;
+
+# Content Security Policy - dynamically configured.
+# API_DOMAIN_CSP is set by the entrypoint from the API_DOMAIN env var; empty =>
+# only 'self' (same-domain deployment), otherwise it is appended to connect-src.
+# Note: React/Vite requires 'unsafe-inline' for dynamic styles.
+# img-src includes https://*.r2.cloudflarestorage.com for screenshot/replay uploads.
+# font-src includes https://*.demo.bugspotter.io for Next.js optimized fonts.
+# connect-src includes R2 for fetching replay JSON and *.demo.bugspotter.io for external app data.
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io https://secure.gravatar.com https://*.atl-paas.net; font-src 'self' data: https://*.demo.bugspotter.io; connect-src 'self' https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io${API_DOMAIN_CSP}; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none';" always;

--- a/apps/admin/nginx.conf
+++ b/apps/admin/nginx.conf
@@ -31,19 +31,12 @@ server {
         # Note: font/woff and font/woff2 excluded - already compressed (WOFF uses zlib, WOFF2 uses Brotli)
         # Gzipping provides <1% reduction while consuming CPU cycles
 
-    # Security headers (DRY: extracted to reusable snippets)
-    include /etc/nginx/snippets/security-headers-common.conf;
-    include /etc/nginx/snippets/security-headers-hsts.conf;
-    include /etc/nginx/snippets/security-headers-permissions.conf;
-    
-    # Content Security Policy - PRODUCTION
-    # Note: React/Vite requires 'unsafe-inline' for dynamic styles
-    # img-src includes https://*.r2.cloudflarestorage.com for screenshot/replay uploads
-    # img-src includes https://secure.gravatar.com for Gravatar avatars
-    # img-src includes https://*.atl-paas.net for Jira avatars (both prod.public.atl-paas.net and prod.public-atl-paas.net patterns across all regions)
-    # font-src includes https://*.demo.bugspotter.io for Next.js optimized fonts
-    # connect-src includes R2 for fetching replay JSON files and *.demo.bugspotter.io for external app data
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io https://secure.gravatar.com https://*.atl-paas.net; font-src 'self' data: https://*.demo.bugspotter.io; connect-src 'self' https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
+    # Security headers (CSP + HSTS + framing/sniffing/referrer/permissions),
+    # consolidated into one snippet. It MUST also be re-included inside every
+    # location that sets its own add_header (config.js / assets / .html below),
+    # because nginx drops all inherited add_header directives from a location that
+    # defines any of its own.
+    include /etc/nginx/snippets/security-headers-prod.conf;
 
     # API proxy
     location /api/ {
@@ -76,6 +69,8 @@ server {
     location = /config.js {
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers-prod.conf;
     }
 
     # Cache static assets (CDN-optimized)
@@ -90,6 +85,8 @@ server {
         add_header Access-Control-Allow-Origin $cors_origin always;
         # CRITICAL: Tell CDN to cache separately per origin to prevent serving wrong CORS headers
         add_header Vary Origin always;
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers-prod.conf;
     }
 
     # Cache HTML with short TTL (for SPA navigation)
@@ -97,6 +94,8 @@ server {
         expires 5m;
         add_header Cache-Control "public, max-age=300, must-revalidate";
         etag on;
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers-prod.conf;
     }
 
     # Disable access to hidden files

--- a/apps/admin/nginx.conf.template
+++ b/apps/admin/nginx.conf.template
@@ -31,20 +31,13 @@ server {
         # Note: font/woff and font/woff2 excluded - already compressed (WOFF uses zlib, WOFF2 uses Brotli)
         # Gzipping provides <1% reduction while consuming CPU cycles
 
-    # Security headers (DRY: extracted to reusable snippets)
-    include /etc/nginx/snippets/security-headers-common.conf;
-    include /etc/nginx/snippets/security-headers-hsts.conf;
-    include /etc/nginx/snippets/security-headers-permissions.conf;
-    
-    # Content Security Policy - Dynamically configured
-    # API_DOMAIN_CSP is set by entrypoint script based on API_DOMAIN env var
-    # If API_DOMAIN is empty, only 'self' is allowed (same-domain deployment)
-    # If API_DOMAIN is set, it's added to connect-src with proper spacing
-    # Note: React/Vite requires 'unsafe-inline' for dynamic styles
-    # img-src includes https://*.r2.cloudflarestorage.com for screenshot/replay uploads
-    # font-src includes https://*.demo.bugspotter.io for Next.js optimized fonts
-    # connect-src includes R2 for fetching replay JSON files and *.demo.bugspotter.io for external app data
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io https://secure.gravatar.com https://*.atl-paas.net; font-src 'self' data: https://*.demo.bugspotter.io; connect-src 'self' https://*.r2.cloudflarestorage.com https://*.demo.bugspotter.io${API_DOMAIN_CSP}; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
+    # Security headers (CSP + HSTS + framing/sniffing/referrer/permissions),
+    # consolidated into one snippet. It MUST also be re-included inside every
+    # location that sets its own add_header (config.js / assets / .html below),
+    # because nginx drops all inherited add_header directives from a location that
+    # defines any of its own. Rendered from security-headers.conf.template by the
+    # entrypoint (envsubst fills ${API_DOMAIN_CSP}).
+    include /etc/nginx/snippets/security-headers.conf;
 
     # API proxy (for same-domain deployments)
     # In Docker Compose: proxies /api/* to backend container
@@ -79,6 +72,8 @@ server {
     location = /config.js {
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers.conf;
     }
 
     # Cache static assets (CDN-optimized)
@@ -93,6 +88,8 @@ server {
         add_header Access-Control-Allow-Origin $cors_origin always;
         # CRITICAL: Tell CDN to cache separately per origin to prevent serving wrong CORS headers
         add_header Vary Origin always;
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers.conf;
     }
 
     # Cache HTML with short TTL (for SPA navigation)
@@ -100,6 +97,10 @@ server {
         expires 5m;
         add_header Cache-Control "public, max-age=300, must-revalidate";
         etag on;
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        # SPA routes try_files to /index.html, which re-matches THIS location, so
+        # without this include every HTML document is served with no CSP/HSTS.
+        include /etc/nginx/snippets/security-headers.conf;
     }
 
     # Disable access to hidden files

--- a/apps/admin/nginx.dev.conf
+++ b/apps/admin/nginx.dev.conf
@@ -31,16 +31,12 @@ server {
         # Note: font/woff and font/woff2 excluded - already compressed (WOFF uses zlib, WOFF2 uses Brotli)
         # Gzipping provides <1% reduction while consuming CPU cycles
 
-    # Security headers (DRY: extracted to reusable snippets)
-    # Note: HSTS not included in dev config - development typically runs on HTTP
-    include /etc/nginx/snippets/security-headers-common.conf;
-    include /etc/nginx/snippets/security-headers-permissions.conf;
-    
-    # Content Security Policy - DEVELOPMENT (relaxed for Vite HMR)
-    # img-src includes https://*.r2.cloudflarestorage.com for screenshot/replay uploads
-    # img-src includes https://secure.gravatar.com and https://*.atl-paas.net for Jira avatars
-    # connect-src includes R2 for fetching replay JSON files
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.r2.cloudflarestorage.com https://secure.gravatar.com https://*.atl-paas.net; font-src 'self' data:; connect-src 'self' https://*.r2.cloudflarestorage.com http://localhost:* http://api:* ws://localhost:*; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
+    # Security headers (CSP + framing/sniffing/referrer/permissions; no HSTS in
+    # dev), consolidated into one snippet. It MUST also be re-included inside every
+    # location that sets its own add_header (config.js / assets / .html below),
+    # because nginx drops all inherited add_header directives from a location that
+    # defines any of its own.
+    include /etc/nginx/snippets/security-headers-dev.conf;
 
     # API proxy
     location /api/ {
@@ -73,6 +69,8 @@ server {
     location = /config.js {
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers-dev.conf;
     }
 
     # Cache static assets (CDN-optimized)
@@ -87,6 +85,8 @@ server {
         add_header Access-Control-Allow-Origin $cors_origin always;
         # CRITICAL: Tell CDN to cache separately per origin to prevent serving wrong CORS headers
         add_header Vary Origin always;
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers-dev.conf;
     }
 
     # Cache HTML with short TTL (for SPA navigation)
@@ -94,6 +94,8 @@ server {
         expires 5m;
         add_header Cache-Control "public, max-age=300, must-revalidate";
         etag on;
+        # Re-apply security headers: this location's add_header suppresses inheritance.
+        include /etc/nginx/snippets/security-headers-dev.conf;
     }
 
     # Disable access to hidden files

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -17,10 +17,11 @@
     "test:e2e:ci": "CI=true playwright test --project=chromium --retries=2",
     "test:e2e:notifications": "playwright test notification-delivery.spec.ts",
     "test:e2e:notifications:headed": "playwright test notification-delivery.spec.ts --headed",
-    "test:nginx": "node tests/nginx/config-validation.test.mjs && node tests/nginx/cors-origin.test.mjs && node tests/nginx/cache-directives.test.mjs",
+    "test:nginx": "node tests/nginx/config-validation.test.mjs && node tests/nginx/cors-origin.test.mjs && node tests/nginx/cache-directives.test.mjs && node tests/nginx/security-headers.test.mjs",
     "test:nginx:config": "node tests/nginx/config-validation.test.mjs",
     "test:nginx:cors": "node tests/nginx/cors-origin.test.mjs",
     "test:nginx:cache": "node tests/nginx/cache-directives.test.mjs",
+    "test:nginx:security": "node tests/nginx/security-headers.test.mjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\""
   },

--- a/apps/admin/tests/nginx/security-headers.test.mjs
+++ b/apps/admin/tests/nginx/security-headers.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * Nginx Security-Header Inheritance Tests (regression guard for #258)
+ *
+ * nginx does NOT inherit `add_header` directives into a `location` that defines
+ * any `add_header` of its own. The admin config sets cache-control / CORS headers
+ * per location, which silently strips the server-scope security headers (CSP,
+ * HSTS, X-Frame-Options, ...) from every browser-facing response (HTML documents,
+ * hashed assets, config.js) unless the security-header snippet is re-included in
+ * each such location.
+ *
+ * These tests fail if any location defines its own add_header but does NOT
+ * re-include the security-header snippet - i.e. they PROVE the header-drop bug
+ * cannot silently return.
+ *
+ * Run with: node apps/admin/tests/nginx/security-headers.test.mjs
+ */
+
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const ADMIN_DIR = join(__dirname, '../..');
+const SNIPPETS_DIR = join(ADMIN_DIR, 'nginx-snippets');
+
+// Each deployable config and the security-header snippet it must re-include.
+const CONFIGS = [
+  { name: 'nginx.conf.template', file: 'nginx.conf.template', snippet: 'security-headers.conf' },
+  { name: 'nginx.conf', file: 'nginx.conf', snippet: 'security-headers-prod.conf' },
+  { name: 'nginx.dev.conf', file: 'nginx.dev.conf', snippet: 'security-headers-dev.conf' },
+];
+
+/**
+ * Extract every `location <spec> { ... }` block body via brace-depth matching.
+ * (These configs do not nest locations, so first-level matching is sufficient.)
+ * @returns {{spec: string, body: string}[]}
+ */
+function extractLocationBlocks(content) {
+  const blocks = [];
+  const re = /location\s+([^{]+?)\s*\{/g;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    const spec = m[1].trim();
+    let depth = 1;
+    let i = re.lastIndex;
+    const start = i;
+    while (i < content.length && depth > 0) {
+      const ch = content[i];
+      if (ch === '{') {
+        depth++;
+      } else if (ch === '}') {
+        depth--;
+      }
+      i++;
+    }
+    blocks.push({ spec, body: content.slice(start, i - 1) });
+    re.lastIndex = i;
+  }
+  return blocks;
+}
+
+const includeLine = (snippet) => `include /etc/nginx/snippets/${snippet};`;
+
+describe('Nginx security-header inheritance (#258 regression guard)', () => {
+  for (const cfg of CONFIGS) {
+    describe(cfg.name, () => {
+      const content = readFileSync(join(ADMIN_DIR, cfg.file), 'utf-8');
+      const wanted = includeLine(cfg.snippet);
+      const locations = extractLocationBlocks(content);
+      // Server scope = file with all location blocks removed.
+      let serverScope = content;
+      for (const loc of locations) {
+        serverScope = serverScope.replace(loc.body, '');
+      }
+
+      it('applies the security-header snippet at server scope', () => {
+        assert.ok(
+          serverScope.includes(wanted),
+          `${cfg.name} must include ${cfg.snippet} at server scope`
+        );
+      });
+
+      it('re-applies the security-header snippet in EVERY location that sets its own add_header', () => {
+        const offenders = locations
+          .filter((loc) => /add_header/.test(loc.body))
+          .filter((loc) => !loc.body.includes(wanted))
+          .map((loc) => loc.spec);
+
+        assert.deepStrictEqual(
+          offenders,
+          [],
+          `These locations set add_header but drop the security headers (nginx does not ` +
+            `inherit add_header into them) - re-include ${cfg.snippet}: ${offenders.join(', ')}`
+        );
+      });
+
+      it('covers the browser-facing locations (config.js, assets, .html)', () => {
+        // Guards against the offender list being trivially empty (e.g. locations renamed).
+        const specs = locations.map((l) => l.spec);
+        assert.ok(
+          specs.some((s) => s.includes('/config.js')),
+          `${cfg.name} should have a /config.js location`
+        );
+        assert.ok(
+          specs.some((s) => s.includes('.html')),
+          `${cfg.name} should have a .html location`
+        );
+        assert.ok(
+          specs.some((s) => /\.\(js\|css/.test(s)),
+          `${cfg.name} should have a static-asset location`
+        );
+      });
+    });
+  }
+
+  describe('security-header snippets', () => {
+    it('security-headers.conf.template carries the CSP with the envsubst fragment', () => {
+      const snippet = readFileSync(join(SNIPPETS_DIR, 'security-headers.conf.template'), 'utf-8');
+      assert.match(snippet, /Content-Security-Policy/, 'must define CSP');
+      assert.match(snippet, /\$\{API_DOMAIN_CSP\}/, 'must keep the ${API_DOMAIN_CSP} fragment');
+      assert.match(snippet, /style-src[^;]*'unsafe-inline'/, 'style-src must keep unsafe-inline');
+    });
+
+    it('every snippet umbrella pulls in the shared static headers', () => {
+      for (const snippet of ['security-headers.conf.template', 'security-headers-prod.conf']) {
+        const content = readFileSync(join(SNIPPETS_DIR, snippet), 'utf-8');
+        for (const dep of [
+          'security-headers-common.conf',
+          'security-headers-hsts.conf',
+          'security-headers-permissions.conf',
+        ]) {
+          assert.ok(content.includes(dep), `${snippet} must include ${dep}`);
+        }
+      }
+      // Dev omits HSTS by design (runs on HTTP).
+      const dev = readFileSync(join(SNIPPETS_DIR, 'security-headers-dev.conf'), 'utf-8');
+      assert.ok(dev.includes('security-headers-common.conf'), 'dev must include common');
+      assert.ok(dev.includes('security-headers-permissions.conf'), 'dev must include permissions');
+      assert.ok(!dev.includes('security-headers-hsts.conf'), 'dev must NOT include HSTS');
+    });
+  });
+});

--- a/apps/admin/tests/nginx/security-headers.test.mjs
+++ b/apps/admin/tests/nginx/security-headers.test.mjs
@@ -85,8 +85,12 @@ describe('Nginx security-header inheritance (#258 regression guard)', () => {
       });
 
       it('re-applies the security-header snippet in EVERY location that sets its own add_header', () => {
+        // Match actual `add_header` directives (line-start, optional indent), not
+        // the substring - the location bodies carry comments that mention
+        // "add_header" (e.g. "this location's add_header suppresses inheritance").
+        const setsAddHeader = /^[ \t]*add_header\b/m;
         const offenders = locations
-          .filter((loc) => /add_header/.test(loc.body))
+          .filter((loc) => setsAddHeader.test(loc.body))
           .filter((loc) => !loc.body.includes(wanted))
           .map((loc) => loc.spec);
 
@@ -123,6 +127,24 @@ describe('Nginx security-header inheritance (#258 regression guard)', () => {
       assert.match(snippet, /Content-Security-Policy/, 'must define CSP');
       assert.match(snippet, /\$\{API_DOMAIN_CSP\}/, 'must keep the ${API_DOMAIN_CSP} fragment');
       assert.match(snippet, /style-src[^;]*'unsafe-inline'/, 'style-src must keep unsafe-inline');
+    });
+
+    it('every snippet carries a CSP with unsafe-inline for styles', () => {
+      // Guards each snippet independently - deleting CSP from the prod or dev
+      // snippet must not slip through on the template snippet's check alone.
+      for (const snippet of [
+        'security-headers.conf.template',
+        'security-headers-prod.conf',
+        'security-headers-dev.conf',
+      ]) {
+        const content = readFileSync(join(SNIPPETS_DIR, snippet), 'utf-8');
+        assert.match(content, /Content-Security-Policy/, `${snippet} must define CSP`);
+        assert.match(
+          content,
+          /style-src[^;]*'unsafe-inline'/,
+          `${snippet} style-src must keep unsafe-inline`
+        );
+      }
     });
 
     it('every snippet umbrella pulls in the shared static headers', () => {


### PR DESCRIPTION
nginx doesn't inherit `add_header` into a location that sets its own, so the per-location cache-control/CORS blocks silently stripped CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy and Permissions-Policy from every browser-facing response (HTML, assets, config.js). Verified live: app.kz.bugspotter.io served none of them.

Consolidates the header set into one snippet per config and includes it at server scope and inside every location with its own add_header. Regression test fails if a location sets add_header without re-including the snippet; proven with a real nginx run - all 6 headers now present on `/`, SPA routes, assets and config.js.

Closes #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)