### PR TITLE
ci(deploy): wire off-site backup profile into Yandex deploy (opt-in, guarded)

### DIFF
--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -184,6 +184,22 @@ jobs:
           cache-from: type=gha,scope=payment
           cache-to: type=gha,mode=max,scope=payment
 
+      # Off-site backup runner image. Only built when backups are configured
+      # (BACKUP_S3_ENDPOINT var set), so deploys stay unchanged until the owner
+      # provisions an off-site bucket. See BACKUP.md and issue #262.
+      - name: Build and push Backup image
+        if: vars.BACKUP_S3_ENDPOINT != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/backup/Dockerfile
+          push: true
+          tags: |
+            ${{ env.YC_REGISTRY }}/${{ secrets.YC_REGISTRY_ID }}/bugspotter-backup:sha-${{ github.sha }}
+            ${{ env.YC_REGISTRY }}/${{ secrets.YC_REGISTRY_ID }}/bugspotter-backup:latest
+          cache-from: type=gha,scope=backup
+          cache-to: type=gha,mode=max,scope=backup
+
   # ================================================================
   # Step 3: Deploy to VM via SSH
   # ================================================================
@@ -278,6 +294,16 @@ jobs:
           S3_REGION=${{ vars.S3_REGION || 'ru-central1' }}
           S3_FORCE_PATH_STYLE=${{ vars.S3_FORCE_PATH_STYLE || 'true' }}
           SIGNED_URL_EXPIRATION_SECONDS=${{ vars.SIGNED_URL_EXPIRATION_SECONDS || '2592000' }}
+
+          # Off-site Backups (opt-in - see BACKUP.md, issue #262). The runner
+          # starts only when BACKUP_S3_ENDPOINT + BACKUP_S3_ACCESS_KEY are set;
+          # unset => the lines below are empty and the deploy skips the profile.
+          BACKUP_IMAGE=${{ env.YC_REGISTRY }}/${{ secrets.YC_REGISTRY_ID }}/bugspotter-backup:latest
+          BACKUP_S3_ENDPOINT=${{ vars.BACKUP_S3_ENDPOINT }}
+          BACKUP_S3_BUCKET=${{ vars.BACKUP_S3_BUCKET || 'bugspotter-backups' }}
+          BACKUP_S3_ACCESS_KEY=${{ secrets.BACKUP_S3_ACCESS_KEY }}
+          BACKUP_S3_SECRET_KEY=${{ secrets.BACKUP_S3_SECRET_KEY }}
+          BACKUP_S3_REGION=${{ vars.BACKUP_S3_REGION || 'us-east-1' }}
 
           # API Server
           # Container always listens on port 3000 internally (hardcoded in docker-compose.yml).
@@ -548,6 +574,20 @@ jobs:
             $COMPOSE --profile intelligence up -d --no-build
           else
             echo "⏭️ Skipping intelligence (requires INTELLIGENCE_ENABLED=true and INTELLIGENCE_DB_PASSWORD)"
+          fi
+
+          # Start the off-site backup runner when configured. Requires BOTH the
+          # endpoint and an access key in .env, so a half-set config skips rather
+          # than crash-looping the container on empty credentials.
+          if grep -qE '^BACKUP_S3_ENDPOINT=.+' .env 2>/dev/null \
+            && grep -qE '^BACKUP_S3_ACCESS_KEY=.+' .env 2>/dev/null; then
+            echo "Starting off-site backup runner..."
+            $COMPOSE --profile backup pull || {
+              echo "⚠️ Failed to pull backup image; continuing with existing" >&2
+            }
+            $COMPOSE --profile backup up -d --no-build
+          else
+            echo "⏭️ Skipping off-site backup (BACKUP_S3_ENDPOINT + BACKUP_S3_ACCESS_KEY not set in .env)"
           fi
 
           # Ensure monitoring stack is running when GRAFANA_ADMIN_PASSWORD is configured.


### PR DESCRIPTION
Completes the deploy-side half of the off-site backup runner (#261) so production provisioning (#262) reduces to setting the vars/secrets. Purely additive and inert until configured - a stock deploy is byte-for-byte unchanged in behavior.

## Changes (all guarded)
- **Build + push** the `bugspotter-backup` image, gated on `vars.BACKUP_S3_ENDPOINT` being set - no build cost on deploys until backups are enabled
- **Write** `BACKUP_IMAGE` + `BACKUP_S3_*` into the prod `.env` (empty lines when the vars/secrets are unset)
- **Start** the `backup` profile only when BOTH `BACKUP_S3_ENDPOINT` and `BACKUP_S3_ACCESS_KEY` are present in `.env`, mirroring the existing intelligence guard - a half-configured deploy skips rather than crash-looping the container on empty credentials (`restart: unless-stopped` + `require_env` would otherwise loop)

## To enable in prod (owner, tracked in #262)
Set repo **vars** `BACKUP_S3_ENDPOINT` (master switch) + optional `BACKUP_S3_BUCKET`/`BACKUP_S3_REGION`, and **secrets** `BACKUP_S3_ACCESS_KEY` / `BACKUP_S3_SECRET_KEY`. Next deploy builds the image and starts the runner; then run a restore drill per BACKUP.md.

## Verification
- `actionlint` clean
- Guard logic mirrors the proven intelligence/monitoring conditional-profile pattern already in this workflow
- No change to the data-residency default; no change to any existing service

Refs #262

Assisted-by: claude-opus-4-8 (agent)