### PR TITLE
fix(admin): refuse to start when the CSP omits the storage host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -428,6 +428,14 @@ API_DOMAIN=
 #   STORAGE_DOMAIN=*.storage.yandexcloud.kz
 #   STORAGE_DOMAIN=s3.your-cloud.example
 #   STORAGE_DOMAIN=http://minio.internal:9000
+#
+# This must stay in step with S3_ENDPOINT above: browsers fetch presigned URLs
+# from that host directly, so a CSP that omits it breaks session replay
+# ("Failed to fetch") and blanks screenshots while every server-side check
+# passes. The admin entrypoint refuses to start on a mismatch rather than
+# serving a silently degraded CSP. Loopback and compose-service endpoints
+# (http://minio:9000) are skipped - they are unreachable from the browser
+# regardless, which is what docker-compose.storage.yml is for.
 STORAGE_DOMAIN=
 
 # Jira user-picker avatars load from Atlassian-fixed CDNs (secure.gravatar.com,

--- a/.env.example
+++ b/.env.example
@@ -436,6 +436,18 @@ API_DOMAIN=
 # serving a silently degraded CSP. Loopback and compose-service endpoints
 # (http://minio:9000) are skipped - they are unreachable from the browser
 # regardless, which is what docker-compose.storage.yml is for.
+#
+# The host to allow is the one presigned URLs resolve to, which depends on
+# S3_FORCE_PATH_STYLE: with path style it is the endpoint host itself, without
+# it the bucket becomes a subdomain, so allow *.<endpoint> or
+# <bucket>.<endpoint>. Storage addressed by a public IP cannot be allowed at
+# all - a CSP source expression only ever matches the IP literal 127.0.0.1 -
+# so give the object store a hostname.
+#
+# S3_ENDPOINT is optional on AWS S3, where the SDK derives the endpoint itself.
+# The entrypoint has nothing to compare against then and stays quiet, so an AWS
+# deployment must set STORAGE_DOMAIN by hand - *.s3.<region>.amazonaws.com, or
+# the bucket's own host.
 STORAGE_DOMAIN=
 
 # Jira user-picker avatars load from Atlassian-fixed CDNs (secure.gravatar.com,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
       - name: Run AI-SDLC script tests
         run: node --test scripts/ai-sdlc/*.test.mjs
 
+      # Covers the container entrypoints' env validation, including the
+      # STORAGE_DOMAIN vs S3_ENDPOINT CSP cross-check. Pure POSIX shell with no
+      # dependencies, and nothing else exercises it - the code only runs inside
+      # a built image, so a regression here surfaces as a broken deployment.
+      - name: Run entrypoint env validation tests
+        run: sh scripts/test-validate-api-domain.sh
+
   test-backend-db:
     name: Backend Database Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,15 @@ jobs:
       - name: Run entrypoint env validation tests
         run: sh scripts/test-validate-api-domain.sh
 
+      # The step above runs under the runner's dash. In production this script
+      # is sourced by the admin image's entrypoint, which is nginx:alpine, so
+      # the shell that actually executes it is busybox ash - a different
+      # implementation with its own gaps. Run the suite there too.
+      - name: Run entrypoint env validation tests under busybox ash
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w alpine:3 \
+            sh scripts/test-validate-api-domain.sh
+
   test-backend-db:
     name: Backend Database Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -421,6 +421,12 @@ services:
       # with no server-side symptom. Loopback / compose-service endpoints are
       # skipped. See scripts/shared/validate-api-domain.sh.
       S3_ENDPOINT: ${S3_ENDPOINT:-}
+      # Same cross-check: these two decide which host presigned URLs actually
+      # resolve to. Path-style leaves the endpoint host alone, virtual-hosted
+      # addressing puts the bucket in front of it, and only the second form is
+      # covered by a "*.endpoint" CSP source.
+      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-}
+      S3_BUCKET: ${S3_BUCKET:-}
       # Set to true to drop the Jira avatar CDNs (secure.gravatar.com,
       # *.atl-paas.net) from the admin CSP on a strictly data-localized
       # deployment. Empty/unset keeps them allowed. See .env.example.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -414,6 +414,13 @@ services:
       # https, or an explicit http(s):// scheme is preserved for HTTP-only
       # stores). Empty => only same-origin storage is allowed. See .env.example.
       STORAGE_DOMAIN: ${STORAGE_DOMAIN:-}
+      # Read-only cross-check input, not a second storage setting: the
+      # entrypoint refuses to start when a public S3_ENDPOINT is not covered by
+      # STORAGE_DOMAIN, because the browser fetches presigned URLs from that
+      # host directly and a CSP that omits it breaks replay and screenshots
+      # with no server-side symptom. Loopback / compose-service endpoints are
+      # skipped. See scripts/shared/validate-api-domain.sh.
+      S3_ENDPOINT: ${S3_ENDPOINT:-}
       # Set to true to drop the Jira avatar CDNs (secure.gravatar.com,
       # *.atl-paas.net) from the admin CSP on a strictly data-localized
       # deployment. Empty/unset keeps them allowed. See .env.example.

--- a/scripts/shared/validate-api-domain.sh
+++ b/scripts/shared/validate-api-domain.sh
@@ -149,4 +149,105 @@ validate_storage_domain() {
         export STORAGE_CSP=""
         echo "STORAGE_DOMAIN not set - only same-origin storage allowed in CSP"
     fi
+
+    validate_storage_csp_covers_endpoint
+}
+
+# Split "http(s)://host[:port][/path]" into _origin_scheme + _origin_host,
+# dropping a default port so https://x and https://x:443 compare equal. A bare
+# host defaults to https, matching how STORAGE_DOMAIN is documented.
+_split_origin() {
+    case "$1" in
+        https://*) _origin_scheme="https://"; _origin_host="${1#https://}" ;;
+        http://*)  _origin_scheme="http://";  _origin_host="${1#http://}" ;;
+        *)         _origin_scheme="https://"; _origin_host="$1" ;;
+    esac
+
+    _origin_host="${_origin_host%%/*}"
+
+    if [ "$_origin_scheme" = "https://" ]; then
+        _origin_host="${_origin_host%:443}"
+    else
+        _origin_host="${_origin_host%:80}"
+    fi
+}
+
+# Cross-check the storage CSP against the endpoint the browser is actually sent
+# to, and refuse to start when it is not covered.
+#
+# The admin never proxies object storage: it asks the API for a presigned URL
+# and the browser talks to the store directly, so the CSP must name that host
+# in img-src (screenshots) and connect-src (the replay fetch). That makes
+# STORAGE_DOMAIN and S3_ENDPOINT two settings for one fact, and a host
+# migration moves only S3_ENDPOINT. Production drifted exactly that way: the
+# admin served "connect-src 'self'" against storage.kz.bugspotter.io, so the
+# replay player showed a bare "Failed to fetch" and screenshots rendered blank
+# while every health check stayed green. A CSP-blocked fetch rejects with an
+# opaque TypeError, so nothing in the logs points at the CSP - hence failing
+# here, at deploy time, where the operator is still watching.
+#
+# Only public endpoints are checked. A compose service name or a loopback
+# address is unreachable from the browser whatever the CSP says (that is the
+# separate failure docker-compose.storage.yml documents), so dev stacks running
+# S3_ENDPOINT=http://minio:9000 are left alone.
+validate_storage_csp_covers_endpoint() {
+    [ -n "$S3_ENDPOINT" ] || return 0
+
+    _split_origin "$S3_ENDPOINT"
+    _endpoint_scheme="$_origin_scheme"
+    _endpoint_host="$_origin_host"
+
+    case "$_endpoint_host" in
+        localhost|localhost:*|127.0.0.1|127.0.0.1:*|\[::1\]|\[::1\]:*) return 0 ;;
+        *.*) ;;
+        *) return 0 ;;
+    esac
+
+    if [ -z "$STORAGE_DOMAIN" ]; then
+        echo "ERROR: S3_ENDPOINT is ${_endpoint_scheme}${_endpoint_host} but STORAGE_DOMAIN is empty" >&2
+        echo "The admin CSP would allow same-origin storage only: session replay fails with a bare" >&2
+        echo "'Failed to fetch' and screenshots render blank, with nothing failing server-side." >&2
+        echo "Set STORAGE_DOMAIN=${_endpoint_host} (or the wildcard covering it, e.g. *.${_endpoint_host#*.})." >&2
+        echo "Storage served from the admin's own origin is the one case to set it to that host too." >&2
+        exit 1
+    fi
+
+    _split_origin "$STORAGE_DOMAIN"
+    _csp_scheme="$_origin_scheme"
+    _csp_host="$_origin_host"
+
+    # A CSP host-source carrying a scheme only matches that scheme, so an
+    # http:// source against an https:// endpoint blocks every request.
+    if [ "$_csp_scheme" != "$_endpoint_scheme" ]; then
+        echo "ERROR: STORAGE_DOMAIN scheme ($_csp_scheme) does not match S3_ENDPOINT ($_endpoint_scheme)" >&2
+        echo "S3_ENDPOINT=$S3_ENDPOINT, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
+        echo "A CSP host-source with a scheme matches only that scheme, so the admin would block" >&2
+        echo "every screenshot and replay request. Set STORAGE_DOMAIN=${_endpoint_scheme}${_csp_host}." >&2
+        exit 1
+    fi
+
+    case "$_endpoint_host" in
+        "$_csp_host") return 0 ;;
+    esac
+
+    case "$_csp_host" in
+        \*.*)
+            _csp_base="${_csp_host#\*.}"
+            # "*.X" also covers X itself: with virtual-hosted-style addressing
+            # the presigned URL host is <bucket>.X, a subdomain of the endpoint.
+            if [ "$_endpoint_host" = "$_csp_base" ]; then
+                return 0
+            fi
+            case "$_endpoint_host" in
+                *".$_csp_base") return 0 ;;
+            esac
+            ;;
+    esac
+
+    echo "ERROR: STORAGE_DOMAIN does not cover S3_ENDPOINT" >&2
+    echo "S3_ENDPOINT=$S3_ENDPOINT, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
+    echo "The admin CSP would block screenshots (img-src) and the replay fetch (connect-src)," >&2
+    echo "which surfaces in the browser as 'Failed to fetch' and nowhere else." >&2
+    echo "Set STORAGE_DOMAIN=${_endpoint_host} or a wildcard that covers it." >&2
+    exit 1
 }

--- a/scripts/shared/validate-api-domain.sh
+++ b/scripts/shared/validate-api-domain.sh
@@ -153,9 +153,10 @@ validate_storage_domain() {
     validate_storage_csp_covers_endpoint
 }
 
-# Split "http(s)://host[:port][/path]" into _origin_scheme + _origin_host,
-# dropping a default port so https://x and https://x:443 compare equal. A bare
-# host defaults to https, matching how STORAGE_DOMAIN is documented.
+# Split "http(s)://[userinfo@]host[:port][/path]" into _origin_scheme +
+# _origin_host, dropping a default port so https://x and https://x:443 compare
+# equal. A bare host defaults to https, matching how STORAGE_DOMAIN is
+# documented.
 _split_origin() {
     case "$1" in
         https://*) _origin_scheme="https://"; _origin_host="${1#https://}" ;;
@@ -164,6 +165,13 @@ _split_origin() {
     esac
 
     _origin_host="${_origin_host%%/*}"
+
+    # Drop userinfo. A CSP host-source never carries one, so keeping it would
+    # fail an otherwise-correct endpoint, and it is the one part of an
+    # S3_ENDPOINT that can hold a secret - these values are echoed into the
+    # container log on mismatch. Strip through the LAST "@": a host cannot
+    # contain one, so greedy is right even for an unencoded password.
+    _origin_host="${_origin_host##*@}"
 
     if [ "$_origin_scheme" = "https://" ]; then
         _origin_host="${_origin_host%:443}"
@@ -220,7 +228,9 @@ validate_storage_csp_covers_endpoint() {
     # http:// source against an https:// endpoint blocks every request.
     if [ "$_csp_scheme" != "$_endpoint_scheme" ]; then
         echo "ERROR: STORAGE_DOMAIN scheme ($_csp_scheme) does not match S3_ENDPOINT ($_endpoint_scheme)" >&2
-        echo "S3_ENDPOINT=$S3_ENDPOINT, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
+        # Report the parsed origin, never the raw endpoint: userinfo is stripped
+        # by then, and the log is readable to anyone with `docker logs`.
+        echo "endpoint=${_endpoint_scheme}${_endpoint_host}, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
         echo "A CSP host-source with a scheme matches only that scheme, so the admin would block" >&2
         echo "every screenshot and replay request. Set STORAGE_DOMAIN=${_endpoint_scheme}${_csp_host}." >&2
         exit 1
@@ -245,7 +255,7 @@ validate_storage_csp_covers_endpoint() {
     esac
 
     echo "ERROR: STORAGE_DOMAIN does not cover S3_ENDPOINT" >&2
-    echo "S3_ENDPOINT=$S3_ENDPOINT, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
+    echo "endpoint=${_endpoint_scheme}${_endpoint_host}, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
     echo "The admin CSP would block screenshots (img-src) and the replay fetch (connect-src)," >&2
     echo "which surfaces in the browser as 'Failed to fetch' and nowhere else." >&2
     echo "Set STORAGE_DOMAIN=${_endpoint_host} or a wildcard that covers it." >&2

--- a/scripts/shared/validate-api-domain.sh
+++ b/scripts/shared/validate-api-domain.sh
@@ -212,7 +212,7 @@ validate_storage_csp_covers_endpoint() {
     _endpoint_host="$_origin_host"
 
     case "$_endpoint_host" in
-        localhost|localhost:*|127.0.0.1|127.0.0.1:*|\[::1\]|\[::1\]:*) return 0 ;;
+        localhost|localhost:*|\[::1\]|\[::1\]:*) return 0 ;;
         # An IPv6 literal is bracketed and carries no dot, so it has to be
         # matched before the dotted-host test or it reads as a bare service name
         # and is skipped instead of rejected below.
@@ -220,6 +220,15 @@ validate_storage_csp_covers_endpoint() {
         *.*) ;;
         *) return 0 ;;
     esac
+
+    # Loopback is all of 127.0.0.0/8, not just 127.0.0.1. Any of it is
+    # unreachable from a browser on another machine whatever the CSP says, so it
+    # belongs with the skips above rather than with the IP rejection below - it
+    # is tested here only because a loopback literal is dotted and would
+    # otherwise have to be spelled out in the arm above.
+    if printf '%s' "${_endpoint_host%%:*}" | grep -qE '^127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'; then
+        return 0
+    fi
 
     # CSP cannot express a public IP literal. The grammar accepts one, but
     # matching is defined so that "only 127.0.0.1 will actually match a URL when
@@ -248,11 +257,20 @@ validate_storage_csp_covers_endpoint() {
         if [ -n "$S3_BUCKET" ]; then
             _request_host="${S3_BUCKET}.${_endpoint_host}"
         else
-            # Virtual-hosted, but the bucket was not passed in, so the real host
-            # cannot be built. Accept a wildcard on the endpoint host, which is
-            # what would cover <bucket>.<endpoint>, rather than fail a
-            # deployment on a value this container was never given.
+            # No bucket, so the real host cannot be built. Both readings stay
+            # open here: a wildcard on the endpoint host, which is what covers
+            # <bucket>.<endpoint>, and the endpoint host itself, because a
+            # container that was given neither variable may simply be running
+            # against a compose file that predates them while addressing storage
+            # path-style. Refusing to boot on that guess would take down a
+            # working admin over configuration it was never handed, which is a
+            # worse failure than the one this guard exists to catch. Say so
+            # rather than passing quietly.
             _wildcard_covers_base="yes"
+            echo "WARNING: S3_BUCKET is not set, so the storage CSP could only be checked against" >&2
+            echo "the endpoint host. With virtual-hosted-style addressing the bucket becomes a" >&2
+            echo "subdomain of it, and that host was not verified. Pass S3_BUCKET and" >&2
+            echo "S3_FORCE_PATH_STYLE to check the host presigned URLs actually resolve to." >&2
         fi
     fi
 

--- a/scripts/shared/validate-api-domain.sh
+++ b/scripts/shared/validate-api-domain.sh
@@ -178,6 +178,12 @@ _split_origin() {
     else
         _origin_host="${_origin_host%:80}"
     fi
+
+    # CSP matches hosts ASCII case-insensitively, and the URL parser lowercases
+    # a URL's host before the CSP is consulted, so "STORAGE.example.com" and
+    # "storage.example.com" are one host. Shell comparison is case-sensitive;
+    # without this a working deployment fails the check below.
+    _origin_host=$(printf '%s' "$_origin_host" | tr 'A-Z' 'a-z')
 }
 
 # Cross-check the storage CSP against the endpoint the browser is actually sent
@@ -207,15 +213,54 @@ validate_storage_csp_covers_endpoint() {
 
     case "$_endpoint_host" in
         localhost|localhost:*|127.0.0.1|127.0.0.1:*|\[::1\]|\[::1\]:*) return 0 ;;
+        # An IPv6 literal is bracketed and carries no dot, so it has to be
+        # matched before the dotted-host test or it reads as a bare service name
+        # and is skipped instead of rejected below.
+        \[*\]|\[*\]:*) ;;
         *.*) ;;
         *) return 0 ;;
     esac
+
+    # CSP cannot express a public IP literal. The grammar accepts one, but
+    # matching is defined so that "only 127.0.0.1 will actually match a URL when
+    # used in a source expression" (CSP3, host-part matching) - so no
+    # STORAGE_DOMAIN value can unblock storage addressed by IP, and accepting
+    # one here would pass a deployment the browser still breaks. Loopback is
+    # already returned above.
+    if _is_ip_literal "$_endpoint_host"; then
+        echo "ERROR: S3_ENDPOINT addresses storage by IP (${_endpoint_scheme}${_endpoint_host})" >&2
+        echo "A CSP source expression only ever matches the IP literal 127.0.0.1, so no" >&2
+        echo "STORAGE_DOMAIN can allow this host and screenshots and replay stay blocked." >&2
+        echo "Give the object store a DNS hostname and point S3_ENDPOINT at that." >&2
+        exit 1
+    fi
+
+    # Which host the browser is actually sent to depends on the addressing
+    # style, so the CSP has to be checked against that host, not the endpoint.
+    # Path-style keeps the bucket in the path and leaves the host alone;
+    # virtual-hosted-style moves the bucket in front of it. Mirrors the
+    # backend's parsing: only the literal "true" enables path style
+    # (parseBooleanEnv in packages/backend/src/config/validators.ts), and
+    # forcePathStyle defaults to false.
+    _request_host="$_endpoint_host"
+    _wildcard_covers_base="no"
+    if [ "$S3_FORCE_PATH_STYLE" != "true" ]; then
+        if [ -n "$S3_BUCKET" ]; then
+            _request_host="${S3_BUCKET}.${_endpoint_host}"
+        else
+            # Virtual-hosted, but the bucket was not passed in, so the real host
+            # cannot be built. Accept a wildcard on the endpoint host, which is
+            # what would cover <bucket>.<endpoint>, rather than fail a
+            # deployment on a value this container was never given.
+            _wildcard_covers_base="yes"
+        fi
+    fi
 
     if [ -z "$STORAGE_DOMAIN" ]; then
         echo "ERROR: S3_ENDPOINT is ${_endpoint_scheme}${_endpoint_host} but STORAGE_DOMAIN is empty" >&2
         echo "The admin CSP would allow same-origin storage only: session replay fails with a bare" >&2
         echo "'Failed to fetch' and screenshots render blank, with nothing failing server-side." >&2
-        echo "Set STORAGE_DOMAIN=${_endpoint_host} (or the wildcard covering it, e.g. *.${_endpoint_host#*.})." >&2
+        echo "Set STORAGE_DOMAIN=${_request_host} (or the wildcard covering it, e.g. *.${_request_host#*.})." >&2
         echo "Storage served from the admin's own origin is the one case to set it to that host too." >&2
         exit 1
     fi
@@ -236,28 +281,43 @@ validate_storage_csp_covers_endpoint() {
         exit 1
     fi
 
-    case "$_endpoint_host" in
+    case "$_request_host" in
         "$_csp_host") return 0 ;;
     esac
 
+    # Plain CSP wildcard semantics: "*.X" covers a subdomain of X, not X itself.
+    # The one exception is the unknown-bucket case above, where "*.X" is the
+    # correct value for a host this container cannot construct.
     case "$_csp_host" in
         \*.*)
             _csp_base="${_csp_host#\*.}"
-            # "*.X" also covers X itself: with virtual-hosted-style addressing
-            # the presigned URL host is <bucket>.X, a subdomain of the endpoint.
-            if [ "$_endpoint_host" = "$_csp_base" ]; then
-                return 0
-            fi
-            case "$_endpoint_host" in
+            case "$_request_host" in
                 *".$_csp_base") return 0 ;;
             esac
+            if [ "$_wildcard_covers_base" = "yes" ] && [ "$_request_host" = "$_csp_base" ]; then
+                return 0
+            fi
             ;;
     esac
 
-    echo "ERROR: STORAGE_DOMAIN does not cover S3_ENDPOINT" >&2
-    echo "endpoint=${_endpoint_scheme}${_endpoint_host}, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
+    echo "ERROR: STORAGE_DOMAIN does not cover the host presigned URLs point at" >&2
+    echo "endpoint=${_endpoint_scheme}${_endpoint_host}, request host=${_request_host}, STORAGE_DOMAIN=$STORAGE_DOMAIN" >&2
+    if [ "$_request_host" != "$_endpoint_host" ]; then
+        echo "S3_FORCE_PATH_STYLE is not true, so the bucket is addressed as a subdomain." >&2
+    fi
     echo "The admin CSP would block screenshots (img-src) and the replay fetch (connect-src)," >&2
     echo "which surfaces in the browser as 'Failed to fetch' and nowhere else." >&2
-    echo "Set STORAGE_DOMAIN=${_endpoint_host} or a wildcard that covers it." >&2
+    echo "Set STORAGE_DOMAIN=${_request_host} or a wildcard that covers it." >&2
     exit 1
+}
+
+# True when the host (with any port or IPv6 brackets) is an IP literal rather
+# than a DNS name. IPv4 only needs the dotted-quad shape; anything in brackets
+# is an IPv6 literal by URL syntax.
+_is_ip_literal() {
+    case "$1" in
+        \[*\]|\[*\]:*) return 0 ;;
+    esac
+
+    printf '%s' "${1%%:*}" | grep -qE '^[0-9]{1,3}(\.[0-9]{1,3}){3}$'
 }

--- a/scripts/test-validate-api-domain.sh
+++ b/scripts/test-validate-api-domain.sh
@@ -253,11 +253,17 @@ test_storage_pair() {
     local test_name="$1"
     local endpoint="$2"
     local domain="$3"
-    local expect="$4" # "pass" or "fail"
+    local expect="$4"          # "pass" or "fail"
+    # "-" not ":-": an explicitly passed empty path-style is a case under test
+    # (unset means virtual-hosted), so it must not collapse to the default.
+    local path_style="${5-true}" # default: bucket in the path, host untouched
+    local bucket="${6-}"
 
     (
         export S3_ENDPOINT="$endpoint"
         export STORAGE_DOMAIN="$domain"
+        export S3_FORCE_PATH_STYLE="$path_style"
+        export S3_BUCKET="$bucket"
         . ./scripts/shared/validate-api-domain.sh
         validate_storage_domain
     ) > /dev/null 2>&1
@@ -284,14 +290,56 @@ test_storage_pair "Public endpoint covered by exact host" \
 test_storage_pair "Unrelated STORAGE_DOMAIN is rejected" \
     "https://storage.kz.bugspotter.io" "s3.other-cloud.example" "fail"
 
-# Virtual-hosted-style addressing puts the bucket in front of the endpoint
-# host, so "*.X" has to cover both X itself and <bucket>.X.
-test_storage_pair "Wildcard covers the endpoint host itself" \
-    "https://s3.example.com" "*.s3.example.com" "pass"
-test_storage_pair "Wildcard covers a bucket subdomain" \
+# Wildcards follow plain CSP semantics against the host the browser is sent to.
+test_storage_pair "Wildcard covers a subdomain of its base" \
     "https://bucket.s3.example.com" "*.s3.example.com" "pass"
 test_storage_pair "Wildcard does not cover an unrelated host" \
     "https://s3.evil.example" "*.s3.example.com" "fail"
+
+# Which host that is depends on the addressing style. Path-style keeps the
+# bucket in the path, so "*.X" does NOT cover an endpoint of X - accepting it
+# would pass a deployment the browser still blocks.
+test_storage_pair "Path-style: wildcard does not cover the endpoint host" \
+    "https://s3.example.com" "*.s3.example.com" "fail" "true" "bucket"
+test_storage_pair "Path-style: exact endpoint host is covered" \
+    "https://s3.example.com" "s3.example.com" "pass" "true" "bucket"
+
+# Virtual-hosted-style moves the bucket in front of the host, so the reverse
+# holds: the wildcard is required and the bare endpoint host is not enough.
+test_storage_pair "Virtual-hosted: wildcard covers <bucket>.<endpoint>" \
+    "https://s3.example.com" "*.s3.example.com" "pass" "false" "bucket"
+test_storage_pair "Virtual-hosted: bare endpoint host is not enough" \
+    "https://s3.example.com" "s3.example.com" "fail" "false" "bucket"
+test_storage_pair "Virtual-hosted: the bucket subdomain itself is covered" \
+    "https://s3.example.com" "bucket.s3.example.com" "pass" "false" "bucket"
+
+# Anything other than the literal "true" means virtual-hosted, matching
+# parseBooleanEnv on the backend side.
+test_storage_pair "Unset path-style is treated as virtual-hosted" \
+    "https://s3.example.com" "*.s3.example.com" "pass" "" "bucket"
+
+# Without a bucket the real host cannot be built, so a wildcard on the endpoint
+# host is accepted rather than failing on a value the container never got.
+test_storage_pair "Virtual-hosted with no bucket accepts the endpoint wildcard" \
+    "https://s3.example.com" "*.s3.example.com" "pass" "false" ""
+
+# CSP matches hosts case-insensitively and the URL parser lowercases the host
+# before the CSP is consulted, so a mixed-case endpoint is the same deployment.
+test_storage_pair "Mixed-case endpoint matches a lowercase STORAGE_DOMAIN" \
+    "https://STORAGE.Example.COM" "storage.example.com" "pass"
+test_storage_pair "Mixed-case STORAGE_DOMAIN matches a lowercase endpoint" \
+    "https://storage.example.com" "STORAGE.example.com" "pass"
+
+# A CSP source expression only ever matches the IP literal 127.0.0.1 (CSP3),
+# so storage addressed by a public IP cannot be unblocked by any value here.
+test_storage_pair "Public IPv4 endpoint is rejected" \
+    "https://198.51.100.10" "198.51.100.10" "fail"
+test_storage_pair "Public IPv4 endpoint with a port is rejected" \
+    "https://198.51.100.10:9000" "198.51.100.10:9000" "fail"
+test_storage_pair "Public IPv6 endpoint is rejected" \
+    "https://[2001:db8::1]" "storage.example.com" "fail"
+test_storage_pair "Loopback IP is still skipped, not rejected" \
+    "http://127.0.0.1:9000" "" "pass"
 
 # A CSP host-source with a scheme matches only that scheme, and a bare
 # STORAGE_DOMAIN means https - so an HTTP-only store must say so.

--- a/scripts/test-validate-api-domain.sh
+++ b/scripts/test-validate-api-domain.sh
@@ -158,6 +158,11 @@ PASSED=$((PASSED + 1))
 echo ""
 echo "${YELLOW}=== Testing validate_storage_domain() ===${NC}"
 
+# validate_storage_domain() now cross-checks against S3_ENDPOINT. Clear it so
+# an inherited value from the caller's shell cannot skew the cases below, which
+# are about STORAGE_DOMAIN alone.
+unset S3_ENDPOINT
+
 # Valid STORAGE_DOMAIN hosts (bare host, no scheme; wildcard allowed)
 test_valid "Wildcard host" "STORAGE_DOMAIN" "*.storage.yandexcloud.kz" "validate_storage_domain"
 test_valid "Plain host" "STORAGE_DOMAIN" "s3.your-cloud.example" "validate_storage_domain"
@@ -237,6 +242,101 @@ else
     FAILED=$((FAILED + 1))
 fi
 unset STORAGE_CSP
+
+echo ""
+echo "${YELLOW}=== Testing storage CSP vs S3_ENDPOINT cross-check ===${NC}"
+
+# Run the full validate_storage_domain() path in a subshell, since the guard
+# exits rather than returning. Asserting through the public entry point also
+# proves the cross-check is actually wired into it.
+test_storage_pair() {
+    local test_name="$1"
+    local endpoint="$2"
+    local domain="$3"
+    local expect="$4" # "pass" or "fail"
+
+    (
+        export S3_ENDPOINT="$endpoint"
+        export STORAGE_DOMAIN="$domain"
+        . ./scripts/shared/validate-api-domain.sh
+        validate_storage_domain
+    ) > /dev/null 2>&1
+    local exit_code=$?
+
+    if [ "$expect" = "pass" ] && [ $exit_code -eq 0 ]; then
+        echo "${GREEN}✓${NC} PASS: $test_name"
+        PASSED=$((PASSED + 1))
+    elif [ "$expect" = "fail" ] && [ $exit_code -ne 0 ]; then
+        echo "${GREEN}✓${NC} PASS: $test_name"
+        PASSED=$((PASSED + 1))
+    else
+        echo "${RED}✗${NC} FAIL: $test_name (expected $expect, exit $exit_code)"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+# The production regression this guard exists for: storage moved to a public
+# host, STORAGE_DOMAIN stayed empty, and the admin served connect-src 'self'.
+test_storage_pair "Public endpoint with empty STORAGE_DOMAIN is rejected" \
+    "https://storage.kz.bugspotter.io" "" "fail"
+test_storage_pair "Public endpoint covered by exact host" \
+    "https://storage.kz.bugspotter.io" "storage.kz.bugspotter.io" "pass"
+test_storage_pair "Unrelated STORAGE_DOMAIN is rejected" \
+    "https://storage.kz.bugspotter.io" "s3.other-cloud.example" "fail"
+
+# Virtual-hosted-style addressing puts the bucket in front of the endpoint
+# host, so "*.X" has to cover both X itself and <bucket>.X.
+test_storage_pair "Wildcard covers the endpoint host itself" \
+    "https://s3.example.com" "*.s3.example.com" "pass"
+test_storage_pair "Wildcard covers a bucket subdomain" \
+    "https://bucket.s3.example.com" "*.s3.example.com" "pass"
+test_storage_pair "Wildcard does not cover an unrelated host" \
+    "https://s3.evil.example" "*.s3.example.com" "fail"
+
+# A CSP host-source with a scheme matches only that scheme, and a bare
+# STORAGE_DOMAIN means https - so an HTTP-only store must say so.
+test_storage_pair "Scheme mismatch is rejected" \
+    "http://storage.example.com" "storage.example.com" "fail"
+test_storage_pair "Matching http scheme is accepted" \
+    "http://storage.example.com" "http://storage.example.com" "pass"
+
+# Ports: the default port is implicit in a CSP host-source, a custom one is not.
+test_storage_pair "Explicit default port matches an omitted one" \
+    "https://storage.example.com:443" "storage.example.com" "pass"
+test_storage_pair "Custom port must be declared" \
+    "https://storage.example.com:9000" "storage.example.com" "fail"
+test_storage_pair "Custom port declared on both sides" \
+    "https://storage.example.com:9000" "storage.example.com:9000" "pass"
+
+# A path on the endpoint is not part of the CSP host-source.
+test_storage_pair "Endpoint path is ignored" \
+    "https://storage.example.com/bucket" "storage.example.com" "pass"
+
+# Dev stacks must not be caught by this: a compose service name or loopback is
+# unreachable from the browser whatever the CSP says.
+test_storage_pair "Compose service endpoint is skipped" \
+    "http://minio:9000" "" "pass"
+test_storage_pair "localhost endpoint is skipped" \
+    "http://localhost:9000" "" "pass"
+test_storage_pair "127.0.0.1 endpoint is skipped" \
+    "http://127.0.0.1:9000" "" "pass"
+
+# Unset S3_ENDPOINT keeps the pre-existing behaviour exactly (local disk
+# storage, or an admin container not given the endpoint).
+(
+    unset S3_ENDPOINT STORAGE_DOMAIN
+    . ./scripts/shared/validate-api-domain.sh
+    validate_storage_domain
+) > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "${GREEN}✓${NC} PASS: No S3_ENDPOINT leaves the empty case untouched"
+    PASSED=$((PASSED + 1))
+else
+    echo "${RED}✗${NC} FAIL: No S3_ENDPOINT should not fail validation"
+    FAILED=$((FAILED + 1))
+fi
+
+unset S3_ENDPOINT STORAGE_DOMAIN STORAGE_CSP
 
 echo ""
 echo "${YELLOW}=== Test Summary ===${NC}"

--- a/scripts/test-validate-api-domain.sh
+++ b/scripts/test-validate-api-domain.sh
@@ -312,6 +312,35 @@ test_storage_pair "Custom port declared on both sides" \
 test_storage_pair "Endpoint path is ignored" \
     "https://storage.example.com/bucket" "storage.example.com" "pass"
 
+# Userinfo is not part of a CSP host-source either, so an endpoint carrying one
+# must still be recognised as covered rather than failing the deploy.
+test_storage_pair "Endpoint userinfo is ignored" \
+    "https://key:secret@storage.example.com" "storage.example.com" "pass"
+test_storage_pair "Endpoint userinfo does not mask a real mismatch" \
+    "https://key:secret@storage.example.com" "s3.other-cloud.example" "fail"
+
+# ... and the diagnostics printed on that mismatch must not echo the secret:
+# the entrypoint's output is readable to anyone with `docker logs`.
+storage_leak_output=$(
+    export S3_ENDPOINT="https://key:sup3rs3cret@storage.example.com"
+    export STORAGE_DOMAIN="s3.other-cloud.example"
+    . ./scripts/shared/validate-api-domain.sh
+    # Inside the substitution, or the guard's stderr escapes to the terminal
+    # and this assertion passes against empty output.
+    validate_storage_domain 2>&1
+)
+case "$storage_leak_output" in
+    *sup3rs3cret*)
+        echo "${RED}✗${NC} FAIL: endpoint credentials leaked into the error output"
+        FAILED=$((FAILED + 1))
+        ;;
+    *)
+        echo "${GREEN}✓${NC} PASS: endpoint credentials are not echoed on mismatch"
+        PASSED=$((PASSED + 1))
+        ;;
+esac
+unset storage_leak_output
+
 # Dev stacks must not be caught by this: a compose service name or loopback is
 # unreachable from the browser whatever the CSP says.
 test_storage_pair "Compose service endpoint is skipped" \

--- a/scripts/test-validate-api-domain.sh
+++ b/scripts/test-validate-api-domain.sh
@@ -254,9 +254,10 @@ test_storage_pair() {
     local endpoint="$2"
     local domain="$3"
     local expect="$4"          # "pass" or "fail"
-    # "-" not ":-": an explicitly passed empty path-style is a case under test
-    # (unset means virtual-hosted), so it must not collapse to the default.
-    local path_style="${5-true}" # default: bucket in the path, host untouched
+    # Default to the product's own default rather than to path-style, so a case
+    # that omits these exercises what a real deployment does. "-" not ":-": an
+    # explicitly passed empty path-style is itself a case under test.
+    local path_style="${5-}" # unset => virtual-hosted, as the backend reads it
     local bucket="${6-}"
 
     (
@@ -340,6 +341,17 @@ test_storage_pair "Public IPv6 endpoint is rejected" \
     "https://[2001:db8::1]" "storage.example.com" "fail"
 test_storage_pair "Loopback IP is still skipped, not rejected" \
     "http://127.0.0.1:9000" "" "pass"
+# Loopback is 127.0.0.0/8, not one address.
+test_storage_pair "Any 127.0.0.0/8 address is skipped" \
+    "http://127.0.0.2:9000" "" "pass"
+# A host that merely starts with "127." is a DNS name, not loopback.
+test_storage_pair "A DNS name starting with 127. is not treated as loopback" \
+    "https://127.storage.example.com" "" "fail"
+
+# The wildcard match is anchored on a label boundary: "*.s3.example.com" must
+# not swallow "buckets3.example.com".
+test_storage_pair "Wildcard does not match across a label boundary" \
+    "https://buckets3.example.com" "*.s3.example.com" "fail"
 
 # A CSP host-source with a scheme matches only that scheme, and a bare
 # STORAGE_DOMAIN means https - so an HTTP-only store must say so.


### PR DESCRIPTION
The admin entrypoint now cross-checks `STORAGE_DOMAIN` against `S3_ENDPOINT` and
exits instead of serving a CSP that silently blocks screenshots and the replay
fetch. Browser-unreachable endpoints (compose service names, loopback) are
skipped, so dev stacks are untouched; purely additive, no behaviour change for a
correctly configured deployment.

Production was already remediated by hand - see the issue for the command and
rollback. Commit body has the reasoning.

Refs #302

Assisted-by: claude-opus-5 (agent)
