### PR TITLE
fix(share): stop stripping screenshot_url from shared replay views

### DIFF
--- a/packages/backend/src/api/schemas/share-token-schema.ts
+++ b/packages/backend/src/api/schemas/share-token-schema.ts
@@ -126,6 +126,12 @@ export const getSharedReplaySchema = {
                 status: { type: 'string' },
                 priority: { type: 'string' },
                 created_at: { type: 'string', format: 'date-time' },
+                // The route computes these presigned URLs, but Fastify strips any
+                // property a response schema does not declare - so without these two
+                // lines the screenshot silently never reaches the shared view,
+                // however healthy storage is.
+                screenshot_url: { type: 'string', nullable: true },
+                thumbnail_url: { type: 'string', nullable: true },
               },
             },
             session: {

--- a/packages/backend/src/api/schemas/share-token-schema.ts
+++ b/packages/backend/src/api/schemas/share-token-schema.ts
@@ -130,8 +130,8 @@ export const getSharedReplaySchema = {
                 // property a response schema does not declare - so without these two
                 // lines the screenshot silently never reaches the shared view,
                 // however healthy storage is.
-                screenshot_url: { type: 'string', nullable: true },
-                thumbnail_url: { type: 'string', nullable: true },
+                screenshot_url: { type: 'string', format: 'uri', nullable: true },
+                thumbnail_url: { type: 'string', format: 'uri', nullable: true },
               },
             },
             session: {

--- a/packages/backend/src/api/schemas/share-token-schema.ts
+++ b/packages/backend/src/api/schemas/share-token-schema.ts
@@ -182,7 +182,12 @@ export const getSharedReplaySchema = {
                 },
               },
             },
-            replay_url: { type: 'string', format: 'uri' },
+            // nullable because the route returns null for a share with no
+            // replay - metadata-only shares are supported (session-service
+            // hasShareableContent). Without it fast-json-stringify coerces the
+            // null to "", so the endpoint advertised a URI and sent an empty
+            // string.
+            replay_url: { type: 'string', format: 'uri', nullable: true },
             share_info: {
               type: 'object',
               required: ['view_count', 'expires_at', 'password_protected'],

--- a/packages/backend/tests/api/share-token-schema.test.ts
+++ b/packages/backend/tests/api/share-token-schema.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Guards the shared-replay response schema against silently dropping media URLs.
+ *
+ * Fastify serializes a response through its schema and removes any property the
+ * schema does not declare. The share route signs screenshot and thumbnail URLs
+ * and puts them on `bug_report` (share-tokens.ts), but they were absent from the
+ * schema, so every shared link lost them - with no error anywhere, and storage
+ * perfectly healthy. `replay_url` was unaffected only because it is declared one
+ * level up on `data`, and that asymmetry is what made it read as a storage bug.
+ *
+ * The test drives a real Fastify instance rather than calling the handler,
+ * because the stripping happens in serialization: a handler-level assertion
+ * passes while the client receives nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Fastify from 'fastify';
+import { getSharedReplaySchema } from '../../src/api/schemas/share-token-schema.js';
+
+/** A response body shaped like the one share-tokens.ts builds. */
+function sharedReplayPayload() {
+  return {
+    success: true as const,
+    data: {
+      bug_report: {
+        id: '3f24a1d7-1816-4553-b29d-5df19586f882',
+        title: 'Checkout crash',
+        description: 'Payment processor undefined',
+        status: 'open',
+        priority: 'medium',
+        created_at: new Date(0).toISOString(),
+        screenshot_url: 'https://storage.example.com/screenshots/a/original.png?X-Amz-Signature=x',
+        thumbnail_url: 'https://storage.example.com/screenshots/a-thumb/original.png?X-Amz-Sig=y',
+      },
+      replay_url: 'https://storage.example.com/replays/a/replay.gz?X-Amz-Signature=z',
+      share_info: {
+        view_count: 1,
+        expires_at: new Date(0).toISOString(),
+        password_protected: false,
+      },
+    },
+    timestamp: new Date(0).toISOString(),
+  };
+}
+
+// The schema validates the request too: params require a >=32-char token.
+const TOKEN = 'a'.repeat(43);
+const URL = `/replays/shared/${TOKEN}`;
+
+async function serializeThroughSchema(
+  payload: ReturnType<typeof sharedReplayPayload> = sharedReplayPayload()
+) {
+  const app = Fastify();
+  app.get('/replays/shared/:token', { schema: getSharedReplaySchema }, async () => payload);
+  const response = await app.inject({ method: 'GET', url: URL });
+  await app.close();
+  return { statusCode: response.statusCode, body: JSON.parse(response.body) };
+}
+
+describe('getSharedReplaySchema', () => {
+  it('keeps screenshot_url and thumbnail_url on the shared bug report', async () => {
+    const { statusCode, body } = await serializeThroughSchema();
+
+    expect(statusCode).toBe(200);
+    // The assertion that fails when either property is dropped from the schema.
+    expect(body.data.bug_report.screenshot_url).toBe(
+      sharedReplayPayload().data.bug_report.screenshot_url
+    );
+    expect(body.data.bug_report.thumbnail_url).toBe(
+      sharedReplayPayload().data.bug_report.thumbnail_url
+    );
+  });
+
+  it('still returns replay_url and the rest of the bug report', async () => {
+    const { body } = await serializeThroughSchema();
+
+    expect(body.data.replay_url).toBe(sharedReplayPayload().data.replay_url);
+    expect(body.data.bug_report.id).toBe(sharedReplayPayload().data.bug_report.id);
+    expect(body.data.bug_report.title).toBe('Checkout crash');
+  });
+
+  it('accepts null media URLs, for a report that has no screenshot', async () => {
+    const payload = sharedReplayPayload();
+    payload.data.bug_report.screenshot_url = null as unknown as string;
+    payload.data.bug_report.thumbnail_url = null as unknown as string;
+
+    const { statusCode, body } = await serializeThroughSchema(payload);
+
+    expect(statusCode).toBe(200);
+    expect(body.data.bug_report.screenshot_url).toBeNull();
+    expect(body.data.bug_report.thumbnail_url).toBeNull();
+  });
+});

--- a/packages/backend/tests/api/share-token-schema.test.ts
+++ b/packages/backend/tests/api/share-token-schema.test.ts
@@ -45,14 +45,14 @@ function sharedReplayPayload() {
 
 // The schema validates the request too: params require a >=32-char token.
 const TOKEN = 'a'.repeat(43);
-const URL = `/replays/shared/${TOKEN}`;
+const SHARE_PATH = `/replays/shared/${TOKEN}`;
 
 async function serializeThroughSchema(
   payload: ReturnType<typeof sharedReplayPayload> = sharedReplayPayload()
 ) {
   const app = Fastify();
   app.get('/replays/shared/:token', { schema: getSharedReplaySchema }, async () => payload);
-  const response = await app.inject({ method: 'GET', url: URL });
+  const response = await app.inject({ method: 'GET', url: SHARE_PATH });
   await app.close();
   return { statusCode: response.statusCode, body: JSON.parse(response.body) };
 }
@@ -72,11 +72,28 @@ describe('getSharedReplaySchema', () => {
   });
 
   it('still returns replay_url and the rest of the bug report', async () => {
-    const { body } = await serializeThroughSchema();
+    const { statusCode, body } = await serializeThroughSchema();
 
+    expect(statusCode).toBe(200);
     expect(body.data.replay_url).toBe(sharedReplayPayload().data.replay_url);
     expect(body.data.bug_report.id).toBe(sharedReplayPayload().data.bug_report.id);
     expect(body.data.bug_report.title).toBe('Checkout crash');
+  });
+
+  it('returns null replay_url for a metadata-only share, not an empty string', async () => {
+    // The route returns null when replay_key is absent, and metadata-only
+    // shares are supported. While replay_url was declared non-nullable,
+    // fast-json-stringify coerced that null to "" - the endpoint promised a
+    // URI and sent an empty string, which no consumer could tell apart from a
+    // signing failure.
+    const payload = sharedReplayPayload();
+    payload.data.replay_url = null as unknown as string;
+
+    const { statusCode, body } = await serializeThroughSchema(payload);
+
+    expect(statusCode).toBe(200);
+    expect(body.data.replay_url).toBeNull();
+    expect(body.data.replay_url).not.toBe('');
   });
 
   it('accepts null media URLs, for a report that has no screenshot', async () => {

--- a/packages/backend/tests/api/share-tokens.test.ts
+++ b/packages/backend/tests/api/share-tokens.test.ts
@@ -78,9 +78,15 @@ describe('Share Token Routes', () => {
 
   afterAll(async () => {
     // Cleanup
-    if (testBugReport?.id) await db.bugReports.delete(testBugReport.id);
-    if (testProject?.id) await db.projects.delete(testProject.id);
-    if (testUser?.id) await db.users.delete(testUser.id);
+    if (testBugReport?.id) {
+      await db.bugReports.delete(testBugReport.id);
+    }
+    if (testProject?.id) {
+      await db.projects.delete(testProject.id);
+    }
+    if (testUser?.id) {
+      await db.users.delete(testUser.id);
+    }
     await server.close();
     await db.close();
   });
@@ -270,6 +276,14 @@ describe('Share Token Routes', () => {
         priority: testBugReport.priority,
       });
       expect(body.data.bug_report).toHaveProperty('created_at');
+
+      // Presence, not value: the route signs these from the report's keys, but
+      // Fastify drops any property the response schema does not declare, so an
+      // undeclared field arrives as absent rather than null. Asserting the key
+      // exists is what catches that, and it holds whether or not this fixture
+      // has a screenshot.
+      expect(body.data.bug_report).toHaveProperty('screenshot_url');
+      expect(body.data.bug_report).toHaveProperty('thumbnail_url');
 
       // Verify share_info structure
       expect(body.data.share_info).toMatchObject({

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       'tests/api/trust-proxy.test.ts',
       'tests/api/analytics-routes.test.ts',
       'tests/api/media-urls.test.ts',
+      'tests/api/share-token-schema.test.ts',
       // Pure unit (mocked DB) — no testcontainer needed.
       'tests/analytics/analytics-scope.test.ts',
       'tests/analytics/analytics-auth.test.ts',


### PR DESCRIPTION
A shared link could never show a screenshot. The route computes presigned screenshot
and thumbnail URLs and passes them in the response, but the response schema declared
only six properties on `bug_report`, and Fastify removes anything a response schema
does not declare — so both were computed and silently discarded.

`replay_url` survived only because it *is* declared, which is the asymmetry that made
this look like a storage problem. Reviewing that turned up the mirror defect one level
up: `replay_url` was declared non-nullable while the route returns `null` for a
metadata-only share, so fast-json-stringify was coercing it to `""`. Fixed here too.

Confirmed still live against production before merging: the shared endpoint returns
`bug_report` with neither media key present.

Guarded by a schema-level test that drives a real Fastify instance — verified as a real
guard by removing each fix and watching the corresponding assertion fail — plus presence
assertions on the route-level test. Deliberately no mock-based assertion that signed
values travel the route; that belongs against real storage.

Refs #316

Assisted-by: claude-opus-5 (agent)
