### PR TITLE
fix(ai-sdlc): log CLI turn count, wall time and token usage

### DIFF
--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -91,6 +91,53 @@ async function callViaApi({ prompt, maxTokens, timeoutMs, model }) {
   return { text: data.content[0].text, stopReason: data.stop_reason };
 }
 
+// The CLI's `--output-format json` envelope carries operational fields this
+// module used to discard: turn count, wall time, and token usage. Without them
+// a slow call is a black box. impl-agent run 30761885485 spent its entire 780s
+// timeout on a response the script itself had measured at ~6594 output tokens,
+// and nothing in the log could distinguish one slow turn from a multi-turn loop.
+//
+// `num_turns` is the load-bearing field. callViaCli passes `--tools=` precisely
+// to get a single-shot completion; a call reporting more than one turn means
+// that flag is not holding and an agentic loop is running, which is a bug with
+// a fix rather than latency to wait out. Surfaced as a warning so it cannot be
+// missed in a CI log.
+//
+// Every field is read defensively: the CLI's envelope is not a contract this
+// repo controls, and telemetry must never be able to fail a run that produced
+// a usable result.
+export function logCliTelemetry(data, log = console) {
+  const turns = typeof data?.num_turns === 'number' ? data.num_turns : null;
+  const parts = [];
+  if (turns !== null) {
+    parts.push(`turns=${turns}`);
+  }
+  if (typeof data?.duration_ms === 'number') {
+    parts.push(`wall=${Math.round(data.duration_ms / 1000)}s`);
+  }
+  if (typeof data?.duration_api_ms === 'number') {
+    parts.push(`api=${Math.round(data.duration_api_ms / 1000)}s`);
+  }
+  if (typeof data?.usage?.input_tokens === 'number') {
+    parts.push(`in=${data.usage.input_tokens}`);
+  }
+  if (typeof data?.usage?.output_tokens === 'number') {
+    parts.push(`out=${data.usage.output_tokens}`);
+  }
+  if (typeof data?.total_cost_usd === 'number') {
+    parts.push(`cost=$${data.total_cost_usd.toFixed(4)}`);
+  }
+
+  log.log(`claude CLI: ${parts.length > 0 ? parts.join(' ') : 'no telemetry fields in response'}`);
+
+  if (turns !== null && turns > 1) {
+    log.warn(
+      `claude CLI reported ${turns} turns for a call made with --tools=, which should be ` +
+        `single-shot. Tool disabling is not holding and this call ran an agentic loop.`
+    );
+  }
+}
+
 // No `maxTokens` param here (deliberately) — the CLI has no per-call
 // output-token cap to forward it to. See the module header comment.
 async function callViaCli({ prompt, timeoutMs, model }) {
@@ -189,6 +236,7 @@ async function callViaCli({ prompt, timeoutMs, model }) {
         reject(new Error(`Unexpected claude CLI response shape: ${JSON.stringify(data)}`));
         return;
       }
+      logCliTelemetry(data);
       resolve({ text: data.result, stopReason: data.stop_reason });
     });
 

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -69,7 +69,68 @@ process.env.LLM_BACKEND = 'cli';
 process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
 process.env.PATH = `${DIR}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`;
 
-const { callClaude } = await import('./llm-client.mjs');
+const { callClaude, logCliTelemetry } = await import('./llm-client.mjs');
+
+// Collects what logCliTelemetry emits so the assertions below read the real
+// output rather than trusting the function was called.
+function captureLog() {
+  const lines = { log: [], warn: [] };
+  return {
+    lines,
+    logger: {
+      log: (m) => lines.log.push(m),
+      warn: (m) => lines.warn.push(m),
+    },
+  };
+}
+
+test('logCliTelemetry surfaces turns, wall time, tokens and cost from the CLI envelope', () => {
+  const { lines, logger } = captureLog();
+
+  logCliTelemetry(
+    {
+      num_turns: 1,
+      duration_ms: 474_000,
+      duration_api_ms: 470_500,
+      usage: { input_tokens: 21_400, output_tokens: 6594 },
+      total_cost_usd: 0.1234,
+    },
+    logger
+  );
+
+  assert.equal(lines.log.length, 1);
+  assert.match(lines.log[0], /turns=1/);
+  assert.match(lines.log[0], /wall=474s/);
+  assert.match(lines.log[0], /api=471s/);
+  assert.match(lines.log[0], /in=21400/);
+  assert.match(lines.log[0], /out=6594/);
+  assert.match(lines.log[0], /cost=\$0\.1234/);
+  assert.equal(lines.warn.length, 0, 'a single-turn call must not warn');
+});
+
+test('logCliTelemetry warns when the CLI reports more than one turn despite --tools=', () => {
+  const { lines, logger } = captureLog();
+
+  logCliTelemetry({ num_turns: 50, duration_ms: 330_000 }, logger);
+
+  assert.equal(lines.warn.length, 1);
+  assert.match(lines.warn[0], /50 turns/);
+  assert.match(lines.warn[0], /--tools=/);
+});
+
+test('logCliTelemetry tolerates an envelope carrying no telemetry fields', () => {
+  const { lines, logger } = captureLog();
+
+  // The CLI's JSON shape is not a contract this repo controls. Telemetry must
+  // never throw and fail a run that already produced a usable result.
+  assert.doesNotThrow(() => logCliTelemetry({ result: 'ok' }, logger));
+  assert.doesNotThrow(() => logCliTelemetry(undefined, logger));
+
+  assert.equal(lines.warn.length, 0);
+  for (const line of lines.log) {
+    assert.match(line, /no telemetry fields/);
+  }
+});
 
 test('callViaCli strips ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN from the spawned child env, keeps other vars', async () => {
   process.env.ANTHROPIC_API_KEY = 'sk-ant-leaked-key';


### PR DESCRIPTION
`callViaCli` got the CLI's full `--output-format json` envelope and kept only `result` and `stop_reason`. Turn count, duration and token usage were thrown away, which made the pipeline's slowest step opaque.

Concretely: impl-agent run 30761885485 spent its entire 780s timeout on a response `generate-impl.mjs` had itself measured at ~6594 output tokens. Nothing in the log could tell whether that was one slow turn or a multi-turn loop.

`num_turns` is the field that matters. This module's header records the empirical basis for passing `--tools=`: 50 turns and 5m30s with `--allowedTools ""`, versus 1-2 turns "well under a minute" with `--tools=`. The two #269 impl runs took 7m54s and over 13m, well outside that envelope. Whether the flag still holds under a large prompt is the open question, and it was unanswerable from a CI log until now.

A call reporting more than one turn warns explicitly, since that is a bug with a fix rather than latency to wait out.

Every field is read defensively. The CLI envelope is not a contract this repo controls, and telemetry must never fail a run that already produced a usable result. Tests cover the populated case, the multi-turn warning, and an envelope with no telemetry fields at all.

`node --test scripts/ai-sdlc/*.test.mjs`: 66 pass (63 before). Prettier and ESLint clean.

Refs #269