### PR TITLE
feat(ai-sdlc): guard Gate 4 on the issue, warn on closing keywords in impl PRs

### DIFF
--- a/.github/workflows/gate-guard.yml
+++ b/.github/workflows/gate-guard.yml
@@ -1,0 +1,104 @@
+name: Gate Guard
+
+# Gate 4 (deploy) is a human action: a pipeline issue is meant to stay open at
+# `needs-deploy` until someone has actually deployed and verified. Nothing
+# enforced that. An implementation PR whose body said `Closes #NNN` instead of
+# `Refs #NNN` auto-closed the issue on merge, so it never reached the gate and
+# Gate 4 silently did not happen - no error, no warning, indistinguishable from
+# success. PR #283 was written that way and was caught only by hand.
+#
+# `PR Link` cannot catch this: it accepts `Closes` and `Refs` identically,
+# because it only asks whether SOME issue is referenced. It is also deliberately
+# a pure offline string function, and teaching it about issue state would give a
+# required check a network failure mode. More importantly, a closing keyword is
+# only one route to skipping Gate 4 - a human clicking "Close issue" does
+# identical damage, and no PR-body check will ever see that. So the guard lives
+# on the issue, where the gate lives.
+#
+# This workflow never blocks anything. Worst case it posts a comment.
+#
+# Refs #269.
+
+on:
+  issues:
+    types: [closed]
+
+# Serialised per issue: a close/reopen storm must not race itself.
+concurrency:
+  group: gate-guard-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  issues: write
+
+jobs:
+  gate-4:
+    name: Gate Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Test the guard
+        run: node --test scripts/ai-sdlc/check-gate-4.test.mjs
+
+      # An issue closed as a side effect of a merged PR has a `closed` timeline
+      # event carrying a commit_id; one closed by a person does not. That is the
+      # line between "a keyword did this" (restore it) and "someone decided
+      # this" (leave it alone), so it is worth the extra API call.
+      - name: Determine whether a merge closed this issue
+        id: cause
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          CLOSED_BY_MERGE="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/timeline?per_page=100" \
+            --paginate \
+            --jq '[.[] | select(.event == "closed") | .commit_id] | last | if . == null then "false" else "true" end')"
+          echo "closed_by_merge=${CLOSED_BY_MERGE}" >> "$GITHUB_OUTPUT"
+          echo "closed_by_merge=${CLOSED_BY_MERGE}"
+
+      - name: Decide
+        id: decide
+        env:
+          # Raw JSON, not a joined string: label names can contain commas and
+          # spaces, and an Actions expression cannot emit a real newline as a
+          # join separator.
+          ISSUE_LABELS_JSON: ${{ toJSON(github.event.issue.labels) }}
+          ISSUE_STATE_REASON: ${{ github.event.issue.state_reason }}
+          CLOSED_BY_MERGE: ${{ steps.cause.outputs.closed_by_merge }}
+        run: node scripts/ai-sdlc/check-gate-4.mjs
+
+      - name: Reopen and restore the deploy gate
+        if: steps.decide.outputs.action == 'restore'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GATE: ${{ steps.decide.outputs.gate }}
+          BODY: ${{ steps.decide.outputs.comment }}
+        run: |
+          set -euo pipefail
+          gh issue reopen "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY"
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label "$GATE" --add-label needs-deploy
+          printf '%s' "$BODY" | gh issue comment "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" --body-file -
+
+      - name: Note that the gate was skipped
+        if: steps.decide.outputs.action == 'comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          BODY: ${{ steps.decide.outputs.comment }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$BODY" | gh issue comment "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" --body-file -

--- a/.github/workflows/gate-guard.yml
+++ b/.github/workflows/gate-guard.yml
@@ -59,12 +59,30 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-          CLOSED_BY_MERGE="$(gh api \
+          # `--paginate` applies `--jq` to each page separately, not to the
+          # concatenated result, so any expression that aggregates (`last`,
+          # `length`, a wrapping `[...]`) silently aggregates per page and emits
+          # one line per page. On an issue with over 100 timeline events - easy
+          # for a pipeline issue that moved through several gates - that wrote a
+          # multi-line value into $GITHUB_OUTPUT and the runner rejected it.
+          # So: emit one token per `closed` event and aggregate in the shell,
+          # where `tail -n 1` sees every page. The timeline is chronological, so
+          # the last such token is the close that is being handled now.
+          LAST_CLOSE="$(gh api \
             "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/timeline?per_page=100" \
             --paginate \
-            --jq '[.[] | select(.event == "closed") | .commit_id] | last | if . == null then "false" else "true" end')"
+            --jq '.[] | select(.event == "closed") | if .commit_id == null then "human" else "merge" end' \
+            | tail -n 1)"
+          # No token at all means the timeline has not caught up with the event
+          # that triggered this run. Treated as "not a merge", which downgrades
+          # the outcome to a comment rather than reopening an issue on a guess.
+          if [ "$LAST_CLOSE" = "merge" ]; then
+            CLOSED_BY_MERGE=true
+          else
+            CLOSED_BY_MERGE=false
+          fi
           echo "closed_by_merge=${CLOSED_BY_MERGE}" >> "$GITHUB_OUTPUT"
-          echo "closed_by_merge=${CLOSED_BY_MERGE}"
+          echo "closed_by_merge=${CLOSED_BY_MERGE} (last close event: ${LAST_CLOSE:-none})"
 
       - name: Decide
         id: decide

--- a/.github/workflows/pr-link.yml
+++ b/.github/workflows/pr-link.yml
@@ -54,4 +54,7 @@ jobs:
         env:
           # PR body via env, never inlined into run: as an actions expression
           PR_BODY: ${{ github.event.pull_request.body }}
+          # Branch name selects implementation PRs for the Gate-4 advisory
+          # warning. Advisory only - it never changes this check's exit code.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: node scripts/check-pr-link.mjs

--- a/scripts/ai-sdlc/check-gate-4.mjs
+++ b/scripts/ai-sdlc/check-gate-4.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Gate 4 guard: decides what to do when a pipeline issue is closed.
+//
+// The pipeline's label gates end at `needs-deploy`, and Gate 4 (deploy) is a
+// human action - the issue is meant to stay open until someone has actually
+// deployed and verified. Nothing enforced that. An implementation PR whose body
+// said `Closes #NNN` instead of `Refs #NNN` auto-closed the issue on merge, so
+// it never reached `needs-deploy` and Gate 4 silently did not happen. No error,
+// no warning; it looked exactly like success.
+//
+// PR #283 was written that way and caught by hand, only because PR #277 (the
+// previous feature) happened to use `Refs` and its issue is consequently still
+// open at `needs-deploy`. `PR Link` accepts both keywords - it only asks whether
+// SOME issue is referenced - so nothing in CI could have caught it.
+//
+// Why the guard lives here rather than in `check-pr-link.mjs`: a closing keyword
+// is only one route to skipping Gate 4. A human clicking "Close issue" does
+// identical damage, and no amount of PR-body checking will ever see that. The
+// gate is a property of the issue, so the check belongs on the issue. It also
+// keeps `PR Link` a pure offline string function with no network failure mode,
+// which is why that required check is reliable today.
+//
+// This module is the decision only - it performs no mutations. The workflow
+// (.github/workflows/gate-guard.yml) supplies the facts and carries out the
+// action, so the interesting logic stays testable without a live GitHub.
+
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Gates a pipeline issue passes through BEFORE Gate 4. An issue closing while
+// still carrying one of these never reached the deploy gate.
+export const PRE_DEPLOY_GATES = ['needs-spec', 'needs-adr', 'agent-working', 'needs-review'];
+
+export const DEPLOY_GATE = 'needs-deploy';
+
+/**
+ * Decide what should happen to a freshly-closed issue.
+ *
+ * @param {object} input
+ * @param {string[]} input.labels        - label names on the issue at close time
+ * @param {string|null} input.stateReason - GitHub's `completed` | `not_planned` | null
+ * @param {boolean} input.closedByMerge  - true if a merged PR closed it, not a person
+ * @returns {{action: 'ignore'|'comment'|'restore', gate: string|null, reason: string}}
+ */
+export function decideGateAction({ labels = [], stateReason = null, closedByMerge = false }) {
+  const gate = PRE_DEPLOY_GATES.find((g) => labels.includes(g)) ?? null;
+
+  if (gate === null) {
+    // Either not a pipeline issue at all, or it already reached `needs-deploy`
+    // and closing it is the expected end of the line.
+    return { action: 'ignore', gate: null, reason: 'no pre-deploy gate label' };
+  }
+
+  // `not_planned` is a deliberate judgment that the work should not happen -
+  // issue #238 was closed exactly this way after its spec turned out to be
+  // built on a hallucinated package. Gate 4 does not apply to work that is not
+  // being done, and second-guessing that call would make this guard a nuisance.
+  if (stateReason === 'not_planned') {
+    return { action: 'ignore', gate, reason: 'closed as not planned' };
+  }
+
+  // A person closing an issue by hand is making a decision. Say the gate was
+  // skipped, then leave it alone - reopening under someone would be fighting
+  // the human this pipeline exists to keep in the loop.
+  if (!closedByMerge) {
+    return { action: 'comment', gate, reason: 'closed by a person, not by a merge' };
+  }
+
+  // Closed as a side effect of a merge: nobody decided this, a keyword did.
+  // Restoring is the whole point of the guard.
+  return { action: 'restore', gate, reason: 'auto-closed by a merged PR' };
+}
+
+/**
+ * The comment body posted for the `comment` and `restore` actions.
+ * Written to be useful to a human reading it cold on the issue.
+ */
+export function buildComment({ action, gate }) {
+  const skipped =
+    `This issue closed while still labelled \`${gate}\`, so it never reached ` +
+    `\`${DEPLOY_GATE}\` and **Gate 4 (deploy) was skipped**.`;
+
+  if (action === 'restore') {
+    return (
+      `${skipped}\n\n` +
+      `It was closed automatically by a merged PR, which happens when the PR body ` +
+      `uses a closing keyword (\`Closes\`/\`Fixes\`/\`Resolves\`) instead of \`Refs\`. ` +
+      `Nobody decided to skip the gate - a keyword did.\n\n` +
+      `Reopened and moved to \`${DEPLOY_GATE}\`. Close it again once the change is ` +
+      `actually deployed and verified.\n\n` +
+      `To avoid this, reference the issue with \`Refs #NNN\` in implementation PRs. ` +
+      `\`impl-agent.yml\` already does this for agent-generated PRs.`
+    );
+  }
+
+  return (
+    `${skipped}\n\n` +
+    `Left as-is because a person closed it rather than a merge. If that was ` +
+    `deliberate, nothing to do. If Gate 4 still needs to happen, reopen and set ` +
+    `\`${DEPLOY_GATE}\`.`
+  );
+}
+
+function main() {
+  // Labels arrive as the raw JSON array from the event payload
+  // (`toJSON(github.event.issue.labels)`). Separator-joined forms are not safe
+  // here: label names may legitimately contain commas or spaces, and Actions
+  // expressions cannot emit a real newline as a join separator.
+  let labels = [];
+  const raw = process.env.ISSUE_LABELS_JSON;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        labels = parsed.map((l) => (typeof l === 'string' ? l : l?.name)).filter(Boolean);
+      }
+    } catch {
+      // Fail open, loudly. This guard must never be the reason an issue-close
+      // workflow errors; the worst outcome of a bad parse is no comment.
+      console.warn(`gate-4 guard: could not parse ISSUE_LABELS_JSON, treating as no labels`);
+    }
+  }
+
+  const decision = decideGateAction({
+    labels,
+    stateReason: process.env.ISSUE_STATE_REASON || null,
+    closedByMerge: process.env.CLOSED_BY_MERGE === 'true',
+  });
+
+  console.log(`gate-4 guard: ${decision.action} (${decision.reason})`);
+
+  // Consumed by the workflow via $GITHUB_OUTPUT.
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) {
+    appendFileSync(out, `action=${decision.action}\ngate=${decision.gate ?? ''}\n`);
+    if (decision.action !== 'ignore') {
+      // Randomised heredoc delimiter, same reason as generate-impl.mjs: the
+      // comment body is partly issue-derived, and a fixed delimiter appearing
+      // inside it would let the value escape into the output file.
+      const delimiter = `EOF_COMMENT_${Math.random().toString(36).slice(2)}`;
+      appendFileSync(out, `comment<<${delimiter}\n${buildComment(decision)}\n${delimiter}\n`);
+    }
+  }
+}
+
+// Only run when invoked directly, so the exports above stay importable by tests.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/ai-sdlc/check-gate-4.test.mjs
+++ b/scripts/ai-sdlc/check-gate-4.test.mjs
@@ -1,0 +1,111 @@
+// Tests for check-gate-4.mjs. Zero-dependency: run with `node --test`.
+//
+// The four-way split is the point of this file. A guard that reopens too
+// eagerly is worse than no guard, because it fights the human it exists to
+// protect - so "closed by a person" and "closed as not planned" are asserted
+// as hands-off just as firmly as the auto-close case is asserted as restored.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { decideGateAction, buildComment, PRE_DEPLOY_GATES, DEPLOY_GATE } from './check-gate-4.mjs';
+
+test('restores an issue auto-closed by a merged PR while still at a pre-deploy gate', () => {
+  // The #283 scenario: PR body said `Closes #269` rather than `Refs #269`.
+  const d = decideGateAction({
+    labels: ['agent-working', 'enhancement'],
+    stateReason: 'completed',
+    closedByMerge: true,
+  });
+
+  assert.equal(d.action, 'restore');
+  assert.equal(d.gate, 'agent-working');
+});
+
+test('leaves an issue closed by a person alone, but says the gate was skipped', () => {
+  const d = decideGateAction({
+    labels: ['needs-review'],
+    stateReason: 'completed',
+    closedByMerge: false,
+  });
+
+  // Comment, not restore: a person closing an issue is a decision, and
+  // reopening under them would make this guard a nuisance.
+  assert.equal(d.action, 'comment');
+  assert.equal(d.gate, 'needs-review');
+});
+
+test('ignores an issue closed as not planned', () => {
+  // Issue #238 was closed exactly this way, after its spec turned out to rest
+  // on a hallucinated package. Gate 4 does not apply to work nobody is doing.
+  const d = decideGateAction({
+    labels: ['agent-working'],
+    stateReason: 'not_planned',
+    closedByMerge: true,
+  });
+
+  assert.equal(d.action, 'ignore');
+});
+
+test('ignores an issue that already reached needs-deploy', () => {
+  const d = decideGateAction({
+    labels: [DEPLOY_GATE, 'enhancement'],
+    stateReason: 'completed',
+    closedByMerge: true,
+  });
+
+  assert.equal(d.action, 'ignore');
+  assert.equal(d.gate, null);
+});
+
+test('ignores an issue carrying no gate label at all', () => {
+  // Ordinary bugs and chores are not on the pipeline spine and must not be
+  // touched - this guard has `issues: write`, so over-reach is the main risk.
+  const d = decideGateAction({
+    labels: ['bug', 'good first issue'],
+    stateReason: 'completed',
+    closedByMerge: true,
+  });
+
+  assert.equal(d.action, 'ignore');
+});
+
+test('ignores an issue with no labels and no state reason', () => {
+  assert.equal(decideGateAction({}).action, 'ignore');
+});
+
+test('every pre-deploy gate label is recognised', () => {
+  // Guards against a label being added to the pipeline and silently not
+  // covered here.
+  for (const gate of PRE_DEPLOY_GATES) {
+    const d = decideGateAction({ labels: [gate], stateReason: 'completed', closedByMerge: true });
+    assert.equal(d.action, 'restore', `${gate} must be treated as pre-deploy`);
+    assert.equal(d.gate, gate);
+  }
+});
+
+test('picks the earliest gate when an issue somehow carries two', () => {
+  const d = decideGateAction({
+    labels: ['needs-review', 'needs-spec'],
+    stateReason: 'completed',
+    closedByMerge: true,
+  });
+
+  // PRE_DEPLOY_GATES is in pipeline order, so `find` reports the earlier one.
+  assert.equal(d.gate, 'needs-spec');
+});
+
+test('the restore comment explains the cause and names the fix', () => {
+  const body = buildComment({ action: 'restore', gate: 'agent-working' });
+
+  assert.match(body, /Gate 4 \(deploy\) was skipped/);
+  assert.match(body, /agent-working/);
+  assert.match(body, /Reopened and moved to `needs-deploy`/);
+  assert.match(body, /Refs #NNN/, 'must tell the reader how to avoid it next time');
+});
+
+test('the comment-only body does not claim the issue was reopened', () => {
+  const body = buildComment({ action: 'comment', gate: 'needs-review' });
+
+  assert.match(body, /Left as-is/);
+  assert.doesNotMatch(body, /Reopened/);
+});

--- a/scripts/check-pr-link.mjs
+++ b/scripts/check-pr-link.mjs
@@ -49,8 +49,15 @@ function hasReference(body) {
 // accept-list (it takes `Closes`/`Fixes`/`Resolves` but not `Closed`/`Fixed`/
 // `Resolved`). Matched in full here so the warning below is not blind to a
 // form that still auto-closes an issue.
+//
+// `:?` because GitHub's docs state the keyword "can be followed by colons",
+// so `Closes: #10` closes the issue exactly like `Closes #10`. REFERENCE above
+// deliberately does not accept that form: it is the blocking check, a body
+// carrying only `Closes: #10` fails it and the author is told to add a
+// reference, which is a safe direction to be wrong in. This one is advisory,
+// so the cost of missing a form is a warning that never fires.
 const CLOSING =
-  /(?<!\p{L})(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#[0-9]+(?![0-9\p{L}])/iu;
+  /(?<!\p{L})(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#[0-9]+(?![0-9\p{L}])/iu;
 
 /**
  * Warn - never fail - when an implementation PR uses a closing keyword.

--- a/scripts/check-pr-link.mjs
+++ b/scripts/check-pr-link.mjs
@@ -45,6 +45,51 @@ function hasReference(body) {
   return body.split(/\r?\n/).some((line) => REFERENCE.test(line));
 }
 
+// GitHub's full set of closing keywords, which is wider than this guard's own
+// accept-list (it takes `Closes`/`Fixes`/`Resolves` but not `Closed`/`Fixed`/
+// `Resolved`). Matched in full here so the warning below is not blind to a
+// form that still auto-closes an issue.
+const CLOSING =
+  /(?<!\p{L})(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#[0-9]+(?![0-9\p{L}])/iu;
+
+/**
+ * Warn - never fail - when an implementation PR uses a closing keyword.
+ *
+ * Merging such a PR auto-closes the linked issue, so it never reaches
+ * `needs-deploy` and Gate 4 (deploy) is silently skipped. PR #283 was written
+ * this way and was caught by hand, not by CI.
+ *
+ * This is advisory on purpose. The real guard is `.github/workflows/
+ * gate-guard.yml`, which watches the issue itself and therefore also catches a
+ * human closing it by hand - something no PR-body check can see. Failing here
+ * instead would put a hard gate on a heuristic (a branch-name prefix) and add
+ * friction to every ordinary PR that legitimately closes an issue.
+ *
+ * Deliberately not exported: this module calls main() unconditionally at load,
+ * and adding a main-guard to a Tier-1 required check risks the one failure mode
+ * that matters here - a wrong guard means main() never runs and every PR passes
+ * silently. Exercised through the CLI in check-pr-link.test.mjs instead.
+ *
+ * @returns {boolean} true when a warning was emitted
+ */
+function warnOnClosingKeyword(body, headRef, log = console) {
+  if (!headRef || !headRef.startsWith('impl/')) {
+    return false;
+  }
+  const line = body.split(/\r?\n/).find((l) => CLOSING.test(l));
+  if (!line) {
+    return false;
+  }
+  // ::warning:: surfaces in the Actions UI and the PR's checks tab without
+  // affecting the exit code.
+  log.log(
+    `::warning::This looks like an implementation PR (branch "${headRef}") and its body ` +
+      `uses a closing keyword: "${line.trim()}". Merging will auto-close the issue, ` +
+      `skipping Gate 4 (needs-deploy). Use "Refs #NNN" unless you mean to close it.`
+  );
+  return true;
+}
+
 function fail() {
   console.error('FAIL: PR body must reference a GitHub issue or ADR.');
   console.error('');
@@ -83,6 +128,10 @@ function main() {
     fail();
   }
   console.log('OK: PR body references a GitHub issue or ADR.');
+
+  // Advisory only, and deliberately after the pass line so it can never be
+  // mistaken for the reason a run failed.
+  warnOnClosingKeyword(body, process.env.HEAD_REF ?? '');
 }
 
 main();

--- a/scripts/check-pr-link.test.mjs
+++ b/scripts/check-pr-link.test.mjs
@@ -182,3 +182,61 @@ test('unreadable --message file exits 1 with a clean error', () => {
     assert.match(`${e.stdout || ''}${e.stderr || ''}`, /cannot read/);
   }
 });
+
+// --- Gate-4 advisory warning ---
+//
+// An implementation PR using a closing keyword auto-closes its issue on merge,
+// so the issue never reaches `needs-deploy` and Gate 4 is silently skipped
+// (PR #283, caught by hand). These assert the warning fires without ever
+// changing the exit code - the hard guard is gate-guard.yml, on the issue.
+
+// Same as runEnv, but with a branch name, which is what selects impl PRs.
+function runBranch(body, headRef) {
+  try {
+    const out = execFileSync('node', [SCRIPT], {
+      encoding: 'utf8',
+      env: { ...process.env, PR_BODY: body, HEAD_REF: headRef },
+    });
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status, out: `${e.stdout || ''}${e.stderr || ''}` };
+  }
+}
+
+test('warns, but still passes, when an impl PR uses a closing keyword', () => {
+  const r = runBranch('Closes #269', 'impl/issue-269-llm-unavailable');
+  assert.equal(r.code, 0, 'the warning must never fail the required check');
+  assert.match(r.out, /::warning::/);
+  assert.match(r.out, /Gate 4/);
+  assert.match(r.out, /Refs #NNN/);
+});
+
+test('does not warn when an impl PR uses Refs', () => {
+  const r = runBranch('Refs #269', 'impl/issue-269-llm-unavailable');
+  assert.equal(r.code, 0);
+  assert.doesNotMatch(r.out, /::warning::/);
+});
+
+test('does not warn on a non-impl branch, even with a closing keyword', () => {
+  // Ordinary PRs legitimately close issues; only the pipeline's impl PRs are
+  // subject to Gate 4.
+  const r = runBranch('Closes #123', 'fix/some-bug');
+  assert.equal(r.code, 0);
+  assert.doesNotMatch(r.out, /::warning::/);
+});
+
+test('warns on closing keyword forms the accept-list itself does not take', () => {
+  // "Fixed"/"Closed"/"Resolved" still auto-close on GitHub but are not in
+  // REFERENCE, so the body needs a separate valid reference to pass at all.
+  for (const kw of ['Fixed', 'Closed', 'Resolved']) {
+    const r = runBranch(`Refs #1\n${kw} #269`, 'impl/x');
+    assert.equal(r.code, 0);
+    assert.match(r.out, /::warning::/, `${kw} must be recognised as closing`);
+  }
+});
+
+test('no branch name means no warning', () => {
+  const r = runBranch('Closes #269', '');
+  assert.equal(r.code, 0);
+  assert.doesNotMatch(r.out, /::warning::/);
+});

--- a/scripts/check-pr-link.test.mjs
+++ b/scripts/check-pr-link.test.mjs
@@ -235,6 +235,15 @@ test('warns on closing keyword forms the accept-list itself does not take', () =
   }
 });
 
+test('warns on the colon form, which GitHub also treats as closing', () => {
+  // GitHub's docs: the keyword "can be followed by colons", so `Closes: #10`
+  // closes the issue. REFERENCE does not accept that form, hence the separate
+  // `Refs #1` that gets the body past the blocking check.
+  const r = runBranch('Refs #1\nCloses: #269', 'impl/issue-269-llm-unavailable');
+  assert.equal(r.code, 0);
+  assert.match(r.out, /::warning::/);
+});
+
 test('no branch name means no warning', () => {
   const r = runBranch('Closes #269', '');
   assert.equal(r.code, 0);


### PR DESCRIPTION
Implements decision 1 from `core-intelligence-features/open-decisions.md`: **option C plus the advisory warning.**

## The problem

Gate 4 (deploy) is a human action - a pipeline issue is meant to stay open at `needs-deploy` until someone has actually deployed and verified. Nothing enforced that.

An implementation PR whose body says `Closes #NNN` instead of `Refs #NNN` auto-closes the issue on merge, so it never reaches the gate and **Gate 4 silently does not happen**. No error, no warning, indistinguishable from success.

Both branches of this are live in the repo: PR #277 said `Refs #237`, and #237 is open at `needs-deploy` today. PR #283 said `Closes #269` and was changed before merge only because I compared the two by hand.

`PR Link` cannot catch it. It accepts `Closes` and `Refs` identically, because it only asks whether *some* issue is referenced.

## Why the guard is on the issue, not the PR

A closing keyword is only one route to skipping Gate 4. A human clicking "Close issue" does identical damage, and no amount of PR-body checking will ever see that. The gate is a property of the issue, so the check belongs there.

It also keeps `PR Link` a pure offline string function. Teaching it about issue state would give a required check a network failure mode, and that check's reliability is exactly what makes it useful.

## What this adds

**`gate-guard.yml` + `scripts/ai-sdlc/check-gate-4.mjs`** - on `issues: closed`:

| Situation | Action |
|---|---|
| Auto-closed by a merged PR while at a pre-deploy gate | **Restore**: reopen, set `needs-deploy`, comment explaining the cause and the fix |
| Closed by a person | **Comment only** - a person closing an issue is a decision; reopening under them would make this a nuisance |
| Closed as `not_planned` | **Ignore** - Gate 4 does not apply to work nobody is doing (this is how #238 was closed) |
| No pre-deploy gate label, or already at `needs-deploy` | **Ignore** |

The decision is a pure function so it is testable without a live GitHub; the workflow supplies the facts and performs the mutations. The merge-versus-human distinction comes from whether the issue's `closed` timeline event carries a `commit_id`.

This workflow never blocks anything. Worst case it posts a comment.

**`check-pr-link.mjs`** - an advisory `::warning::` when an `impl/` branch uses a closing keyword. It matches GitHub's full closing set (`closed`/`fixed`/`resolved` too, which the accept-list itself does not take) and **never changes the exit code**.

## Verification

`node --test scripts/ai-sdlc/*.test.mjs scripts/check-pr-link.test.mjs` -> **142 pass, 0 fail** (10 new for the decision logic, 5 for the warning). `pnpm test:unit` -> 3101 pass. `actionlint` clean on both workflows. prettier@3.6.2 and eslint clean.

The decision tests assert the hands-off cases as firmly as the restore case, because a guard that reopens too eagerly is worse than no guard.

Also exercised end to end via the real env-var path, confirming `$GITHUB_OUTPUT` gets `action`, `gate` and a heredoc-delimited `comment`.

## Note

`check-gate-4.mjs` uses the standard `pathToFileURL` main-guard. `check-pr-link.mjs` deliberately does **not** get one: it calls `main()` unconditionally today, and a wrong guard on a Tier-1 required check fails open and silently passes every PR. The new function is therefore not exported and is exercised through the CLI instead.

Refs #269

Assisted-by: claude-opus-5 (agent)