### PR TITLE
feat(intelligence): distinguish 503 llm_unavailable from other 5xx

### DIFF
--- a/packages/backend/src/services/intelligence/intelligence-client.ts
+++ b/packages/backend/src/services/intelligence/intelligence-client.ts
@@ -500,7 +500,9 @@ export function mapIntelligenceError(
           : '30',
         10
       );
-      const retryAfter = Math.min(Number.isNaN(raw) ? 30 : raw, 120);
+      // Clamp both ends: a malformed negative header would otherwise survive as
+      // a negative duration, and this field exists to be turned into a delay.
+      const retryAfter = Math.max(0, Math.min(Number.isNaN(raw) ? 30 : raw, 120));
       return new IntelligenceError(
         `Intelligence ${method} ${path} failed: ${detail}`,
         'llm_unavailable',

--- a/packages/backend/src/services/intelligence/intelligence-client.ts
+++ b/packages/backend/src/services/intelligence/intelligence-client.ts
@@ -310,14 +310,11 @@ export class IntelligenceClient {
       return await this.circuitBreaker.execute(
         async () => this.requestWithRetry<T>(method, path, data, extraConfig),
         // Only trip the breaker on server/network/rate-limit errors — client errors (4xx)
-        // indicate the service is healthy, just rejecting our input.
-        // Note: requestWithRetry wraps errors into IntelligenceError, so we check that.
-        (error) => {
-          if (error instanceof IntelligenceError) {
-            return error.code !== 'client_error';
-          }
-          return true;
-        }
+        // indicate the service is healthy, just rejecting our input, and
+        // `llm_unavailable` means the service is healthy but its LLM backend is
+        // transiently down. Note: requestWithRetry wraps errors into
+        // IntelligenceError, so the predicate checks that.
+        shouldTripCircuitBreaker
       );
     } catch (error) {
       // Re-throw IntelligenceError as-is — it's already wrapped
@@ -425,44 +422,7 @@ export class IntelligenceClient {
   }
 
   private wrapError(error: unknown, method: string, path: string): IntelligenceError {
-    if (error instanceof CircuitOpenError) {
-      return new IntelligenceError(error.message, 'circuit_open', 503);
-    }
-
-    if (axios.isAxiosError(error)) {
-      const status = error.response?.status ?? 0;
-      const rawDetail =
-        typeof error.response?.data === 'object' && error.response?.data !== null
-          ? (error.response.data as Record<string, unknown>).detail
-          : undefined;
-      // detail could be a string or an object — coerce to string safely
-      const detail =
-        typeof rawDetail === 'string'
-          ? rawDetail
-          : rawDetail !== undefined
-            ? JSON.stringify(rawDetail)
-            : error.message;
-
-      const code =
-        status === 0
-          ? 'network_error'
-          : status === 429
-            ? 'rate_limit_error'
-            : status >= 500
-              ? 'server_error'
-              : 'client_error';
-      return new IntelligenceError(
-        `Intelligence ${method} ${path} failed: ${detail}`,
-        code,
-        status
-      );
-    }
-
-    return new IntelligenceError(
-      `Intelligence ${method} ${path} failed: ${error instanceof Error ? error.message : String(error)}`,
-      'unknown',
-      0
-    );
+    return mapIntelligenceError(error, method, path);
   }
 }
 
@@ -471,12 +431,113 @@ export class IntelligenceClient {
  * Used to distinguish intelligence failures from other errors in handlers.
  */
 export class IntelligenceError extends Error {
+  /**
+   * Seconds the upstream asked us to wait, parsed from `Retry-After`. Metadata
+   * only: no caller reads it yet. `IntelligenceClient` is shared by a queue
+   * worker that could absorb the wait and by request-path routes that cannot,
+   * so honouring the hint belongs to the caller, not to the client.
+   */
+  public readonly retryAfter?: number;
+  /**
+   * Whether this error should count against the circuit breaker. Left undefined
+   * by every error that does not opt out, so `shouldTripCircuitBreaker` falls
+   * back to the code-based default rather than needing a per-code string check.
+   */
+  public readonly tripCircuitBreaker?: boolean;
+
   constructor(
     message: string,
     public readonly code: string,
-    public readonly statusCode: number
+    public readonly statusCode: number,
+    options?: { retryAfter?: number; tripCircuitBreaker?: boolean }
   ) {
     super(message);
     this.name = 'IntelligenceError';
+    this.retryAfter = options?.retryAfter;
+    this.tripCircuitBreaker = options?.tripCircuitBreaker;
   }
+}
+
+/**
+ * Maps an arbitrary thrown value onto an `IntelligenceError`.
+ *
+ * Exported (and taking `method`/`path` explicitly, which is how the message
+ * prefix is built) so unit tests can drive the mapping directly instead of
+ * staging a full retry sequence through a public client method.
+ */
+export function mapIntelligenceError(
+  error: unknown,
+  method: string,
+  path: string
+): IntelligenceError {
+  if (error instanceof CircuitOpenError) {
+    return new IntelligenceError(error.message, 'circuit_open', 503);
+  }
+
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status ?? 0;
+    const body =
+      typeof error.response?.data === 'object' && error.response?.data !== null
+        ? (error.response.data as Record<string, unknown>)
+        : undefined;
+    const rawDetail = body?.detail;
+    // detail could be a string or an object — coerce to string safely
+    const detail =
+      typeof rawDetail === 'string'
+        ? rawDetail
+        : rawDetail !== undefined
+          ? JSON.stringify(rawDetail)
+          : error.message;
+
+    // A 503 carrying code `llm_unavailable` is the intelligence service telling
+    // us its LLM backend is transiently down, not that the service itself is
+    // broken. Treating it like any other 5xx trips the breaker and degrades
+    // every intelligence feature for what is usually a cold start.
+    if (status === 503 && body?.code === 'llm_unavailable') {
+      const raw = parseInt(
+        typeof error.response?.headers?.['retry-after'] === 'string'
+          ? error.response.headers['retry-after']
+          : '30',
+        10
+      );
+      const retryAfter = Math.min(Number.isNaN(raw) ? 30 : raw, 120);
+      return new IntelligenceError(
+        `Intelligence ${method} ${path} failed: ${detail}`,
+        'llm_unavailable',
+        503,
+        { retryAfter, tripCircuitBreaker: false }
+      );
+    }
+
+    const code =
+      status === 0
+        ? 'network_error'
+        : status === 429
+          ? 'rate_limit_error'
+          : status >= 500
+            ? 'server_error'
+            : 'client_error';
+    return new IntelligenceError(`Intelligence ${method} ${path} failed: ${detail}`, code, status);
+  }
+
+  return new IntelligenceError(
+    `Intelligence ${method} ${path} failed: ${error instanceof Error ? error.message : String(error)}`,
+    'unknown',
+    0
+  );
+}
+
+/**
+ * Whether an error should count as a circuit-breaker failure.
+ *
+ * Takes `unknown` rather than `IntelligenceError` because the predicate this
+ * replaces also had to handle values that were never wrapped, which it counted
+ * as failures. Reads the opt-out flag first so no per-code string check is
+ * needed here as new recoverable conditions are added.
+ */
+export function shouldTripCircuitBreaker(error: unknown): boolean {
+  if (error instanceof IntelligenceError) {
+    return error.tripCircuitBreaker ?? error.code !== 'client_error';
+  }
+  return true;
 }

--- a/packages/backend/tests/services/intelligence/intelligence-client.test.ts
+++ b/packages/backend/tests/services/intelligence/intelligence-client.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   IntelligenceClient,
   IntelligenceError,
+  mapIntelligenceError,
+  shouldTripCircuitBreaker,
 } from '../../../src/services/intelligence/intelligence-client.js';
 import type { IntelligenceClientConfig } from '../../../src/services/intelligence/types.js';
 
@@ -29,19 +31,23 @@ vi.mock('axios', async () => {
   };
 });
 
-function createAxiosError(
-  status: number,
-  detail?: string
-): Error & { isAxiosError: boolean; response?: unknown } {
+// Takes an object rather than positional args so a test can set both a body
+// `code` and response headers, which the 503 `llm_unavailable` mapping reads.
+function createAxiosError({
+  status,
+  data = {},
+  headers = {},
+}: {
+  status: number;
+  data?: unknown;
+  headers?: Record<string, string>;
+}): Error & { isAxiosError: boolean; response?: unknown } {
   const error = new Error(`Request failed with status ${status}`) as Error & {
     isAxiosError: boolean;
-    response?: { status: number; data: unknown };
+    response?: { status: number; data: unknown; headers: Record<string, string> };
   };
   error.isAxiosError = true;
-  error.response = {
-    status,
-    data: detail ? { detail } : {},
-  };
+  error.response = { status, data, headers };
   return error;
 }
 
@@ -83,7 +89,9 @@ describe('IntelligenceClient', () => {
 
   describe('wrapError classification', () => {
     it('should classify 5xx as server_error', async () => {
-      mockAxiosInstance.request.mockRejectedValue(createAxiosError(500, 'Internal error'));
+      mockAxiosInstance.request.mockRejectedValue(
+        createAxiosError({ status: 500, data: { detail: 'Internal error' } })
+      );
 
       await expect(client.analyzeBug({ bug_id: '1', title: 'test' })).rejects.toThrow(
         IntelligenceError
@@ -99,7 +107,9 @@ describe('IntelligenceClient', () => {
     });
 
     it('should classify 4xx as client_error', async () => {
-      mockAxiosInstance.request.mockRejectedValue(createAxiosError(404, 'Not found'));
+      mockAxiosInstance.request.mockRejectedValue(
+        createAxiosError({ status: 404, data: { detail: 'Not found' } })
+      );
 
       try {
         await client.analyzeBug({ bug_id: '1', title: 'test' });
@@ -111,7 +121,9 @@ describe('IntelligenceClient', () => {
     });
 
     it('should classify 429 as rate_limit_error', async () => {
-      mockAxiosInstance.request.mockRejectedValue(createAxiosError(429, 'Rate limited'));
+      mockAxiosInstance.request.mockRejectedValue(
+        createAxiosError({ status: 429, data: { detail: 'Rate limited' } })
+      );
 
       try {
         await client.analyzeBug({ bug_id: '1', title: 'test' });
@@ -135,7 +147,7 @@ describe('IntelligenceClient', () => {
     });
 
     it('should handle object detail in error response', async () => {
-      const error = createAxiosError(400);
+      const error = createAxiosError({ status: 400 });
       (error.response as { data: unknown }).data = {
         detail: { field: 'title', reason: 'required' },
       };
@@ -152,10 +164,90 @@ describe('IntelligenceClient', () => {
     });
   });
 
+  describe('503 llm_unavailable mapping', () => {
+    const map = (e: unknown) => mapIntelligenceError(e, 'POST', '/analyze');
+
+    const llmUnavailable = (retryAfterHeader?: string) =>
+      createAxiosError({
+        status: 503,
+        data: { code: 'llm_unavailable', detail: 'LLM backend unavailable' },
+        headers: retryAfterHeader === undefined ? {} : { 'retry-after': retryAfterHeader },
+      });
+
+    it('maps 503 + llm_unavailable to a distinct code, not server_error', () => {
+      expect(map(llmUnavailable('30')).code).toBe('llm_unavailable');
+    });
+
+    it('keeps the same message prefix the generic >=500 branch uses', () => {
+      expect(map(llmUnavailable('30')).message).toBe(
+        'Intelligence POST /analyze failed: LLM backend unavailable'
+      );
+    });
+
+    it('reads Retry-After, caps it at 120 s, and defaults to 30 s', () => {
+      expect(map(llmUnavailable('45')).retryAfter).toBe(45);
+      expect(map(llmUnavailable('999')).retryAfter).toBe(120);
+      expect(map(llmUnavailable()).retryAfter).toBe(30);
+      expect(map(llmUnavailable('not-a-number')).retryAfter).toBe(30);
+    });
+
+    it('leaves a plain 500 mapping exactly as before', () => {
+      const err = map(createAxiosError({ status: 500, data: { detail: 'Internal error' } }));
+      expect(err.code).toBe('server_error');
+      expect(err.statusCode).toBe(500);
+      expect(err.retryAfter).toBeUndefined();
+      expect(err.tripCircuitBreaker).toBeUndefined();
+    });
+
+    it('falls a 503 without the llm_unavailable body code through to server_error', () => {
+      const err = map(createAxiosError({ status: 503, data: { detail: 'Service unavailable' } }));
+      expect(err.code).toBe('server_error');
+      expect(err.retryAfter).toBeUndefined();
+    });
+
+    it('does not treat a non-object body as carrying the code', () => {
+      // Upstream error pages arrive as an HTML string, not an object. Reading
+      // `.code` off it must not throw and must not match.
+      const err = map(createAxiosError({ status: 503, data: '<html>502 Bad Gateway</html>' }));
+      expect(err.code).toBe('server_error');
+    });
+  });
+
+  describe('shouldTripCircuitBreaker', () => {
+    const map = (e: unknown) => mapIntelligenceError(e, 'POST', '/analyze');
+
+    it('does not trip for llm_unavailable, which carries the opt-out flag', () => {
+      const err = map(
+        createAxiosError({
+          status: 503,
+          data: { code: 'llm_unavailable', detail: 'LLM backend unavailable' },
+          headers: { 'retry-after': '30' },
+        })
+      );
+      expect(err.tripCircuitBreaker).toBe(false);
+      expect(shouldTripCircuitBreaker(err)).toBe(false);
+    });
+
+    // The three below pin the behaviour of the predicate that was extracted
+    // from the inline lambda, so the extraction cannot silently change it.
+    it('does not trip for client errors', () => {
+      expect(shouldTripCircuitBreaker(map(createAxiosError({ status: 404 })))).toBe(false);
+    });
+
+    it('trips for server errors', () => {
+      expect(shouldTripCircuitBreaker(map(createAxiosError({ status: 500 })))).toBe(true);
+    });
+
+    it('trips for values that were never wrapped into an IntelligenceError', () => {
+      expect(shouldTripCircuitBreaker(new Error('boom'))).toBe(true);
+      expect(shouldTripCircuitBreaker(undefined)).toBe(true);
+    });
+  });
+
   describe('retry behavior', () => {
     it('should retry on 5xx errors', async () => {
       mockAxiosInstance.request
-        .mockRejectedValueOnce(createAxiosError(502, 'Bad gateway'))
+        .mockRejectedValueOnce(createAxiosError({ status: 502, data: { detail: 'Bad gateway' } }))
         .mockResolvedValueOnce({ status: 200, data: { bug_id: '1' } });
 
       const result = await client.analyzeBug({ bug_id: '1', title: 'test' });
@@ -165,7 +257,7 @@ describe('IntelligenceClient', () => {
 
     it('should retry on 429 errors', async () => {
       mockAxiosInstance.request
-        .mockRejectedValueOnce(createAxiosError(429, 'Rate limited'))
+        .mockRejectedValueOnce(createAxiosError({ status: 429, data: { detail: 'Rate limited' } }))
         .mockResolvedValueOnce({ status: 200, data: { bug_id: '1' } });
 
       const result = await client.analyzeBug({ bug_id: '1', title: 'test' });
@@ -174,7 +266,9 @@ describe('IntelligenceClient', () => {
     });
 
     it('should not retry on 4xx client errors', async () => {
-      mockAxiosInstance.request.mockRejectedValue(createAxiosError(400, 'Bad request'));
+      mockAxiosInstance.request.mockRejectedValue(
+        createAxiosError({ status: 400, data: { detail: 'Bad request' } })
+      );
 
       await expect(client.analyzeBug({ bug_id: '1', title: 'test' })).rejects.toThrow(
         IntelligenceError
@@ -195,7 +289,9 @@ describe('IntelligenceClient', () => {
 
     it('should respect maxRetries limit', async () => {
       // maxRetries=2 means initial + 2 retries = 3 total attempts
-      mockAxiosInstance.request.mockRejectedValue(createAxiosError(500, 'Server error'));
+      mockAxiosInstance.request.mockRejectedValue(
+        createAxiosError({ status: 500, data: { detail: 'Server error' } })
+      );
 
       await expect(client.analyzeBug({ bug_id: '1', title: 'test' })).rejects.toThrow(
         IntelligenceError
@@ -223,7 +319,9 @@ describe('IntelligenceClient', () => {
 
   describe('circuit breaker integration', () => {
     it('should not trip circuit on 4xx errors', async () => {
-      mockAxiosInstance.request.mockRejectedValue(createAxiosError(400, 'Bad request'));
+      mockAxiosInstance.request.mockRejectedValue(
+        createAxiosError({ status: 400, data: { detail: 'Bad request' } })
+      );
 
       // Make many 4xx calls — circuit should NOT open
       for (let i = 0; i < 10; i++) {
@@ -267,7 +365,9 @@ describe('IntelligenceClient', () => {
     });
 
     it('propagates an IntelligenceError on upstream failure', async () => {
-      mockAxiosInstance.request.mockRejectedValue(createAxiosError(503, 'unavailable'));
+      mockAxiosInstance.request.mockRejectedValue(
+        createAxiosError({ status: 503, data: { detail: 'unavailable' } })
+      );
       await expect(client.getServiceStatus()).rejects.toThrow(IntelligenceError);
     });
   });

--- a/packages/backend/tests/services/intelligence/intelligence-client.test.ts
+++ b/packages/backend/tests/services/intelligence/intelligence-client.test.ts
@@ -191,6 +191,11 @@ describe('IntelligenceClient', () => {
       expect(map(llmUnavailable('not-a-number')).retryAfter).toBe(30);
     });
 
+    it('floors a negative Retry-After at 0 rather than passing it through', () => {
+      expect(map(llmUnavailable('-5')).retryAfter).toBe(0);
+      expect(map(llmUnavailable('-999')).retryAfter).toBe(0);
+    });
+
     it('leaves a plain 500 mapping exactly as before', () => {
       const err = map(createAxiosError({ status: 500, data: { detail: 'Internal error' } }));
       expect(err.code).toBe('server_error');


### PR DESCRIPTION
Implements spec `docs/specs/0269-intelligence-client-ts-distinguish-503-l.md` by hand, after the impl-agent failed twice on it (run 30761439985 wrote only the test file while its summary described a two-file change; run 30761885485 hit the 780s CLI timeout).

## What

`wrapError` mapped every status `>= 500` to `'server_error'`, so a transient LLM outage tripped the circuit breaker as hard as a real service defect and degraded every intelligence feature through a routine cold start.

A 503 carrying body code `llm_unavailable` now maps to its own code, with `retryAfter` parsed from `Retry-After` (default 30 s, capped at 120 s) and `tripCircuitBreaker: false`.

`mapIntelligenceError` and `shouldTripCircuitBreaker` are extracted as exported functions so tests can drive them directly rather than staging a full retry sequence through a public method. `wrapError` stays as a thin delegation, so no internal call site changes.

`retryAfter` is metadata only, per the spec's Out of scope. `IntelligenceClient` is shared by `queue/workers/intelligence-worker.ts`, which could absorb a 30-120 s wait, and by `api/routes/sdk-similar.ts` and friends, which cannot. Honouring the hint belongs to the caller. The follow-up for the worker has independent motivation: queue backoff is exponential 1s/2s/4s over 3 attempts, so a `Retry-After: 30` outage exhausts every attempt in about 7 seconds today.

## Verification

- `pnpm --filter @bugspotter/backend test:unit`: **2976 pass** (2966 before, 10 new).
- The new tests exercise the branch rather than documenting it: disabling the 503 condition fails exactly 3 of them. The message-prefix test correctly still passes, since the generic branch produces the same prefix.
- Existing coverage acts as the regression check. `createAxiosError` converted from positional to object form at all 10 call sites, and the pre-existing "propagates an IntelligenceError on upstream failure" test sends a 503 *without* the body code, so it pins the fall-through path.
- ESLint and Prettier clean.

## One thing the spec got wrong

Spec 0269's Verification block says to run `pnpm --filter @bugspotter/backend typecheck`. **That command cannot pass**: it reports 184 errors on clean `main`, in unrelated test files. This change adds zero to that count (184 before, 184 after), but the spec's stated verification step was unsatisfiable as written and nobody caught it because nobody ran it.

Refs #269
