### PR TITLE
docs(backup): document the off-site backup profile (compose header + DOCKER.md)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -408,7 +408,7 @@ Before deploying to production:
    - Monitor worker queue metrics
 
 5. ✅ **Plan backups**:
-   - Enable the off-site backup runner (`--profile backup`, see BACKUP.md)
+   - Enable the off-site backup runner (`--profile backup`, see [BACKUP.md](BACKUP.md))
    - S3/MinIO bucket versioning
    - Redis AOF persistence
 
@@ -566,10 +566,10 @@ api:
 ### Automated off-site backups (recommended)
 
 There is a built-in, opt-in backup runner behind the `backup` profile. It dumps
-the main Postgres and intelligence-db and mirrors object storage to any
-S3-compatible off-site bucket (a different provider/region than primary), with
-grandfather-father-son retention. It is read-only on every source and inert until
-you set the `BACKUP_S3_*` credentials.
+the main Postgres (and intelligence-db when `INTELLIGENCE_ENABLED=true`) and
+mirrors object storage to any S3-compatible off-site bucket (a different
+provider/region than primary), with grandfather-father-son retention. It is
+read-only on every source and inert until you set the `BACKUP_S3_*` credentials.
 
 ```bash
 # Configure BACKUP_S3_* in .env (see .env.example), then:
@@ -577,7 +577,7 @@ docker compose --profile backup up -d pg-backup
 docker compose logs -f pg-backup
 ```
 
-Provisioning, retention, and the restore drill are documented in **`BACKUP.md`**;
+Provisioning, retention, and the restore drill are documented in [BACKUP.md](BACKUP.md);
 check freshness with the `bs-backup-health` skill.
 
 ### Manual / ad-hoc backup
@@ -585,11 +585,11 @@ check freshness with the `bs-backup-health` skill.
 For a one-off dump without the runner:
 
 ```bash
-# Backup PostgreSQL
-docker compose exec postgres pg_dump -U bugspotter bugspotter > backup.sql
+# Backup PostgreSQL (honors the container's configured POSTGRES_USER/POSTGRES_DB)
+docker compose exec postgres sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' > backup.sql
 
 # Restore
-docker compose exec -T postgres psql -U bugspotter bugspotter < backup.sql
+docker compose exec -T postgres sh -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB"' < backup.sql
 
 # Backup MinIO bucket
 docker compose exec minio mc mirror minio/bugspotter /backup/bugspotter

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -408,7 +408,7 @@ Before deploying to production:
    - Monitor worker queue metrics
 
 5. ✅ **Plan backups**:
-   - Database backups (pg_dump)
+   - Enable the off-site backup runner (`--profile backup`, see BACKUP.md)
    - S3/MinIO bucket versioning
    - Redis AOF persistence
 
@@ -563,7 +563,26 @@ api:
 
 ## Backups
 
-### Database Backup
+### Automated off-site backups (recommended)
+
+There is a built-in, opt-in backup runner behind the `backup` profile. It dumps
+the main Postgres and intelligence-db and mirrors object storage to any
+S3-compatible off-site bucket (a different provider/region than primary), with
+grandfather-father-son retention. It is read-only on every source and inert until
+you set the `BACKUP_S3_*` credentials.
+
+```bash
+# Configure BACKUP_S3_* in .env (see .env.example), then:
+docker compose --profile backup up -d pg-backup
+docker compose logs -f pg-backup
+```
+
+Provisioning, retention, and the restore drill are documented in **`BACKUP.md`**;
+check freshness with the `bs-backup-health` skill.
+
+### Manual / ad-hoc backup
+
+For a one-off dump without the runner:
 
 ```bash
 # Backup PostgreSQL
@@ -571,15 +590,9 @@ docker compose exec postgres pg_dump -U bugspotter bugspotter > backup.sql
 
 # Restore
 docker compose exec -T postgres psql -U bugspotter bugspotter < backup.sql
-```
 
-### MinIO Backup
-
-```bash
-# Backup bucket
+# Backup MinIO bucket
 docker compose exec minio mc mirror minio/bugspotter /backup/bugspotter
-
-# Or use MinIO's built-in replication
 ```
 
 ## Monitoring

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@
 # - postgres, redis, minio: Development only (profile: dev)
 # - intelligence, intelligence-db, ollama: AI features (profile: intelligence)
 # - prometheus, grafana, etc.: Monitoring only (profile: monitoring)
+# - pg-backup: Off-site backups only (profile: backup) - opt-in, see BACKUP.md
 #
 # Development:
 #   .env.example sets COMPOSE_PROFILES=dev so `docker compose up` starts local


### PR DESCRIPTION
Follow-up doc debt from #261. The off-site backup runner (`profiles: [backup]`) shipped, but the overview docs still described only manual `pg_dump`.

- `docker-compose.yml` service header: add the `pg-backup` / `backup` profile line (it listed dev/intelligence/monitoring but not backup)
- `DOCKER.md` Backups section: lead with the automated runner (`--profile backup`, link `BACKUP.md` + `bs-backup-health`), keep the manual dump as an ad-hoc fallback; the "Plan backups" checklist now points at the runner

Docs only - no behavior change.

Refs #262

Assisted-by: claude-opus-4-8 (agent)