### PR TITLE
fix(ai-sdlc): make check-impl-scope symmetric - catch under-delivery too

### DIFF
--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -106,10 +106,14 @@ jobs:
           IMPL_MODEL_LOW: ${{ vars.IMPL_MODEL_LOW }}
         run: node scripts/ai-sdlc/generate-impl.mjs
 
-      # Hard gate: the scaffold must not write a file the ratified spec
-      # never declared under "Files touched" - an unambiguous comparison,
-      # not a judgment call, so unlike check-spec-scope.mjs's advisory
-      # warning this fails the workflow outright.
+      # Hard gate: the scaffold's file list and the ratified spec's "Files
+      # touched" list must match EXACTLY - no file written that the spec
+      # never declared, and no file declared that the scaffold never wrote.
+      # An unambiguous comparison, not a judgment call, so unlike
+      # check-spec-scope.mjs's advisory warning this fails the workflow
+      # outright. FILES_WRITTEN is passed even when empty: an empty value
+      # means the scaffold wrote nothing, which the gate must fail rather
+      # than skip.
       - name: Check impl scope against spec
         env:
           SPEC_FILE: ${{ steps.spec.outputs.spec_file }}

--- a/scripts/ai-sdlc/check-impl-scope.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.mjs
@@ -1,10 +1,19 @@
 #!/usr/bin/env node
-// Hard gate: fails if the impl-agent's generated scaffold wrote a file the
-// linked spec never declared under "Files touched". Unlike
-// check-spec-scope.mjs's cap (which needs a judgment call about "how big is
-// too big"), this is an unambiguous comparison between two already-concrete
-// lists - there is no legitimate reason for a freshly-generated scaffold to
-// silently diverge from the spec a human already ratified.
+// Hard gate: fails if the impl-agent's generated scaffold and the linked
+// spec's "Files touched" list disagree IN EITHER DIRECTION - a file written
+// but not declared, or declared but not written. Unlike check-spec-scope.mjs's
+// cap (which needs a judgment call about "how big is too big"), this is an
+// unambiguous comparison between two already-concrete lists - there is no
+// legitimate reason for a freshly-generated scaffold to silently diverge from
+// the spec a human already ratified.
+//
+// The declared-but-not-written direction was missing until 2026-08-02, which
+// made this gate asymmetric in the dangerous direction: it blocked the agent
+// from doing MORE than the spec allowed, but let it silently do LESS. Issue
+// #237's successful run wrote 3 of 4 declared files, skipping a whole test
+// suite, so four acceptance criteria shipped unverified behind a green check.
+// Over-delivery is loud (unexpected files in the diff); under-delivery is
+// invisible, which is exactly why it needs the machine to catch it.
 //
 // Scope, stated honestly: this only checks the scaffold at generation time
 // (comparing generate-impl.mjs's own `files_written` output against the
@@ -28,6 +37,21 @@ import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
 export function findUndeclaredPaths(writtenPaths, declaredPaths) {
   const declared = new Set(declaredPaths);
   return writtenPaths.filter((p) => !declared.has(p));
+}
+
+/**
+ * Returns the subset of declaredPaths the scaffold never wrote.
+ *
+ * The mirror of findUndeclaredPaths, and just as load-bearing. Without it
+ * this gate was asymmetric: it caught the agent writing MORE than the
+ * ratified spec allowed, but not LESS. Issue #237's successful run wrote 3
+ * of 4 declared files, silently skipping the worker test suite - so four
+ * acceptance criteria shipped unverified while the gate reported green, and
+ * it was only caught by diffing the two lists by hand afterwards.
+ */
+export function findUnwrittenPaths(writtenPaths, declaredPaths) {
+  const written = new Set(writtenPaths);
+  return declaredPaths.filter((p) => !written.has(p));
 }
 
 function main() {
@@ -64,21 +88,47 @@ function main() {
     .filter(Boolean);
   const undeclared = findUndeclaredPaths(writtenPaths, declaredPaths);
 
-  if (undeclared.length > 0) {
-    console.error('Impl scope check FAILED - the scaffold wrote files the spec never declared:\n');
-    for (const p of undeclared) {
-      console.error(`  ${p}`);
+  const unwritten = findUnwrittenPaths(writtenPaths, declaredPaths);
+
+  if (undeclared.length > 0 || unwritten.length > 0) {
+    console.error('Impl scope check FAILED - the scaffold does not match the ratified spec.\n');
+
+    if (undeclared.length > 0) {
+      console.error('Wrote files the spec never declared:');
+      for (const p of undeclared) {
+        console.error(`  + ${p}`);
+      }
+      console.error(
+        '\n  Either the spec is missing these paths, or the scaffold drifted from what was\n' +
+          '  ratified. Fix the spec and re-run, or investigate the drift.\n'
+      );
     }
-    console.error(
-      `\nDeclared in ${SPEC_FILE}:\n${declaredPaths.map((p) => `  ${p}`).join('\n')}\n\n` +
-        'Either the spec is missing these paths (fix the spec first, re-run) or the scaffold ' +
-        'drifted from what was ratified - either way this needs a human look before it ships ' +
-        'as a draft PR.'
-    );
+
+    if (unwritten.length > 0) {
+      console.error('Did NOT write files the spec declared:');
+      for (const p of unwritten) {
+        console.error(`  - ${p}`);
+      }
+      console.error(
+        '\n  A ratified spec is a contract: silently delivering less than it promises is how\n' +
+          '  acceptance criteria ship unverified (see issue #237, where a skipped test file\n' +
+          '  left four ACs unchecked behind a green gate). Two possible causes, both needing\n' +
+          '  a human:\n' +
+          '    1. The agent dropped work         -> re-run, or write the missing file by hand.\n' +
+          '    2. The spec over-declared a file  -> amend the spec, then re-run. Re-running\n' +
+          '       without amending will fail identically, since the agent will keep\n' +
+          '       (correctly) deciding that file needs no change.\n'
+      );
+    }
+
+    console.error(`Declared in ${SPEC_FILE}:\n${declaredPaths.map((p) => `  ${p}`).join('\n')}`);
     process.exit(1);
   }
 
-  console.log(`Impl scope check passed — ${writtenPaths.length} written file(s) all declared.`);
+  console.log(
+    `Impl scope check passed - ${writtenPaths.length} written file(s) exactly match the ` +
+      `${declaredPaths.length} declared in the spec.`
+  );
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {

--- a/scripts/ai-sdlc/check-impl-scope.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.mjs
@@ -22,16 +22,36 @@
 // not attempt.
 //
 // Required env vars: SPEC_FILE, FILES_WRITTEN (comma-separated, matching
-// generate-impl.mjs's GITHUB_OUTPUT format).
-// Exit 1 if any written file is undeclared, OR if the ratified spec can't be
-// read or has no parseable "Files touched" line — a hard gate that no-ops on
-// a malformed baseline isn't a gate, it's a trap door. Exit 0 only when the
-// comparison actually ran and came back clean (or there's nothing written to
-// check, per FILES_WRITTEN being empty).
+// generate-impl.mjs's GITHUB_OUTPUT format). FILES_WRITTEN must be SET, but
+// may be empty — an empty value means the scaffold wrote nothing, which is
+// under-delivery of EVERY declared path rather than a reason to skip the
+// check. It short-circuited to exit 0 until 2026-08-02, which left the most
+// extreme version of the #237 bug (zero of N declared files) passing green
+// through the gate built to catch it.
+// Exit 1 if the two lists disagree in either direction, OR if the ratified
+// spec can't be read or has no parseable "Files touched" line — a hard gate
+// that no-ops on a malformed baseline isn't a gate, it's a trap door.
+// Exit 0 only when the comparison actually ran and came back clean.
 
 import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
+
+/**
+ * Canonicalize a repo-relative path for set comparison.
+ *
+ * The two sides of this comparison are produced very differently: written
+ * paths come from generate-impl.mjs, already normalized by node's
+ * `relative()` (no `./`, forward slashes); declared paths are lifted
+ * verbatim out of backticks in human-ratified, LLM-drafted markdown. A
+ * stray `./` or a stray space on the spec side would otherwise make the
+ * SAME file show up in BOTH failure lists at once - reported as written-but-
+ * undeclared and declared-but-unwritten simultaneously - which is a
+ * confusing false failure that costs a full generation run.
+ */
+export function normalizePath(p) {
+  return p.trim().replaceAll('\\', '/').replace(/^\.\//, '');
+}
 
 /** Returns the subset of writtenPaths not present in declaredPaths. */
 export function findUndeclaredPaths(writtenPaths, declaredPaths) {
@@ -60,9 +80,17 @@ function main() {
     console.error('Missing SPEC_FILE');
     process.exit(1);
   }
-  if (!FILES_WRITTEN) {
-    console.warn('Impl scope check: FILES_WRITTEN is empty — nothing to check.');
-    process.exit(0);
+  // Deliberately `=== undefined`, not falsy. An EMPTY FILES_WRITTEN must
+  // fall through to the comparison below: "wrote nothing" is the maximal
+  // under-delivery, not an absence of work to check. Only an env var that
+  // was never plumbed through at all is a caller error, and it is treated
+  // like a missing SPEC_FILE rather than waved through.
+  if (FILES_WRITTEN === undefined) {
+    console.error(
+      "Missing FILES_WRITTEN. Set it to generate-impl.mjs's files_written output; " +
+        'an empty string is valid and means the scaffold wrote nothing.'
+    );
+    process.exit(1);
   }
 
   let spec;
@@ -73,8 +101,8 @@ function main() {
     process.exit(1);
   }
 
-  const declaredPaths = extractDeclaredPaths(spec);
-  if (!declaredPaths || declaredPaths.length === 0) {
+  const declaredPaths = (extractDeclaredPaths(spec) ?? []).map(normalizePath).filter(Boolean);
+  if (declaredPaths.length === 0) {
     console.error(
       'Impl scope check FAILED: spec has no parseable "Files touched:" line, so the ' +
         'scaffold cannot be checked against it. Fix the ratified spec\'s "Files touched" ' +
@@ -83,11 +111,8 @@ function main() {
     process.exit(1);
   }
 
-  const writtenPaths = FILES_WRITTEN.split(',')
-    .map((p) => p.trim())
-    .filter(Boolean);
+  const writtenPaths = FILES_WRITTEN.split(',').map(normalizePath).filter(Boolean);
   const undeclared = findUndeclaredPaths(writtenPaths, declaredPaths);
-
   const unwritten = findUnwrittenPaths(writtenPaths, declaredPaths);
 
   if (undeclared.length > 0 || unwritten.length > 0) {
@@ -109,6 +134,15 @@ function main() {
       for (const p of unwritten) {
         console.error(`  - ${p}`);
       }
+      if (writtenPaths.length === 0) {
+        console.error(
+          '\n  The scaffold wrote NOTHING - every declared path is missing. generate-impl.mjs\n' +
+            '  already aborts on zero writes, so an empty FILES_WRITTEN arriving here usually\n' +
+            '  means the env plumbing between the two steps broke, not that the model produced\n' +
+            "  nothing. Check the generate step's files_written output before re-running."
+        );
+      }
+
       console.error(
         '\n  A ratified spec is a contract: silently delivering less than it promises is how\n' +
           '  acceptance criteria ship unverified (see issue #237, where a skipped test file\n' +

--- a/scripts/ai-sdlc/check-impl-scope.test.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.test.mjs
@@ -3,7 +3,7 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { findUndeclaredPaths } from './check-impl-scope.mjs';
+import { findUndeclaredPaths, findUnwrittenPaths } from './check-impl-scope.mjs';
 
 describe('findUndeclaredPaths', () => {
   test('returns an empty array when every written path was declared', () => {
@@ -24,14 +24,60 @@ describe('findUndeclaredPaths', () => {
     assert.deepEqual(findUndeclaredPaths(written, declared), ['packages/x.ts', 'packages/y.ts']);
   });
 
-  test('a declared path never written is not itself a violation', () => {
-    // findUndeclaredPaths only checks the write-side; a spec declaring a
-    // file that ends up unwritten is a different (unhandled) concern.
+  test('a declared path never written is not flagged by THIS function', () => {
+    // findUndeclaredPaths only checks the write-side. The declared-but-not-
+    // written direction is findUnwrittenPaths's job (see below) - this test
+    // pins the split in responsibility, not an "it's fine" verdict.
     const declared = ['packages/a.ts', 'packages/never-written.ts'];
     assert.deepEqual(findUndeclaredPaths(['packages/a.ts'], declared), []);
   });
 
   test('empty written list is always clean', () => {
     assert.deepEqual(findUndeclaredPaths([], ['packages/a.ts']), []);
+  });
+});
+
+describe('findUnwrittenPaths', () => {
+  test('returns an empty array when every declared path was written', () => {
+    const declared = ['packages/a.ts', 'packages/b.ts'];
+    assert.deepEqual(findUnwrittenPaths(['packages/a.ts', 'packages/b.ts'], declared), []);
+  });
+
+  test('flags a declared path the scaffold never wrote', () => {
+    // The exact #237 shape: spec declared 4 files, scaffold wrote 3,
+    // silently skipping the worker test suite.
+    const declared = [
+      'packages/backend/src/api/routes/intelligence.ts',
+      'packages/backend/src/queue/workers/intelligence-worker.ts',
+      'packages/backend/tests/api/intelligence-routes.test.ts',
+      'packages/backend/tests/queue/intelligence-worker.test.ts',
+    ];
+    const written = declared.slice(0, 3);
+    assert.deepEqual(findUnwrittenPaths(written, declared), [
+      'packages/backend/tests/queue/intelligence-worker.test.ts',
+    ]);
+  });
+
+  test('flags multiple unwritten paths independently', () => {
+    const declared = ['packages/a.ts', 'packages/b.ts', 'packages/c.ts'];
+    assert.deepEqual(findUnwrittenPaths(['packages/b.ts'], declared), [
+      'packages/a.ts',
+      'packages/c.ts',
+    ]);
+  });
+
+  test('an extra written path is not flagged by THIS function', () => {
+    // Mirror of the split above: over-delivery is findUndeclaredPaths's job.
+    const declared = ['packages/a.ts'];
+    assert.deepEqual(findUnwrittenPaths(['packages/a.ts', 'packages/extra.ts'], declared), []);
+  });
+
+  test('empty written list flags every declared path', () => {
+    // Note main() short-circuits on an empty FILES_WRITTEN before reaching
+    // here, so this is the pure-function contract, not the CLI's behavior.
+    assert.deepEqual(findUnwrittenPaths([], ['packages/a.ts', 'packages/b.ts']), [
+      'packages/a.ts',
+      'packages/b.ts',
+    ]);
   });
 });

--- a/scripts/ai-sdlc/check-impl-scope.test.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.test.mjs
@@ -1,9 +1,17 @@
-// Tests for check-impl-scope.mjs's pure logic. Zero-dependency, run with
-// `node --test`.
+// Tests for check-impl-scope.mjs. The pure helpers are covered directly;
+// main() is covered by spawning the real CLI, because the bug this file's
+// last describe() block exists to pin lived entirely in main()'s control
+// flow, where a helper-only suite could never have seen it. Zero-dependency,
+// run with `node --test`.
 
-import { test, describe } from 'node:test';
+import { test, describe, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { findUndeclaredPaths, findUnwrittenPaths } from './check-impl-scope.mjs';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findUndeclaredPaths, findUnwrittenPaths, normalizePath } from './check-impl-scope.mjs';
 
 describe('findUndeclaredPaths', () => {
   test('returns an empty array when every written path was declared', () => {
@@ -73,11 +81,142 @@ describe('findUnwrittenPaths', () => {
   });
 
   test('empty written list flags every declared path', () => {
-    // Note main() short-circuits on an empty FILES_WRITTEN before reaching
-    // here, so this is the pure-function contract, not the CLI's behavior.
+    // main() reaches this case now (it used to exit 0 on an empty
+    // FILES_WRITTEN before ever getting here) - see the CLI block below,
+    // which pins that end to end.
     assert.deepEqual(findUnwrittenPaths([], ['packages/a.ts', 'packages/b.ts']), [
       'packages/a.ts',
       'packages/b.ts',
     ]);
+  });
+});
+
+describe('normalizePath', () => {
+  test('leaves an already-canonical path untouched', () => {
+    assert.equal(normalizePath('packages/backend/src/a.ts'), 'packages/backend/src/a.ts');
+  });
+
+  test('strips a leading "./" so the two sides of the comparison agree', () => {
+    // generate-impl.mjs emits paths through node's relative(), which never
+    // produces a "./" prefix; a spec author (or the model drafting one) can
+    // easily write it. Without this they would mismatch in BOTH directions.
+    assert.equal(normalizePath('./packages/a.ts'), 'packages/a.ts');
+  });
+
+  test('trims surrounding whitespace', () => {
+    assert.equal(normalizePath('  packages/a.ts \n'), 'packages/a.ts');
+  });
+
+  test('normalizes backslash separators to forward slashes', () => {
+    assert.equal(normalizePath('packages\\backend\\src\\a.ts'), 'packages/backend/src/a.ts');
+  });
+});
+
+// --- CLI-level tests for main() -------------------------------------------
+// The escape hatch these pin: an empty FILES_WRITTEN used to exit 0 BEFORE
+// the spec was read, so "wrote 0 of N declared files" - the most extreme
+// under-delivery there is - passed the very gate built to catch #237.
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'check-impl-scope.mjs');
+const DIR = mkdtempSync(join(tmpdir(), 'check-impl-scope-test-'));
+after(() => rmSync(DIR, { recursive: true, force: true }));
+
+function writeSpec(name, filesTouched) {
+  const path = join(DIR, name);
+  writeFileSync(
+    path,
+    [
+      '# Spec: fixture',
+      '',
+      `**Files touched:** ${filesTouched}`,
+      '**Blocking prerequisites:** none',
+      '',
+      '## Problem',
+      '',
+      'Fixture spec.',
+      '',
+    ].join('\n'),
+    'utf8'
+  );
+  return path;
+}
+
+/** Runs the real CLI with a clean slate for the two env vars under test. */
+function runCli(env) {
+  const base = { ...process.env };
+  delete base.SPEC_FILE;
+  delete base.FILES_WRITTEN;
+  return spawnSync(process.execPath, [SCRIPT], { env: { ...base, ...env }, encoding: 'utf8' });
+}
+
+describe('CLI', () => {
+  const TWO_FILES = '`packages/a.ts`, `packages/b.ts`';
+
+  test('exits 0 when written and declared match exactly', () => {
+    const spec = writeSpec('match.md', TWO_FILES);
+    const r = runCli({ SPEC_FILE: spec, FILES_WRITTEN: 'packages/a.ts,packages/b.ts' });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /Impl scope check passed/);
+  });
+
+  test('exits 1 when FILES_WRITTEN is empty but the spec declares paths', () => {
+    // The regression this whole block exists for: 0-of-N must not pass.
+    const spec = writeSpec('empty-written.md', TWO_FILES);
+    const r = runCli({ SPEC_FILE: spec, FILES_WRITTEN: '' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Did NOT write files the spec declared/);
+    assert.match(r.stderr, /packages\/a\.ts/);
+    assert.match(r.stderr, /packages\/b\.ts/);
+    assert.match(r.stderr, /wrote NOTHING/);
+  });
+
+  test('exits 1 when FILES_WRITTEN is not set at all', () => {
+    // Distinct from empty: an unset var means a caller never plumbed it
+    // through, which is a configuration error, not a zero-write scaffold.
+    const spec = writeSpec('unset-written.md', TWO_FILES);
+    const r = runCli({ SPEC_FILE: spec });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Missing FILES_WRITTEN/);
+  });
+
+  test('exits 1 on under-delivery, naming only the missing path', () => {
+    const spec = writeSpec('under.md', TWO_FILES);
+    const r = runCli({ SPEC_FILE: spec, FILES_WRITTEN: 'packages/a.ts' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Did NOT write files the spec declared:\n {2}- packages\/b\.ts/);
+    assert.doesNotMatch(r.stderr, /Wrote files the spec never declared/);
+  });
+
+  test('exits 1 on over-delivery, naming only the undeclared path', () => {
+    const spec = writeSpec('over.md', TWO_FILES);
+    const r = runCli({
+      SPEC_FILE: spec,
+      FILES_WRITTEN: 'packages/a.ts,packages/b.ts,packages/sneaky.ts',
+    });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Wrote files the spec never declared:\n {2}\+ packages\/sneaky\.ts/);
+    assert.doesNotMatch(r.stderr, /Did NOT write files the spec declared/);
+  });
+
+  test('reports BOTH directions in a single run', () => {
+    const spec = writeSpec('both.md', TWO_FILES);
+    const r = runCli({ SPEC_FILE: spec, FILES_WRITTEN: 'packages/a.ts,packages/sneaky.ts' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Wrote files the spec never declared:\n {2}\+ packages\/sneaky\.ts/);
+    assert.match(r.stderr, /Did NOT write files the spec declared:\n {2}- packages\/b\.ts/);
+  });
+
+  test('a spec that declares "./"-prefixed paths still matches', () => {
+    const spec = writeSpec('dot-slash.md', '`./packages/a.ts`, `./packages/b.ts`');
+    const r = runCli({ SPEC_FILE: spec, FILES_WRITTEN: 'packages/a.ts,packages/b.ts' });
+    assert.equal(r.status, 0, r.stderr);
+  });
+
+  test('exits 1 when the spec has no parseable "Files touched" list', () => {
+    const path = join(DIR, 'no-files-touched.md');
+    writeFileSync(path, '# Spec: fixture\n\n## Problem\n\nNo files field.\n', 'utf8');
+    const r = runCli({ SPEC_FILE: path, FILES_WRITTEN: 'packages/a.ts' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /no parseable "Files touched:" line/);
   });
 });


### PR DESCRIPTION
The gate verified that every **written** file was **declared**, but never that every **declared** file was **written**. That asymmetry ran the wrong way: it blocked the agent from doing *more* than the ratified spec allowed, while letting it silently do *less*.

Issue #237's successful run hit exactly this. The spec declared four files; the scaffold wrote three, skipping the worker test suite entirely. Four acceptance criteria (E/F/G/H) shipped unverified behind a green check — caught only by diffing the two lists by hand afterwards.

Over-delivery is loud: unexpected files show up in the diff. **Under-delivery is invisible**, which is precisely why it needs the machine.

**Changes:**
- `findUnwrittenPaths`, the mirror of `findUndeclaredPaths`.
- Both directions reported in one pass, so a mixed failure doesn't hide half of itself.
- The failure output spells out the two possible causes, since they need different fixes:
  1. **Agent dropped work** → re-run, or write the missing file by hand.
  2. **Spec over-declared** → amend the spec *first*. Re-running without amending fails identically, because the agent will keep (correctly) deciding that file needs no change.

**Verified end to end against the real #237 spec**, not just via unit tests:

| Scenario | Expected | Result |
|---|---|---|
| The exact run-5 shape (3 of 4 written) | fail | ✅ fails, names the missing file |
| All 4 declared files written | pass | ✅ passes |
| Extra undeclared file | fail | ✅ still fails (prior behavior intact) |
| Both directions at once | report both | ✅ reports both |

47/47 script tests pass (was 42). One prior test asserted the old one-directional behavior; it's been rewritten to pin the split in responsibility between the two functions rather than imply under-delivery is acceptable.

Refs #237