### PR TITLE
fix: unblock single-box hosting (S3 endpoint, exporters, Grafana dashboards)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,23 @@ jobs:
           REDIS_PASSWORD: test
           GRAFANA_ADMIN_PASSWORD: test
 
+      - name: Validate compose with monitoring + yandex overrides
+        # The production deploy applies all three files, so the merged result
+        # is what actually runs there - validate that combination too.
+        run: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml -f docker-compose.yandex.yml config --quiet
+        env:
+          JWT_SECRET: test
+          CORS_ORIGINS: http://localhost:3000
+          # The steps above share a different filler, but a newly added copy of
+          # it trips gitleaks' generic-api-key rule (the existing copies predate
+          # that gate). This one is already allowlisted in .gitleaks.toml.
+          ENCRYPTION_KEY: ci_encryption_key_for_testing_only_32bytes
+          POSTGRES_HOST: localhost
+          POSTGRES_PASSWORD: test
+          REDIS_HOST: localhost
+          REDIS_PASSWORD: test
+          GRAFANA_ADMIN_PASSWORD: test
+
       - name: Validate compose with intelligence profile
         run: docker compose -f docker-compose.yml --profile intelligence config --quiet
         env:

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -218,6 +218,7 @@ jobs:
           sparse-checkout: |
             docker-compose.yml
             docker-compose.monitoring.yml
+            docker-compose.yandex.yml
             docker/intelligence
             monitoring
             scripts
@@ -407,6 +408,8 @@ jobs:
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/docker-compose.yml
           scp -i ~/.ssh/deploy_key docker-compose.monitoring.yml \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/docker-compose.monitoring.yml
+          scp -i ~/.ssh/deploy_key docker-compose.yandex.yml \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/docker-compose.yandex.yml
           scp -r -i ~/.ssh/deploy_key monitoring/. \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/bugspotter/monitoring
 
@@ -516,7 +519,9 @@ jobs:
           # Always include the monitoring override so compose knows about all
           # services. This prevents --remove-orphans from killing monitoring
           # containers and ensures monitoring images are pulled alongside app images.
-          COMPOSE="docker compose -f docker-compose.yml -f docker-compose.monitoring.yml"
+          # docker-compose.yandex.yml comes last so its managed-cluster TLS
+          # settings win over the container defaults in the other two files.
+          COMPOSE="docker compose -f docker-compose.yml -f docker-compose.monitoring.yml -f docker-compose.yandex.yml"
 
           # Pull new images (app + demo + monitoring)
           # demo now lives behind `profiles: [demo]`, so it must be named

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -19,8 +19,8 @@ x-logging: &default-logging
   logging:
     driver: json-file
     options:
-      max-size: "10m"
-      max-file: "5"
+      max-size: '10m'
+      max-file: '5'
 
 services:
   prometheus:
@@ -92,6 +92,12 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      # provisioning/dashboards/dashboards.yml points the file provider at
+      # /var/lib/grafana/dashboards. Nothing ever created it, so the provider
+      # logged "failed to search for dashboards" every 10s - 44k lines on the
+      # production box. Mounting the directory makes the provider valid and
+      # gives dashboards somewhere to live.
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
     networks:
       - bugspotter
     ports:
@@ -188,9 +194,11 @@ services:
     container_name: bugspotter-postgres-exporter
     restart: unless-stopped
     environment:
-      DATA_SOURCE_NAME: postgresql://${POSTGRES_USER:-bugspotter}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@${POSTGRES_HOST:?POSTGRES_HOST is required}:6432/${POSTGRES_DB:-bugspotter}?sslmode=verify-full&sslrootcert=/etc/ssl/certs/yandex-ca.pem
-    volumes:
-      - /opt/bugspotter/yandex-ca.pem:/etc/ssl/certs/yandex-ca.pem:ro
+      # Port and sslmode are parameterised because the topology differs: a
+      # managed cluster answers on a pooler port behind TLS, a container on
+      # the compose network answers on 5432 in plaintext that never leaves
+      # the host. Defaults target the container case.
+      DATA_SOURCE_NAME: postgresql://${POSTGRES_USER:-bugspotter}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@${POSTGRES_HOST:?POSTGRES_HOST is required}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-bugspotter}?sslmode=${POSTGRES_SSLMODE:-disable}
     networks:
       - bugspotter
     healthcheck:
@@ -215,11 +223,10 @@ services:
     container_name: bugspotter-redis-exporter
     restart: unless-stopped
     environment:
-      REDIS_ADDR: rediss://${REDIS_HOST:?REDIS_HOST is required}:6380
+      # rediss/6380 for a managed cluster, redis/6379 for a container on the
+      # compose network. Defaults target the container case.
+      REDIS_ADDR: ${REDIS_SCHEME:-redis}://${REDIS_HOST:?REDIS_HOST is required}:${REDIS_PORT:-6379}
       REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
-      REDIS_EXPORTER_TLS_CA_CERT_FILE: /etc/ssl/certs/yandex-ca.pem
-    volumes:
-      - /opt/bugspotter/yandex-ca.pem:/etc/ssl/certs/yandex-ca.pem:ro
     networks:
       - bugspotter
     healthcheck:
@@ -237,30 +244,6 @@ services:
           memory: 32M
           cpus: '0.05'
 
-  # ==========================================================================
-  # Application services — mount Yandex Cloud KZ CA certificate
-  # ==========================================================================
-  # NODE_EXTRA_CA_CERTS tells Node.js to trust the Yandex Cloud KZ private CA
-  # for all TLS connections (PostgreSQL, Redis/Valkey, S3, SMTP).
-  # The cert file is downloaded during VM setup (see YANDEX_CLOUD_DEPLOYMENT_GUIDE.md §11.3).
-  api:
-    environment:
-      NODE_EXTRA_CA_CERTS: /app/certs/yandex-ca.pem
-    volumes:
-      - /opt/bugspotter/yandex-ca.pem:/app/certs/yandex-ca.pem:ro
-
-  worker:
-    environment:
-      NODE_EXTRA_CA_CERTS: /app/certs/yandex-ca.pem
-    volumes:
-      - /opt/bugspotter/yandex-ca.pem:/app/certs/yandex-ca.pem:ro
-
-  payment-service:
-    environment:
-      NODE_EXTRA_CA_CERTS: /app/certs/yandex-ca.pem
-    volumes:
-      - /opt/bugspotter/yandex-ca.pem:/app/certs/yandex-ca.pem:ro
-
   # Dozzle — Real-time Docker Log Viewer
   # The full definition lives in docker-compose.yml (base). This override only
   # adds the production port binding. Keep this minimal — Docker Compose merges
@@ -277,7 +260,6 @@ volumes:
     driver: local
   alertmanager_data:
     driver: local
-
 # Note: the bugspotter network is defined in the base docker-compose.yml.
 # Docker Compose merges top-level sections from all -f files, so services
 # here can reference networks: [bugspotter] without redefining it.

--- a/docker-compose.yandex.yml
+++ b/docker-compose.yandex.yml
@@ -1,0 +1,59 @@
+# ============================================================================
+# BugSpotter - Yandex Cloud KZ overrides
+# ============================================================================
+# Applied on top of the base and monitoring files by the production deploy
+# (see .github/workflows/deploy-yandex.yml):
+#
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.monitoring.yml \
+#                  -f docker-compose.yandex.yml up -d
+#
+# Everything here is specific to running against Yandex Cloud KZ managed
+# Postgres/Valkey, which answer on pooler ports and terminate TLS with a
+# private CA. The base and monitoring files default to the single-box
+# topology - containers on the compose bridge, plaintext, no CA - so these
+# settings cannot live there: an unconditional bind mount makes Docker create
+# a directory at /opt/bugspotter/yandex-ca.pem on any host that has no such
+# file, which then breaks the very services it was meant to configure.
+#
+# The cert is downloaded during VM setup (see YANDEX_CLOUD_DEPLOYMENT_GUIDE.md).
+
+services:
+  # Managed Postgres is reached through the pooler behind TLS signed by the
+  # Yandex private CA, so the exporter needs both verify-full and the CA file.
+  postgres-exporter:
+    environment:
+      DATA_SOURCE_NAME: postgresql://${POSTGRES_USER:-bugspotter}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@${POSTGRES_HOST:?POSTGRES_HOST is required}:${POSTGRES_PORT:-6432}/${POSTGRES_DB:-bugspotter}?sslmode=${POSTGRES_SSLMODE:-verify-full}&sslrootcert=/etc/ssl/certs/yandex-ca.pem
+    volumes:
+      - /opt/bugspotter/yandex-ca.pem:/etc/ssl/certs/yandex-ca.pem:ro
+
+  # Managed Valkey likewise: rediss on the TLS port, same private CA.
+  redis-exporter:
+    environment:
+      REDIS_ADDR: ${REDIS_SCHEME:-rediss}://${REDIS_HOST:?REDIS_HOST is required}:${REDIS_PORT:-6380}
+      REDIS_EXPORTER_TLS_CA_CERT_FILE: /etc/ssl/certs/yandex-ca.pem
+    volumes:
+      - /opt/bugspotter/yandex-ca.pem:/etc/ssl/certs/yandex-ca.pem:ro
+
+  # NODE_EXTRA_CA_CERTS is set in the production .env and passed through by the
+  # base file, but nothing else mounts the file it names. Node does not fail on
+  # a missing path - it starts and silently keeps only the default trust store -
+  # so without these mounts TLS to managed Postgres, Valkey and Object Storage
+  # fails at connection time rather than at boot.
+  api:
+    environment:
+      NODE_EXTRA_CA_CERTS: /app/certs/yandex-ca.pem
+    volumes:
+      - /opt/bugspotter/yandex-ca.pem:/app/certs/yandex-ca.pem:ro
+
+  worker:
+    environment:
+      NODE_EXTRA_CA_CERTS: /app/certs/yandex-ca.pem
+    volumes:
+      - /opt/bugspotter/yandex-ca.pem:/app/certs/yandex-ca.pem:ro
+
+  payment-service:
+    environment:
+      NODE_EXTRA_CA_CERTS: /app/certs/yandex-ca.pem
+    volumes:
+      - /opt/bugspotter/yandex-ca.pem:/app/certs/yandex-ca.pem:ro

--- a/monitoring/grafana/dashboards/README.md
+++ b/monitoring/grafana/dashboards/README.md
@@ -1,0 +1,12 @@
+# Grafana dashboards
+
+Dashboard JSON dropped in this directory is provisioned automatically at
+startup by `../provisioning/dashboards/dashboards.yml`, which watches
+`/var/lib/grafana/dashboards` inside the container.
+
+The directory is mounted read-only, so dashboards edited in the Grafana UI
+are not written back here. To keep a dashboard, export it (Share, Export,
+"Export for sharing externally") and commit the JSON.
+
+This directory needs to exist even when empty. Without it the file provider
+cannot stat its path and logs an error on every scan interval.

--- a/monitoring/grafana/dashboards/bugspotter-application.json
+++ b/monitoring/grafana/dashboards/bugspotter-application.json
@@ -1,0 +1,419 @@
+{
+  "uid": "bugspotter-application",
+  "title": "BugSpotter — Application",
+  "description": "API and worker health: traffic, latency, queues, runtime. Every query is built from metrics the services actually expose.",
+  "tags": ["bugspotter"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "API",
+      "description": "Whether Prometheus can scrape the API. Not a measure of whether requests succeed.",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "up{job=\"bugspotter-api\"}",
+          "instant": true,
+          "legendFormat": "api"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "0": { "text": "DOWN", "index": 1 }, "1": { "text": "UP", "index": 0 } }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Worker",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "up{job=\"bugspotter-worker\"}",
+          "instant": true,
+          "legendFormat": "worker"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "0": { "text": "DOWN", "index": 1 }, "1": { "text": "UP", "index": 0 } }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "5xx rate",
+      "description": "Share of responses in the 5xx class over the last 5 minutes. Reads as no data until traffic exists.",
+      "gridPos": { "h": 4, "w": 5, "x": 8, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(rate(http_requests_total{status_code=~\"5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(http_requests_total[5m])), 0.001)",
+          "instant": true,
+          "legendFormat": "5xx"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Requests / sec",
+      "gridPos": { "h": 4, "w": 5, "x": 13, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_requests_total[5m]))",
+          "instant": true,
+          "legendFormat": "rps"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "none",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "decimals": 2, "min": 0 },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Queued jobs",
+      "description": "Total depth across all BullMQ queues. Sustained growth means workers are not keeping up.",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(max by (queue_name) (queue_depth))",
+          "instant": true,
+          "legendFormat": "queued"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Traffic",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by status",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (status_code) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{status_code}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request latency",
+      "description": "Percentiles from http_request_duration_seconds. One axis: all three series share the same unit.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Queues and database",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Queue depth by queue",
+      "description": "BullMQ depth per queue. Flat zero is the healthy state for an idle system. api and worker both report the same queues, so max-by collapses the duplicate pair rather than summing it.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (queue_name) (queue_depth)",
+          "legendFormat": "{{queue_name}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Database connection pool",
+      "description": "Sustained non-zero 'waiting' means the pool is undersized for the load.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (state) (db_connection_pool_size)",
+          "legendFormat": "{{state}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Node.js runtime",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Heap used",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (job) (nodejs_heap_size_used_bytes)",
+          "legendFormat": "{{job}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Event loop lag (p99)",
+      "description": "The clearest signal that a Node process is CPU-starved or blocked.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (job) (nodejs_eventloop_lag_p99_seconds)",
+          "legendFormat": "{{job}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/bugspotter-infrastructure.json
+++ b/monitoring/grafana/dashboards/bugspotter-infrastructure.json
@@ -1,0 +1,443 @@
+{
+  "uid": "bugspotter-infrastructure",
+  "title": "BugSpotter — Infrastructure",
+  "description": "Host, PostgreSQL and Redis. Queries target the single-box topology: containers on the compose network, not managed services.",
+  "tags": ["bugspotter"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Host",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "CPU used",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))",
+          "instant": true,
+          "legendFormat": "cpu"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.75 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Memory used",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "instant": true,
+          "legendFormat": "memory"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.8 },
+              { "color": "red", "value": 0.92 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Root disk used",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - (node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})",
+          "instant": true,
+          "legendFormat": "disk"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.75 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Load (1m)",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [{ "refId": "A", "expr": "node_load1", "instant": true, "legendFormat": "load1" }],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "none",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 2, "min": 0 },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU by mode",
+      "description": "Excludes idle so the plot shows work rather than headroom. Watch 'steal' - on shared vCPU it means the hypervisor took time from us.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (mode) (rate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) / on() group_left() count(count by (cpu) (node_cpu_seconds_total))",
+          "legendFormat": "{{mode}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Memory",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes",
+          "legendFormat": "used"
+        },
+        { "refId": "B", "expr": "node_memory_MemTotal_bytes", "legendFormat": "total" }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "total" },
+            "properties": [
+              { "id": "custom.fillOpacity", "value": 0 },
+              { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [8, 8] } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "row",
+      "title": "PostgreSQL",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "PostgreSQL",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [{ "refId": "A", "expr": "pg_up", "instant": true, "legendFormat": "pg" }],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "0": { "text": "DOWN", "index": 1 }, "1": { "text": "UP", "index": 0 } }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Database size",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "pg_database_size_bytes{datname=\"bugspotter\"}",
+          "instant": true,
+          "legendFormat": "bugspotter"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "none",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": { "defaults": { "unit": "bytes", "min": 0 }, "overrides": [] }
+    },
+    {
+      "type": "timeseries",
+      "title": "Connections by database",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (datname) (pg_stat_database_numbackends)",
+          "legendFormat": "{{datname}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Database size over time",
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "pg_database_size_bytes{datname=\"bugspotter\"}",
+          "legendFormat": "bugspotter"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "title": "Redis",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Redis",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 23 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [{ "refId": "A", "expr": "redis_up", "instant": true, "legendFormat": "redis" }],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "0": { "text": "DOWN", "index": 1 }, "1": { "text": "UP", "index": 0 } }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Clients",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 23 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "redis_connected_clients",
+          "instant": true,
+          "legendFormat": "clients"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "none",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "min": 0 },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Redis memory",
+      "description": "maxmemory is 256mb with noeviction, so approaching the ceiling means writes start failing rather than keys being dropped.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "datasource": { "type": "prometheus", "uid": "bugspotter-prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "redis_memory_used_bytes", "legendFormat": "used" },
+        { "refId": "B", "expr": "redis_memory_max_bytes > 0", "legendFormat": "maxmemory" }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "maxmemory" },
+            "properties": [
+              { "id": "custom.fillOpacity", "value": 0 },
+              { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [8, 8] } }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,7 +1,11 @@
 apiVersion: 1
 
 datasources:
+  # uid is pinned so provisioned dashboards can reference it. Without it
+  # Grafana generates a random uid per install and every dashboard panel
+  # binds to a datasource that does not exist on the next box.
   - name: Prometheus
+    uid: bugspotter-prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090

--- a/packages/backend/src/config/validators.ts
+++ b/packages/backend/src/config/validators.ts
@@ -245,8 +245,15 @@ function isLoopback(hostname: string): boolean {
  * Check if a hostname can only resolve inside the container network.
  *
  * A single-label hostname is a compose service name - `minio`, `postgres`,
- * `redis`. It has no public DNS meaning, so traffic addressed to it never
- * leaves the host. Publicly reachable endpoints are always dotted.
+ * `redis`. It carries no public DNS delegation, so traffic addressed to it
+ * does not leave the host.
+ *
+ * The shape check is deliberately narrow: only a bare DNS label qualifies
+ * (letters, digits, hyphen, and the underscore Compose permits in service
+ * names). Everything else is rejected, which matters most for IP literals -
+ * the WHATWG URL parser returns IPv6 addresses bracketed and often dotless
+ * (`[2001:db8::1]`), so a dot-only test would have let a routable address
+ * through as "internal".
  *
  * Localhost and loopback are excluded deliberately: those stay rejected in
  * production by validateProductionHostname, because they signal a config
@@ -254,7 +261,10 @@ function isLoopback(hostname: string): boolean {
  * container-to-container link.
  */
 function isInternalServiceHost(hostname: string): boolean {
-  return !hostname.includes('.') && !isLocalhost(hostname) && !isLoopback(hostname);
+  if (!/^[a-z0-9_-]+$/i.test(hostname)) {
+    return false;
+  }
+  return !isLocalhost(hostname) && !isLoopback(hostname);
 }
 
 /**

--- a/packages/backend/src/config/validators.ts
+++ b/packages/backend/src/config/validators.ts
@@ -242,6 +242,22 @@ function isLoopback(hostname: string): boolean {
 }
 
 /**
+ * Check if a hostname can only resolve inside the container network.
+ *
+ * A single-label hostname is a compose service name - `minio`, `postgres`,
+ * `redis`. It has no public DNS meaning, so traffic addressed to it never
+ * leaves the host. Publicly reachable endpoints are always dotted.
+ *
+ * Localhost and loopback are excluded deliberately: those stay rejected in
+ * production by validateProductionHostname, because they signal a config
+ * that was never updated from a developer default rather than a deliberate
+ * container-to-container link.
+ */
+function isInternalServiceHost(hostname: string): boolean {
+  return !hostname.includes('.') && !isLocalhost(hostname) && !isLoopback(hostname);
+}
+
+/**
  * Check if IPv4 address is in private range (RFC 1918)
  */
 function isPrivateIPv4(hostname: string): boolean {
@@ -511,8 +527,12 @@ export function validateS3Endpoint(
       errors.push(`S3_ENDPOINT must use http:// or https:// protocol. Got: ${url.protocol}`);
     }
 
-    // In production, require HTTPS for security
-    if (env === 'production' && url.protocol !== 'https:') {
+    // In production, require HTTPS for security. Container-network traffic is
+    // exempt: an endpoint like http://minio:9000 never leaves the host, which
+    // is the same reasoning that already lets DATABASE_URL and REDIS_URL reach
+    // `postgres` and `redis` over plaintext. Requiring TLS there would force a
+    // certificate on a link that is not observable from outside the machine.
+    if (env === 'production' && url.protocol !== 'https:' && !isInternalServiceHost(url.hostname)) {
       errors.push('S3_ENDPOINT must use https:// in production for security');
     }
 

--- a/packages/backend/tests/config/validators.test.ts
+++ b/packages/backend/tests/config/validators.test.ts
@@ -449,6 +449,32 @@ describe('Configuration Validators', () => {
       expect(errors).toEqual([]);
     });
 
+    it('should accept plaintext HTTP to a container service name in production', () => {
+      // Single-box deployments reach MinIO over the compose network, where the
+      // traffic never leaves the host. Same reasoning that already permits
+      // postgres:5432 and redis:6379 without TLS.
+      ['http://minio:9000', 'http://minio', 'http://storage:9000'].forEach((endpoint) => {
+        expect(validateS3Endpoint(endpoint, 'minio', 'production')).toEqual([]);
+      });
+    });
+
+    it('should still reject plaintext HTTP to a routable host in production', () => {
+      // The exemption must not widen to anything reachable from outside the
+      // host, which is the case the https rule exists for.
+      const errors = validateS3Endpoint('http://s3.example.com', 's3', 'production');
+      expect(errors).toContain('S3_ENDPOINT must use https:// in production for security');
+    });
+
+    it('should still reject localhost and loopback in production', () => {
+      // Undotted, but these mean "someone shipped a developer default", not a
+      // deliberate container link, so they stay rejected.
+      const localhost = validateS3Endpoint('http://localhost:9000', 'minio', 'production');
+      expect(localhost.some((e) => e.includes('cannot use localhost'))).toBe(true);
+
+      const loopback = validateS3Endpoint('http://127.0.0.1:9000', 'minio', 'production');
+      expect(loopback.some((e) => e.includes('cannot use loopback'))).toBe(true);
+    });
+
     it('should require endpoint for minio backend', () => {
       const errors = validateS3Endpoint(undefined, 'minio', 'production');
       expect(errors).toContain('S3_ENDPOINT is required for minio storage');

--- a/packages/backend/tests/config/validators.test.ts
+++ b/packages/backend/tests/config/validators.test.ts
@@ -465,6 +465,25 @@ describe('Configuration Validators', () => {
       expect(errors).toContain('S3_ENDPOINT must use https:// in production for security');
     });
 
+    it('should still reject plaintext HTTP to an IP literal in production', () => {
+      // `new URL('http://[2001:db8::1]:9000').hostname` is '[2001:db8::1]' -
+      // bracketed and dotless - so the exemption must key on the DNS-label
+      // shape, not merely on the absence of a dot.
+      [
+        'http://[2001:db8::1]:9000',
+        'http://[fe80::1]:9000',
+        'http://[::ffff:1.2.3.4]:9000',
+      ].forEach((endpoint) => {
+        expect(validateS3Endpoint(endpoint, 'minio', 'production')).toContain(
+          'S3_ENDPOINT must use https:// in production for security'
+        );
+      });
+
+      expect(validateS3Endpoint('http://93.184.216.34:9000', 's3', 'production')).toContain(
+        'S3_ENDPOINT must use https:// in production for security'
+      );
+    });
+
     it('should still reject localhost and loopback in production', () => {
       // Undotted, but these mean "someone shipped a developer default", not a
       // deliberate container link, so they stay rejected.


### PR DESCRIPTION
Unblocks running the whole stack on one box: the production config validator rejected `http://minio:9000` even though `postgres:5432` and `redis:6379` already pass, and the monitoring exporters were hardcoded to Yandex pooler ports and its private CA.

Also adds the two Grafana dashboards that never existed, and fixes the dashboard provisioner that has been logging an error every 10s on production (44k lines).

All 27 dashboard queries were executed against a live Prometheus before committing; that caught the 5xx panel reading "No data" instead of 0%, and `sum(queue_depth)` double-counting because api and worker both export it.

Refs ADR-0005: the plaintext-on-the-bridge argument is the same one that ADR already makes for Postgres/Redis/MinIO as the core data plane on customer infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
