### PR TITLE
fix(#237): spec sample violated prefer-const, hard-failing the commit hook

### DIFF
--- a/docs/specs/0237-intelligence-backend-proxy-must-forward-.md
+++ b/docs/specs/0237-intelligence-backend-proxy-must-forward-.md
@@ -81,7 +81,12 @@ async function resolveOrgThreshold(
 ```ts
 // Replace the existing handler body (lines 216-222):
 const { projectId, id } = request.params;
-let { threshold, limit } = request.query;
+// `limit` is destructured separately as a const: with `let { threshold, limit }`,
+// ESLint's prefer-const (default `destructuring: "any"`) errors on `limit`,
+// which is never reassigned. The pre-commit hook runs `eslint --fix`, and this
+// is not auto-fixable, so it hard-fails the commit.
+const { limit } = request.query;
+let threshold = request.query.threshold;
 const client = await resolveClient(request, clientFactory, intelligenceClient);
 
 if (threshold === undefined) {

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -326,7 +326,8 @@ RULES:
 7. Do NOT generate package.json, pnpm-lock.yaml, or any config file changes.
 8. Do NOT generate more than 6 files total.
 9. Scaffold tests must use the same test helpers as the example (do not invent new ones).
-10. Every generated file must compile without errors given reasonable stub imports.`;
+10. Every generated file must compile without errors given reasonable stub imports.
+11. Generated code must also pass ESLint, not just tsc — the commit step runs \`eslint --fix\` in a pre-commit hook and a remaining error hard-fails the run. Auto-fixable issues are handled for you; the ones that are not include \`prefer-const\` on a partially-reassigned destructuring (\`let { a, b }\` where only \`a\` is reassigned — declare \`b\` as a separate \`const\`). If a spec's own sample code would violate such a rule, follow the spec's intent and emit the lint-clean equivalent.`;
 
 // staticContext used to be sent as a separate cache_control-marked content
 // block so repeated same-day runs skipped re-sending it; llm-client.mjs's


### PR DESCRIPTION
**Attempt 4 (run 30742896988) got further than any previous run.** Generation succeeded, the impl-scope gate passed, and critically **the build passed** - the failure mode that killed attempt 2. It died at the very last step, in the pre-commit hook, on one lint error:

```
intelligence.ts:226:24  error  'limit' is never reassigned. Use 'const' instead  prefer-const
```

**The cause is this spec's own `Changes` sample**, which prescribes `let { threshold, limit } = request.query;`. ESLint's `prefer-const` with its default `destructuring: "any"` reports `limit`, since only `threshold` is reassigned. It is **not auto-fixable** - splitting a destructuring declaration is a structural change the fixer won't make - so `eslint --fix` in the hook surfaces it as a hard error.

The agent reproduced the spec exactly, which is the #275 fix working as intended. **The defect was my spec's code, not the agent's output.**

Reproduced both forms against the repo's real eslint config:

| Form | Result |
|---|---|
| `let { threshold, limit } = request.query;` | `error 'limit' is never reassigned` |
| `const { limit } = ...; let threshold = request.query.threshold;` | clean |

**Changes:**
- Fix the spec's sample to the lint-clean form, with a comment explaining why it's split (so a future editor doesn't "tidy" it back).
- Add **RULE 11** to `generate-impl.mjs`: generated code must pass ESLint, not just `tsc`, calling out `prefer-const`-on-partial-destructuring specifically as the non-auto-fixable case, and instructing the agent to emit the lint-clean equivalent if a spec's own sample would violate a rule.

42/42 script tests pass; prettier clean.

Refs #237