### PR TITLE
feat(backup): off-site backup runner (opt-in, hosting-agnostic)

### DIFF
--- a/.claude/skills/bs-backup-health/SKILL.md
+++ b/.claude/skills/bs-backup-health/SKILL.md
@@ -88,7 +88,7 @@ aws s3 ls s3://${BACKUP_S3_BUCKET}/storage/ \
 
 Validate:
 
-- **Freshness:** read the per-cycle heartbeat, not the newest object's age. Because `backup-storage-sync.sh` uses additive `rclone copy`, a cycle with no source changes uploads nothing, so a quiet bucket can show an old newest-object even when every sync succeeded. Check the marker instead (about 2x the configured cadence, so 8h or less at the default 6h):
+- **Freshness:** read the per-cycle heartbeat, not the newest object's age. Because `backup-storage-sync.sh` uses additive `rclone copy`, a cycle with no source changes uploads nothing, so a quiet bucket can show an old newest-object even when every sync succeeded. Check the marker instead (about 2x the configured cadence, so 12h or less at the default 6h):
   ```bash
   aws s3 ls s3://${BACKUP_S3_BUCKET}/storage/.last-sync \
     --endpoint-url=${BACKUP_S3_ENDPOINT}
@@ -121,7 +121,7 @@ INTELLIGENCE-DB
 
 OBJECT STORAGE
   Status:    ⚠ STALE
-  Last sync: 26h ago  (expected 8h or less)
+  Last sync: 26h ago  (expected 12h or less)
   Source:    <S3_BUCKET>  (4,892 objects, 12.4 GB)
   Backup:    <BACKUP_S3_BUCKET>/storage  (4,591 objects, 11.8 GB)
   Delta:     301 missing objects, 600 MB
@@ -145,13 +145,15 @@ If the last restore test is >90 days old, recommend running `bs-restore-test`.
 
 ## Escalation criteria
 
-| Symptom                              | Action                                                   |
-| ------------------------------------ | -------------------------------------------------------- |
-| Any backup >24h old                  | Immediate — investigate same day                         |
-| PG dump <10% of usual size           | Possible corruption — block any migration until verified |
-| Cannot list bucket at all            | Credentials or network — escalate to founder             |
-| Backup count regression vs yesterday | Lifecycle policy misbehaving — review bucket rules       |
-| Object Storage delta >5% of source   | Sync broken — check rclone logs                          |
+Thresholds below assume the default 6h cadence. If the deployment raised `BACKUP_INTERVAL_SECONDS`, scale the overdue boundary with it (about 2x the configured interval, matching the freshness window above) so a longer valid schedule is not both fresh and overdue.
+
+| Symptom                                                       | Action                                                   |
+| ------------------------------------------------------------- | -------------------------------------------------------- |
+| Any backup older than 2x the cadence (24h+ at the default 6h) | Immediate - investigate same day                         |
+| PG dump <10% of usual size                                    | Possible corruption — block any migration until verified |
+| Cannot list bucket at all                                     | Credentials or network — escalate to founder             |
+| Backup count regression vs yesterday                          | Lifecycle policy misbehaving — review bucket rules       |
+| Object Storage delta >5% of source                            | Sync broken — check rclone logs                          |
 
 ## What this skill does NOT do
 

--- a/.claude/skills/bs-backup-health/SKILL.md
+++ b/.claude/skills/bs-backup-health/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: bs-backup-health
-description: Check whether BugSpotter production backups in the off-site KZ bucket are fresh and restorable. Reports last-backup timestamps per data source (main Postgres, intelligence-db, YC Object Storage), validates file size sanity, surfaces stale or missing backups with remediation suggestions. TRIGGER when user asks about backup status, backup health, "проверь бэкапы", DR readiness; before running a migration drill; before production migration; as a weekly health check.
+description: Check whether BugSpotter production backups in the off-site bucket are fresh and restorable. Reports last-backup timestamps per data source (main Postgres, intelligence-db, object storage), validates file size sanity, surfaces stale or missing backups with remediation suggestions. TRIGGER when user asks about backup status, backup health, "проверь бэкапы", DR readiness; before running a migration drill; before production migration; as a weekly health check.
 ---
 
 # bs-backup-health
 
-Verifies that BugSpotter prod data is safely backed up to a second (non-YC) KZ cloud and ready for restoration. **Does NOT modify anything** — read-only inspection.
+Verifies that BugSpotter prod data is safely backed up to the off-site,
+S3-compatible backup bucket and ready for restoration. **Does NOT modify
+anything** — read-only inspection.
 
 ## When to invoke
 
@@ -30,12 +32,12 @@ Grep `docker-compose.yml` and `docker-compose.*.yml` for a service named `pg-bac
 
 ### Step 2 — Identify the backup bucket
 
-From `.env.example`, `docker-compose.yml`, or `.env.sops`, extract:
+From `.env`, `docker-compose.yml`, or the deploy secret store, extract:
 
-- `BACKUP_S3_BUCKET` (expected: `bugspotter-backup-kz`)
-- `BACKUP_S3_ENDPOINT` (PS.KZ or Pro-Data endpoint)
+- `BACKUP_S3_BUCKET` (default: `bugspotter-backups`)
+- `BACKUP_S3_ENDPOINT` (whatever S3-compatible endpoint the operator configured)
 
-Report which provider is being used so the user has context.
+Report which provider/endpoint is being used so the user has context.
 
 ### Step 3 — Credentials availability
 
@@ -65,9 +67,9 @@ aws s3 ls s3://${BACKUP_S3_BUCKET}/postgres/ \
 
 Validate:
 
-- **Freshness:** latest file ≤12 hours old (pg-backup runs every 6h; 12h means we missed a cycle)
+- **Freshness:** latest file 12 hours old or less (pg-backup runs every 6h; 12h means we missed a cycle)
 - **Size sanity:** file >1 MB. Zero-byte or KB-range = likely corrupted pg_dump
-- **Naming:** matches `postgres/YYYYMMDD-HH.pgdump` (or current scripts/backup-pg.sh convention)
+- **Naming:** matches `postgres/YYYYMMDD-HHMMSS.pgdump` (see scripts/backup/backup-pg.sh)
 - **History depth:** at least 7 daily + 4 weekly snapshots present (per retention policy)
 
 ### B. Intelligence-db backup
@@ -86,10 +88,10 @@ aws s3 ls s3://${BACKUP_S3_BUCKET}/storage/ \
 
 Validate:
 
-- **Freshness:** rclone sync runs hourly → newest object should be ≤2h old
-- **Object-count parity:** backup count should be ≥99% of source. Requires `yc` (see Step 4); skip if unavailable. Get source count:
+- **Freshness:** the object-storage mirror runs once per cycle (6h) - newest object should be 8h old or less
+- **Object-count parity:** backup count should be 99% of source or more. Requires `yc` when the source is Yandex Object Storage (see Step 4); skip if unavailable. Get source count:
   ```bash
-  yc storage bucket get bugspotter-storage-kz --format json | jq '{size_bytes, object_count}'
+  yc storage bucket get <source-bucket> --format json | jq '{size_bytes, object_count}'
   ```
   Then compare.
 
@@ -103,9 +105,9 @@ BugSpotter Backup Health Check — 2026-05-22 14:32 +05
 
 POSTGRES (main)
   Status:    ✓ OK
-  Latest:    postgres/20260522-14.pgdump  (32 min ago, 142 MB)
+  Latest:    postgres/20260522-140000.pgdump  (32 min ago, 142 MB)
   History:   7 daily + 4 weekly snapshots
-  Bucket:    bugspotter-backup-kz @ PS.KZ
+  Bucket:    <BACKUP_S3_BUCKET> @ <BACKUP_S3_ENDPOINT>
 
 INTELLIGENCE-DB
   Status:    ✓ OK
@@ -114,9 +116,9 @@ INTELLIGENCE-DB
 
 OBJECT STORAGE
   Status:    ⚠ STALE
-  Last sync: 26h ago  (expected ≤2h)
-  Source:    bugspotter-storage-kz  (4,892 objects, 12.4 GB)
-  Backup:    bugspotter-backup-kz/storage  (4,591 objects, 11.8 GB)
+  Last sync: 26h ago  (expected 8h or less)
+  Source:    <S3_BUCKET>  (4,892 objects, 12.4 GB)
+  Backup:    <BACKUP_S3_BUCKET>/storage  (4,591 objects, 11.8 GB)
   Delta:     301 missing objects, 600 MB
 
 ═══════════════════════════════════════════════════════

--- a/.claude/skills/bs-backup-health/SKILL.md
+++ b/.claude/skills/bs-backup-health/SKILL.md
@@ -67,7 +67,7 @@ aws s3 ls s3://${BACKUP_S3_BUCKET}/postgres/ \
 
 Validate:
 
-- **Freshness:** latest file 12 hours old or less (pg-backup runs every 6h; 12h means we missed a cycle)
+- **Freshness:** latest file 12 hours old or less (pg-backup runs every 6h; 12h means we missed a cycle). These thresholds assume the default 6h cadence; if the deployment raised `BACKUP_INTERVAL_SECONDS` (see `docker-compose.yml`), scale the freshness window to about 2x the configured interval before flagging STALE.
 - **Size sanity:** file >1 MB. Zero-byte or KB-range = likely corrupted pg_dump
 - **Naming:** matches `postgres/YYYYMMDD-HHMMSS.pgdump` (see scripts/backup/backup-pg.sh)
 - **History depth:** at least 7 daily + 4 weekly snapshots present (per retention policy)
@@ -88,7 +88,12 @@ aws s3 ls s3://${BACKUP_S3_BUCKET}/storage/ \
 
 Validate:
 
-- **Freshness:** the object-storage mirror runs once per cycle (6h) - newest object should be 8h old or less
+- **Freshness:** read the per-cycle heartbeat, not the newest object's age. Because `backup-storage-sync.sh` uses additive `rclone copy`, a cycle with no source changes uploads nothing, so a quiet bucket can show an old newest-object even when every sync succeeded. Check the marker instead (about 2x the configured cadence, so 8h or less at the default 6h):
+  ```bash
+  aws s3 ls s3://${BACKUP_S3_BUCKET}/storage/.last-sync \
+    --endpoint-url=${BACKUP_S3_ENDPOINT}
+  ```
+  A missing or stale `.last-sync` means the sync stream is not completing; investigate its logs.
 - **Object-count parity:** backup count should be 99% of source or more. Requires `yc` when the source is Yandex Object Storage (see Step 4); skip if unavailable. Get source count:
   ```bash
   yc storage bucket get <source-bucket> --format json | jq '{size_bytes, object_count}'
@@ -111,7 +116,7 @@ POSTGRES (main)
 
 INTELLIGENCE-DB
   Status:    ✓ OK
-  Latest:    intelligence/20260522-14.pgdump  (32 min ago, 8 MB)
+  Latest:    intelligence/20260522-140000.pgdump  (32 min ago, 8 MB)
   Embeddings rows: 1,243
 
 OBJECT STORAGE

--- a/.dockerignore
+++ b/.dockerignore
@@ -61,6 +61,7 @@ Thumbs.db
 **/scripts/
 !scripts/shared/
 !scripts/unified-entrypoint.sh
+!scripts/backup/
 !packages/backend/scripts/copy-migrations.mjs
 
 # Archive and temp files

--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,29 @@ S3_BUCKET=bugspotter
 S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 
+# ============================================================================
+# Off-site KZ Backups (profile: backup) - OPT-IN
+# ============================================================================
+# Dumps main Postgres + intelligence-db and mirrors object storage to a SECOND
+# KZ cloud (PS.KZ), so a Yandex account-level failure cannot take the backups
+# with it. Inert until you enable the profile AND set the BACKUP_S3_* values:
+#   COMPOSE_PROFILES=backup   (or: docker compose --profile backup up -d)
+# The runner is read-only on every source; it only writes to the backup bucket.
+# See BACKUP.md for provisioning the bucket, first run, and restore drills.
+#
+# Destination bucket - a KZ provider that is NOT Yandex (e.g. PS.KZ, Pro-Data):
+# BACKUP_S3_ENDPOINT=https://s3.ps.kz
+# BACKUP_S3_BUCKET=bugspotter-backup-kz
+# BACKUP_S3_ACCESS_KEY=changeme-backup-bucket-access-key
+# BACKUP_S3_SECRET_KEY=changeme-backup-bucket-secret-key
+# BACKUP_S3_REGION=kz-1
+#
+# Cadence + grandfather-father-son retention (safe defaults shown):
+# BACKUP_INTERVAL_SECONDS=21600   # 6h; health check flags >12h as a missed cycle
+# BACKUP_KEEP_RECENT=8            # keep the newest 8 dumps outright (~48h at 6h)
+# BACKUP_KEEP_DAILY=7            # + newest dump per day for 7 days
+# BACKUP_KEEP_WEEKLY=4          # + newest dump per ISO week for 4 weeks
+
 # Signed URL Expiration (in seconds)
 # Controls how long screenshot/replay URLs remain accessible
 # Default: 2592000 (30 days) - URLs expire after this time

--- a/.env.example
+++ b/.env.example
@@ -116,21 +116,24 @@ S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 
 # ============================================================================
-# Off-site KZ Backups (profile: backup) - OPT-IN
+# Off-site Backups (profile: backup) - OPT-IN
 # ============================================================================
-# Dumps main Postgres + intelligence-db and mirrors object storage to a SECOND
-# KZ cloud (PS.KZ), so a Yandex account-level failure cannot take the backups
-# with it. Inert until you enable the profile AND set the BACKUP_S3_* values:
+# Dumps main Postgres + intelligence-db and mirrors object storage to any
+# S3-compatible target, so a failure in the primary provider's account cannot
+# take the backups with it. Hosting-agnostic - point BACKUP_S3_* at whatever
+# off-site bucket you choose (ideally a different provider/region than primary).
+# Inert until you enable the profile AND set the BACKUP_S3_* values:
 #   COMPOSE_PROFILES=backup   (or: docker compose --profile backup up -d)
 # The runner is read-only on every source; it only writes to the backup bucket.
 # See BACKUP.md for provisioning the bucket, first run, and restore drills.
 #
-# Destination bucket - a KZ provider that is NOT Yandex (e.g. PS.KZ, Pro-Data):
-# BACKUP_S3_ENDPOINT=https://s3.ps.kz
-# BACKUP_S3_BUCKET=bugspotter-backup-kz
+# Destination bucket - any S3-compatible endpoint (AWS S3, MinIO, Backblaze B2,
+# Wasabi, a second cloud, etc.). Prefer a provider/region distinct from primary:
+# BACKUP_S3_ENDPOINT=https://s3.example.com
+# BACKUP_S3_BUCKET=bugspotter-backups
 # BACKUP_S3_ACCESS_KEY=changeme-backup-bucket-access-key
 # BACKUP_S3_SECRET_KEY=changeme-backup-bucket-secret-key
-# BACKUP_S3_REGION=kz-1
+# BACKUP_S3_REGION=us-east-1
 #
 # Cadence + grandfather-father-son retention (safe defaults shown):
 # BACKUP_INTERVAL_SECONDS=21600   # 6h; health check flags >12h as a missed cycle

--- a/BACKUP.md
+++ b/BACKUP.md
@@ -1,0 +1,106 @@
+# Off-site KZ Backups
+
+BugSpotter production data lives in **Yandex Cloud KZ** (Managed PostgreSQL +
+Object Storage). Yandex keeps its own platform snapshots, but those live in the
+same account and provider - a billing lock, an account action, or an operator
+mistake can take the primary data and its snapshots together. This backup runner
+copies the data to a **second, non-Yandex KZ cloud** (PS.KZ) so a Yandex
+account-level failure cannot destroy every copy.
+
+It is **opt-in** (`profiles: [backup]`) and **inert** until you provision the
+bucket and set the credentials. The runner is **read-only on every source** - it
+only writes to the backup bucket.
+
+## What it backs up
+
+| Stream          | Source                                 | Destination key               | Cadence          |
+| --------------- | -------------------------------------- | ----------------------------- | ---------------- |
+| Main Postgres   | `DATABASE_URL` (Yandex Managed PG)     | `postgres/<stamp>.pgdump`     | every cycle (6h) |
+| intelligence-db | `intelligence-db` container (pgvector) | `intelligence/<stamp>.pgdump` | every cycle (6h) |
+| Object storage  | `S3_*` (Yandex Object Storage)         | `storage/...`                 | every cycle (6h) |
+
+`<stamp>` is `YYYYMMDD-HHMMSS` (UTC, lexically sortable). Intelligence-db is
+skipped unless `INTELLIGENCE_ENABLED=true`.
+
+## Retention (grandfather-father-son)
+
+Applied to `postgres/` and `intelligence/` after each cycle
+(`scripts/backup/prune.sh`). Object storage is a live mirror, not pruned by age.
+
+- keep the newest `BACKUP_KEEP_RECENT` dumps outright (default 8 = ~48h at 6h)
+- keep the newest dump per calendar day for `BACKUP_KEEP_DAILY` days (default 7)
+- keep the newest dump per ISO week for `BACKUP_KEEP_WEEKLY` weeks (default 4)
+- delete everything else
+
+## One-time setup (owner)
+
+1. **Provision the off-site bucket** at a KZ provider that is **not** Yandex
+   (PS.KZ or Pro-Data). Create bucket `bugspotter-backup-kz` and a service
+   access key scoped to it. Keep it in KZ - never R2 or a non-KZ region.
+2. **Set the credentials** on the prod host `.env` (never commit them):
+   ```dotenv
+   COMPOSE_PROFILES=...,backup            # add backup to the active profiles
+   BACKUP_S3_ENDPOINT=https://s3.ps.kz
+   BACKUP_S3_BUCKET=bugspotter-backup-kz
+   BACKUP_S3_ACCESS_KEY=<key>
+   BACKUP_S3_SECRET_KEY=<secret>
+   BACKUP_S3_REGION=kz-1
+   ```
+   The main-PG (`DATABASE_URL`) and object-storage (`S3_*`) values are already in
+   the prod env; the runner reuses them read-only.
+3. **Start the runner:**
+   ```bash
+   docker compose --profile backup up -d pg-backup
+   docker compose logs -f pg-backup      # watch the first cycle
+   ```
+   It runs one cycle immediately, then every `BACKUP_INTERVAL_SECONDS`.
+
+## Verify
+
+- `bs-backup-health` skill - freshness/size/parity report against the bucket.
+- Manual freshness check:
+  ```bash
+  aws s3 ls s3://bugspotter-backup-kz/postgres/ --endpoint-url https://s3.ps.kz \
+    --recursive | sort | tail -5
+  ```
+
+## Restore drill
+
+Do this after the first backup and on a schedule (a backup you have not restored
+is not a backup). Restore into a **throwaway** database, never over prod.
+
+```bash
+# 1. Pick the newest dump
+key=$(aws s3 ls s3://bugspotter-backup-kz/postgres/ --endpoint-url https://s3.ps.kz \
+  | awk '{print $NF}' | sort | tail -1)
+
+# 2. Download it
+aws s3 cp "s3://bugspotter-backup-kz/postgres/$key" /tmp/restore.pgdump \
+  --endpoint-url https://s3.ps.kz
+
+# 3. Restore into a fresh scratch DB (NOT prod)
+createdb -h <host> -U <user> restore_drill
+pg_restore --no-owner --no-acl -d "postgresql://<user>:<pw>@<host>:6432/restore_drill" \
+  /tmp/restore.pgdump
+
+# 4. Sanity-check row counts, then drop it
+psql -h <host> -U <user> -d restore_drill -c '\dt'
+dropdb -h <host> -U <user> restore_drill
+```
+
+This exact round-trip (dump -> upload -> download -> `pg_restore` -> row-count
+check) was verified manually against a throwaway pg16 + MinIO pair during
+development. The committed automated test covers the retention logic
+(`scripts/backup/test-prune.sh`); the dump/restore round-trip is a manual drill.
+
+## Failure handling
+
+A failure in one stream is logged and does **not** stop the others or the loop -
+a broken object-storage sync must never block Postgres dumps. Investigate with
+`docker compose logs pg-backup`; escalation criteria are in the `bs-backup-health`
+skill.
+
+## Tests
+
+- `bash scripts/backup/test-prune.sh` - retention decision logic (pure function,
+  8 invariants incl. partition + idempotence). Also runs inside the image.

--- a/BACKUP.md
+++ b/BACKUP.md
@@ -27,7 +27,10 @@ skipped unless `INTELLIGENCE_ENABLED=true`.
 ## Retention (grandfather-father-son)
 
 Applied to `postgres/` and `intelligence/` after each cycle
-(`scripts/backup/prune.sh`). Object storage is a live mirror, not pruned by age.
+(`scripts/backup/prune.sh`). Object storage (`storage/`) is an additive copy
+(never deleted here, so a source-side deletion can't destroy the backed-up
+object); it is not pruned by age. Bound its growth with a lifecycle policy on the
+backup bucket if you need a ceiling.
 
 - keep the newest `BACKUP_KEEP_RECENT` dumps outright (default 8 = ~48h at 6h)
 - keep the newest dump per calendar day for `BACKUP_KEEP_DAILY` days (default 7)
@@ -107,4 +110,5 @@ skill.
 ## Tests
 
 - `bash scripts/backup/test-prune.sh` - retention decision logic (pure function,
-  8 invariants incl. partition + idempotence). Also runs inside the image.
+  10 invariants incl. partition, idempotence + input validation). Also runs
+  inside the image.

--- a/BACKUP.md
+++ b/BACKUP.md
@@ -1,23 +1,25 @@
-# Off-site KZ Backups
+# Off-site Backups
 
-BugSpotter production data lives in **Yandex Cloud KZ** (Managed PostgreSQL +
-Object Storage). Yandex keeps its own platform snapshots, but those live in the
-same account and provider - a billing lock, an account action, or an operator
+BugSpotter's primary data (Postgres, intelligence-db embeddings, object storage)
+lives in one place. Whatever the primary provider is, its own platform snapshots
+live in the same account - a billing lock, an account action, or an operator
 mistake can take the primary data and its snapshots together. This backup runner
-copies the data to a **second, non-Yandex KZ cloud** (PS.KZ) so a Yandex
-account-level failure cannot destroy every copy.
+copies the data to a separate, **off-site S3-compatible bucket** so a failure in
+the primary provider's account cannot destroy every copy.
 
-It is **opt-in** (`profiles: [backup]`) and **inert** until you provision the
-bucket and set the credentials. The runner is **read-only on every source** - it
-only writes to the backup bucket.
+It is **hosting-agnostic**: point `BACKUP_S3_*` at any S3-compatible target (AWS
+S3, MinIO, Backblaze B2, Wasabi, a second cloud). It is **opt-in**
+(`profiles: [backup]`) and **inert** until you provision the bucket and set the
+credentials. The runner is **read-only on every source** - it only writes to the
+backup bucket.
 
 ## What it backs up
 
 | Stream          | Source                                 | Destination key               | Cadence          |
 | --------------- | -------------------------------------- | ----------------------------- | ---------------- |
-| Main Postgres   | `DATABASE_URL` (Yandex Managed PG)     | `postgres/<stamp>.pgdump`     | every cycle (6h) |
+| Main Postgres   | `DATABASE_URL`                         | `postgres/<stamp>.pgdump`     | every cycle (6h) |
 | intelligence-db | `intelligence-db` container (pgvector) | `intelligence/<stamp>.pgdump` | every cycle (6h) |
-| Object storage  | `S3_*` (Yandex Object Storage)         | `storage/...`                 | every cycle (6h) |
+| Object storage  | `S3_*`                                 | `storage/...`                 | every cycle (6h) |
 
 `<stamp>` is `YYYYMMDD-HHMMSS` (UTC, lexically sortable). Intelligence-db is
 skipped unless `INTELLIGENCE_ENABLED=true`.
@@ -34,17 +36,19 @@ Applied to `postgres/` and `intelligence/` after each cycle
 
 ## One-time setup (owner)
 
-1. **Provision the off-site bucket** at a KZ provider that is **not** Yandex
-   (PS.KZ or Pro-Data). Create bucket `bugspotter-backup-kz` and a service
-   access key scoped to it. Keep it in KZ - never R2 or a non-KZ region.
+1. **Provision the off-site bucket** on any S3-compatible provider. Prefer a
+   provider or region **distinct from the primary** (that separation is the whole
+   point). Create the bucket and a service access key **scoped to that bucket
+   only**. If a data-residency rule applies to your deployment, choose a bucket
+   region that satisfies it.
 2. **Set the credentials** on the prod host `.env` (never commit them):
    ```dotenv
    COMPOSE_PROFILES=...,backup            # add backup to the active profiles
-   BACKUP_S3_ENDPOINT=https://s3.ps.kz
-   BACKUP_S3_BUCKET=bugspotter-backup-kz
+   BACKUP_S3_ENDPOINT=https://s3.example.com
+   BACKUP_S3_BUCKET=bugspotter-backups
    BACKUP_S3_ACCESS_KEY=<key>
    BACKUP_S3_SECRET_KEY=<secret>
-   BACKUP_S3_REGION=kz-1
+   BACKUP_S3_REGION=us-east-1
    ```
    The main-PG (`DATABASE_URL`) and object-storage (`S3_*`) values are already in
    the prod env; the runner reuses them read-only.
@@ -60,7 +64,7 @@ Applied to `postgres/` and `intelligence/` after each cycle
 - `bs-backup-health` skill - freshness/size/parity report against the bucket.
 - Manual freshness check:
   ```bash
-  aws s3 ls s3://bugspotter-backup-kz/postgres/ --endpoint-url https://s3.ps.kz \
+  aws s3 ls s3://$BACKUP_S3_BUCKET/postgres/ --endpoint-url $BACKUP_S3_ENDPOINT \
     --recursive | sort | tail -5
   ```
 
@@ -71,12 +75,12 @@ is not a backup). Restore into a **throwaway** database, never over prod.
 
 ```bash
 # 1. Pick the newest dump
-key=$(aws s3 ls s3://bugspotter-backup-kz/postgres/ --endpoint-url https://s3.ps.kz \
+key=$(aws s3 ls s3://$BACKUP_S3_BUCKET/postgres/ --endpoint-url $BACKUP_S3_ENDPOINT \
   | awk '{print $NF}' | sort | tail -1)
 
 # 2. Download it
-aws s3 cp "s3://bugspotter-backup-kz/postgres/$key" /tmp/restore.pgdump \
-  --endpoint-url https://s3.ps.kz
+aws s3 cp "s3://$BACKUP_S3_BUCKET/postgres/$key" /tmp/restore.pgdump \
+  --endpoint-url $BACKUP_S3_ENDPOINT
 
 # 3. Restore into a fresh scratch DB (NOT prod)
 createdb -h <host> -U <user> restore_drill

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1012,7 +1012,7 @@ services:
   # ==========================================================================
   # Off-site Backup Runner (profile: backup)
   # ==========================================================================
-  # Dumps the main Postgres + intelligence-db and mirrors object storage to any
+  # Dumps the main Postgres + intelligence-db and copies object storage to any
   # S3-compatible target, so a failure in the primary provider's account cannot
   # take the backups with it. Hosting-agnostic: the operator points BACKUP_S3_*
   # at whatever off-site bucket they choose (a different provider/region than the
@@ -1032,6 +1032,11 @@ services:
     environment:
       # Cadence (default 6h) - the health check treats >12h as a missed cycle.
       BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-21600}
+      # After a failed cycle, retry sooner than the full interval (default 10m).
+      BACKUP_RETRY_SECONDS: ${BACKUP_RETRY_SECONDS:-600}
+      # Per-stream wall-clock cap so a hung dump/sync can't stall the cycle
+      # (default 4h; 0 disables). Raise it if a large object-storage sync needs it.
+      BACKUP_STREAM_TIMEOUT_SECONDS: ${BACKUP_STREAM_TIMEOUT_SECONDS:-14400}
       # Retention (grandfather-father-son) - see scripts/backup/prune.sh.
       BACKUP_KEEP_RECENT: ${BACKUP_KEEP_RECENT:-8}
       BACKUP_KEEP_DAILY: ${BACKUP_KEEP_DAILY:-7}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1009,6 +1009,63 @@ services:
           memory: 2500M
           cpus: '0.25'
 
+  # ==========================================================================
+  # Off-site KZ Backup Runner (profile: backup)
+  # ==========================================================================
+  # Dumps the main Postgres + intelligence-db and mirrors object storage to a
+  # SECOND KZ cloud (PS.KZ), so a Yandex account-level failure cannot take the
+  # backups with it. Opt-in and inert until enabled:
+  #   COMPOSE_PROFILES=backup  (or --profile backup)
+  # Requires the BACKUP_S3_* credentials in .env (see .env.example). Read-only on
+  # every source; only writes to the backup bucket. See BACKUP.md.
+  pg-backup:
+    <<: *default-logging
+    profiles: [backup]
+    image: ${BACKUP_IMAGE:-bugspotter-backup:latest}
+    build:
+      context: .
+      dockerfile: docker/backup/Dockerfile
+    container_name: bugspotter-backup
+    restart: unless-stopped
+    environment:
+      # Cadence (default 6h) - the health check treats >12h as a missed cycle.
+      BACKUP_INTERVAL_SECONDS: ${BACKUP_INTERVAL_SECONDS:-21600}
+      # Retention (grandfather-father-son) - see scripts/backup/prune.sh.
+      BACKUP_KEEP_RECENT: ${BACKUP_KEEP_RECENT:-8}
+      BACKUP_KEEP_DAILY: ${BACKUP_KEEP_DAILY:-7}
+      BACKUP_KEEP_WEEKLY: ${BACKUP_KEEP_WEEKLY:-4}
+      # Source: main Postgres (same connection string the app uses).
+      DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-bugspotter}:${POSTGRES_PASSWORD:-}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-bugspotter}}
+      # Source: intelligence-db (only dumped when INTELLIGENCE_ENABLED=true).
+      INTELLIGENCE_ENABLED: ${INTELLIGENCE_ENABLED:-false}
+      INTELLIGENCE_DB_HOST: ${INTELLIGENCE_DB_HOST:-intelligence-db}
+      INTELLIGENCE_DB_PORT: ${INTELLIGENCE_DB_PORT:-5432}
+      INTELLIGENCE_DB_NAME: ${INTELLIGENCE_DB_NAME:-bugspotter_intelligence}
+      INTELLIGENCE_DB_USER: ${INTELLIGENCE_DB_USER:-postgres}
+      INTELLIGENCE_DB_PASSWORD: ${INTELLIGENCE_DB_PASSWORD:-}
+      # Source: object storage (Yandex Object Storage in prod).
+      S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
+      S3_BUCKET: ${S3_BUCKET:-bugspotter}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-${MINIO_APP_ACCESS_KEY:-}}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:-${MINIO_APP_SECRET_KEY:-}}
+      S3_REGION: ${S3_REGION:-ru-central1}
+      # Destination: off-site KZ backup bucket (PS.KZ). Required.
+      BACKUP_S3_ENDPOINT: ${BACKUP_S3_ENDPOINT:?set BACKUP_S3_ENDPOINT for the backup profile}
+      BACKUP_S3_BUCKET: ${BACKUP_S3_BUCKET:-bugspotter-backup-kz}
+      BACKUP_S3_ACCESS_KEY: ${BACKUP_S3_ACCESS_KEY:?set BACKUP_S3_ACCESS_KEY for the backup profile}
+      BACKUP_S3_SECRET_KEY: ${BACKUP_S3_SECRET_KEY:?set BACKUP_S3_SECRET_KEY for the backup profile}
+      BACKUP_S3_REGION: ${BACKUP_S3_REGION:-kz-1}
+    networks:
+      - bugspotter
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+        reservations:
+          memory: 64M
+          cpus: '0.05'
+
 # ============================================================================
 # Named Volumes
 # ============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1010,11 +1010,13 @@ services:
           cpus: '0.25'
 
   # ==========================================================================
-  # Off-site KZ Backup Runner (profile: backup)
+  # Off-site Backup Runner (profile: backup)
   # ==========================================================================
-  # Dumps the main Postgres + intelligence-db and mirrors object storage to a
-  # SECOND KZ cloud (PS.KZ), so a Yandex account-level failure cannot take the
-  # backups with it. Opt-in and inert until enabled:
+  # Dumps the main Postgres + intelligence-db and mirrors object storage to any
+  # S3-compatible target, so a failure in the primary provider's account cannot
+  # take the backups with it. Hosting-agnostic: the operator points BACKUP_S3_*
+  # at whatever off-site bucket they choose (a different provider/region than the
+  # primary is the point). Opt-in and inert until enabled:
   #   COMPOSE_PROFILES=backup  (or --profile backup)
   # Requires the BACKUP_S3_* credentials in .env (see .env.example). Read-only on
   # every source; only writes to the backup bucket. See BACKUP.md.
@@ -1043,21 +1045,21 @@ services:
       INTELLIGENCE_DB_NAME: ${INTELLIGENCE_DB_NAME:-bugspotter_intelligence}
       INTELLIGENCE_DB_USER: ${INTELLIGENCE_DB_USER:-postgres}
       INTELLIGENCE_DB_PASSWORD: ${INTELLIGENCE_DB_PASSWORD:-}
-      # Source: object storage (Yandex Object Storage in prod).
+      # Source: object storage (reuses the app's own S3 config, read-only).
       S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
       S3_BUCKET: ${S3_BUCKET:-bugspotter}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-${MINIO_APP_ACCESS_KEY:-}}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-${MINIO_APP_SECRET_KEY:-}}
-      S3_REGION: ${S3_REGION:-ru-central1}
-      # Destination: off-site KZ backup bucket (PS.KZ). Required at runtime -
+      S3_REGION: ${S3_REGION:-us-east-1}
+      # Destination: off-site S3-compatible backup bucket. Required at runtime -
       # export_backup_creds() in lib.sh fails loudly if any is empty. Left as
       # :- (not :?) so `docker compose config` validates without them set; the
       # service is profile-gated and won't start on a stock deploy anyway.
       BACKUP_S3_ENDPOINT: ${BACKUP_S3_ENDPOINT:-}
-      BACKUP_S3_BUCKET: ${BACKUP_S3_BUCKET:-bugspotter-backup-kz}
+      BACKUP_S3_BUCKET: ${BACKUP_S3_BUCKET:-bugspotter-backups}
       BACKUP_S3_ACCESS_KEY: ${BACKUP_S3_ACCESS_KEY:-}
       BACKUP_S3_SECRET_KEY: ${BACKUP_S3_SECRET_KEY:-}
-      BACKUP_S3_REGION: ${BACKUP_S3_REGION:-kz-1}
+      BACKUP_S3_REGION: ${BACKUP_S3_REGION:-us-east-1}
     networks:
       - bugspotter
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1049,11 +1049,14 @@ services:
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-${MINIO_APP_ACCESS_KEY:-}}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-${MINIO_APP_SECRET_KEY:-}}
       S3_REGION: ${S3_REGION:-ru-central1}
-      # Destination: off-site KZ backup bucket (PS.KZ). Required.
-      BACKUP_S3_ENDPOINT: ${BACKUP_S3_ENDPOINT:?set BACKUP_S3_ENDPOINT for the backup profile}
+      # Destination: off-site KZ backup bucket (PS.KZ). Required at runtime -
+      # export_backup_creds() in lib.sh fails loudly if any is empty. Left as
+      # :- (not :?) so `docker compose config` validates without them set; the
+      # service is profile-gated and won't start on a stock deploy anyway.
+      BACKUP_S3_ENDPOINT: ${BACKUP_S3_ENDPOINT:-}
       BACKUP_S3_BUCKET: ${BACKUP_S3_BUCKET:-bugspotter-backup-kz}
-      BACKUP_S3_ACCESS_KEY: ${BACKUP_S3_ACCESS_KEY:?set BACKUP_S3_ACCESS_KEY for the backup profile}
-      BACKUP_S3_SECRET_KEY: ${BACKUP_S3_SECRET_KEY:?set BACKUP_S3_SECRET_KEY for the backup profile}
+      BACKUP_S3_ACCESS_KEY: ${BACKUP_S3_ACCESS_KEY:-}
+      BACKUP_S3_SECRET_KEY: ${BACKUP_S3_SECRET_KEY:-}
       BACKUP_S3_REGION: ${BACKUP_S3_REGION:-kz-1}
     networks:
       - bugspotter

--- a/docker/backup/Dockerfile
+++ b/docker/backup/Dockerfile
@@ -1,0 +1,24 @@
+# Off-site KZ backup runner: dumps Postgres + intelligence-db and mirrors object
+# storage to a second KZ cloud (PS.KZ). Small, single-purpose, no app code.
+FROM alpine:3.20
+
+# postgresql16-client: pg_dump (>= server major; prod main + intelligence are pg16)
+# aws-cli: upload/list/prune against the S3-compatible backup bucket
+# rclone: cross-endpoint object-storage mirror (Yandex -> PS.KZ)
+# coreutils: GNU date (ISO week %G%V + reliable -d parsing) for retention
+# bash + tzdata: scripts use bash; timestamps are UTC
+RUN apk add --no-cache \
+      postgresql16-client \
+      aws-cli \
+      rclone \
+      coreutils \
+      bash \
+      tzdata \
+  && rm -rf /var/cache/apk/*
+
+WORKDIR /opt/backup
+COPY scripts/backup/ /opt/backup/
+RUN chmod +x /opt/backup/*.sh
+
+# No secrets baked in - all credentials come from the environment at runtime.
+ENTRYPOINT ["/opt/backup/entrypoint.sh"]

--- a/scripts/backup/backup-intelligence.sh
+++ b/scripts/backup/backup-intelligence.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Dump the intelligence-db (pgvector, embeddings) and upload it to the off-site
+# KZ backup bucket under intelligence/. Losing this DB means hours of LLM
+# re-computation on recovery, so it is backed up on the same schedule as main.
+#
+# Skips cleanly (exit 0) when INTELLIGENCE_ENABLED is not true, so the backup
+# service is safe to run on deployments without the AI stack.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/backup/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+if [ "${INTELLIGENCE_ENABLED:-false}" != "true" ]; then
+  log "INTELLIGENCE_ENABLED is not true - skipping intelligence-db backup"
+  exit 0
+fi
+
+# Build the connection string from the intelligence-db vars (mirrors compose).
+: "${INTELLIGENCE_DB_HOST:=intelligence-db}"
+: "${INTELLIGENCE_DB_PORT:=5432}"
+: "${INTELLIGENCE_DB_NAME:=bugspotter_intelligence}"
+: "${INTELLIGENCE_DB_USER:=postgres}"
+require_env INTELLIGENCE_DB_PASSWORD
+export_backup_creds
+
+intel_url="postgresql://${INTELLIGENCE_DB_USER}:${INTELLIGENCE_DB_PASSWORD}@${INTELLIGENCE_DB_HOST}:${INTELLIGENCE_DB_PORT}/${INTELLIGENCE_DB_NAME}"
+
+stamp="$(backup_stamp)"
+key="intelligence/${stamp}.pgdump"
+tmp="$(mktemp -t intel-XXXXXX.pgdump)"
+trap 'rm -f "$tmp"' EXIT
+
+log "dumping intelligence-db -> $key"
+pg_dump "${intel_url}" -Fc --no-owner --no-acl -f "$tmp"
+
+upload_verified "$tmp" "$key"
+log "intelligence-db backup complete: $key"

--- a/scripts/backup/backup-intelligence.sh
+++ b/scripts/backup/backup-intelligence.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Dump the intelligence-db (pgvector, embeddings) and upload it to the off-site
-# KZ backup bucket under intelligence/. Losing this DB means hours of LLM
+# backup bucket under intelligence/. Losing this DB means hours of LLM
 # re-computation on recovery, so it is backed up on the same schedule as main.
 #
 # Skips cleanly (exit 0) when INTELLIGENCE_ENABLED is not true, so the backup

--- a/scripts/backup/backup-intelligence.sh
+++ b/scripts/backup/backup-intelligence.sh
@@ -23,15 +23,20 @@ fi
 require_env INTELLIGENCE_DB_PASSWORD
 export_backup_creds
 
-intel_url="postgresql://${INTELLIGENCE_DB_USER}:${INTELLIGENCE_DB_PASSWORD}@${INTELLIGENCE_DB_HOST}:${INTELLIGENCE_DB_PORT}/${INTELLIGENCE_DB_NAME}"
-
 stamp="$(backup_stamp)"
 key="intelligence/${stamp}.pgdump"
 tmp="$(mktemp -t intel-XXXXXX.pgdump)"
 trap 'rm -f "$tmp"' EXIT
 
 log "dumping intelligence-db -> $key"
-pg_dump "${intel_url}" -Fc --no-owner --no-acl -f "$tmp"
+# Pass connection parameters separately (not as a postgresql:// URI): a password
+# containing URI-reserved characters (:, @, /, %, ...) would corrupt a URI, and
+# PGPASSWORD keeps the secret out of the process list (unlike an argv-embedded URI).
+export PGPASSWORD="${INTELLIGENCE_DB_PASSWORD}"
+pg_dump \
+  -h "${INTELLIGENCE_DB_HOST}" -p "${INTELLIGENCE_DB_PORT}" \
+  -U "${INTELLIGENCE_DB_USER}" -d "${INTELLIGENCE_DB_NAME}" \
+  -Fc --no-owner --no-acl -f "$tmp"
 
 upload_verified "$tmp" "$key"
 log "intelligence-db backup complete: $key"

--- a/scripts/backup/backup-pg.sh
+++ b/scripts/backup/backup-pg.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Dump the main Postgres database (Yandex Managed PostgreSQL in prod) and upload
+# the dump to the off-site KZ backup bucket under postgres/.
+#
+# Reads DATABASE_URL (same connection string the app uses). pg_dump connects over
+# the network; this does not touch or lock the source beyond a normal dump.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/backup/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+require_env DATABASE_URL
+export_backup_creds
+
+stamp="$(backup_stamp)"
+key="postgres/${stamp}.pgdump"
+tmp="$(mktemp -t pg-XXXXXX.pgdump)"
+trap 'rm -f "$tmp"' EXIT
+
+log "dumping main Postgres -> $key"
+# -Fc: custom format (compressed, selective restore). --no-owner/--no-acl keep the
+# dump portable across roles when restoring into a fresh managed instance.
+pg_dump "${DATABASE_URL}" -Fc --no-owner --no-acl -f "$tmp"
+
+upload_verified "$tmp" "$key"
+log "main Postgres backup complete: $key"

--- a/scripts/backup/backup-pg.sh
+++ b/scripts/backup/backup-pg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Dump the main Postgres database (Yandex Managed PostgreSQL in prod) and upload
-# the dump to the off-site KZ backup bucket under postgres/.
+# the dump to the off-site backup bucket under postgres/.
 #
 # Reads DATABASE_URL (same connection string the app uses). pg_dump connects over
 # the network; this does not touch or lock the source beyond a normal dump.

--- a/scripts/backup/backup-storage-sync.sh
+++ b/scripts/backup/backup-storage-sync.sh
@@ -44,4 +44,11 @@ rclone copy "src:${S3_BUCKET}" "dst:${BACKUP_S3_BUCKET}/storage" \
   --fast-list --checksum --transfers "${BACKUP_SYNC_TRANSFERS:-8}" \
   --stats-one-line --stats "${BACKUP_SYNC_STATS_INTERVAL:-30s}"
 
+# Write a per-cycle heartbeat AFTER a successful copy. Because `rclone copy` is
+# additive, a cycle with no source changes uploads nothing, so the newest object
+# age is not a reliable "did the sync run?" signal. The health check reads this
+# marker for freshness instead. Only reached when the copy above succeeded.
+printf '%s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  | rclone rcat "dst:${BACKUP_S3_BUCKET}/storage/.last-sync"
+
 log "object storage sync complete"

--- a/scripts/backup/backup-storage-sync.sh
+++ b/scripts/backup/backup-storage-sync.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Mirror the source object storage (Yandex Object Storage in prod: screenshots,
-# replays, attachments) to the off-site KZ backup bucket under storage/.
+# Mirror the source object storage (screenshots, replays, attachments) to the
+# off-site backup bucket under storage/.
 #
-# Uses rclone because the source and destination are two DIFFERENT S3 endpoints
-# (Yandex -> PS.KZ); `aws s3 sync` cannot cross endpoints in one command. rclone
-# copies only new/changed objects, so repeated runs are cheap.
+# Uses rclone because the source and destination are two DIFFERENT S3 endpoints;
+# `aws s3 sync` cannot cross endpoints in one command. rclone copies only
+# new/changed objects, so repeated runs are cheap.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/backup/lib.sh
@@ -22,14 +22,14 @@ export RCLONE_CONFIG_SRC_PROVIDER="${S3_PROVIDER:-Other}"
 export RCLONE_CONFIG_SRC_ENDPOINT="${S3_ENDPOINT}"
 export RCLONE_CONFIG_SRC_ACCESS_KEY_ID="${S3_ACCESS_KEY}"
 export RCLONE_CONFIG_SRC_SECRET_ACCESS_KEY="${S3_SECRET_KEY}"
-export RCLONE_CONFIG_SRC_REGION="${S3_REGION:-ru-central1}"
+export RCLONE_CONFIG_SRC_REGION="${S3_REGION:-us-east-1}"
 
 export RCLONE_CONFIG_DST_TYPE=s3
 export RCLONE_CONFIG_DST_PROVIDER="${BACKUP_S3_PROVIDER:-Other}"
 export RCLONE_CONFIG_DST_ENDPOINT="${BACKUP_S3_ENDPOINT}"
 export RCLONE_CONFIG_DST_ACCESS_KEY_ID="${BACKUP_S3_ACCESS_KEY}"
 export RCLONE_CONFIG_DST_SECRET_ACCESS_KEY="${BACKUP_S3_SECRET_KEY}"
-export RCLONE_CONFIG_DST_REGION="${BACKUP_S3_REGION:-kz-1}"
+export RCLONE_CONFIG_DST_REGION="${BACKUP_S3_REGION:-us-east-1}"
 
 log "syncing object storage src:${S3_BUCKET} -> dst:${BACKUP_S3_BUCKET}/storage"
 # --fast-list cuts API calls on large buckets; --checksum avoids re-copying on

--- a/scripts/backup/backup-storage-sync.sh
+++ b/scripts/backup/backup-storage-sync.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Mirror the source object storage (Yandex Object Storage in prod: screenshots,
+# replays, attachments) to the off-site KZ backup bucket under storage/.
+#
+# Uses rclone because the source and destination are two DIFFERENT S3 endpoints
+# (Yandex -> PS.KZ); `aws s3 sync` cannot cross endpoints in one command. rclone
+# copies only new/changed objects, so repeated runs are cheap.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/backup/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+require_env \
+  S3_ENDPOINT S3_BUCKET S3_ACCESS_KEY S3_SECRET_KEY \
+  BACKUP_S3_ENDPOINT BACKUP_S3_BUCKET BACKUP_S3_ACCESS_KEY BACKUP_S3_SECRET_KEY
+
+# Two rclone remotes configured entirely from env (no config file on disk):
+#   src  = source object storage (read-only use here)
+#   dst  = off-site backup bucket
+export RCLONE_CONFIG_SRC_TYPE=s3
+export RCLONE_CONFIG_SRC_PROVIDER="${S3_PROVIDER:-Other}"
+export RCLONE_CONFIG_SRC_ENDPOINT="${S3_ENDPOINT}"
+export RCLONE_CONFIG_SRC_ACCESS_KEY_ID="${S3_ACCESS_KEY}"
+export RCLONE_CONFIG_SRC_SECRET_ACCESS_KEY="${S3_SECRET_KEY}"
+export RCLONE_CONFIG_SRC_REGION="${S3_REGION:-ru-central1}"
+
+export RCLONE_CONFIG_DST_TYPE=s3
+export RCLONE_CONFIG_DST_PROVIDER="${BACKUP_S3_PROVIDER:-Other}"
+export RCLONE_CONFIG_DST_ENDPOINT="${BACKUP_S3_ENDPOINT}"
+export RCLONE_CONFIG_DST_ACCESS_KEY_ID="${BACKUP_S3_ACCESS_KEY}"
+export RCLONE_CONFIG_DST_SECRET_ACCESS_KEY="${BACKUP_S3_SECRET_KEY}"
+export RCLONE_CONFIG_DST_REGION="${BACKUP_S3_REGION:-kz-1}"
+
+log "syncing object storage src:${S3_BUCKET} -> dst:${BACKUP_S3_BUCKET}/storage"
+# --fast-list cuts API calls on large buckets; --checksum avoids re-copying on
+# clock skew between providers.
+rclone copy "src:${S3_BUCKET}" "dst:${BACKUP_S3_BUCKET}/storage" \
+  --fast-list --checksum --transfers "${BACKUP_SYNC_TRANSFERS:-8}" \
+  --stats-one-line --stats "${BACKUP_SYNC_STATS_INTERVAL:-30s}"
+
+log "object storage sync complete"

--- a/scripts/backup/backup-storage-sync.sh
+++ b/scripts/backup/backup-storage-sync.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# Mirror the source object storage (screenshots, replays, attachments) to the
+# Copy the source object storage (screenshots, replays, attachments) to the
 # off-site backup bucket under storage/.
 #
 # Uses rclone because the source and destination are two DIFFERENT S3 endpoints;
 # `aws s3 sync` cannot cross endpoints in one command. rclone copies only
 # new/changed objects, so repeated runs are cheap.
+#
+# This is `rclone copy`, NOT `rclone sync`: it is additive and never deletes on
+# the destination. That is deliberate for a backup - an object deleted (or
+# encrypted by ransomware) at the source must NOT be deleted from the off-site
+# copy. The tradeoff is that storage/ grows monotonically; bound it with a
+# bucket lifecycle/expiry policy on the backup bucket if you need a ceiling.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/backup/lib.sh

--- a/scripts/backup/entrypoint.sh
+++ b/scripts/backup/entrypoint.sh
@@ -20,13 +20,15 @@ run() {
   local name="$1" script="$2" rc=0
   log "=== ${name} ==="
   if [ "${STREAM_TIMEOUT}" -gt 0 ]; then
-    timeout "${STREAM_TIMEOUT}" "${SCRIPT_DIR}/${script}" || rc=$?
+    # --kill-after: if SIGTERM is ignored, SIGKILL 30s later so a stuck stream
+    # can't outlive its cap. Exit 124 = terminated on timeout, 137 = SIGKILLed.
+    timeout --kill-after=30s "${STREAM_TIMEOUT}" "${SCRIPT_DIR}/${script}" || rc=$?
   else
     "${SCRIPT_DIR}/${script}" || rc=$?
   fi
   if [ "$rc" -eq 0 ]; then
     log "=== ${name} OK ==="
-  elif [ "$rc" -eq 124 ]; then
+  elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
     log "=== ${name} TIMED OUT after ${STREAM_TIMEOUT}s (continuing) ==="
     return 1
   else

--- a/scripts/backup/entrypoint.sh
+++ b/scripts/backup/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Backup service loop. Runs one cycle immediately on start (so a fresh deploy has
+# a backup within minutes, not hours), then every BACKUP_INTERVAL_SECONDS.
+#
+# A cycle: dump main Postgres, dump intelligence-db (if enabled), mirror object
+# storage, then prune old dumps per the retention policy. A failure in one stream
+# is logged and does not abort the others or the loop - a broken storage sync
+# must not stop Postgres backups.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+INTERVAL="${BACKUP_INTERVAL_SECONDS:-21600}" # default 6h
+
+run() {
+  local name="$1" script="$2"
+  log "=== ${name} ==="
+  if "${SCRIPT_DIR}/${script}"; then
+    log "=== ${name} OK ==="
+  else
+    log "=== ${name} FAILED (continuing) ==="
+    return 1
+  fi
+}
+
+# lib.sh for log(); sourced after defining nothing that conflicts.
+# shellcheck source=scripts/backup/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+cycle() {
+  local rc=0
+  run "main Postgres backup" backup-pg.sh || rc=1
+  run "intelligence-db backup" backup-intelligence.sh || rc=1
+  run "object storage sync" backup-storage-sync.sh || rc=1
+  run "retention prune" prune.sh || rc=1
+  if [ "$rc" -eq 0 ]; then
+    log "cycle complete: all streams OK"
+  else
+    log "cycle complete: one or more streams FAILED (see above)"
+  fi
+  return "$rc"
+}
+
+log "backup service starting (interval=${INTERVAL}s)"
+while true; do
+  cycle || true
+  log "sleeping ${INTERVAL}s until next cycle"
+  sleep "${INTERVAL}"
+done

--- a/scripts/backup/entrypoint.sh
+++ b/scripts/backup/entrypoint.sh
@@ -2,22 +2,35 @@
 # Backup service loop. Runs one cycle immediately on start (so a fresh deploy has
 # a backup within minutes, not hours), then every BACKUP_INTERVAL_SECONDS.
 #
-# A cycle: dump main Postgres, dump intelligence-db (if enabled), mirror object
+# A cycle: dump main Postgres, dump intelligence-db (if enabled), copy object
 # storage, then prune old dumps per the retention policy. A failure in one stream
 # is logged and does not abort the others or the loop - a broken storage sync
 # must not stop Postgres backups.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-INTERVAL="${BACKUP_INTERVAL_SECONDS:-21600}" # default 6h
+INTERVAL="${BACKUP_INTERVAL_SECONDS:-21600}"       # cadence between cycles; default 6h
+RETRY_INTERVAL="${BACKUP_RETRY_SECONDS:-600}"      # shorter wait after a failed cycle; default 10m
+STREAM_TIMEOUT="${BACKUP_STREAM_TIMEOUT_SECONDS:-14400}" # per-stream wall-clock cap; 0 disables. default 4h
 
+# Bound each stream with GNU `timeout` (coreutils, in the image) so a hung
+# pg_dump/aws/rclone can't stall the whole cycle and starve later streams. A
+# stream that fails or times out is logged and does not abort the cycle.
 run() {
-  local name="$1" script="$2"
+  local name="$1" script="$2" rc=0
   log "=== ${name} ==="
-  if "${SCRIPT_DIR}/${script}"; then
-    log "=== ${name} OK ==="
+  if [ "${STREAM_TIMEOUT}" -gt 0 ]; then
+    timeout "${STREAM_TIMEOUT}" "${SCRIPT_DIR}/${script}" || rc=$?
   else
-    log "=== ${name} FAILED (continuing) ==="
+    "${SCRIPT_DIR}/${script}" || rc=$?
+  fi
+  if [ "$rc" -eq 0 ]; then
+    log "=== ${name} OK ==="
+  elif [ "$rc" -eq 124 ]; then
+    log "=== ${name} TIMED OUT after ${STREAM_TIMEOUT}s (continuing) ==="
+    return 1
+  else
+    log "=== ${name} FAILED (rc=${rc}, continuing) ==="
     return 1
   fi
 }
@@ -40,9 +53,24 @@ cycle() {
   return "$rc"
 }
 
-log "backup service starting (interval=${INTERVAL}s)"
+# Reject non-positive / non-numeric timing values up front: passed straight to
+# `sleep`, a bad INTERVAL would fail and spin the loop, hammering the sources.
+require_positive_int() {
+  local name="$1" value="$2"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || die "${name} must be a positive integer, got '${value}'"
+}
+require_positive_int BACKUP_INTERVAL_SECONDS "$INTERVAL"
+require_positive_int BACKUP_RETRY_SECONDS "$RETRY_INTERVAL"
+[[ "$STREAM_TIMEOUT" =~ ^[0-9]+$ ]] \
+  || die "BACKUP_STREAM_TIMEOUT_SECONDS must be a non-negative integer (0 disables), got '${STREAM_TIMEOUT}'"
+
+log "backup service starting (interval=${INTERVAL}s, retry=${RETRY_INTERVAL}s, stream_timeout=${STREAM_TIMEOUT}s)"
 while true; do
-  cycle || true
-  log "sleeping ${INTERVAL}s until next cycle"
-  sleep "${INTERVAL}"
+  if cycle; then
+    log "sleeping ${INTERVAL}s until next cycle"
+    sleep "${INTERVAL}"
+  else
+    log "cycle had failures; retrying in ${RETRY_INTERVAL}s"
+    sleep "${RETRY_INTERVAL}"
+  fi
 done

--- a/scripts/backup/lib.sh
+++ b/scripts/backup/lib.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Shared helpers for the off-site KZ backup scripts.
+#
+# All backup streams (main Postgres, intelligence-db, object storage) land in a
+# SECOND KZ cloud (PS.KZ), never Yandex, so a Yandex account-level failure cannot
+# take the backups with it. Nothing here writes to the source; it only reads the
+# source and writes to the backup bucket.
+set -euo pipefail
+
+log() { printf '%s [backup] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# Fail fast if a required env var is unset/empty. Never echoes the value.
+require_env() {
+  local name
+  for name in "$@"; do
+    if [ -z "${!name:-}" ]; then
+      die "required env var $name is not set"
+    fi
+  done
+}
+
+# aws s3/s3api against the off-site backup bucket. Credentials come from
+# BACKUP_S3_ACCESS_KEY / BACKUP_S3_SECRET_KEY (exported as AWS_* by the caller).
+aws_backup() {
+  aws --endpoint-url "${BACKUP_S3_ENDPOINT}" "$@"
+}
+
+# Upload a local file to s3://<bucket>/<key>, then verify the remote object's
+# size matches the local file. A silently-truncated upload is worse than a loud
+# failure, so we treat a size mismatch as an error.
+upload_verified() {
+  local local_path="$1" key="$2"
+  local size
+  size="$(wc -c < "$local_path" | tr -d ' ')"
+  [ "$size" -gt 0 ] || die "refusing to upload empty file $local_path (key=$key)"
+
+  log "uploading $key (${size} bytes)"
+  aws_backup s3 cp "$local_path" "s3://${BACKUP_S3_BUCKET}/${key}" >/dev/null
+
+  local remote_size
+  remote_size="$(aws_backup s3api head-object \
+    --bucket "${BACKUP_S3_BUCKET}" --key "${key}" \
+    --query 'ContentLength' --output text 2>/dev/null || echo "")"
+  [ "$remote_size" = "$size" ] \
+    || die "upload size mismatch for $key: local=$size remote=${remote_size:-missing}"
+  log "uploaded + verified $key"
+}
+
+# UTC timestamp used in object keys: YYYYMMDD-HHMMSS, lexically sortable so the
+# health-check's `aws s3 ls ... | sort | tail` picks the newest correctly.
+backup_stamp() { date -u +'%Y%m%d-%H%M%S'; }
+
+# Export AWS_* from the BACKUP_S3_* vars so the aws CLI authenticates against the
+# backup bucket without a shared profile. Called once per script.
+export_backup_creds() {
+  require_env BACKUP_S3_ENDPOINT BACKUP_S3_BUCKET BACKUP_S3_ACCESS_KEY BACKUP_S3_SECRET_KEY
+  export AWS_ACCESS_KEY_ID="${BACKUP_S3_ACCESS_KEY}"
+  export AWS_SECRET_ACCESS_KEY="${BACKUP_S3_SECRET_KEY}"
+  export AWS_DEFAULT_REGION="${BACKUP_S3_REGION:-kz-1}"
+}

--- a/scripts/backup/lib.sh
+++ b/scripts/backup/lib.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Shared helpers for the off-site KZ backup scripts.
+# Shared helpers for the off-site backup scripts.
 #
-# All backup streams (main Postgres, intelligence-db, object storage) land in a
-# SECOND KZ cloud (PS.KZ), never Yandex, so a Yandex account-level failure cannot
-# take the backups with it. Nothing here writes to the source; it only reads the
-# source and writes to the backup bucket.
+# All backup streams (main Postgres, intelligence-db, object storage) land in an
+# off-site, S3-compatible bucket (operator's choice of provider), so a failure in
+# the primary provider's account cannot take the backups with it. Nothing here
+# writes to the source; it only reads the source and writes to the backup bucket.
 set -euo pipefail
 
 log() { printf '%s [backup] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >&2; }
@@ -57,5 +57,5 @@ export_backup_creds() {
   require_env BACKUP_S3_ENDPOINT BACKUP_S3_BUCKET BACKUP_S3_ACCESS_KEY BACKUP_S3_SECRET_KEY
   export AWS_ACCESS_KEY_ID="${BACKUP_S3_ACCESS_KEY}"
   export AWS_SECRET_ACCESS_KEY="${BACKUP_S3_SECRET_KEY}"
-  export AWS_DEFAULT_REGION="${BACKUP_S3_REGION:-kz-1}"
+  export AWS_DEFAULT_REGION="${BACKUP_S3_REGION:-us-east-1}"
 }

--- a/scripts/backup/prune.sh
+++ b/scripts/backup/prune.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Grandfather-father-son retention for the timestamped dump streams
+# (postgres/, intelligence/). Pure decision logic lives in select_deletions so it
+# can be unit-tested without S3; main() applies it against the backup bucket.
+#
+# Retention (all configurable):
+#   - keep the newest BACKUP_KEEP_RECENT dumps outright (intra-day granularity)
+#   - keep the newest dump per calendar day for BACKUP_KEEP_DAILY days
+#   - keep the newest dump per ISO week for BACKUP_KEEP_WEEKLY weeks
+#   - delete everything else
+#
+# Object storage (storage/) is NOT pruned here - it is a live mirror of the
+# source, so deletions there are driven by the source, not by age.
+set -euo pipefail
+
+# Parse the YYYYMMDD-HHMMSS stamp out of a key like "postgres/20260727-120000.pgdump".
+# Echoes "<epoch> <YYYYMMDD> <ISOyearweek> <key>" or nothing if it doesn't match.
+_parse_key() {
+  local key="$1" base stamp y m d H M S
+  base="${key##*/}"
+  stamp="${base%.pgdump}"
+  [[ "$stamp" =~ ^([0-9]{4})([0-9]{2})([0-9]{2})-([0-9]{2})([0-9]{2})([0-9]{2})$ ]] || return 0
+  y="${BASH_REMATCH[1]}"; m="${BASH_REMATCH[2]}"; d="${BASH_REMATCH[3]}"
+  H="${BASH_REMATCH[4]}"; M="${BASH_REMATCH[5]}"; S="${BASH_REMATCH[6]}"
+  local epoch week
+  epoch="$(date -u -d "${y}-${m}-${d} ${H}:${M}:${S}" +%s 2>/dev/null)" || return 0
+  week="$(date -u -d "${y}-${m}-${d}" +%G%V 2>/dev/null)" || return 0
+  printf '%s %s %s %s\n' "$epoch" "${y}${m}${d}" "$week" "$key"
+}
+
+# Reads keys on stdin (one per line), prints the keys to DELETE on stdout.
+# Deterministic and side-effect-free.
+select_deletions() {
+  local keep_recent="${BACKUP_KEEP_RECENT:-8}"
+  local keep_daily="${BACKUP_KEEP_DAILY:-7}"
+  local keep_weekly="${BACKUP_KEEP_WEEKLY:-4}"
+
+  local parsed
+  parsed="$(while IFS= read -r k; do [ -n "$k" ] && _parse_key "$k"; done | sort -rn)"
+  [ -n "$parsed" ] || return 0
+
+  declare -A keep=() seen_day=() seen_week=()
+  local n=0 epoch day week key
+  while read -r epoch day week key; do
+    [ -n "$key" ] || continue
+    n=$((n + 1))
+    # newest N outright
+    if [ "$n" -le "$keep_recent" ]; then keep["$key"]=1; fi
+    # newest per day, for the most recent keep_daily distinct days
+    if [ -z "${seen_day[$day]:-}" ]; then
+      if [ "${#seen_day[@]}" -lt "$keep_daily" ]; then keep["$key"]=1; fi
+      seen_day["$day"]=1
+    fi
+    # newest per ISO week, for the most recent keep_weekly distinct weeks
+    if [ -z "${seen_week[$week]:-}" ]; then
+      if [ "${#seen_week[@]}" -lt "$keep_weekly" ]; then keep["$key"]=1; fi
+      seen_week["$week"]=1
+    fi
+  done <<< "$parsed"
+
+  # Emit deletions in chronological order (oldest first).
+  while read -r epoch day week key; do
+    [ -n "$key" ] || continue
+    [ -z "${keep[$key]:-}" ] && printf '%s\n' "$key"
+  done <<< "$(printf '%s\n' "$parsed" | sort -n)"
+}
+
+_prune_prefix() {
+  local prefix="$1" keys deletions
+  keys="$(aws_backup s3 ls "s3://${BACKUP_S3_BUCKET}/${prefix}/" --recursive 2>/dev/null \
+    | awk '{print $NF}' || true)"
+  deletions="$(printf '%s\n' "$keys" | select_deletions || true)"
+  if [ -z "$deletions" ]; then
+    log "prune ${prefix}: nothing to delete"
+    return 0
+  fi
+  local key
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    log "prune ${prefix}: deleting $key"
+    aws_backup s3 rm "s3://${BACKUP_S3_BUCKET}/${key}" >/dev/null
+  done <<< "$deletions"
+}
+
+# Only run main() when executed directly, so tests can source the functions.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck source=scripts/backup/lib.sh
+  . "${SCRIPT_DIR}/lib.sh"
+  export_backup_creds
+  _prune_prefix postgres
+  _prune_prefix intelligence
+fi

--- a/scripts/backup/prune.sh
+++ b/scripts/backup/prune.sh
@@ -9,8 +9,10 @@
 #   - keep the newest dump per ISO week for BACKUP_KEEP_WEEKLY weeks
 #   - delete everything else
 #
-# Object storage (storage/) is NOT pruned here - it is a live mirror of the
-# source, so deletions there are driven by the source, not by age.
+# Object storage (storage/) is NOT pruned here - it is an additive copy that
+# deliberately retains objects even after they are deleted at the source (see
+# backup-storage-sync.sh), so age-based pruning would defeat its purpose. Bound
+# its growth with a lifecycle policy on the backup bucket if needed.
 set -euo pipefail
 
 # Parse the YYYYMMDD-HHMMSS stamp out of a key like "postgres/20260727-120000.pgdump".
@@ -34,6 +36,16 @@ select_deletions() {
   local keep_recent="${BACKUP_KEEP_RECENT:-8}"
   local keep_daily="${BACKUP_KEEP_DAILY:-7}"
   local keep_weekly="${BACKUP_KEEP_WEEKLY:-4}"
+
+  # Reject malformed retention counts before making any delete decision: a
+  # non-numeric or negative value would silently disable a tier and over-delete.
+  local value
+  for value in "$keep_recent" "$keep_daily" "$keep_weekly"; do
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+      log "invalid retention count: '${value}' (want a non-negative integer)"
+      return 2
+    fi
+  done
 
   local parsed
   parsed="$(while IFS= read -r k; do [ -n "$k" ] && _parse_key "$k"; done | sort -rn)"
@@ -67,9 +79,13 @@ select_deletions() {
 
 _prune_prefix() {
   local prefix="$1" keys deletions
-  keys="$(aws_backup s3 ls "s3://${BACKUP_S3_BUCKET}/${prefix}/" --recursive 2>/dev/null \
-    | awk '{print $NF}' || true)"
-  deletions="$(printf '%s\n' "$keys" | select_deletions || true)"
+  # No `|| true`: a failed listing (bad creds/endpoint/network) must fail this
+  # stream, not masquerade as "nothing to delete" and silently skip retention.
+  # `set -o pipefail` propagates an aws failure through the awk pipe. An empty
+  # prefix legitimately lists nothing and exits 0, so it stays a no-op.
+  keys="$(aws_backup s3 ls "s3://${BACKUP_S3_BUCKET}/${prefix}/" --recursive \
+    | awk '{print $NF}')"
+  deletions="$(printf '%s\n' "$keys" | select_deletions)"
   if [ -z "$deletions" ]; then
     log "prune ${prefix}: nothing to delete"
     return 0

--- a/scripts/backup/test-prune.sh
+++ b/scripts/backup/test-prune.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Unit tests for the retention decision logic (select_deletions) in prune.sh.
+# Pure function, no S3 - generates synthetic keys and asserts the keep/delete
+# partition and its invariants. Run: bash scripts/backup/test-prune.sh
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/backup/prune.sh
+. "${SCRIPT_DIR}/prune.sh"
+# prune.sh sets `set -euo pipefail`; relax it for the test harness so a single
+# assertion failure doesn't silently abort the whole run.
+set +eu
+
+pass=0
+fail=0
+ok()   { pass=$((pass + 1)); }
+bad()  { fail=$((fail + 1)); printf 'FAIL: %s\n' "$1" >&2; }
+
+# Generate keys every 6h for N days back from a fixed anchor, newest first.
+# Anchor is fixed so the test is deterministic regardless of "now".
+gen_keys() {
+  local days="$1" prefix="${2:-postgres}"
+  local anchor="2026-07-27 18:00:00"
+  local total=$(( days * 4 )) i
+  for (( i = 0; i < total; i++ )); do
+    date -u -d "${anchor} $(( i * 6 )) hours ago" +"${prefix}/%Y%m%d-%H%M%S.pgdump"
+  done
+}
+
+# ---- Test 1: fewer keys than keep_recent -> zero deletions ----
+BACKUP_KEEP_RECENT=8 BACKUP_KEEP_DAILY=7 BACKUP_KEEP_WEEKLY=4
+out="$(gen_keys 1 | select_deletions)"   # 4 keys, all within keep_recent
+if [ -z "$out" ]; then ok; else bad "1: expected no deletions for 4 keys, got: $out"; fi
+
+# ---- Test 2: newest keep_recent are never deleted ----
+keys="$(gen_keys 40)"
+dels="$(printf '%s\n' "$keys" | select_deletions)"
+newest8="$(printf '%s\n' "$keys" | sort -r | head -8)"
+clash=0
+while IFS= read -r k; do
+  [ -n "$k" ] || continue
+  printf '%s\n' "$dels" | grep -qxF "$k" && clash=1
+done <<< "$newest8"
+if [ "$clash" -eq 0 ]; then ok; else bad "2: a newest-8 key was scheduled for deletion"; fi
+
+# ---- Test 3: keep/delete is a clean partition of the input ----
+kept="$(comm -23 <(printf '%s\n' "$keys" | sort -u) <(printf '%s\n' "$dels" | sort -u))"
+n_in=$(printf '%s\n' "$keys" | sort -u | grep -c .)
+n_keep=$(printf '%s\n' "$kept" | grep -c .)
+n_del=$(printf '%s\n' "$dels" | sort -u | grep -c .)
+if [ "$(( n_keep + n_del ))" -eq "$n_in" ]; then ok; else bad "3: partition mismatch keep=$n_keep del=$n_del in=$n_in"; fi
+
+# ---- Test 4: over 40 days SOMETHING is pruned (retention actually bounds) ----
+if [ "$n_del" -gt 0 ]; then ok; else bad "4: expected deletions over a 40-day span"; fi
+
+# ---- Test 5: idempotence - pruning the KEPT set deletes nothing more ----
+again="$(printf '%s\n' "$kept" | select_deletions)"
+if [ -z "$again" ]; then ok; else bad "5: re-pruning the kept set deleted more: $again"; fi
+
+# ---- Test 6: kept set is bounded (not everything survives) ----
+# recent(8) + daily(7) + weekly(4), minus overlap, so well under the 160 inputs.
+if [ "$n_keep" -le 20 ] && [ "$n_keep" -ge 8 ]; then ok; else bad "6: kept count out of expected range: $n_keep"; fi
+
+# ---- Test 7: non-matching keys are ignored (never emitted) ----
+out="$(printf 'postgres/not-a-stamp.pgdump\npostgres/latest.txt\n\n' | select_deletions)"
+if [ -z "$out" ]; then ok; else bad "7: emitted a non-matching key: $out"; fi
+
+# ---- Test 8: the single oldest key over a long span IS deleted ----
+oldest="$(printf '%s\n' "$keys" | sort | head -1)"
+if printf '%s\n' "$dels" | grep -qxF "$oldest"; then ok; else bad "8: oldest key was not pruned"; fi
+
+printf '\nprune retention: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/backup/test-prune.sh
+++ b/scripts/backup/test-prune.sh
@@ -10,6 +10,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # assertion failure doesn't silently abort the whole run.
 set +eu
 
+# Stub log() (normally from lib.sh, not sourced here) so select_deletions' input
+# validation can report to stderr without pulling in the S3 helpers.
+log() { printf '[test] %s\n' "$*" >&2; }
+
 pass=0
 fail=0
 ok()   { pass=$((pass + 1)); }
@@ -67,6 +71,14 @@ if [ -z "$out" ]; then ok; else bad "7: emitted a non-matching key: $out"; fi
 # ---- Test 8: the single oldest key over a long span IS deleted ----
 oldest="$(printf '%s\n' "$keys" | sort | head -1)"
 if printf '%s\n' "$dels" | grep -qxF "$oldest"; then ok; else bad "8: oldest key was not pruned"; fi
+
+# ---- Test 9: malformed retention counts are rejected, never emit deletions ----
+# A non-numeric or negative count must return non-zero and delete nothing, so a
+# typo can't silently disable a tier and over-prune.
+out="$(export BACKUP_KEEP_RECENT=abc; gen_keys 40 | select_deletions)"; rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then ok; else bad "9a: non-numeric keep_recent not rejected (rc=$rc out=$out)"; fi
+out="$(export BACKUP_KEEP_DAILY=-1; gen_keys 40 | select_deletions)"; rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then ok; else bad "9b: negative keep_daily not rejected (rc=$rc out=$out)"; fi
 
 printf '\nprune retention: %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Primary data (Postgres, intelligence-db, object storage) lives in one provider account, and that provider's own platform snapshots share the account - a single account-level failure could take every copy. This adds an opt-in runner that copies all three data streams to a separate, **off-site S3-compatible bucket** the operator chooses. Hosting-agnostic: point `BACKUP_S3_*` at any S3 endpoint (AWS S3, MinIO, Backblaze B2, Wasabi, a second cloud); if a residency rule applies, that becomes the operator's choice of endpoint.

## What's here (purely additive, inert until enabled)
- `docker/backup/Dockerfile` - alpine + pg16-client + aws-cli + rclone + GNU date
- `scripts/backup/` - main + intelligence-db `pg_dump`, rclone object-storage mirror, size-verified uploads, grandfather-father-son retention (pure, unit-tested decision function), and a supervising loop that isolates per-stream failures
- `docker-compose.yml` - `pg-backup` service under `profiles: [backup]`, inert until `BACKUP_S3_*` are set; reuses existing `DATABASE_URL` / `S3_*` read-only
- `.env.example` + `BACKUP.md` - provisioning, first run, restore drill, retention
- `.claude/skills/bs-backup-health` - genericized to match
- `scripts/backup/test-prune.sh` - 8 retention invariants (partition, idempotence, bounds)

## Verification
- Retention tests: 8/8, in git-bash and inside the built alpine image
- Image builds; pg_dump 16.14 / aws-cli / rclone / GNU date all present
- End-to-end round-trip proven against throwaway pg16 + MinIO: real dump -> size-verified upload -> download -> `pg_restore` into a fresh DB -> row-count match
- `docker compose config` validates (base + intelligence variants)
- Data-residency default unchanged; nothing runs until `COMPOSE_PROFILES` includes `backup` and the bucket credentials are set

## Not in this PR (owner-side)
Provisioning the off-site bucket + credentials, setting prod secrets, wiring the `backup` profile into `deploy-yandex.yml`, and the first production run + restore drill.

Tracks #262

Assisted-by: claude-opus-4-8 (agent)