### PR TITLE
fix(email): support relay alternative SMTP ports (2465/2587)

### DIFF
--- a/packages/backend/src/queue/workers/notifications/email-notifier.ts
+++ b/packages/backend/src/queue/workers/notifications/email-notifier.ts
@@ -191,7 +191,11 @@ export class EmailNotifier implements INotifier {
         smtp: {
           host: smtpHost,
           port: smtpPort,
-          ...resolveSmtpTls(smtpPort),
+          // Only `secure` survives: this config is mapped field-by-field onto
+          // EmailChannelConfig below, and createTransporter re-derives
+          // requireTLS from the port there. Spreading the whole result would
+          // carry a requireTLS that nothing downstream reads.
+          secure: resolveSmtpTls(smtpPort).secure,
           auth: {
             user: smtpUser,
             pass: smtpPass,

--- a/packages/backend/src/queue/workers/notifications/email-notifier.ts
+++ b/packages/backend/src/queue/workers/notifications/email-notifier.ts
@@ -14,6 +14,7 @@ import type {
 import { DEFAULT_NOTIFIER_CONFIG } from './notifier-interface.js';
 import { EmailChannelHandler } from '../../../services/notifications/email-handler.js';
 import type { EmailChannelConfig } from '../../../types/notifications.js';
+import { resolveSmtpTls } from '../../../utils/smtp-tls.js';
 
 /**
  * Email notifier configuration
@@ -190,7 +191,7 @@ export class EmailNotifier implements INotifier {
         smtp: {
           host: smtpHost,
           port: smtpPort,
-          secure: smtpPort === 465,
+          ...resolveSmtpTls(smtpPort),
           auth: {
             user: smtpUser,
             pass: smtpPass,

--- a/packages/backend/src/saas/services/invitation-email.service.ts
+++ b/packages/backend/src/saas/services/invitation-email.service.ts
@@ -9,6 +9,7 @@ import type { Transporter } from 'nodemailer';
 import { config } from '../../config.js';
 import { getLogger } from '../../logger.js';
 import { ConfigurationError } from '../../api/middleware/error.js';
+import { resolveSmtpTls } from '../../utils/smtp-tls.js';
 
 export type EmailLocale = 'en' | 'ru' | 'kk';
 
@@ -132,13 +133,12 @@ export class InvitationEmailService {
       );
     }
 
-    const useSecure = port === 465;
+    const tlsOptions = resolveSmtpTls(port);
 
     this.transporter = nodemailer.createTransport({
       host,
       port,
-      secure: useSecure,
-      requireTLS: port === 587,
+      ...tlsOptions,
       auth: { user, pass },
       tls: {
         rejectUnauthorized: process.env.SMTP_TLS_REJECT_UNAUTHORIZED !== 'false',

--- a/packages/backend/src/saas/services/org-request-email.service.ts
+++ b/packages/backend/src/saas/services/org-request-email.service.ts
@@ -9,6 +9,7 @@ import type { Transporter } from 'nodemailer';
 import { config } from '../../config.js';
 import { getLogger } from '../../logger.js';
 import { ConfigurationError } from '../../api/middleware/error.js';
+import { resolveSmtpTls } from '../../utils/smtp-tls.js';
 
 export type EmailLocale = 'en' | 'ru' | 'kk';
 
@@ -240,13 +241,12 @@ export class OrgRequestEmailService {
       );
     }
 
-    const useSecure = port === 465;
+    const tlsOptions = resolveSmtpTls(port);
 
     this.transporter = nodemailer.createTransport({
       host,
       port,
-      secure: useSecure,
-      requireTLS: port === 587,
+      ...tlsOptions,
       auth: { user, pass },
       tls: {
         rejectUnauthorized: process.env.SMTP_TLS_REJECT_UNAUTHORIZED !== 'false',

--- a/packages/backend/src/saas/services/signup-email.service.ts
+++ b/packages/backend/src/saas/services/signup-email.service.ts
@@ -17,6 +17,7 @@ import type { Transporter } from 'nodemailer';
 import { config } from '../../config.js';
 import { getLogger } from '../../logger.js';
 import { ConfigurationError } from '../../api/middleware/error.js';
+import { resolveSmtpTls } from '../../utils/smtp-tls.js';
 
 export type EmailLocale = 'en' | 'ru' | 'kk';
 
@@ -105,13 +106,12 @@ export class SignupEmailService {
       );
     }
 
-    const useSecure = port === 465;
+    const tlsOptions = resolveSmtpTls(port);
 
     this.transporter = nodemailer.createTransport({
       host,
       port,
-      secure: useSecure,
-      requireTLS: port === 587,
+      ...tlsOptions,
       auth: { user, pass },
       tls: {
         rejectUnauthorized: process.env.SMTP_TLS_REJECT_UNAUTHORIZED !== 'false',

--- a/packages/backend/src/services/auth/password-reset-email.service.ts
+++ b/packages/backend/src/services/auth/password-reset-email.service.ts
@@ -13,6 +13,7 @@ import type { Transporter } from 'nodemailer';
 import { config } from '../../config.js';
 import { getLogger } from '../../logger.js';
 import { ConfigurationError } from '../../api/middleware/error.js';
+import { resolveSmtpTls } from '../../utils/smtp-tls.js';
 
 export type EmailLocale = 'en' | 'ru' | 'kk';
 
@@ -96,13 +97,12 @@ export class PasswordResetEmailService {
       );
     }
 
-    const useSecure = port === 465;
+    const tlsOptions = resolveSmtpTls(port);
 
     this.transporter = nodemailer.createTransport({
       host,
       port,
-      secure: useSecure,
-      requireTLS: port === 587,
+      ...tlsOptions,
       auth: { user, pass },
       tls: {
         rejectUnauthorized: process.env.SMTP_TLS_REJECT_UNAUTHORIZED !== 'false',

--- a/packages/backend/src/services/notifications/email-handler.ts
+++ b/packages/backend/src/services/notifications/email-handler.ts
@@ -27,15 +27,20 @@ function createTransporter(config: EmailChannelConfig): Transporter {
   // build a transporter cannot drift. smtp_secure stays an operator override:
   // it can force implicit TLS off for a channel, but never on for a port that
   // does not speak it.
+  //
+  // The channel config is stored as unvalidated JSON, so smtp_secure can be
+  // absent on a persisted record even though the type marks it required. Fall
+  // back to the port's own policy rather than to `undefined`, which would
+  // otherwise open a plaintext connection against a TLS-only listener.
   const portTls = resolveSmtpTls(config.smtp_port);
-  const useSecure = config.smtp_secure && portTls.secure;
+  const useSecure = (config.smtp_secure ?? portTls.secure) && portTls.secure;
   const requireTls = portTls.requireTLS || !useSecure;
 
   return nodemailer.createTransport({
     host: config.smtp_host,
     port: config.smtp_port,
-    secure: useSecure, // true for 465, false for other ports
-    requireTLS: requireTls, // true for 587 to force STARTTLS
+    secure: useSecure, // implicit TLS: 465 and 2465
+    requireTLS: requireTls, // force STARTTLS: 25, 587, 2525, 2587 and unknown ports
     auth: {
       user: config.smtp_user,
       pass: config.smtp_pass,

--- a/packages/backend/src/services/notifications/email-handler.ts
+++ b/packages/backend/src/services/notifications/email-handler.ts
@@ -11,6 +11,7 @@ import type {
   DeliveryResult,
 } from '../../types/notifications.js';
 import { getLogger } from '../../logger.js';
+import { resolveSmtpTls } from '../../utils/smtp-tls.js';
 
 const logger = getLogger();
 
@@ -22,11 +23,13 @@ const logger = getLogger();
  * Create SMTP transporter from config
  */
 function createTransporter(config: EmailChannelConfig): Transporter {
-  // Port 465 uses direct SSL (secure: true)
-  // Port 587 uses STARTTLS (secure: false, but still encrypted)
-  // See: https://nodemailer.com/smtp/#tls-options
-  const useSecure = config.smtp_secure && config.smtp_port === 465;
-  const requireTls = config.smtp_port === 587 || !useSecure;
+  // Port -> transport security lives in resolveSmtpTls so the six places that
+  // build a transporter cannot drift. smtp_secure stays an operator override:
+  // it can force implicit TLS off for a channel, but never on for a port that
+  // does not speak it.
+  const portTls = resolveSmtpTls(config.smtp_port);
+  const useSecure = config.smtp_secure && portTls.secure;
+  const requireTls = portTls.requireTLS || !useSecure;
 
   return nodemailer.createTransport({
     host: config.smtp_host,

--- a/packages/backend/src/utils/smtp-tls.ts
+++ b/packages/backend/src/utils/smtp-tls.ts
@@ -1,0 +1,49 @@
+/**
+ * SMTP transport security, derived from the port.
+ *
+ * Nodemailer needs two separate flags and they are easy to get subtly wrong:
+ *   - `secure: true`  — wrap the connection in TLS immediately (SMTPS)
+ *   - `requireTLS`    — plaintext connect, then refuse to continue unless
+ *                       STARTTLS succeeds
+ *
+ * Setting neither leaves STARTTLS *opportunistic*: nodemailer upgrades if the
+ * server advertises it, and silently sends credentials in the clear if a
+ * network attacker strips the advertisement. So every supported port must map
+ * to one flag or the other, never to neither.
+ *
+ * Alongside the IANA ports, this recognises the 2xxx aliases that relays
+ * publish for hosts which block outbound 25/465/587 — a very common VPS
+ * anti-spam default. Resend, SendGrid, Mailgun and Postmark all offer them.
+ * Treating 2465 as "not secure" would attempt plaintext SMTP against a
+ * TLS-only listener and fail with an opaque timeout.
+ */
+
+/** Ports that expect TLS from the first byte (SMTPS). */
+const IMPLICIT_TLS_PORTS = new Set([465, 2465]);
+
+/** Ports that expect a plaintext greeting followed by a STARTTLS upgrade. */
+const STARTTLS_PORTS = new Set([25, 587, 2525, 2587]);
+
+export interface SmtpTlsOptions {
+  /** Connect with TLS immediately. */
+  secure: boolean;
+  /** Fail rather than continue unencrypted if STARTTLS is unavailable. */
+  requireTLS: boolean;
+}
+
+/**
+ * Map an SMTP port to nodemailer's transport security flags.
+ *
+ * Unknown ports fall back to requiring STARTTLS. That is the safe default: a
+ * misconfigured port fails loudly instead of quietly sending credentials in
+ * plaintext.
+ */
+export function resolveSmtpTls(port: number): SmtpTlsOptions {
+  if (IMPLICIT_TLS_PORTS.has(port)) {
+    return { secure: true, requireTLS: false };
+  }
+  if (STARTTLS_PORTS.has(port)) {
+    return { secure: false, requireTLS: true };
+  }
+  return { secure: false, requireTLS: true };
+}

--- a/packages/backend/tests/services/notifications/email-handler.test.ts
+++ b/packages/backend/tests/services/notifications/email-handler.test.ts
@@ -103,6 +103,33 @@ describe('EmailChannelHandler', () => {
       });
     });
 
+    it('should use implicit TLS on an SMTPS port when smtp_secure is absent', async () => {
+      // The channel config is persisted as unvalidated JSON, so smtp_secure can
+      // be missing even though the type marks it required. Defaulting it to
+      // false would open a plaintext connection against a TLS-only listener.
+      const { smtp_secure: _omitted, ...withoutSecure } = config;
+      const payload: NotificationPayload = {
+        to: 'test@example.com',
+        subject: 'Test',
+        body: 'Body',
+      };
+
+      mockTransporter.sendMail.mockResolvedValue({
+        messageId: '<msg-123@example.com>',
+        accepted: [],
+        rejected: [],
+        response: '250 OK',
+      });
+
+      for (const port of [465, 2465]) {
+        (nodemailer.createTransport as Mock).mockClear();
+        await handler.send({ ...withoutSecure, smtp_port: port } as typeof config, payload);
+        expect(nodemailer.createTransport).toHaveBeenCalledWith(
+          expect.objectContaining({ port, secure: true, requireTLS: false })
+        );
+      }
+    });
+
     it('should format from address with name', async () => {
       const payload: NotificationPayload = {
         to: 'test@example.com',

--- a/packages/backend/tests/utils/smtp-tls.test.ts
+++ b/packages/backend/tests/utils/smtp-tls.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSmtpTls } from '../../src/utils/smtp-tls.js';
+
+describe('resolveSmtpTls', () => {
+  it('uses implicit TLS on the SMTPS ports', () => {
+    for (const port of [465, 2465]) {
+      expect(resolveSmtpTls(port)).toEqual({ secure: true, requireTLS: false });
+    }
+  });
+
+  it('requires STARTTLS on the submission ports', () => {
+    for (const port of [25, 587, 2525, 2587]) {
+      expect(resolveSmtpTls(port)).toEqual({ secure: false, requireTLS: true });
+    }
+  });
+
+  it('handles relay alternative ports, which is the whole point', () => {
+    // Hosts commonly block outbound 25/465/587 as an anti-spam default, so
+    // relays publish 2xxx aliases. Treating 2465 as plaintext attempts a bare
+    // SMTP greeting against a TLS-only listener and fails on an opaque timeout.
+    expect(resolveSmtpTls(2465).secure).toBe(true);
+    expect(resolveSmtpTls(2587).requireTLS).toBe(true);
+  });
+
+  it('never leaves a port with opportunistic-only TLS', () => {
+    // secure:false + requireTLS:false is the dangerous combination - nodemailer
+    // upgrades if STARTTLS is advertised and sends credentials in the clear if
+    // an attacker strips the advertisement. No port may resolve to it.
+    const ports = [25, 465, 587, 2222, 2465, 2525, 2587, 8025, 0, -1, 65535];
+    for (const port of ports) {
+      const { secure, requireTLS } = resolveSmtpTls(port);
+      expect(secure || requireTLS, `port ${port} allows unencrypted fallback`).toBe(true);
+    }
+  });
+
+  it('fails closed on an unknown port', () => {
+    expect(resolveSmtpTls(1234)).toEqual({ secure: false, requireTLS: true });
+  });
+});

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       'tests/api/intelligence-routes.test.ts',
       'tests/api/services/**/*.test.ts',
       'tests/cache/**/*.test.ts',
+      'tests/utils/**/*.test.ts',
       // Only include pure unit tests from tests/db/ (no database required)
       'tests/db/filter-builder.test.ts',
       'tests/db/filter-builder-edge-cases.test.ts',


### PR DESCRIPTION
Production stopped sending mail after the host move — outbound 25/465/587 are blocked, a common VPS anti-spam default. Relays publish 2xxx aliases for this case and both 2465 and 2587 are reachable, but the port-to-TLS mapping didn't know them: six places hardcoded `port === 465` / `port === 587`, so 2465 resolved to plaintext against a TLS-only listener and 2587 left STARTTLS merely opportunistic.

Centralises it in `resolveSmtpTls()` and fails closed — an unknown port requires STARTTLS rather than allowing an unencrypted fallback.

Also adds `tests/utils/**` to the unit include list; it was missing, so 118 existing tests had never run. Suite goes 2966 → 3089, all passing.

Refs ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)