### PR TITLE
fix(storage): document and support a public MinIO endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,9 +118,9 @@ STORAGE_BACKEND=minio
 # it here keeps the stack working except for browser uploads.
 #
 # Running the API outside Docker (pnpm dev) against the published MinIO? Use
-# http://localhost:9000 - plain http is accepted only for localhost and
-# 127.0.0.1. Note a Docker-hosted API cannot use that value, since localhost
-# inside the container is the container itself.
+# http://localhost:9000, or whatever port MINIO_PORT publishes - plain http is
+# accepted only for localhost and 127.0.0.1. A Docker-hosted API cannot use
+# that value, since localhost inside the container is the container itself.
 #
 # Deploying MinIO on a public host? Put a TLS reverse proxy in front of it and
 # set this to that hostname - see docker-compose.storage.yml. Leaving it as the

--- a/.env.example
+++ b/.env.example
@@ -110,8 +110,17 @@ MINIO_APP_SECRET_KEY=changeme-generate-with-openssl-rand-base64-32
 STORAGE_BACKEND=minio
 # IMPORTANT: uploads do not go through the API. The API returns a presigned S3
 # URL and the browser PUTs directly to it, so this must be a hostname the
-# BROWSER can reach, over HTTPS. The internal http://minio:9000 default only
-# works where the browser is on the same machine (local dev).
+# BROWSER can reach, over HTTPS.
+#
+# The http://minio:9000 default is a compose service name: it resolves only
+# inside the compose network, never from a browser, whatever machine that
+# browser is on. It is correct for the API's own server-side calls, so leaving
+# it here keeps the stack working except for browser uploads.
+#
+# Running the API outside Docker (pnpm dev) against the published MinIO? Use
+# http://localhost:9000 - plain http is accepted only for localhost and
+# 127.0.0.1. Note a Docker-hosted API cannot use that value, since localhost
+# inside the container is the container itself.
 #
 # Deploying MinIO on a public host? Put a TLS reverse proxy in front of it and
 # set this to that hostname - see docker-compose.storage.yml. Leaving it as the

--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,15 @@ MINIO_APP_SECRET_KEY=changeme-generate-with-openssl-rand-base64-32
 #   - Set STORAGE_BACKEND=s3 or r2
 # ============================================================================
 STORAGE_BACKEND=minio
+# IMPORTANT: uploads do not go through the API. The API returns a presigned S3
+# URL and the browser PUTs directly to it, so this must be a hostname the
+# BROWSER can reach, over HTTPS. The internal http://minio:9000 default only
+# works where the browser is on the same machine (local dev).
+#
+# Deploying MinIO on a public host? Put a TLS reverse proxy in front of it and
+# set this to that hostname - see docker-compose.storage.yml. Leaving it as the
+# internal address makes screenshot and replay uploads fail with
+# "upload requires HTTPS" while the API itself looks healthy.
 S3_ENDPOINT=http://minio:9000
 S3_ACCESS_KEY=bugspotter-app-user
 S3_SECRET_KEY=changeme-generate-with-openssl-rand-base64-32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,6 +732,20 @@ jobs:
           REDIS_PASSWORD: test
           GRAFANA_ADMIN_PASSWORD: test
 
+      - name: Validate compose with storage overlay
+        # docker-compose.storage.yml is opt-in (MinIO-on-the-box), so it is not
+        # part of the deploy combination above and would otherwise never be
+        # parsed by CI.
+        run: docker compose -f docker-compose.yml -f docker-compose.storage.yml --profile dev config --quiet
+        env:
+          JWT_SECRET: test
+          CORS_ORIGINS: http://localhost:3000
+          ENCRYPTION_KEY: ci_encryption_key_for_testing_only_32bytes
+          POSTGRES_PASSWORD: test
+          REDIS_PASSWORD: test
+          MINIO_ROOT_PASSWORD: test-minio-root-password
+          MINIO_APP_SECRET_KEY: test-minio-app-secret-key
+
       - name: Validate compose with intelligence profile
         run: docker compose -f docker-compose.yml --profile intelligence config --quiet
         env:

--- a/docker-compose.storage.yml
+++ b/docker-compose.storage.yml
@@ -1,0 +1,66 @@
+# ============================================================================
+# BugSpotter - Public object storage endpoint
+# ============================================================================
+# Publishes MinIO on loopback so a host reverse proxy can serve it over HTTPS
+# at a public hostname.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.storage.yml \
+#     --profile infra up -d minio
+#
+# WHY THIS IS NEEDED
+# ------------------
+# Uploads do not go through the API. The API returns a presigned S3 URL and the
+# browser (SDK or extension) PUTs directly to it. That URL is built from
+# S3_ENDPOINT, so S3_ENDPOINT must be a hostname the *browser* can reach, over
+# HTTPS.
+#
+# With the default S3_ENDPOINT=http://minio:9000 the browser receives
+# `http://minio:9000/...`, which fails twice: `minio` is a compose service name
+# with no public DNS, and the SDK rejects non-HTTPS upload URLs outright
+# (isSecureEndpoint in @bugspotter/common allows http only for localhost).
+# Server-side storage keeps working, so this presents as "screenshot upload
+# requires HTTPS" in the client while the API looks perfectly healthy.
+#
+# Managed object storage (S3, R2, Yandex) does not need this file - those
+# endpoints are already public HTTPS. It is specifically for MinIO-on-the-box.
+#
+# HOST SIDE
+# ---------
+# Terminate TLS at the host proxy and forward to 127.0.0.1:9000. Two settings
+# are not optional:
+#
+#   server {
+#       listen 443 ssl http2;
+#       server_name storage.example.com;
+#
+#       ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+#       ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+#
+#       # Replays are multi-MB gzip blobs; nginx's 1m default 413s them while
+#       # smaller screenshots succeed, which makes the failure look random.
+#       client_max_body_size 200m;
+#       proxy_request_buffering off;
+#
+#       location / {
+#           proxy_pass http://127.0.0.1:9000;
+#           # MinIO recomputes the SigV4 signature over the Host header. If the
+#           # proxy rewrites it, every request fails SignatureDoesNotMatch.
+#           proxy_set_header Host $host;
+#           proxy_set_header X-Forwarded-Proto $scheme;
+#       }
+#   }
+#
+# Then set S3_ENDPOINT=https://storage.example.com and restart api + worker.
+#
+# Verify with a real round trip rather than a health check - a presigned GET
+# returning 404 (not 403) proves the signature survived the proxy:
+#
+#   mc share upload local/<bucket>/probe.png     # generates a presigned POST
+#   curl ... -F file=@probe.png                   # expect HTTP 204
+# ============================================================================
+
+services:
+  minio:
+    ports:
+      # Loopback only. The host proxy is what exposes this publicly, with TLS.
+      - '127.0.0.1:${MINIO_HOST_PORT:-9000}:9000'

--- a/docker-compose.storage.yml
+++ b/docker-compose.storage.yml
@@ -50,7 +50,12 @@
 #       }
 #   }
 #
-# Then set S3_ENDPOINT=https://storage.example.com and restart api + worker.
+# Then set S3_ENDPOINT=https://storage.example.com and recreate api + worker.
+# `docker compose restart` is not enough: it reuses the existing containers,
+# which keep the value baked in when they were created. Only `up -d` picks the
+# new one up.
+#
+#   docker compose up -d api worker
 #
 # Verify with a real round trip rather than a health check - a presigned GET
 # returning 404 (not 403) proves the signature survived the proxy:

--- a/docker-compose.storage.yml
+++ b/docker-compose.storage.yml
@@ -5,7 +5,7 @@
 # at a public hostname.
 #
 #   docker compose -f docker-compose.yml -f docker-compose.storage.yml \
-#     --profile infra up -d minio
+#     --profile dev up -d minio
 #
 # WHY THIS IS NEEDED
 # ------------------
@@ -63,4 +63,7 @@ services:
   minio:
     ports:
       # Loopback only. The host proxy is what exposes this publicly, with TLS.
-      - '127.0.0.1:${MINIO_HOST_PORT:-9000}:9000'
+      # MINIO_PORT is the name docker-compose.override.yml already publishes
+      # under and .env.example already documents - same knob, so reuse it
+      # rather than adding a second one for the same binding.
+      - '127.0.0.1:${MINIO_PORT:-9000}:9000'


### PR DESCRIPTION
Screenshot and replay uploads broke after moving to MinIO-on-the-box. Uploads bypass the API — it returns a presigned S3 URL and the browser PUTs directly to it — so `S3_ENDPOINT=http://minio:9000` handed browsers an unreachable, non-HTTPS URL. The SDK rejects it outright, and server-side storage keeps working, so it presents as "upload requires HTTPS" while every health check stays green.

Adds `docker-compose.storage.yml` (publishes MinIO on loopback for a TLS proxy) and documents the two settings that break it silently otherwise: `client_max_body_size` and Host passthrough for SigV4.

Verified in production: presigned POST from outside returned 204 and the object landed.

Refs ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)