### PR TITLE
fix(ai-sdlc): raise agent LLM/step/job time budgets, refuse unsatisfiable specs

### DIFF
--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -67,6 +67,10 @@ jobs:
 
       - name: Generate ADR
         id: gen
+        # 6m > generate-adr.mjs's own 300s (5m) LLM timeout, so the script's
+        # error wins over a silent step kill. One LLM call in this job, so the
+        # 15m job cap has ample room around it.
+        timeout-minutes: 6
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -33,7 +33,16 @@ jobs:
     name: Draft spec
     if: github.event.label.name == 'needs-spec'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 22m. This job makes TWO sequential LLM calls - generate-spec.mjs (420s)
+    # and verify-spec.mjs (420s) - so the job cap has to contain 840s of model
+    # budget plus setup. At 15m (900s) it did not: worst case was ~840s of LLM
+    # plus checkout, setup-node, `npm install -g @anthropic-ai/claude-code`,
+    # prettier, git push and two `gh` calls. The failure mode was the worst
+    # available - GitHub cancels the job mid-call, so a spec that generate-spec
+    # already wrote to disk is discarded uncommitted, after both calls were
+    # paid for. Step caps below bound each call individually; this bounds the
+    # whole job with room for the setup around them.
+    timeout-minutes: 22
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +56,9 @@ jobs:
 
       - name: Generate spec
         id: gen
+        # 8m > generate-spec.mjs's own 420s (7m) LLM timeout, so the script's
+        # error message wins over a silent step kill.
+        timeout-minutes: 8
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -57,6 +69,12 @@ jobs:
         run: node scripts/ai-sdlc/generate-spec.mjs
 
       - name: Verify and patch spec (adversarial factual check)
+        # 8m > verify-spec.mjs's own 420s (7m) LLM timeout. Important here
+        # specifically: verify-spec.mjs deliberately exits 0 on any error so a
+        # verifier hiccup preserves the already-generated spec. A step kill
+        # bypasses that design and loses the spec, so the cap must sit above
+        # the script's own timeout, never below it.
+        timeout-minutes: 8
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/scripts/ai-sdlc/generate-adr.mjs
+++ b/scripts/ai-sdlc/generate-adr.mjs
@@ -137,7 +137,8 @@ try {
   //      than generate-spec" is no longer a small number either.
   // max_tokens here is still half of generate-spec's (2048 vs 4096), and
   // output tokens dominate wall time, so ~300s is the proportionate budget
-  // rather than a flat copy of 420s. adr-agent.yml's step cap is 15 min.
+  // rather than a flat copy of 420s. adr-agent.yml caps this step at 6m,
+  // above this 300s, inside a 15m job cap that holds only this one LLM call.
   ({ text: adrContent, stopReason } = await callClaude({
     prompt,
     maxTokens: 2048,

--- a/scripts/ai-sdlc/generate-adr.mjs
+++ b/scripts/ai-sdlc/generate-adr.mjs
@@ -126,16 +126,22 @@ Rules:
 
 let adrContent, stopReason;
 try {
-  // 120s: this prompt is much smaller than generate-spec.mjs's (no
-  // TEMPLATE.md, no source-file tree — just one ~1200-char example ADR plus
-  // the issue body and an optional ~1500-char spec excerpt) and max_tokens
-  // (2048) is half of generate-spec's (4096), so it needs less time than
-  // generate-spec's 180s. It still needs more than the old API-only 60s
-  // budget to cover the CLI backend's subprocess startup overhead.
+  // 300s. The previous 120s rested on a premise that is no longer true: it
+  // argued this prompt is "much smaller than generate-spec.mjs's (no
+  // TEMPLATE.md, no source-file tree)" and so needs less than that script's
+  // 180s. Both halves broke:
+  //   1. PR #273 added the same ~10KB ADR index here, so the input is no
+  //      longer in a different size class.
+  //   2. generate-spec's 180s was itself below its own measured runtime and
+  //      failed in practice (run 30752527569); it is now 420s, so "less
+  //      than generate-spec" is no longer a small number either.
+  // max_tokens here is still half of generate-spec's (2048 vs 4096), and
+  // output tokens dominate wall time, so ~300s is the proportionate budget
+  // rather than a flat copy of 420s. adr-agent.yml's step cap is 15 min.
   ({ text: adrContent, stopReason } = await callClaude({
     prompt,
     maxTokens: 2048,
-    timeoutMs: 120_000,
+    timeoutMs: 300_000,
   }));
 } catch (err) {
   console.error(err.message);

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -221,6 +221,7 @@ function fenceFor(body) {
 const MAX_LINES_PER_FILE = 1000;
 const declaredPaths = extractDeclaredPaths(SPEC_CONTENT) ?? [];
 let truncatedCount = 0;
+const truncatedFiles = [];
 const currentFiles = declaredPaths
   .filter((p) => isAllowedRepoPath(p) && existsSync(p))
   .map((p) => {
@@ -239,6 +240,7 @@ const currentFiles = declaredPaths
     const fence = fenceFor(body);
     if (isTruncated) {
       truncatedCount += 1;
+      truncatedFiles.push({ path: p, lines: lines.length });
     }
     // A truncated file must be labelled at its own header, not just in the
     // preamble: the repo has source and test files well past this cap
@@ -252,6 +254,28 @@ const currentFiles = declaredPaths
     return `${header}\n${fence}${languageFor(p)}\n${body}\n${fence}`;
   })
   .filter(Boolean);
+
+// Fail BEFORE the model call if the spec is unsatisfiable by construction.
+// Two individually-correct rules collide: the prompt above tells the model
+// never to return a TRUNCATED file (returning one would silently delete
+// everything past the cap), while check-impl-scope.mjs hard-fails when a
+// declared file is not written. A spec declaring an over-cap file therefore
+// deadlocks - the model correctly refuses, the gate correctly fails, and a
+// re-run fails identically. 27 files in packages/backend alone are over the
+// cap, so this is reachable, not theoretical. Detecting it here costs
+// milliseconds; detecting it downstream costs a full 9-13 minute paid run
+// that cannot succeed.
+if (truncatedFiles.length > 0) {
+  console.error(
+    `Refusing to call the model: the spec declares ${truncatedFiles.length} file(s) larger ` +
+      `than the ${MAX_LINES_PER_FILE}-line context cap:\n` +
+      truncatedFiles.map((f) => `  ${f.path} (${f.lines} lines)`).join('\n') +
+      `\n\nThe agent cannot safely return a file it can only partially see, but the impl-scope ` +
+      `gate requires every declared file to be written - so this spec cannot succeed as ` +
+      `written. Narrow the spec to smaller files, split the change, or make this edit by hand.`
+  );
+  process.exit(1);
+}
 
 const currentFilesSection = currentFiles.length
   ? `# Current content of the files you must edit\n\nThese are the current contents of these ` +

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -235,12 +235,22 @@ const currentFiles = declaredPaths
       return null;
     }
     const lines = content.split('\n');
-    const isTruncated = lines.length > MAX_LINES_PER_FILE;
+    // A trailing newline terminates the last line, it does not start a new
+    // one: split('\n') on "a\nb\n" yields three entries, the last of them
+    // empty. Counting entries raw would read every file written with the
+    // usual trailing newline as one line longer than it is, so a file of
+    // exactly MAX_LINES_PER_FILE lines would land over the cap. That was
+    // merely a mislabel while over-cap files were only annotated TRUNCATED;
+    // the preflight below turns over-cap into a hard exit, so the same
+    // off-by-one would now reject a spec that sits exactly at the cap and is
+    // perfectly satisfiable.
+    const lineCount = lines.length - (lines.at(-1) === '' ? 1 : 0);
+    const isTruncated = lineCount > MAX_LINES_PER_FILE;
     const body = isTruncated ? lines.slice(0, MAX_LINES_PER_FILE).join('\n') : content;
     const fence = fenceFor(body);
     if (isTruncated) {
       truncatedCount += 1;
-      truncatedFiles.push({ path: p, lines: lines.length });
+      truncatedFiles.push({ path: p, lines: lineCount });
     }
     // A truncated file must be labelled at its own header, not just in the
     // preamble: the repo has source and test files well past this cap
@@ -248,7 +258,7 @@ const currentFiles = declaredPaths
     // "reproduce it verbatim" applied to a body missing its tail means the
     // agent silently deletes everything past line 1000.
     const header = isTruncated
-      ? `## ${p}\n\nTRUNCATED: showing lines 1-${MAX_LINES_PER_FILE} of ${lines.length}. ` +
+      ? `## ${p}\n\nTRUNCATED: showing lines 1-${MAX_LINES_PER_FILE} of ${lineCount}. ` +
         `Reference only — do NOT return this file.`
       : `## ${p}`;
     return `${header}\n${fence}${languageFor(p)}\n${body}\n${fence}`;

--- a/scripts/ai-sdlc/generate-impl.test.mjs
+++ b/scripts/ai-sdlc/generate-impl.test.mjs
@@ -1,0 +1,187 @@
+// Tests for generate-impl.mjs's over-cap preflight (the MAX_LINES_PER_FILE
+// guard that refuses to call the model when the spec declares a file too big
+// to show the model in full).
+//
+// generate-impl.mjs is a top-level script with no exports — importing it runs
+// it — so the guard is exercised the way check-impl-scope.test.mjs exercises
+// its main(): by spawning the real CLI. Two things make that safe and
+// network-free here:
+//   - a temp dir is passed as cwd, and generate-impl.mjs takes `repoRoot` from
+//     process.cwd(), so fixtures of an exact line count can stand in for real
+//     repo files;
+//   - LLM_BACKEND=cli plus a fake `claude` ahead of everything on PATH (the
+//     same harness llm-client.test.mjs uses), so a run that gets *past* the
+//     guard talks to the fake instead of the API.
+//
+// The fake dumps the prompt it received. That is what makes the pass-side
+// assertions non-vacuous: absence of the dump proves the guard fired before
+// the model call, and its contents prove an at-cap file was injected whole
+// rather than silently labelled TRUNCATED.
+//
+// Zero-dependency, run with `node --test`.
+
+import { test, describe, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Must match MAX_LINES_PER_FILE in generate-impl.mjs.
+const MAX_LINES_PER_FILE = 1000;
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'generate-impl.mjs');
+const BIN_DIR = mkdtempSync(join(tmpdir(), 'generate-impl-bin-'));
+const REPO = mkdtempSync(join(tmpdir(), 'generate-impl-repo-'));
+
+after(() => {
+  rmSync(BIN_DIR, { recursive: true, force: true });
+  rmSync(REPO, { recursive: true, force: true });
+});
+
+// --- fake `claude` on PATH -------------------------------------------------
+// Drains stdin before answering: callViaCli writes the whole prompt to the
+// child's stdin, and the prompt here carries a ~1000-line fixture.
+const IMPL = join(BIN_DIR, 'fake-claude-impl.cjs');
+writeFileSync(
+  IMPL,
+  [
+    "const fs = require('node:fs');",
+    "let input = '';",
+    "process.stdin.setEncoding('utf8');",
+    "process.stdin.on('data', (d) => { input += d; });",
+    "process.stdin.on('end', () => {",
+    '  const dump = process.env.FAKE_CLAUDE_PROMPT_DUMP;',
+    '  if (dump) fs.writeFileSync(dump, input);',
+    '  const payload = {',
+    "    files: [{ path: 'packages/generated.ts', content: 'export const generated = true;\\n' }],",
+    "    summary: 'fake impl',",
+    '  };',
+    "  process.stdout.write(JSON.stringify({ result: JSON.stringify(payload), stop_reason: 'end_turn' }));",
+    '});',
+    '',
+  ].join('\n')
+);
+
+const POSIX_BIN = join(BIN_DIR, 'claude');
+writeFileSync(POSIX_BIN, `#!/usr/bin/env node\nrequire(${JSON.stringify(IMPL)});\n`);
+chmodSync(POSIX_BIN, 0o755);
+writeFileSync(join(BIN_DIR, 'claude.cmd'), `@echo off\r\nnode "${IMPL}" %*\r\n`);
+
+// --- fixtures --------------------------------------------------------------
+/** Writes `count` numbered lines plus the trailing newline every real file has. */
+function writeFixture(relPath, count) {
+  const abs = join(REPO, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(
+    abs,
+    `${Array.from({ length: count }, (_, i) => `const l${i} = ${i};`).join('\n')}\n`,
+    'utf8'
+  );
+  return relPath;
+}
+
+const AT_CAP = writeFixture('packages/at-cap.ts', MAX_LINES_PER_FILE);
+const OVER_CAP = writeFixture('packages/over-cap.ts', MAX_LINES_PER_FILE + 1);
+const SMALL = writeFixture('packages/small.ts', 12);
+
+function spec(...paths) {
+  return [
+    '# Spec: fixture',
+    '',
+    `**Files touched:** ${paths.map((p) => `\`${p}\``).join(', ')}`,
+    '**Blocking prerequisites:** none',
+    '',
+    '## Problem',
+    '',
+    'Fixture spec.',
+    '',
+  ].join('\n');
+}
+
+let runSeq = 0;
+/** Runs the real generate-impl.mjs against the temp repo. */
+function runImpl(specContent) {
+  const promptDump = join(BIN_DIR, `prompt-${runSeq++}.txt`);
+  const env = { ...process.env };
+  delete env.GITHUB_OUTPUT;
+  delete env.ISSUE_LABELS;
+  const result = spawnSync(process.execPath, [SCRIPT], {
+    cwd: REPO,
+    encoding: 'utf8',
+    env: {
+      ...env,
+      PATH: `${BIN_DIR}${process.platform === 'win32' ? ';' : ':'}${env.PATH}`,
+      LLM_BACKEND: 'cli',
+      CLAUDE_CODE_OAUTH_TOKEN: 'test-oauth-token',
+      ISSUE_NUMBER: '999',
+      ISSUE_TITLE: 'fixture issue',
+      SPEC_CONTENT: specContent,
+      FAKE_CLAUDE_PROMPT_DUMP: promptDump,
+    },
+  });
+  return {
+    ...result,
+    modelWasCalled: existsSync(promptDump),
+    prompt: existsSync(promptDump) ? readFileSync(promptDump, 'utf8') : null,
+  };
+}
+
+describe('over-cap preflight', () => {
+  test('refuses before the model call when a declared file is over the cap', () => {
+    const r = runImpl(spec(OVER_CAP));
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /Refusing to call the model/);
+    assert.match(r.stderr, /packages\/over-cap\.ts/);
+    // The reported count is the file's real line count, not split('\n').length.
+    assert.match(r.stderr, new RegExp(`\\(${MAX_LINES_PER_FILE + 1} lines\\)`));
+    // The whole point of the guard: no paid run happened.
+    assert.equal(r.modelWasCalled, false, 'guard must fire before the model call');
+  });
+
+  test('a file of exactly MAX_LINES_PER_FILE lines is at the cap, not over it', () => {
+    // The trailing newline every real file carries makes split('\n') return
+    // MAX_LINES_PER_FILE + 1 entries. Counting those raw would fail this run
+    // with "larger than the cap" for a file that is exactly at it.
+    const r = runImpl(spec(AT_CAP));
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(r.stderr, /Refusing to call the model/);
+    assert.equal(r.modelWasCalled, true);
+    assert.match(r.stdout, /Injecting current content of 1 existing declared file/);
+    assert.doesNotMatch(r.stdout, /truncated/);
+    // Injected whole: both the first and the last line reach the model, and
+    // no TRUNCATED banner tells the model to treat it as read-only.
+    assert.ok(r.prompt.includes('const l0 = 0;'));
+    assert.ok(r.prompt.includes(`const l${MAX_LINES_PER_FILE - 1} = ${MAX_LINES_PER_FILE - 1};`));
+    assert.doesNotMatch(r.prompt, /TRUNCATED/);
+  });
+
+  test('a declared file that does not exist yet does not trip the guard', () => {
+    // New-file specs are the common case; existsSync filters them out before
+    // the line count is ever taken, and they must not read as over-cap.
+    const r = runImpl(spec('packages/brand-new.ts', SMALL));
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(r.stderr, /Refusing to call the model/);
+    assert.equal(r.modelWasCalled, true);
+    assert.match(r.stdout, /Injecting current content of 1 existing declared file/);
+  });
+
+  test('names every over-cap file, not just the first', () => {
+    const r = runImpl(spec(SMALL, OVER_CAP, AT_CAP));
+    assert.equal(r.status, 1, r.stderr);
+    assert.match(r.stderr, /declares 1 file\(s\) larger/);
+    assert.match(r.stderr, /packages\/over-cap\.ts/);
+    // At-cap and under-cap siblings must not be listed as offenders.
+    assert.doesNotMatch(r.stderr, /packages\/at-cap\.ts/);
+    assert.doesNotMatch(r.stderr, /packages\/small\.ts/);
+  });
+});

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -163,7 +163,19 @@ Rules:
 
 let specContent;
 try {
-  ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 180_000 }));
+  // 420s, matching verify-spec.mjs. 180_000 was set when this prompt was
+  // just TEMPLATE.md + the issue body; it has grown a lot since and the
+  // budget was never revisited: PR #240 added the BFS source-tree scanner
+  // and PR #260 added the ~10KB ADR index. Two independent reasons the old
+  // number was wrong:
+  //   1. verify-spec.mjs measured 283.9s for a comparable call on the CLI
+  //      backend and set 420s off that. 180s was below an already-measured
+  //      duration for similar work.
+  //   2. It failed in practice - run 30752527569 (issue #269) died at
+  //      exactly 180000ms having produced nothing.
+  // spec-agent.yml's step budget is 15 min (900s), so this leaves ample
+  // headroom for node startup and the file write afterwards.
+  ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 420_000 }));
 } catch (err) {
   console.error(err.message);
   process.exit(1);

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -173,8 +173,10 @@ try {
   //      duration for similar work.
   //   2. It failed in practice - run 30752527569 (issue #269) died at
   //      exactly 180000ms having produced nothing.
-  // spec-agent.yml's step budget is 15 min (900s), so this leaves ample
-  // headroom for node startup and the file write afterwards.
+  // spec-agent.yml caps this step at 8m, above this 420s, so the error above
+  // wins over a silent step kill. Note the job also runs verify-spec.mjs
+  // (another 420s), so raising either number means re-checking that job's
+  // 22m cap still contains both plus setup - see that file's comments.
   ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 420_000 }));
 } catch (err) {
   console.error(err.message);

--- a/scripts/ai-sdlc/verify-spec.mjs
+++ b/scripts/ai-sdlc/verify-spec.mjs
@@ -105,7 +105,8 @@ console.log(
 let text, stopReason;
 try {
   // 420s: this prompt (spec + up to 15 source files) is larger than
-  // generate-spec's, so it needs more than generate-spec's 180s. Measured
+  // generate-spec's, which is also 420s now (it was 180s when this comment
+  // was first written, and that number turned out to be too small). Measured
   // empirically on the CLI backend with a ~60K-char verify prompt (spec +
   // 4 source files): 283.9s to complete via callClaude's fixed --tools=
   // path (single turn, real corrected output, not a truncation). 420s


### PR DESCRIPTION
`generate-spec.mjs` used **180s** while its sibling `verify-spec.mjs` uses **420s** — and verify-spec's own comment records measuring **283.9s** for a comparable call on the same CLI backend. So generate-spec's budget sat *below an already-measured duration* for similar work.

It also grew without the budget being revisited:
- PR #240 added the BFS source-tree scanner
- PR #260 added the ~10KB ADR index

Run [30752527569](https://github.com/apex-bridge/bugspotter/actions/runs/30752527569) then died at exactly `180000ms` having produced nothing. Same failure class already fixed in `generate-impl.mjs` (600s → 780s, PR #275) — this was the last sibling that never got it.

**`generate-adr.mjs` had the same staleness, for a compounding reason.** Its 120s was justified by a comment arguing the prompt is *"much smaller than generate-spec.mjs's (no TEMPLATE.md, no source-file tree)"* and therefore needs less than that script's 180s. Both halves of that argument are now false: PR #273 added the same ADR index to it, and generate-spec's 180s was itself wrong. Raised to **300s** — proportionate to its half-size `maxTokens` (2048 vs 4096), not a flat copy of 420s, since output tokens dominate wall time.

Resulting per-call budgets:

| Script | Before | After | maxTokens |
|---|---|---|---|
| `generate-spec.mjs` | 180s | **420s** | 4096 |
| `generate-adr.mjs` | 120s | **300s** | 2048 |
| `verify-spec.mjs` | 420s | 420s (unchanged) | 8192 |
| `generate-impl.mjs` | 780s | 780s (unchanged) | 16384 |

59/59 script tests pass; prettier and eslint clean.

**Note on accounting:** filed against its own issue rather than tagged to #269, which merely surfaced it. This is a general pipeline defect affecting every future spec, and tagging it to #269 would inflate that issue's rework-chain the same way #275 inflated #237's — see `metrics-design.md`'s 2026-08-02 note on why that distinction matters.

---

## Also in this PR (found while fixing the above, same failure class)

**Scope note:** this started as the timeout raise for #279. The review pass on that commit turned up two more failures in the same "a paid 9-13 minute run dies with nothing to show for it" class - one introduced by this PR's own first commit (the job cap), one pre-existing (the over-cap deadlock). Kept together rather than split: same class, same budget accounting, all CI-only scripts with no runtime surface. Title and this section updated to say so, per review.

**Workflow time budgets (`spec-agent.yml`, `adr-agent.yml`).** Raising `generate-spec.mjs` to 420s put two sequential LLM calls in one job - generate-spec (420s) + verify-spec (420s) = 840s - inside spec-agent's 900s job cap, with no step caps and ~60-100s of setup. The failure mode is a job *cancellation*, which specifically defeats `verify-spec.mjs`'s design of exiting 0 on error so a verifier hiccup preserves the already-generated spec: a cancel discards it uncommitted after both calls were paid for. Step caps are set deliberately *above* each script's own timeout, so the script's own error message wins over a silent step kill.

| Workflow | Step cap | Script timeout | Job cap |
|---|---|---|---|
| `spec-agent.yml` | 8m x 2 | 420s + 420s | 15m -> **22m** |
| `adr-agent.yml` | **6m** | 300s | 15m |
| `impl-agent.yml` | 18m | 780s | 25m (both unchanged) |

**Over-cap spec deadlock (`generate-impl.mjs`).** Two individually-correct rules collide: the prompt tells the model never to return a TRUNCATED file (returning one silently deletes everything past the 1000-line cap), while `check-impl-scope.mjs` hard-fails when a declared file is not written. A spec declaring an over-cap file therefore cannot succeed - the model correctly refuses, the gate correctly fails, a re-run fails identically. 27 files in `packages/backend` alone are over the cap. Now detected before the model call: milliseconds instead of a paid run that cannot succeed.

**Boundary fix on that guard** (CodeRabbit, 67debfd). Splitting on newlines counts the empty entry after a file's trailing newline, so a file of exactly 1000 lines measured 1001 and was refused as "larger than the cap". Harmless while over-cap only meant a TRUNCATED annotation; a false rejection once it became a hard exit. Adds `generate-impl.test.mjs`, which spawns the real script against 1000- and 1001-line fixtures with a fake `claude` ahead on PATH so nothing reaches the API; 3 of its 4 cases fail against the pre-fix code.

Also corrected three comments that asserted false premises about budgets they do not control (both generate scripts claimed a 15-minute step cap that did not exist; `verify-spec.mjs` still reasoned from generate-spec's old 180s).

63/63 script tests pass; prettier, eslint and actionlint clean.

Closes #279
