### PR TITLE
ci(ai-sdlc): harden spec/ADR pipeline against a repeat of #226/#238

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
+      - name: Run AI-SDLC script tests
+        run: node --test scripts/ai-sdlc/*.test.mjs
+
   test-backend-db:
     name: Backend Database Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -589,7 +592,15 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test-backend-db, test-backend-api, test-backend-services, test-backend-other, playwright-admin]
+    needs:
+      [
+        lint,
+        test-backend-db,
+        test-backend-api,
+        test-backend-services,
+        test-backend-other,
+        playwright-admin,
+      ]
 
     steps:
       - name: Checkout code
@@ -625,7 +636,6 @@ jobs:
           # This ensures @bugspotter/types is available for backend
           pnpm --filter @bugspotter/types run build
           pnpm --recursive --filter "./packages/**" --filter "!@bugspotter/types" run build
-
 
   test-coverage:
     name: Test Coverage
@@ -758,7 +768,19 @@ jobs:
     # block below. Both must move together: removing it from one without
     # the other either lets a failure slip through (only in `needs`) or
     # waits on a job that doesn't gate (only in checks).
-    needs: [lint, test-backend-db, test-backend-api, test-backend-services, test-backend-other, test-backend-integration, playwright-admin, build, test-coverage, validate-compose]
+    needs:
+      [
+        lint,
+        test-backend-db,
+        test-backend-api,
+        test-backend-services,
+        test-backend-other,
+        test-backend-integration,
+        playwright-admin,
+        build,
+        test-coverage,
+        validate-compose,
+      ]
     if: always()
     steps:
       - name: Check all jobs succeeded

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,21 @@ on:
   # one: documentation, workflow YAML (the action's own validation
   # guardrail rejects modified workflows from PR branches anyway),
   # marketing HTML, etc.
+  #
+  # `docs/specs/**` and `docs/adr/**` are deliberately carved back IN
+  # (the trailing `!`-prefixed entries — GitHub Actions evaluates path
+  # patterns in list order and the last match wins, so these override
+  # the broader `**.md`/`docs/**` ignores above them for exactly these
+  # two subtrees). Those two artifact classes are the ones tied to the
+  # pipeline's non-delegable human judgment gates (spec approval, ADR
+  # ratification) — and were, until this fix, the ONLY doc changes that
+  # got zero automatic review. That gap is not hypothetical: it's the
+  # direct mechanism behind the #226/#238 incident (a spec hallucinated
+  # a whole in-repo package; nothing auto-reviewed it, and it took
+  # multiple PR cycles before a human caught it via a manually-triggered
+  # `@claude` review). See docs/specs/0237-intelligence-backend-proxy-
+  # must-forward-.md's own review history for a live example of what
+  # automatic multi-round review on a spec actually catches.
   pull_request:
     types: [opened, ready_for_review, reopened]
     paths-ignore:
@@ -26,6 +41,8 @@ on:
       - '.github/**'
       - '*.html'
       - 'apps/**/*.html'
+      - '!docs/specs/**'
+      - '!docs/adr/**'
   # @claude mentions in PR comments and review threads. The `if:` guard
   # below keeps the workflow from running on issue-comments outside of
   # PRs and on comments that don't address Claude.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,17 +14,19 @@ on:
   # `@claude review PR` (handled below) and that path is rate-limited
   # by being human-driven.
   #
-  # `paths-ignore` skips reviews on changes that don't benefit from
-  # one: documentation, workflow YAML (the action's own validation
-  # guardrail rejects modified workflows from PR branches anyway),
-  # marketing HTML, etc.
+  # This skips reviews on changes that don't benefit from one:
+  # documentation, workflow YAML (the action's own validation guardrail
+  # rejects modified workflows from PR branches anyway), marketing
+  # HTML, etc.
   #
-  # `docs/specs/**` and `docs/adr/**` are deliberately carved back IN
-  # (the trailing `!`-prefixed entries — GitHub Actions evaluates path
-  # patterns in list order and the last match wins, so these override
-  # the broader `**.md`/`docs/**` ignores above them for exactly these
-  # two subtrees). Those two artifact classes are the ones tied to the
-  # pipeline's non-delegable human judgment gates (spec approval, ADR
+  # `docs/specs/**` and `docs/adr/**` are deliberately carved back IN.
+  # This MUST be `paths` (not `paths-ignore`) with a leading `'**'` —
+  # GitHub Actions only supports `!`-negation and list-order/last-match
+  # evaluation for `paths`; a `!`-prefixed entry inside `paths-ignore`
+  # is taken as a literal pattern (never matches any real path) and
+  # silently does nothing, which is exactly the bug this replaced.
+  # These two artifact classes are the ones tied to the pipeline's
+  # non-delegable human judgment gates (spec approval, ADR
   # ratification) — and were, until this fix, the ONLY doc changes that
   # got zero automatic review. That gap is not hypothetical: it's the
   # direct mechanism behind the #226/#238 incident (a spec hallucinated
@@ -35,14 +37,15 @@ on:
   # automatic multi-round review on a spec actually catches.
   pull_request:
     types: [opened, ready_for_review, reopened]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/**'
-      - '*.html'
-      - 'apps/**/*.html'
-      - '!docs/specs/**'
-      - '!docs/adr/**'
+    paths:
+      - '**'
+      - '!**.md'
+      - '!docs/**'
+      - '!.github/**'
+      - '!*.html'
+      - '!apps/**/*.html'
+      - 'docs/specs/**'
+      - 'docs/adr/**'
   # @claude mentions in PR comments and review threads. The `if:` guard
   # below keeps the workflow from running on issue-comments outside of
   # PRs and on comments that don't address Claude.

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -95,6 +95,16 @@ jobs:
           IMPL_MODEL_LOW: ${{ vars.IMPL_MODEL_LOW }}
         run: node scripts/ai-sdlc/generate-impl.mjs
 
+      # Hard gate: the scaffold must not write a file the ratified spec
+      # never declared under "Files touched" - an unambiguous comparison,
+      # not a judgment call, so unlike check-spec-scope.mjs's advisory
+      # warning this fails the workflow outright.
+      - name: Check impl scope against spec
+        env:
+          SPEC_FILE: ${{ steps.spec.outputs.spec_file }}
+          FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
+        run: node scripts/ai-sdlc/check-impl-scope.mjs
+
       - name: Install dependencies (required for ESLint)
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -64,6 +64,16 @@ jobs:
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
         run: node scripts/ai-sdlc/verify-spec.mjs
 
+      # Deterministic follow-up to the LLM pass above: no model call, no
+      # attention/instruction-following failure mode. Fails the workflow
+      # (not advisory) if the spec declares a new path colliding with a
+      # component docs/adr/README.md attributes to a different repo - the
+      # exact shape of the #226/#238 mistake.
+      - name: Verify spec path ownership (deterministic)
+        env:
+          SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
+        run: node scripts/ai-sdlc/verify-spec-ownership.mjs
+
       - name: Format generated files
         env:
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -74,6 +74,14 @@ jobs:
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
         run: node scripts/ai-sdlc/verify-spec-ownership.mjs
 
+      # Advisory only (see the script's own header for why this isn't a
+      # hard cap yet) - warns if the spec's declared scope is large enough
+      # to be worth a second look before ratifying.
+      - name: Check spec scope (advisory)
+        env:
+          SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
+        run: node scripts/ai-sdlc/check-spec-scope.mjs
+
       - name: Format generated files
         env:
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}

--- a/scripts/ai-sdlc/check-impl-scope.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.mjs
@@ -14,8 +14,11 @@
 //
 // Required env vars: SPEC_FILE, FILES_WRITTEN (comma-separated, matching
 // generate-impl.mjs's GITHUB_OUTPUT format).
-// Exit 1 if any written file is undeclared. Exit 0 if the spec has no
-// parseable "Files touched" line (nothing to check against) or is clean.
+// Exit 1 if any written file is undeclared, OR if the ratified spec can't be
+// read or has no parseable "Files touched" line — a hard gate that no-ops on
+// a malformed baseline isn't a gate, it's a trap door. Exit 0 only when the
+// comparison actually ran and came back clean (or there's nothing written to
+// check, per FILES_WRITTEN being empty).
 
 import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
@@ -42,14 +45,18 @@ function main() {
   try {
     spec = readFileSync(SPEC_FILE, 'utf8');
   } catch (err) {
-    console.warn(`Impl scope check: could not read spec file: ${err.message}`);
-    process.exit(0);
+    console.error(`Impl scope check: could not read spec file: ${err.message}`);
+    process.exit(1);
   }
 
   const declaredPaths = extractDeclaredPaths(spec);
   if (!declaredPaths || declaredPaths.length === 0) {
-    console.warn('Impl scope check: spec has no parseable "Files touched:" line — skipping.');
-    process.exit(0);
+    console.error(
+      'Impl scope check FAILED: spec has no parseable "Files touched:" line, so the ' +
+        'scaffold cannot be checked against it. Fix the ratified spec\'s "Files touched" ' +
+        'field rather than skip the check silently.'
+    );
+    process.exit(1);
   }
 
   const writtenPaths = FILES_WRITTEN.split(',')

--- a/scripts/ai-sdlc/check-impl-scope.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Hard gate: fails if the impl-agent's generated scaffold wrote a file the
+// linked spec never declared under "Files touched". Unlike
+// check-spec-scope.mjs's cap (which needs a judgment call about "how big is
+// too big"), this is an unambiguous comparison between two already-concrete
+// lists - there is no legitimate reason for a freshly-generated scaffold to
+// silently diverge from the spec a human already ratified.
+//
+// Scope, stated honestly: this only checks the scaffold at generation time
+// (comparing generate-impl.mjs's own `files_written` output against the
+// spec). It does not re-check later commits a human pushes to the same PR
+// before merge - that's a different, PR-diff-level check this script does
+// not attempt.
+//
+// Required env vars: SPEC_FILE, FILES_WRITTEN (comma-separated, matching
+// generate-impl.mjs's GITHUB_OUTPUT format).
+// Exit 1 if any written file is undeclared. Exit 0 if the spec has no
+// parseable "Files touched" line (nothing to check against) or is clean.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
+
+/** Returns the subset of writtenPaths not present in declaredPaths. */
+export function findUndeclaredPaths(writtenPaths, declaredPaths) {
+  const declared = new Set(declaredPaths);
+  return writtenPaths.filter((p) => !declared.has(p));
+}
+
+function main() {
+  const { SPEC_FILE, FILES_WRITTEN } = process.env;
+  if (!SPEC_FILE) {
+    console.error('Missing SPEC_FILE');
+    process.exit(1);
+  }
+  if (!FILES_WRITTEN) {
+    console.warn('Impl scope check: FILES_WRITTEN is empty — nothing to check.');
+    process.exit(0);
+  }
+
+  let spec;
+  try {
+    spec = readFileSync(SPEC_FILE, 'utf8');
+  } catch (err) {
+    console.warn(`Impl scope check: could not read spec file: ${err.message}`);
+    process.exit(0);
+  }
+
+  const declaredPaths = extractDeclaredPaths(spec);
+  if (!declaredPaths || declaredPaths.length === 0) {
+    console.warn('Impl scope check: spec has no parseable "Files touched:" line — skipping.');
+    process.exit(0);
+  }
+
+  const writtenPaths = FILES_WRITTEN.split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const undeclared = findUndeclaredPaths(writtenPaths, declaredPaths);
+
+  if (undeclared.length > 0) {
+    console.error('Impl scope check FAILED - the scaffold wrote files the spec never declared:\n');
+    for (const p of undeclared) {
+      console.error(`  ${p}`);
+    }
+    console.error(
+      `\nDeclared in ${SPEC_FILE}:\n${declaredPaths.map((p) => `  ${p}`).join('\n')}\n\n` +
+        'Either the spec is missing these paths (fix the spec first, re-run) or the scaffold ' +
+        'drifted from what was ratified - either way this needs a human look before it ships ' +
+        'as a draft PR.'
+    );
+    process.exit(1);
+  }
+
+  console.log(`Impl scope check passed — ${writtenPaths.length} written file(s) all declared.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/ai-sdlc/check-impl-scope.test.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.test.mjs
@@ -1,0 +1,37 @@
+// Tests for check-impl-scope.mjs's pure logic. Zero-dependency, run with
+// `node --test`.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { findUndeclaredPaths } from './check-impl-scope.mjs';
+
+describe('findUndeclaredPaths', () => {
+  test('returns an empty array when every written path was declared', () => {
+    const declared = ['packages/a.ts', 'packages/b.ts'];
+    assert.deepEqual(findUndeclaredPaths(['packages/a.ts', 'packages/b.ts'], declared), []);
+  });
+
+  test('flags a written path absent from the declared list', () => {
+    const declared = ['packages/a.ts'];
+    assert.deepEqual(findUndeclaredPaths(['packages/a.ts', 'packages/sneaky.ts'], declared), [
+      'packages/sneaky.ts',
+    ]);
+  });
+
+  test('flags multiple undeclared paths independently', () => {
+    const declared = ['packages/a.ts'];
+    const written = ['packages/a.ts', 'packages/x.ts', 'packages/y.ts'];
+    assert.deepEqual(findUndeclaredPaths(written, declared), ['packages/x.ts', 'packages/y.ts']);
+  });
+
+  test('a declared path never written is not itself a violation', () => {
+    // findUndeclaredPaths only checks the write-side; a spec declaring a
+    // file that ends up unwritten is a different (unhandled) concern.
+    const declared = ['packages/a.ts', 'packages/never-written.ts'];
+    assert.deepEqual(findUndeclaredPaths(['packages/a.ts'], declared), []);
+  });
+
+  test('empty written list is always clean', () => {
+    assert.deepEqual(findUndeclaredPaths([], ['packages/a.ts']), []);
+  });
+});

--- a/scripts/ai-sdlc/check-spec-scope.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Advisory fan-out check for generated specs: warns (does not fail the
+// build) when a spec's declared "Files touched" list is large enough to be
+// a structural tell that a new package/subsystem is being born rather than
+// a scoped change - spec #238 declared 10 files, 7 of them new, including a
+// from-scratch package.json/tsconfig.json/vitest.config.ts trio.
+//
+// This is deliberately SOFT, unlike verify-spec-ownership.mjs's hard gate:
+// there is no real historical distribution to calibrate a hard cap against
+// yet (bugspotter-metrics did not track files_changed until schema 4).
+// Flip DEFAULT_CAP's enforcement to a hard exit(1) once enough real spec
+// PRs have shipped through it to know what "large" actually means for this
+// repo, rather than guessing a number now and blocking legitimate work on
+// a guess.
+//
+// Required env var: SPEC_FILE. Optional: SPEC_SCOPE_CAP (default 6).
+// Always exits 0 - this is advisory only.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
+
+export const DEFAULT_CAP = 6;
+
+/** Returns a warning string if declaredPaths.length exceeds cap, else null. */
+export function checkFanOut(declaredPaths, cap = DEFAULT_CAP) {
+  if (declaredPaths.length <= cap) {
+    return null;
+  }
+  return (
+    `Spec declares ${declaredPaths.length} files touched (advisory cap: ${cap}). ` +
+    `A spec this large is worth a second look before ratifying - it's the same shape ` +
+    `spec #238 had (10 files, 7 new, including a from-scratch package scaffold) right ` +
+    `before it turned out to be hallucinating an entire package. Not a hard block: a ` +
+    `genuinely large, coherent change is sometimes correct - but if this is several ` +
+    `unrelated things stapled together, splitting it into multiple issues/specs is ` +
+    `usually the better call.`
+  );
+}
+
+function main() {
+  const { SPEC_FILE, SPEC_SCOPE_CAP } = process.env;
+  if (!SPEC_FILE) {
+    console.error('Missing SPEC_FILE');
+    process.exit(1);
+  }
+
+  let spec;
+  try {
+    spec = readFileSync(SPEC_FILE, 'utf8');
+  } catch (err) {
+    console.warn(`Spec scope check: could not read spec file: ${err.message}`);
+    process.exit(0);
+  }
+
+  const declaredPaths = extractDeclaredPaths(spec);
+  if (!declaredPaths) {
+    console.warn('Spec scope check: no "Files touched:" line found — skipping.');
+    process.exit(0);
+  }
+
+  const cap = SPEC_SCOPE_CAP ? Number(SPEC_SCOPE_CAP) : DEFAULT_CAP;
+  const warning = checkFanOut(declaredPaths, cap);
+  if (warning) {
+    console.warn(`::warning::${warning}`);
+  } else {
+    console.log(`Spec scope check: ${declaredPaths.length} file(s) declared, within cap (${cap}).`);
+  }
+  process.exit(0);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/ai-sdlc/check-spec-scope.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.mjs
@@ -16,11 +16,29 @@
 // Required env var: SPEC_FILE. Optional: SPEC_SCOPE_CAP (default 6).
 // Always exits 0 - this is advisory only.
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, appendFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
 
 export const DEFAULT_CAP = 6;
+
+/**
+ * Parses SPEC_SCOPE_CAP into a non-negative integer, falling back to
+ * DEFAULT_CAP for anything unset, non-numeric, negative, or fractional.
+ * `Number('')` and `Number(undefined)` both fall through cleanly since
+ * `Number.isInteger` rejects NaN.
+ */
+export function resolveCap(rawCap, defaultCap = DEFAULT_CAP) {
+  if (!rawCap) {
+    // Covers both "unset" (undefined) and GitHub Actions' habit of
+    // resolving an unconfigured `vars.*` reference to an empty string
+    // rather than leaving the env var absent — `Number('')` is 0, which
+    // Number.isInteger happily accepts, so this must be checked first.
+    return defaultCap;
+  }
+  const parsed = Number(rawCap);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : defaultCap;
+}
 
 /** Returns a warning string if declaredPaths.length exceeds cap, else null. */
 export function checkFanOut(declaredPaths, cap = DEFAULT_CAP) {
@@ -59,10 +77,21 @@ function main() {
     process.exit(0);
   }
 
-  const cap = SPEC_SCOPE_CAP ? Number(SPEC_SCOPE_CAP) : DEFAULT_CAP;
+  const parsedCap = Number(SPEC_SCOPE_CAP);
+  const capIsValid = !SPEC_SCOPE_CAP || (Number.isInteger(parsedCap) && parsedCap >= 0);
+  if (!capIsValid) {
+    console.warn(`Spec scope check: ignoring invalid SPEC_SCOPE_CAP="${SPEC_SCOPE_CAP}".`);
+  }
+  const cap = resolveCap(SPEC_SCOPE_CAP);
   const warning = checkFanOut(declaredPaths, cap);
   if (warning) {
     console.warn(`::warning::${warning}`);
+    // Advisory output that only lands in run-log annotations is easy for a
+    // spec reviewer to miss — they see the PR, not the Action run. Surface
+    // it in the job summary too, when running under GitHub Actions.
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n**Spec scope warning:** ${warning}\n`);
+    }
   } else {
     console.log(`Spec scope check: ${declaredPaths.length} file(s) declared, within cap (${cap}).`);
   }

--- a/scripts/ai-sdlc/check-spec-scope.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.mjs
@@ -24,19 +24,21 @@ export const DEFAULT_CAP = 6;
 
 /**
  * Parses SPEC_SCOPE_CAP into a non-negative integer, falling back to
- * DEFAULT_CAP for anything unset, non-numeric, negative, or fractional.
- * `Number('')` and `Number(undefined)` both fall through cleanly since
- * `Number.isInteger` rejects NaN.
+ * DEFAULT_CAP for anything unset, whitespace-only, non-numeric, negative,
+ * or fractional. `Number('')` and `Number(undefined)` both fall through
+ * cleanly since `Number.isInteger` rejects NaN — but `Number('   ')` is 0,
+ * not NaN, so whitespace must be trimmed away BEFORE the emptiness check
+ * or a whitespace-only value silently becomes a zero-file cap.
  */
 export function resolveCap(rawCap, defaultCap = DEFAULT_CAP) {
-  if (!rawCap) {
-    // Covers both "unset" (undefined) and GitHub Actions' habit of
-    // resolving an unconfigured `vars.*` reference to an empty string
-    // rather than leaving the env var absent — `Number('')` is 0, which
-    // Number.isInteger happily accepts, so this must be checked first.
+  const trimmed = typeof rawCap === 'string' ? rawCap.trim() : rawCap;
+  if (!trimmed) {
+    // Covers "unset" (undefined), whitespace-only, and GitHub Actions'
+    // habit of resolving an unconfigured `vars.*` reference to an empty
+    // string rather than leaving the env var absent.
     return defaultCap;
   }
-  const parsed = Number(rawCap);
+  const parsed = Number(trimmed);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : defaultCap;
 }
 
@@ -77,8 +79,9 @@ function main() {
     process.exit(0);
   }
 
-  const parsedCap = Number(SPEC_SCOPE_CAP);
-  const capIsValid = !SPEC_SCOPE_CAP || (Number.isInteger(parsedCap) && parsedCap >= 0);
+  const trimmedCap = SPEC_SCOPE_CAP?.trim();
+  const parsedCap = Number(trimmedCap);
+  const capIsValid = !trimmedCap || (Number.isInteger(parsedCap) && parsedCap >= 0);
   if (!capIsValid) {
     console.warn(`Spec scope check: ignoring invalid SPEC_SCOPE_CAP="${SPEC_SCOPE_CAP}".`);
   }

--- a/scripts/ai-sdlc/check-spec-scope.test.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.test.mjs
@@ -1,0 +1,30 @@
+// Tests for check-spec-scope.mjs's pure logic. Zero-dependency, run with
+// `node --test`.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkFanOut, DEFAULT_CAP } from './check-spec-scope.mjs';
+
+describe('checkFanOut', () => {
+  test('returns null when the count is at or below the cap', () => {
+    const paths = Array.from({ length: DEFAULT_CAP }, (_, i) => `packages/a/${i}.ts`);
+    assert.equal(checkFanOut(paths), null);
+  });
+
+  test('returns a warning string when the count exceeds the cap', () => {
+    const paths = Array.from({ length: DEFAULT_CAP + 1 }, (_, i) => `packages/a/${i}.ts`);
+    const warning = checkFanOut(paths);
+    assert.ok(warning);
+    assert.match(warning, /declares 7 files touched/);
+  });
+
+  test('respects a custom cap', () => {
+    const paths = ['a', 'b', 'c'];
+    assert.equal(checkFanOut(paths, 3), null);
+    assert.ok(checkFanOut(paths, 2));
+  });
+
+  test('empty list never warns', () => {
+    assert.equal(checkFanOut([]), null);
+  });
+});

--- a/scripts/ai-sdlc/check-spec-scope.test.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.test.mjs
@@ -15,6 +15,14 @@ describe('resolveCap', () => {
     assert.equal(resolveCap(''), DEFAULT_CAP);
   });
 
+  test('falls back to DEFAULT_CAP for a whitespace-only value', () => {
+    // Number('   ') is 0, not NaN — a naive check would silently turn a
+    // whitespace-only SPEC_SCOPE_CAP into a zero-file cap instead of
+    // treating it as unset.
+    assert.equal(resolveCap('   '), DEFAULT_CAP);
+    assert.equal(resolveCap('\t\n'), DEFAULT_CAP);
+  });
+
   test('falls back to DEFAULT_CAP for non-numeric input', () => {
     assert.equal(resolveCap('abc'), DEFAULT_CAP);
   });

--- a/scripts/ai-sdlc/check-spec-scope.test.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.test.mjs
@@ -3,7 +3,31 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { checkFanOut, DEFAULT_CAP } from './check-spec-scope.mjs';
+import { checkFanOut, resolveCap, DEFAULT_CAP } from './check-spec-scope.mjs';
+
+describe('resolveCap', () => {
+  test('parses a valid numeric string', () => {
+    assert.equal(resolveCap('10'), 10);
+  });
+
+  test('falls back to DEFAULT_CAP when unset', () => {
+    assert.equal(resolveCap(undefined), DEFAULT_CAP);
+    assert.equal(resolveCap(''), DEFAULT_CAP);
+  });
+
+  test('falls back to DEFAULT_CAP for non-numeric input', () => {
+    assert.equal(resolveCap('abc'), DEFAULT_CAP);
+  });
+
+  test('falls back to DEFAULT_CAP for a negative or fractional value', () => {
+    assert.equal(resolveCap('-1'), DEFAULT_CAP);
+    assert.equal(resolveCap('2.5'), DEFAULT_CAP);
+  });
+
+  test('zero is a valid cap', () => {
+    assert.equal(resolveCap('0'), 0);
+  });
+});
 
 describe('checkFanOut', () => {
   test('returns null when the count is at or below the cap', () => {

--- a/scripts/ai-sdlc/generate-adr.mjs
+++ b/scripts/ai-sdlc/generate-adr.mjs
@@ -46,6 +46,26 @@ const exampleAdr = exampleFile
   ? readFileSync(`docs/adr/${exampleFile}`, 'utf8').slice(0, 1200)
   : '';
 
+// generate-spec.mjs and verify-spec.mjs both inject docs/adr/README.md (the
+// cross-repo architecture index) into their prompts; this script did not,
+// despite ADR ratification being the human judgment gate that's supposed to
+// catch exactly the failure the index exists to prevent — a component
+// attributed to a fabricated in-repo path instead of its real, separate
+// repo (docs/adr/0007 records bugspotter-intelligence as a Python/FastAPI
+// service in its own repo; #226/#238 hallucinated a TypeScript package for
+// it here, and the human ratification gate that should have caught it had
+// no index to check against either). Without this, the artifact a human is
+// actually asked to ratify is the least-grounded of the three generation
+// steps, not the best-grounded one.
+function safeRead(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+const adrIndex = safeRead('docs/adr/README.md');
+
 const slug = ISSUE_TITLE.toLowerCase()
   .replace(/[^a-z0-9]+/g, '-')
   .replace(/^-+|-+$/g, '')
@@ -60,7 +80,11 @@ Draft ADR-${padded} for GitHub issue #${ISSUE_NUMBER}. Match the style of the ex
 
 EXAMPLE ADR (for style reference only — do not copy its content):
 ${exampleAdr}
-
+${
+  adrIndex
+    ? `\nPROJECT ARCHITECTURE INDEX (docs/adr/README.md — canonical record of which repo owns which component, language, and service boundary; do not state or assume any architecture fact that contradicts it):\n${adrIndex}\n`
+    : ''
+}
 Required sections (use this exact structure):
 # ADR-${padded}: <title>
 
@@ -97,6 +121,7 @@ ${SPEC_CONTENT ? `\nLINKED SPEC:\n${SPEC_CONTENT.slice(0, 1500)}` : ''}
 Rules:
 - Status must be "Proposed" (human ratifies and changes it to "Accepted")
 - Be concrete about consequences; call out residual risks explicitly
+- Do not state or imply that a component lives in this repo, in a particular language, or behind a particular service boundary if the architecture index above attributes it to a different repo — if the issue concerns such a component, say so explicitly rather than inventing an in-repo shape for it
 - Return ONLY the ADR document — no preamble, no explanation, no markdown fences`;
 
 let adrContent, stopReason;

--- a/scripts/ai-sdlc/verify-spec-ownership.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// Deterministic (non-LLM) path-ownership lint for generated specs.
+//
+// verify-spec.mjs's ADR-index injection is a real fix for #226/#238 (a
+// spec-generation agent hallucinated an entire in-repo TypeScript package,
+// packages/bugspotter-intelligence, that docs/adr/0007 attributes to a
+// SEPARATE Python service in its own repo) — but it's a prompt-attention
+// fix: it bets the model will notice a contradiction buried in ~95 lines of
+// injected context, which is exactly the reliability class that failed once
+// already (the ADR file existed in the repo the whole time; the mistake was
+// a model not attending to it, not the fact being unknowable).
+//
+// This script needs no model to notice anything. It greps the spec's
+// declared "Files touched" list against docs/adr/README.md's own
+// "Source repo(s)" column and fails the build on a plain string match. It
+// cannot catch a purely prose-based architecture error that invents no new
+// path — it is a floor, not a replacement for verify-spec.mjs or the ADR-
+// ratification gate.
+//
+// Required env var: SPEC_FILE.
+// Exit 1 on a real ownership violation (hard gate — no LLM call, no
+// attention/instruction-following failure mode, so unlike verify-spec.mjs
+// there's no "hiccup" class of failure to be lenient about).
+// Exit 0 if the spec file / ADR index is missing (nothing to check) or
+// clean.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Parse "| [0007](...) | Decision text | public, intelligence |" rows from
+ * docs/adr/README.md. Returns a Map of normalized, non-public/all repo
+ * token -> Set of ADR numbers that attribute a component to that repo.
+ */
+export function parseAdrOwnership(adrIndexText) {
+  const rowPattern = /\|\s*\[(\d+)\]\([^)]*\)\s*\|[^|]+\|\s*([^|]+?)\s*\|/g;
+  const foreignTokens = new Map();
+  for (const match of adrIndexText.matchAll(rowPattern)) {
+    const [, adrNum, repoCell] = match;
+    const repos = repoCell
+      .split(',')
+      .map((r) => r.trim().toLowerCase())
+      .filter(Boolean);
+    for (const repo of repos) {
+      if (repo === 'public' || repo === 'all') {
+        continue;
+      }
+      if (!foreignTokens.has(repo)) {
+        foreignTokens.set(repo, new Set());
+      }
+      foreignTokens.get(repo).add(adrNum);
+    }
+  }
+  return foreignTokens;
+}
+
+/** Extract backtick-quoted paths from the spec's "**Files touched:**" line. */
+export function extractDeclaredPaths(specText) {
+  const filesTouchedMatch = specText.match(/\*\*Files touched:\*\*\s*(.+)/);
+  if (!filesTouchedMatch) {
+    return null;
+  }
+  return [...filesTouchedMatch[1].matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+}
+
+/** Extract the lowercased body text of the spec's "## Out of scope" section. */
+export function extractOutOfScopeText(specText) {
+  const match = specText.match(/## Out of scope\s*\n([\s\S]*?)(?=\n## |\n$)/);
+  return (match?.[1] ?? '').toLowerCase();
+}
+
+/**
+ * Check declared paths against foreign-repo ownership tokens.
+ * `pathExists` is injected (rather than calling fs.existsSync directly) so
+ * this stays pure and testable without touching the real filesystem.
+ * Returns an array of { path, token, adrNums } violations.
+ */
+export function checkOwnership(declaredPaths, foreignTokens, outOfScopeText, pathExists) {
+  const violations = [];
+  for (const path of declaredPaths) {
+    const segments = path.split('/');
+    const rootIdx = segments.findIndex((s) => s === 'packages' || s === 'apps');
+    if (rootIdx === -1 || rootIdx + 1 >= segments.length) {
+      continue;
+    }
+    const component = segments[rootIdx + 1]
+      .toLowerCase()
+      .replace(/^bugspotter-/, '')
+      .replace(/\.[a-z]+$/, '');
+
+    for (const [token, adrNums] of foreignTokens) {
+      if (component !== token && !component.includes(token) && !token.includes(component)) {
+        continue;
+      }
+
+      const packageRoot = `${segments[rootIdx]}/${segments[rootIdx + 1]}`;
+      if (pathExists(packageRoot)) {
+        continue;
+      }
+      if (outOfScopeText.includes(token)) {
+        continue;
+      }
+
+      violations.push({ path, token, adrNums: [...adrNums] });
+    }
+  }
+  return violations;
+}
+
+function main() {
+  const { SPEC_FILE } = process.env;
+
+  if (!SPEC_FILE) {
+    console.error('Missing SPEC_FILE');
+    process.exit(1);
+  }
+
+  let spec;
+  try {
+    spec = readFileSync(SPEC_FILE, 'utf8');
+  } catch (err) {
+    console.warn(`Spec ownership lint: could not read spec file: ${err.message}`);
+    process.exit(0);
+  }
+
+  const ADR_INDEX_PATH = 'docs/adr/README.md';
+  if (!existsSync(ADR_INDEX_PATH)) {
+    console.warn('Spec ownership lint: docs/adr/README.md not found — skipping.');
+    process.exit(0);
+  }
+  const foreignTokens = parseAdrOwnership(readFileSync(ADR_INDEX_PATH, 'utf8'));
+
+  if (foreignTokens.size === 0) {
+    console.log(
+      'Spec ownership lint: no foreign-repo tokens found in ADR index — nothing to check.'
+    );
+    process.exit(0);
+  }
+
+  const declaredPaths = extractDeclaredPaths(spec);
+  if (!declaredPaths) {
+    console.warn('Spec ownership lint: no "Files touched:" line found — skipping.');
+    process.exit(0);
+  }
+
+  const outOfScopeText = extractOutOfScopeText(spec);
+  const violations = checkOwnership(declaredPaths, foreignTokens, outOfScopeText, existsSync);
+
+  if (violations.length > 0) {
+    console.error('Spec ownership lint FAILED:\n');
+    for (const v of violations) {
+      console.error(
+        `  \`${v.path}\` proposes a new path under a component name ("${v.token}") that ` +
+          `docs/adr/README.md attributes to a different repo (ADR-${v.adrNums.join(', ADR-')}).`
+      );
+    }
+    console.error(
+      '\nIf this is intentional (e.g. a thin client/wrapper that legitimately lives in this ' +
+        'repo), add an explicit line under "## Out of scope" naming the external service so ' +
+        'this check knows it was a deliberate call, not an invented package.'
+    );
+    process.exit(1);
+  }
+
+  console.log(`Spec ownership lint passed — ${declaredPaths.length} declared path(s) checked.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/ai-sdlc/verify-spec-ownership.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.mjs
@@ -54,9 +54,15 @@ export function parseAdrOwnership(adrIndexText) {
   return foreignTokens;
 }
 
-/** Extract backtick-quoted paths from the spec's "**Files touched:**" line. */
+/**
+ * Extract backtick-quoted paths from the spec's "**Files touched:**" field.
+ * Real generated specs put the list on the lines FOLLOWING the label (a
+ * bulleted list — see docs/specs/0238's own "Files touched" block), not on
+ * the same line, so this must capture the whole block up to the next
+ * "**"-prefixed field or "##" heading, not just the first line.
+ */
 export function extractDeclaredPaths(specText) {
-  const filesTouchedMatch = specText.match(/\*\*Files touched:\*\*\s*(.+)/);
+  const filesTouchedMatch = specText.match(/\*\*Files touched:\*\*\s*([\s\S]*?)(?=\n\*\*|\n##|$)/);
   if (!filesTouchedMatch) {
     return null;
   }
@@ -65,7 +71,7 @@ export function extractDeclaredPaths(specText) {
 
 /** Extract the lowercased body text of the spec's "## Out of scope" section. */
 export function extractOutOfScopeText(specText) {
-  const match = specText.match(/## Out of scope\s*\n([\s\S]*?)(?=\n## |\n$)/);
+  const match = specText.match(/## Out of scope\s*\n([\s\S]*?)(?=\n## |$)/);
   return (match?.[1] ?? '').toLowerCase();
 }
 
@@ -89,7 +95,12 @@ export function checkOwnership(declaredPaths, foreignTokens, outOfScopeText, pat
       .replace(/\.[a-z]+$/, '');
 
     for (const [token, adrNums] of foreignTokens) {
-      if (component !== token && !component.includes(token) && !token.includes(component)) {
+      // Exact match, or the component is a hyphenated variant of the token
+      // (e.g. "intelligence-client" for token "intelligence"). Deliberately
+      // NOT bidirectional substring matching: `token.includes(component)`
+      // would flag a legitimate short component like "ext" just because it
+      // is a substring of the foreign token "extension".
+      if (component !== token && !component.startsWith(`${token}-`)) {
         continue;
       }
 

--- a/scripts/ai-sdlc/verify-spec-ownership.test.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.test.mjs
@@ -53,6 +53,35 @@ describe('extractDeclaredPaths', () => {
   test('returns an empty array when the line has no backtick paths', () => {
     assert.deepEqual(extractDeclaredPaths('**Files touched:** none yet'), []);
   });
+
+  test('extracts every path from a multiline bulleted list (real spec shape)', () => {
+    // Matches how generate-spec.mjs and every real ratified spec (e.g.
+    // docs/specs/0238-*.md) actually format this field — a bulleted list on
+    // the lines FOLLOWING the label, not inline with it. A regression here
+    // silently drops every declared path but the first, which is exactly
+    // the #238 shape this whole check exists to catch.
+    const spec = [
+      '**Files touched:**',
+      '',
+      '- `packages/a/one.ts` (new)',
+      '- `packages/a/two.ts`',
+      '- `packages/a/three.ts` (new)',
+      '',
+      '**Blocking prerequisites:** none',
+      '',
+      '## Problem',
+    ].join('\n');
+    assert.deepEqual(extractDeclaredPaths(spec), [
+      'packages/a/one.ts',
+      'packages/a/two.ts',
+      'packages/a/three.ts',
+    ]);
+  });
+
+  test('terminates the block at end of string when Files touched is the last field', () => {
+    const spec = '**Files touched:**\n\n- `packages/a/one.ts`';
+    assert.deepEqual(extractDeclaredPaths(spec), ['packages/a/one.ts']);
+  });
 });
 
 describe('extractOutOfScopeText', () => {
@@ -67,6 +96,18 @@ describe('extractOutOfScopeText', () => {
 
   test('returns empty string when there is no Out of scope section', () => {
     assert.equal(extractOutOfScopeText('# Spec: no such section'), '');
+  });
+
+  test('extracts the section when it is the last thing in the file with no trailing newline', () => {
+    // Ownership check runs BEFORE the "Format generated files" (prettier)
+    // step in spec-agent.yml, so freshly-generated content isn't guaranteed
+    // to end with a newline yet. A missing match here silently drops a
+    // deliberate disclaimer and fails the build on a false positive.
+    const spec = '## Out of scope\n\n- The external `bugspotter-intelligence` python service';
+    assert.match(
+      extractOutOfScopeText(spec),
+      /the external `bugspotter-intelligence` python service/
+    );
   });
 });
 
@@ -125,6 +166,42 @@ describe('checkOwnership', () => {
   test('does not flag paths with no packages/ or apps/ root', () => {
     const violations = checkOwnership(['docs/specs/0001-foo.md'], foreignTokens, '', noPathsExist);
     assert.equal(violations.length, 0);
+  });
+
+  test('checks the apps/ root the same way as packages/', () => {
+    const violations = checkOwnership(
+      ['apps/bugspotter-sdk/src/index.ts'],
+      new Map([['sdk', new Set(['0015'])]]),
+      '',
+      noPathsExist
+    );
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].token, 'sdk');
+  });
+
+  test('does not flag a short legitimate component that is merely a substring of a foreign token', () => {
+    // "ext" is a real, unrelated component name; "extension" is a foreign
+    // token (ADR-0015, the Chrome extension repo). Bidirectional substring
+    // matching (`token.includes(component)`) used to flag this as a
+    // violation purely because "extension".includes("ext") is true.
+    const violations = checkOwnership(
+      ['packages/ext/src/index.ts'],
+      new Map([['extension', new Set(['0015'])]]),
+      '',
+      noPathsExist
+    );
+    assert.equal(violations.length, 0);
+  });
+
+  test('still flags a hyphenated variant of a foreign token', () => {
+    const violations = checkOwnership(
+      ['packages/intelligence-client/src/index.ts'],
+      foreignTokens,
+      '',
+      noPathsExist
+    );
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].token, 'intelligence');
   });
 
   test('flags multiple declared paths independently', () => {

--- a/scripts/ai-sdlc/verify-spec-ownership.test.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.test.mjs
@@ -1,0 +1,143 @@
+// Tests for verify-spec-ownership.mjs's pure logic. Zero-dependency,
+// run with `node --test`.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseAdrOwnership,
+  extractDeclaredPaths,
+  extractOutOfScopeText,
+  checkOwnership,
+} from './verify-spec-ownership.mjs';
+
+const SAMPLE_ADR_INDEX = `
+# Architecture Decision Records
+
+| #                                                     | Decision                                                                   | Source repo(s)       |
+| ------------------------------------------------------ | -------------------------------------------------------------------------- | --------------------- |
+| [0001](0001-pnpm-typescript-monorepo.md)          | pnpm + TypeScript workspace monorepo                           | public         |
+| [0003](0003-dual-licensing-fsl-and-mit.md)        | Dual licensing: FSL-1.1-Apache-2.0 platform, MIT SDK           | all            |
+| [0007](0007-polyglot-python-intelligence-service.md)   | Polyglot: separate Python intelligence service over HTTP + circuit breaker | public, intelligence |
+| [0015](0015-dual-capture-screenshot-and-replay.md)      | Dual capture: screenshot + rrweb session replay                   | sdk, extension         |
+`;
+
+describe('parseAdrOwnership', () => {
+  test('collects foreign (non-public, non-all) repo tokens with their ADR numbers', () => {
+    const result = parseAdrOwnership(SAMPLE_ADR_INDEX);
+    assert.deepEqual([...result.get('intelligence')], ['0007']);
+    assert.deepEqual([...result.get('sdk')], ['0015']);
+    assert.deepEqual([...result.get('extension')], ['0015']);
+  });
+
+  test('excludes public and all tokens', () => {
+    const result = parseAdrOwnership(SAMPLE_ADR_INDEX);
+    assert.equal(result.has('public'), false);
+    assert.equal(result.has('all'), false);
+  });
+
+  test('empty index yields an empty map', () => {
+    assert.equal(parseAdrOwnership('no table here').size, 0);
+  });
+});
+
+describe('extractDeclaredPaths', () => {
+  test('extracts backtick-quoted paths from the Files touched line', () => {
+    const spec = '**Files touched:** `packages/a/b.ts`, `packages/c/d.ts`\n**Blocking:** none';
+    assert.deepEqual(extractDeclaredPaths(spec), ['packages/a/b.ts', 'packages/c/d.ts']);
+  });
+
+  test('returns null when there is no Files touched line', () => {
+    assert.equal(extractDeclaredPaths('# Spec: no such field here'), null);
+  });
+
+  test('returns an empty array when the line has no backtick paths', () => {
+    assert.deepEqual(extractDeclaredPaths('**Files touched:** none yet'), []);
+  });
+});
+
+describe('extractOutOfScopeText', () => {
+  test('extracts and lowercases the Out of scope section body', () => {
+    const spec =
+      '## Out of scope\n\n- The external `bugspotter-intelligence` Python SERVICE\n\n## Constraints\nx';
+    assert.match(
+      extractOutOfScopeText(spec),
+      /the external `bugspotter-intelligence` python service/
+    );
+  });
+
+  test('returns empty string when there is no Out of scope section', () => {
+    assert.equal(extractOutOfScopeText('# Spec: no such section'), '');
+  });
+});
+
+describe('checkOwnership', () => {
+  const foreignTokens = new Map([
+    ['intelligence', new Set(['0007'])],
+    ['sdk', new Set(['0015'])],
+  ]);
+  const noPathsExist = () => false;
+
+  test('flags a new top-level package colliding with a foreign-repo token', () => {
+    const violations = checkOwnership(
+      ['packages/bugspotter-intelligence/src/routes/bugs/similar.ts'],
+      foreignTokens,
+      '',
+      noPathsExist
+    );
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].token, 'intelligence');
+    assert.deepEqual(violations[0].adrNums, ['0007']);
+  });
+
+  test('does not flag a path whose package root already exists', () => {
+    const violations = checkOwnership(
+      ['packages/bugspotter-intelligence/src/routes/bugs/similar.ts'],
+      foreignTokens,
+      '',
+      (p) => p === 'packages/bugspotter-intelligence'
+    );
+    assert.equal(violations.length, 0);
+  });
+
+  test('does not flag a path explicitly disclaimed in Out of scope', () => {
+    const violations = checkOwnership(
+      ['packages/bugspotter-intelligence/src/routes/bugs/similar.ts'],
+      foreignTokens,
+      'the external `bugspotter-intelligence` python service is out of scope',
+      noPathsExist
+    );
+    assert.equal(violations.length, 0);
+  });
+
+  test('does not flag a legitimate nested path that merely mentions the token', () => {
+    // packages/backend/src/services/intelligence/intelligence-client.ts —
+    // the first segment after packages/ is "backend", an existing real
+    // package, not a new "intelligence"-named top-level package.
+    const violations = checkOwnership(
+      ['packages/backend/src/services/intelligence/intelligence-client.ts'],
+      foreignTokens,
+      '',
+      (p) => p === 'packages/backend'
+    );
+    assert.equal(violations.length, 0);
+  });
+
+  test('does not flag paths with no packages/ or apps/ root', () => {
+    const violations = checkOwnership(['docs/specs/0001-foo.md'], foreignTokens, '', noPathsExist);
+    assert.equal(violations.length, 0);
+  });
+
+  test('flags multiple declared paths independently', () => {
+    const violations = checkOwnership(
+      [
+        'packages/bugspotter-intelligence/package.json',
+        'packages/bugspotter-intelligence/src/x.ts',
+        'packages/backend/src/x.ts',
+      ],
+      foreignTokens,
+      '',
+      (p) => p === 'packages/backend'
+    );
+    assert.equal(violations.length, 2);
+  });
+});


### PR DESCRIPTION
Grew out of a strategic question about PR size that turned into parallel lead-engineer analysis, which converged on a real distinction: mechanical/local defects (wrong mocks, duplicate registrations) are caught by exhaustive review of a bounded artifact; architectural/grounding defects like #226/#238's hallucinated package are caught only by what context the generating agent has, not by artifact size. Four fixes follow from that:

1. **`claude-review.yml` excluded `docs/specs/**` and `docs/adr/**`** from automatic PR review (`paths-ignore`) - the two artifact classes tied to this pipeline's non-delegable human judgment gates were the *only* changes getting zero automatic review by default. Plausibly why #238 shipped unreviewed in the first place. Fixed via trailing negation patterns re-including both subtrees.

2. **New `scripts/ai-sdlc/verify-spec-ownership.mjs`** (hard CI gate, no LLM call): parses `docs/adr/README.md`'s own repo-ownership table and fails the build if a spec's declared "Files touched" list proposes a new path colliding with a component attributed to a different repo. Unlike `verify-spec.mjs`'s ADR-index injection (a prompt-attention fix - it bets the model notices a contradiction), this needs no model to notice anything: it's a plain string match. Verified against a reconstruction of the actual #238 shape (fails, citing the real ADRs).

3. **`generate-adr.mjs` never received the ADR index** - only `generate-spec.mjs`/`verify-spec.mjs` did, meaning the artifact a human actually ratifies was the least-grounded of the three generation steps. Fixed with the same injection pattern.

4. **New `check-spec-scope.mjs`** (advisory - no real historical file-count distribution existed to calibrate a hard cap against) and **`check-impl-scope.mjs`** (hard - an unambiguous comparison between a spec's declared files and what the scaffold actually writes, no judgment call needed).

All new scripts follow the pure-function-plus-`main()`-guard pattern (`bugspotter-metrics`' `record-pr.mjs` precedent), with real `node --test` coverage now wired into `ci.yml`'s Lint job - this incidentally activates the previously-orphaned `llm-client.test.mjs` too.

Paired with `apex-bridge/bugspotter-metrics` schema 4 (PRs #13, #14): `files_changed`, `artifact_class`, `review_passes` - the recording infrastructure the checks above needed to calibrate against real data instead of guessing thresholds.

References #226, #238
