### PR TITLE
fix(ai-sdlc): make a timed-out claude CLI call diagnosable

### DIFF
--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -138,6 +138,75 @@ export function logCliTelemetry(data, log = console) {
   }
 }
 
+// How often callViaCli reports that a call is still in flight. The CLI buffers
+// its whole `--output-format json` envelope to the end, so a long call is
+// otherwise indistinguishable from a hung one until the timeout fires.
+const CLI_HEARTBEAT_MS = 60_000;
+
+// logCliTelemetry only ever runs on the success path — it needs a parsed
+// envelope, and a timed-out call never produces one. That left the failure
+// mode we most need to explain as the one emitting no diagnostics at all:
+// impl-agent runs 30761885485 and 31039877104 both burned the full 780s and
+// logged exactly one line, `claude CLI timed out after 780000ms`, discarding
+// every byte the child had written.
+//
+// The byte counts are the load-bearing part, not the tails. `stdout 0B` after
+// 780s means the CLI never emitted its envelope — it was still working, or
+// wedged, and the timeout is the symptom rather than the cause. Non-zero
+// stdout means it produced something we then threw away, which is a parsing
+// or size problem instead. Those need opposite fixes, and today's log cannot
+// tell them apart.
+//
+// Tails are bounded because stderr can carry progress spew and this string
+// goes into an Error message that lands in a CI log.
+export function formatCliTimeout({
+  timeoutMs,
+  elapsedMs = null,
+  stdout = '',
+  stderr = '',
+  tailChars = 1500,
+}) {
+  // Keep this exact prefix: it is the string the run logs have been
+  // identified by across every timeout so far.
+  let message = `claude CLI timed out after ${timeoutMs}ms`;
+  if (typeof elapsedMs === 'number') {
+    message += ` (killed at ${Math.round(elapsedMs / 1000)}s)`;
+  }
+
+  message += `\n  received: stdout ${stdout.length}B, stderr ${stderr.length}B`;
+
+  if (stdout.length === 0 && stderr.length === 0) {
+    message +=
+      '\n  the child wrote nothing at all before being killed — it produced no ' +
+      'envelope, so this is a stalled or still-working call, not an oversized ' +
+      'or malformed response.';
+    return message;
+  }
+
+  const tail = (label, text) => {
+    if (text.length === 0) {
+      return '';
+    }
+    const clipped = text.length > tailChars;
+    return `\n  ${label} tail${clipped ? ` (last ${tailChars} of ${text.length})` : ''}:\n${
+      clipped ? text.slice(-tailChars) : text
+    }`;
+  };
+
+  return message + tail('stderr', stderr.trim()) + tail('stdout', stdout.trim());
+}
+
+// Emitted every CLI_HEARTBEAT_MS while a call is in flight. Byte counts make
+// the difference between "streaming, just slow" and "silent since the first
+// second" visible while the run is still happening, instead of only in the
+// post-mortem.
+export function formatCliProgress({ elapsedMs, stdoutBytes, stderrBytes }) {
+  return (
+    `claude CLI: still running after ${Math.round(elapsedMs / 1000)}s ` +
+    `(stdout ${stdoutBytes}B, stderr ${stderrBytes}B)`
+  );
+}
+
 // No `maxTokens` param here (deliberately) — the CLI has no per-call
 // output-token cap to forward it to. See the module header comment.
 async function callViaCli({ prompt, timeoutMs, model }) {
@@ -190,9 +259,29 @@ async function callViaCli({ prompt, timeoutMs, model }) {
 
     let stdout = '';
     let stderr = '';
+    const startedAt = Date.now();
+
+    // unref'd so a stray interval can never hold the process open on a path
+    // that forgets to clear it; every exit path below clears it anyway.
+    const heartbeat = setInterval(() => {
+      console.log(
+        formatCliProgress({
+          elapsedMs: Date.now() - startedAt,
+          stdoutBytes: stdout.length,
+          stderrBytes: stderr.length,
+        })
+      );
+    }, CLI_HEARTBEAT_MS);
+    heartbeat.unref?.();
+
     const timer = setTimeout(() => {
+      clearInterval(heartbeat);
       child.kill('SIGKILL');
-      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
+      reject(
+        new Error(
+          formatCliTimeout({ timeoutMs, elapsedMs: Date.now() - startedAt, stdout, stderr })
+        )
+      );
     }, timeoutMs);
 
     child.stdout.setEncoding('utf8');
@@ -205,10 +294,12 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     });
     child.on('error', (err) => {
       clearTimeout(timer);
+      clearInterval(heartbeat);
       reject(err);
     });
     child.on('close', (code, signal) => {
       clearTimeout(timer);
+      clearInterval(heartbeat);
       if (code !== 0 || signal) {
         const reason = code !== null ? `code ${code}` : `signal ${signal}`;
         // The claude CLI's error detail (e.g. a billing/auth failure) lands

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -36,6 +36,7 @@
 //   detectable via stopReason === 'max_tokens' regardless of backend.
 
 import { spawn } from 'node:child_process';
+import { Buffer } from 'node:buffer';
 
 const LLM_BACKEND = process.env.LLM_BACKEND || 'api';
 
@@ -173,9 +174,14 @@ export function formatCliTimeout({
     message += ` (killed at ${Math.round(elapsedMs / 1000)}s)`;
   }
 
-  message += `\n  received: stdout ${stdout.length}B, stderr ${stderr.length}B`;
+  // Real UTF-8 byte counts, not String#length: that counts UTF-16 code units,
+  // so any non-ASCII the CLI emits would be under-reported under a "B" label.
+  const stdoutBytes = Buffer.byteLength(stdout, 'utf8');
+  const stderrBytes = Buffer.byteLength(stderr, 'utf8');
 
-  if (stdout.length === 0 && stderr.length === 0) {
+  message += `\n  received: stdout ${stdoutBytes}B, stderr ${stderrBytes}B`;
+
+  if (stdoutBytes === 0 && stderrBytes === 0) {
     message +=
       '\n  the child wrote nothing at all before being killed — it produced no ' +
       'envelope, so this is a stalled or still-working call, not an oversized ' +
@@ -183,12 +189,15 @@ export function formatCliTimeout({
     return message;
   }
 
+  // Clipping is deliberately character-based (slice operates on code units,
+  // and cutting a UTF-8 buffer at a byte offset can split a character), so the
+  // unit is spelled out to keep it distinct from the byte counts above.
   const tail = (label, text) => {
     if (text.length === 0) {
       return '';
     }
     const clipped = text.length > tailChars;
-    return `\n  ${label} tail${clipped ? ` (last ${tailChars} of ${text.length})` : ''}:\n${
+    return `\n  ${label} tail${clipped ? ` (last ${tailChars} chars of ${text.length})` : ''}:\n${
       clipped ? text.slice(-tailChars) : text
     }`;
   };
@@ -267,8 +276,8 @@ async function callViaCli({ prompt, timeoutMs, model }) {
       console.log(
         formatCliProgress({
           elapsedMs: Date.now() - startedAt,
-          stdoutBytes: stdout.length,
-          stderrBytes: stderr.length,
+          stdoutBytes: Buffer.byteLength(stdout, 'utf8'),
+          stderrBytes: Buffer.byteLength(stderr, 'utf8'),
         })
       );
     }, CLI_HEARTBEAT_MS);

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -175,8 +175,19 @@ test('formatCliTimeout clips long output so an Error message cannot flood a CI l
   const message = formatCliTimeout({ timeoutMs: 5000, stdout: huge, tailChars: 100 });
 
   assert.match(message, /stdout 50000B/, 'the true size must still be reported');
-  assert.match(message, /last 100 of 50000/);
+  assert.match(message, /last 100 chars of 50000/);
   assert.ok(message.length < 1000, `expected a clipped message, got ${message.length} chars`);
+});
+
+test('formatCliTimeout counts UTF-8 bytes, not UTF-16 code units', () => {
+  // '😀' is one code point, String#length 2, and 4 bytes on the wire. Reporting
+  // 2 under a "B" label under-reports what the child actually wrote — and the
+  // clipping line must stay in its own unit rather than silently mixing the two.
+  const message = formatCliTimeout({ timeoutMs: 5000, stdout: '😀', stderr: 'café' });
+
+  assert.match(message, /stdout 4B/);
+  assert.match(message, /stderr 5B/, "'café' is 4 code units but 5 UTF-8 bytes");
+  assert.doesNotMatch(message, /stdout 2B/);
 });
 
 test('formatCliProgress reports elapsed time and bytes received so far', () => {

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -44,6 +44,15 @@ writeFileSync(
     // (['-p', '--output-format', ...]).
     'if (argvDumpPath) fs.writeFileSync(argvDumpPath, JSON.stringify(process.argv.slice(2)));',
     "const mode = process.env.FAKE_CLAUDE_MODE || 'success';",
+    // Writes a partial (unparseable) envelope and then never finishes, so the
+    // parent's timeout path fires with real bytes already buffered. `return`
+    // is legal here: CommonJS wraps the module body in a function.
+    "if (mode === 'hang') {",
+    "  process.stdout.write('PARTIAL_ENVELOPE_MARKER');",
+    "  process.stderr.write('FAKE_STDERR_PROGRESS');",
+    '  setTimeout(function () { process.exit(0); }, 5000);',
+    '  return;',
+    '}',
     "if (mode === 'error') {",
     "  process.stdout.write('FAKE_STDOUT_MARKER: upstream billing failure detail');",
     '  process.exit(2);',
@@ -69,7 +78,9 @@ process.env.LLM_BACKEND = 'cli';
 process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
 process.env.PATH = `${DIR}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`;
 
-const { callClaude, logCliTelemetry } = await import('./llm-client.mjs');
+const { callClaude, logCliTelemetry, formatCliTimeout, formatCliProgress } = await import(
+  './llm-client.mjs'
+);
 
 // Collects what logCliTelemetry emits so the assertions below read the real
 // output rather than trusting the function was called.
@@ -130,6 +141,65 @@ test('logCliTelemetry tolerates an envelope carrying no telemetry fields', () =>
   for (const line of lines.log) {
     assert.match(line, /no telemetry fields/);
   }
+});
+
+test('formatCliTimeout reports byte counts and says so explicitly when the child wrote nothing', () => {
+  const message = formatCliTimeout({ timeoutMs: 780_000, elapsedMs: 780_142 });
+
+  // The historical prefix must survive: it is how every timeout so far has
+  // been identified in run logs.
+  assert.match(message, /^claude CLI timed out after 780000ms/);
+  assert.match(message, /killed at 780s/);
+  assert.match(message, /stdout 0B, stderr 0B/);
+  // The distinction the whole diagnostic exists to draw.
+  assert.match(message, /wrote nothing at all/);
+  assert.match(message, /stalled or still-working call/);
+});
+
+test('formatCliTimeout includes the tails when the child did write something', () => {
+  const message = formatCliTimeout({
+    timeoutMs: 5000,
+    stdout: '{"result":"partial',
+    stderr: 'progress: thinking',
+  });
+
+  assert.match(message, /stdout 18B, stderr 18B/);
+  assert.match(message, /\{"result":"partial/);
+  assert.match(message, /progress: thinking/);
+  // The empty-output explanation must NOT appear when output exists.
+  assert.doesNotMatch(message, /wrote nothing at all/);
+});
+
+test('formatCliTimeout clips long output so an Error message cannot flood a CI log', () => {
+  const huge = 'x'.repeat(50_000);
+  const message = formatCliTimeout({ timeoutMs: 5000, stdout: huge, tailChars: 100 });
+
+  assert.match(message, /stdout 50000B/, 'the true size must still be reported');
+  assert.match(message, /last 100 of 50000/);
+  assert.ok(message.length < 1000, `expected a clipped message, got ${message.length} chars`);
+});
+
+test('formatCliProgress reports elapsed time and bytes received so far', () => {
+  const line = formatCliProgress({ elapsedMs: 120_000, stdoutBytes: 0, stderrBytes: 42 });
+
+  assert.match(line, /still running after 120s/);
+  assert.match(line, /stdout 0B, stderr 42B/);
+});
+
+test('callViaCli timeout error carries what the child actually wrote before the kill', async () => {
+  process.env.FAKE_CLAUDE_MODE = 'hang';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+
+  // Proves the forensics reach the real rejection path, not just the pure
+  // formatter: without them this error message is the bare one-liner that
+  // made impl-agent runs 30761885485 and 31039877104 undiagnosable.
+  await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 2500 }), (err) => {
+    assert.match(err.message, /claude CLI timed out after 2500ms/);
+    assert.match(err.message, /received: stdout \d+B, stderr \d+B/);
+    assert.match(err.message, /PARTIAL_ENVELOPE_MARKER/);
+    assert.doesNotMatch(err.message, /wrote nothing at all/);
+    return true;
+  });
 });
 
 test('callViaCli strips ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN from the spawned child env, keeps other vars', async () => {


### PR DESCRIPTION
`logCliTelemetry` (#282) only runs on the success path — it needs a parsed envelope, and a timed-out call never produces one. So the failure mode we most need to explain is the one that emits no diagnostics at all.

impl-agent runs [30761885485](https://github.com/apex-bridge/bugspotter/actions/runs/30761885485) and [31039877104](https://github.com/apex-bridge/bugspotter/actions/runs/31039877104) each burned the full 780s on issue #269 and logged exactly one line, `claude CLI timed out after 780000ms`, discarding every byte the child had written.

## What this adds

- **`formatCliTimeout`** puts elapsed time, stdout/stderr byte counts and bounded tails into the rejection. The byte counts are the load-bearing part: `stdout 0B` after 780s means the CLI never emitted its envelope (stalled or still working), while non-zero stdout means it produced output that was then thrown away. Those need opposite fixes and today's log cannot distinguish them.
- **A 60s heartbeat** (`formatCliProgress`) makes the same distinction visible while the run is still happening rather than only in the post-mortem.

Tails are clipped (default 1500 chars, true size still reported) because stderr can carry progress spew and this string lands in a CI log. The historical `claude CLI timed out after Nms` prefix is preserved, since that is how every timeout so far has been identified in run logs.

## Verification

`node --test scripts/ai-sdlc/*.test.mjs` → 71 pass, 0 fail (was 66). Six new tests: the empty-output case, the with-output case, tail clipping, the heartbeat line, and an end-to-end timeout against a fake `claude` that writes a partial envelope and then hangs.

Adversarially checked: reverting the reject back to the bare one-liner fails exactly the end-to-end test (`not ok 8`), so the test proves the wiring rather than just the formatter.

`pnpm test:unit` → 3090 pass. eslint and prettier@3.6.2 clean.

Refs #269

Assisted-by: claude-opus-5 (agent)
