### PR TITLE
test(storage): fix two stale MinIO permission assertions (closes #264)

### DIFF
--- a/packages/backend/tests/integration/storage-permissions.test.ts
+++ b/packages/backend/tests/integration/storage-permissions.test.ts
@@ -19,6 +19,7 @@ import {
   GetObjectCommand,
   DeleteObjectCommand,
   ListObjectsV2Command,
+  ListBucketsCommand,
   CreateBucketCommand,
   DeleteBucketCommand,
   HeadBucketCommand,
@@ -33,6 +34,13 @@ const TEST_KEY = `screenshots/${TEST_PROJECT_ID}/test-permissions.txt`;
 // Service account credentials (least-privilege)
 // Initialized in beforeAll to avoid hardcoded fallback secrets
 let serviceAccountClient: S3Client;
+
+// Root-credentials client + a probe bucket outside the service account's policy.
+// Only provisioned when root creds are available; used to turn the ListBuckets
+// boundary check into a real regression test instead of a single-bucket no-op.
+let rootClient: S3Client | undefined;
+let probeBucket: string | undefined;
+const rootCredsAvailable = !!(process.env.MINIO_ROOT_USER && process.env.MINIO_ROOT_PASSWORD);
 
 // Helper to convert readable stream to buffer
 async function streamToBuffer(stream: Readable): Promise<Buffer> {
@@ -49,7 +57,7 @@ describe('MinIO Service Account Permission Boundaries', () => {
     !process.env.MINIO_APP_ACCESS_KEY ||
     !process.env.MINIO_APP_SECRET_KEY;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     if (skipTests) {
       console.log('⏭️  Skipping MinIO permission tests (set TEST_MINIO=true to enable)');
       console.log('💡 Also ensure MINIO_APP_ACCESS_KEY and MINIO_APP_SECRET_KEY are set in .env');
@@ -66,6 +74,25 @@ describe('MinIO Service Account Permission Boundaries', () => {
       },
       forcePathStyle: true,
     });
+
+    // When root creds are available, provision a bucket the service account's
+    // policy does not cover. The ListBuckets boundary test then asserts the
+    // scoped account cannot see it - a real regression check that a single
+    // bucket fixture cannot provide.
+    if (rootCredsAvailable) {
+      rootClient = new S3Client({
+        endpoint: process.env.S3_ENDPOINT || 'http://localhost:9000',
+        region: process.env.S3_REGION || 'us-east-1',
+        credentials: {
+          accessKeyId: process.env.MINIO_ROOT_USER!,
+          secretAccessKey: process.env.MINIO_ROOT_PASSWORD!,
+        },
+        forcePathStyle: true,
+      });
+
+      probeBucket = `bugspotter-forbidden-probe-${Date.now()}`;
+      await rootClient.send(new CreateBucketCommand({ Bucket: probeBucket }));
+    }
   });
 
   afterAll(async () => {
@@ -83,6 +110,15 @@ describe('MinIO Service Account Permission Boundaries', () => {
       );
     } catch {
       // Ignore cleanup errors
+    }
+
+    // Tear down the probe bucket provisioned in beforeAll (root creds only)
+    if (probeBucket && rootClient) {
+      try {
+        await rootClient.send(new DeleteBucketCommand({ Bucket: probeBucket }));
+      } catch {
+        // Ignore cleanup errors
+      }
     }
   });
 
@@ -236,12 +272,18 @@ describe('MinIO Service Account Permission Boundaries', () => {
       // policy-scoped user; it returns a FILTERED list containing only the
       // buckets the account has access to. The security property to guarantee is
       // that no OTHER bucket is visible - not that the call is denied outright.
-      const { ListBucketsCommand } = await import('@aws-sdk/client-s3');
-
       const { Buckets } = await serviceAccountClient.send(new ListBucketsCommand({}));
       const names = (Buckets ?? []).map((b) => b.Name);
 
       expect(names).toContain(TEST_BUCKET);
+
+      // With root creds a probe bucket exists outside the policy; the scoped
+      // account must not see it. Without root creds this degrades to the
+      // property check below (which is only meaningful given such a bucket).
+      if (probeBucket) {
+        expect(names).not.toContain(probeBucket);
+      }
+
       expect(names.filter((name) => name !== TEST_BUCKET)).toEqual([]);
     });
   });
@@ -252,13 +294,13 @@ describe('MinIO Service Account Permission Boundaries', () => {
         return;
       }
 
-      const accessKey = process.env.MINIO_APP_ACCESS_KEY || 'bugspotter-app';
+      // The skip guard guarantees MINIO_APP_ACCESS_KEY is set here, so read it
+      // directly - no hardcoded fallback literal (the default varies across
+      // compose variants: bugspotter-app-user vs bugspotter-app).
+      const accessKey = process.env.MINIO_APP_ACCESS_KEY!;
       const rootUser = process.env.MINIO_ROOT_USER || 'minioadmin';
 
       // Service account must be a distinct, non-root identity (least privilege).
-      // Do NOT assert a hardcoded key literal - the default is `bugspotter-app-user`
-      // (see scripts/init-minio.sh / docker-compose.yml) and operators may override it.
-      expect(accessKey).toBeTruthy();
       expect(accessKey).not.toBe(rootUser);
     });
 

--- a/packages/backend/tests/integration/storage-permissions.test.ts
+++ b/packages/backend/tests/integration/storage-permissions.test.ts
@@ -227,18 +227,22 @@ describe('MinIO Service Account Permission Boundaries', () => {
       await expect(serviceAccountClient.send(command)).rejects.toThrow();
     });
 
-    it('should NOT allow listing all buckets', async () => {
+    it('should NOT expose buckets other than its own', async () => {
       if (skipTests) {
         return;
       }
 
-      // MinIO requires ListAllMyBuckets permission to list buckets
-      // Service account should not have this permission
+      // Modern MinIO (RELEASE.2024-10+) does not 403 ListBuckets for a
+      // policy-scoped user; it returns a FILTERED list containing only the
+      // buckets the account has access to. The security property to guarantee is
+      // that no OTHER bucket is visible - not that the call is denied outright.
       const { ListBucketsCommand } = await import('@aws-sdk/client-s3');
 
-      const command = new ListBucketsCommand({});
+      const { Buckets } = await serviceAccountClient.send(new ListBucketsCommand({}));
+      const names = (Buckets ?? []).map((b) => b.Name);
 
-      await expect(serviceAccountClient.send(command)).rejects.toThrow(/Access Denied|Forbidden/i);
+      expect(names).toContain(TEST_BUCKET);
+      expect(names.filter((name) => name !== TEST_BUCKET)).toEqual([]);
     });
   });
 
@@ -251,9 +255,11 @@ describe('MinIO Service Account Permission Boundaries', () => {
       const accessKey = process.env.MINIO_APP_ACCESS_KEY || 'bugspotter-app';
       const rootUser = process.env.MINIO_ROOT_USER || 'minioadmin';
 
-      // Service account credentials should be different from root
+      // Service account must be a distinct, non-root identity (least privilege).
+      // Do NOT assert a hardcoded key literal - the default is `bugspotter-app-user`
+      // (see scripts/init-minio.sh / docker-compose.yml) and operators may override it.
+      expect(accessKey).toBeTruthy();
       expect(accessKey).not.toBe(rootUser);
-      expect(accessKey).toBe('bugspotter-app'); // Verify correct service account
     });
 
     it('should verify environment variables are properly configured', () => {

--- a/packages/backend/tests/integration/storage-permissions.test.ts
+++ b/packages/backend/tests/integration/storage-permissions.test.ts
@@ -25,6 +25,7 @@ import {
   HeadBucketCommand,
 } from '@aws-sdk/client-s3';
 import { Readable } from 'node:stream';
+import { randomUUID } from 'node:crypto';
 
 // Test configuration
 const TEST_BUCKET = process.env.S3_BUCKET || 'bugspotter';
@@ -90,7 +91,9 @@ describe('MinIO Service Account Permission Boundaries', () => {
         forcePathStyle: true,
       });
 
-      probeBucket = `bugspotter-forbidden-probe-${Date.now()}`;
+      // Random suffix so parallel workers / CI jobs sharing a MinIO instance
+      // cannot collide on the bucket name. Stays well under the 63-char limit.
+      probeBucket = `bugspotter-forbidden-probe-${randomUUID().slice(0, 8)}`;
       await rootClient.send(new CreateBucketCommand({ Bucket: probeBucket }));
     }
   });


### PR DESCRIPTION
`storage-permissions.test.ts` false-failed on two assertions against modern MinIO (RELEASE.2024-10+) even though the least-privilege boundary is sound - so the suite would break if `TEST_MINIO` were enabled in CI, and it misread a correct boundary as broken. Both confirmed by running the suite.

- **"listing all buckets"**: MinIO no longer 403s `ListBuckets` for a policy-scoped user - it returns a **filtered** list of only the accessible buckets. Now asserts the real property (no *other* bucket is visible) instead of expecting Access Denied.
- **"not root credentials"**: dropped the hardcoded `expect(accessKey).toBe('bugspotter-app')` (actual default is `bugspotter-app-user`); keep the meaningful check that the service account is a distinct, non-root identity.

## Verification
13/13 with `TEST_MINIO=true` against a local MinIO provisioned by `scripts/init-minio.sh`. Also confirmed the boundary directly: a second bucket created as root is invisible/inaccessible to the scoped account.

Closes #264

Assisted-by: claude-opus-4-8 (agent)