### PR TITLE
chore(backend): gate CI on src typecheck, split test backlog out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,23 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
+      # Required by the typecheck below: packages/backend imports internal
+      # workspace packages (@bugspotter/types, @bugspotter/utils, ...) whose
+      # package.json points `main`/`types` at a dist/ that does not exist
+      # until they are built, and backend's tsconfig has no `paths` mapping
+      # to resolve them from source instead.
+      - name: Build workspace packages
+        run: pnpm build
+
+      # Backend src is clean today; this makes that enforced rather than
+      # incidental. Nothing ran `typecheck` before, `pnpm run lint`'s glob
+      # covers packages/*/src but not packages/*/tests, and vitest transpiles
+      # without checking - so a type error in backend source would have
+      # reached main unnoticed. Scoped to src: the test-side backlog is
+      # tracked by the non-gating `typecheck:tests`.
+      - name: Typecheck backend src
+        run: pnpm --filter @bugspotter/backend typecheck
+
       - name: Run AI-SDLC script tests
         run: node --test scripts/ai-sdlc/*.test.mjs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ Flags that depend on mode are declared in `packages/backend/src/config.ts`.
 ```bash
 ./dev.sh start                                   # bring up the full stack
 pnpm --filter @bugspotter/backend dev            # API on :3000 (single service, no full stack)
-pnpm --filter @bugspotter/backend typecheck      # src-only typecheck
+pnpm --filter @bugspotter/backend typecheck      # src-only typecheck (gates CI)
+pnpm --filter @bugspotter/backend typecheck:tests # tests too; ~184 known errors, not gating
 pnpm --filter @bugspotter/backend test:unit      # no docker needed
 pnpm --filter @bugspotter/backend migrate        # run DB migrations
 pnpm --filter @bugspotter/admin dev              # admin UI on :5173

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,7 +29,8 @@
     "test:integration:watch": "vitest watch --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:cleanup": "bash scripts/cleanup-test-data.sh",
-    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json"
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
+    "typecheck:tests": "tsc --noEmit --project tsconfig.typecheck.tests.json"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.907.0",

--- a/packages/backend/tsconfig.typecheck.json
+++ b/packages/backend/tsconfig.typecheck.json
@@ -5,6 +5,17 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist", "coverage"]
+  // src only, matching tsconfig.json's own `exclude: [..., "tests"]` and the
+  // description in CLAUDE.md. This config previously included tests/**/* as
+  // well, but nothing ever ran it: no workflow invokes `typecheck`, `pnpm run
+  // lint`'s glob covers packages/*/src (not packages/*/tests), and vitest
+  // transpiles TypeScript without checking it. 184 type errors accumulated in
+  // tests behind three green gates.
+  //
+  // src is clean today, so gating on it in CI costs nothing and makes that
+  // state enforced rather than incidental. The test-side debt is real and is
+  // tracked separately via `typecheck:tests` (tsconfig.typecheck.tests.json),
+  // which is deliberately NOT gating until it reaches zero.
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "coverage", "tests"]
 }

--- a/packages/backend/tsconfig.typecheck.tests.json
+++ b/packages/backend/tsconfig.typecheck.tests.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  // Test-side typecheck. NOT wired into CI: it currently reports ~184 errors,
+  // all in tests/ (src is clean). Run it locally with
+  // `pnpm --filter @bugspotter/backend typecheck:tests`.
+  //
+  // The errors cluster into a few root causes rather than 184 independent
+  // problems: partial `vi.fn()` mocks cast to full class types (TS2345),
+  // fixture drift where BugReport gained organization_id and duplicate_of but
+  // literals were never updated (TS2739/TS2741/TS2353), and a mechanical tail
+  // of unused declarations, implicit any params and relative imports missing
+  // a .js extension. Fixing them via shared fixture/mock factories is what
+  // stops the drift recurring; patching each literal only resets the clock.
+  //
+  // When this reaches zero, fold tests/**/* back into tsconfig.typecheck.json
+  // and delete this file, so one gating command covers both.
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", "coverage"]
+}


### PR DESCRIPTION
## Why

`pnpm --filter @bugspotter/backend typecheck` reports **184 errors on clean `main`**, which is how spec 0269 shipped a Verification step that could not pass. Three overlapping blind spots explain it:

- **No workflow invokes `typecheck`.** The script exists in `package.json` and has never run in CI.
- **`pnpm run lint`'s glob is `packages/*/src/**`**, plus `apps/*/src` and `apps/*/tests`. `packages/*/tests` is not covered.
- **Vitest transpiles TypeScript without checking it**, so a type-wrong test still runs green.

Backend tests are therefore unlinted, untypechecked, and executed by a runner that discards types. `tsconfig.typecheck.json` included `tests/**/*`, but since nothing ran it, errors accumulated freely.

## What this does

**`src/` is clean: 0 of the 184 are in source.** But that is luck, not a guarantee - a type error introduced into backend source today reaches `main` unnoticed, because the only thing that would catch it has never run.

This scopes `tsconfig.typecheck.json` to `src` and wires it into the Lint job. It passes today, so gating costs nothing and converts an incidental clean state into an enforced one. The narrowing also realigns the config with `tsconfig.json`'s own `exclude: [..., "tests"]` and with `CLAUDE.md`, which already described this as "src-only typecheck".

The test-side debt is **not** swept away. `typecheck:tests` and `tsconfig.typecheck.tests.json` keep it runnable, with the root causes recorded in the config so the next person doesn't re-derive them:

- 54 TS2345, mostly partial `vi.fn()` mocks cast to full class types
- 67 TS2739/TS2741/TS2353, fixture drift after `BugReport` gained `organization_id` and `duplicate_of` (27 mentions across 10+ files)
- ~25 mechanical: unused declarations, implicit `any` params, relative imports missing `.js`

They cluster into a few shared-factory fixes rather than 184 independent problems. When it reaches zero, the two configs fold back together and this file is deleted.

## The build step

CI needs `pnpm build` before typecheck: backend imports workspace packages whose `main`/`types` point at a `dist/` that does not exist until built, and its tsconfig has no `paths` mapping to resolve them from source. Same constraint `impl-agent.yml` already documents.

## Verified

- `pnpm --filter @bugspotter/backend typecheck` exits 0
- `pnpm --filter @bugspotter/backend typecheck:tests` reports 184
- `actionlint` clean on `ci.yml`
- Prettier clean

Refs #269