### PR TITLE
fix(compose): bind published ports to loopback by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,11 +152,13 @@ SIGNED_URL_EXPIRATION_SECONDS=2592000
 # ============================================================================
 # API container always listens on port 3000 internally (Prometheus scrapes api:3000).
 # This only controls the host port binding.
-# Host binding for the published port, NOT just the port number. Keep the
-# 127.0.0.1 prefix on any host with a public IP: Docker inserts its own
-# nftables rules and bypasses ufw, so a bare "3000" is reachable from the
-# internet even behind a deny-by-default firewall. Drop the prefix only if
-# something outside the machine must reach the container directly.
+# Host binding for the published port, not only the port number. Both forms
+# work: "3000" publishes on every interface (0.0.0.0), "127.0.0.1:3000"
+# publishes on loopback only. Keep the 127.0.0.1 prefix on any host with a
+# public IP: Docker inserts its own nftables rules and bypasses ufw, so a bare
+# "3000" is reachable from the internet even behind a deny-by-default
+# firewall. Drop the prefix only if something outside the machine must reach
+# the container directly.
 API_HOST_PORT=127.0.0.1:3000
 ADMIN_PORT=127.0.0.1:3001
 DEMO_PORT=127.0.0.1:3003

--- a/.env.example
+++ b/.env.example
@@ -152,8 +152,14 @@ SIGNED_URL_EXPIRATION_SECONDS=2592000
 # ============================================================================
 # API container always listens on port 3000 internally (Prometheus scrapes api:3000).
 # This only controls the host port binding.
-API_HOST_PORT=3000
-ADMIN_PORT=3001
+# Host binding for the published port, NOT just the port number. Keep the
+# 127.0.0.1 prefix on any host with a public IP: Docker inserts its own
+# nftables rules and bypasses ufw, so a bare "3000" is reachable from the
+# internet even behind a deny-by-default firewall. Drop the prefix only if
+# something outside the machine must reach the container directly.
+API_HOST_PORT=127.0.0.1:3000
+ADMIN_PORT=127.0.0.1:3001
+DEMO_PORT=127.0.0.1:3003
 # Use 'development' for local Docker testing, 'production' for deployment
 NODE_ENV=development
 

--- a/.github/workflows/deploy-yandex.yml
+++ b/.github/workflows/deploy-yandex.yml
@@ -281,9 +281,13 @@ jobs:
 
           # API Server
           # Container always listens on port 3000 internally (hardcoded in docker-compose.yml).
-          # API_HOST_PORT only controls the host port binding.
-          API_HOST_PORT=${{ vars.API_HOST_PORT || '3000' }}
-          ADMIN_PORT=${{ vars.ADMIN_PORT || '3001' }}
+          # API_HOST_PORT only controls the host port binding, and it is a
+          # binding rather than a bare port: the 127.0.0.1 prefix keeps the
+          # published port off the public interface, because Docker's own
+          # nftables rules bypass ufw. Public traffic arrives over TLS on 443
+          # via the host reverse proxy, which reaches these on loopback.
+          API_HOST_PORT=${{ vars.API_HOST_PORT || '127.0.0.1:3000' }}
+          ADMIN_PORT=${{ vars.ADMIN_PORT || '127.0.0.1:3001' }}
           NODE_ENV=${{ vars.NODE_ENV || 'production' }}
           LOG_LEVEL=${{ vars.LOG_LEVEL || 'warn' }}
           DEPLOYMENT_MODE=${{ vars.DEPLOYMENT_MODE || 'saas' }}
@@ -350,7 +354,8 @@ jobs:
           WORKER_NOTIFICATION_ENABLED=${{ vars.WORKER_NOTIFICATION_ENABLED || 'true' }}
 
           # Demo App
-          DEMO_PORT=${{ vars.DEMO_PORT || '3003' }}
+          # Host binding, same reasoning as API_HOST_PORT above.
+          DEMO_PORT=${{ vars.DEMO_PORT || '127.0.0.1:3003' }}
           DEMO_API_URL=${{ vars.DEMO_API_URL }}
           DEMO_API_KEY=${{ secrets.DEMO_API_KEY }}
           DEMO_ADMIN_URL=${{ vars.DEMO_ADMIN_URL }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -360,7 +360,11 @@ services:
     ports:
       # Container always listens on 3000; only the host binding is configurable.
       # Prometheus scrapes api:3000 — do NOT change the container port.
-      - '${API_HOST_PORT:-3000}:3000'
+      # Loopback by default. Docker writes its own nftables rules and bypasses
+      # ufw entirely, so a published port is reachable from the internet even
+      # with a deny-by-default firewall. Behind a reverse proxy nothing needs a
+      # public binding. Override with API_HOST_PORT=3000 to expose it.
+      - '${API_HOST_PORT:-127.0.0.1:3000}:3000'
     networks:
       - bugspotter
     healthcheck:
@@ -415,7 +419,8 @@ services:
       # deployment. Empty/unset keeps them allowed. See .env.example.
       DISABLE_INTEGRATION_AVATAR_CSP: ${DISABLE_INTEGRATION_AVATAR_CSP:-}
     ports:
-      - '${ADMIN_PORT:-3001}:80'
+      # Loopback by default - see the note on api. Override with ADMIN_PORT=3001.
+      - '${ADMIN_PORT:-127.0.0.1:3001}:80'
     networks:
       - bugspotter
     healthcheck:
@@ -464,7 +469,8 @@ services:
       DEMO_VIEWER_PASSWORD: ${DEMO_VIEWER_PASSWORD:-}
       DEMO_MAGIC_TOKEN: ${DEMO_MAGIC_TOKEN:-}
     ports:
-      - '${DEMO_PORT:-3003}:80'
+      # Loopback by default - see the note on api. Override with DEMO_PORT=3003.
+      - '${DEMO_PORT:-127.0.0.1:3003}:80'
     networks:
       - bugspotter
     healthcheck:


### PR DESCRIPTION
Docker bypasses ufw by writing its own nftables rules, so `api`, `admin` and `demo` publishing on 0.0.0.0 were reachable from the internet on any public-IP host, skipping nginx and TLS. Managed-cloud deployments were only safe because a separate security group blocked those ports at the edge.

Defaults now bind 127.0.0.1; `.env.example` carried the public binding explicitly so it's fixed there too. `API_HOST_PORT=3000` remains the escape hatch. Verified with `docker compose config` both ways.

Refs ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)