### PR TITLE
fix(ai-sdlc): stop dropping maxTokens silently on the CLI backend

### DIFF
--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -389,10 +389,16 @@ try {
   //
   // The deeper cost driver is the response schema: {path, content} means the
   // model re-emits every declared file IN FULL, so editing three ~500-line
-  // files costs ~15K output tokens of mostly-unchanged text against a 16384
-  // cap. That's the real scaling limit here, and a diff/patch-shaped schema
-  // would be the structural fix — deliberately not attempted in this change,
-  // which is scoped to making the current shape work.
+  // files costs ~15K output tokens of mostly-unchanged text. A diff/patch-shaped
+  // schema would be the structural fix — deliberately not attempted in this
+  // change, which is scoped to making the current shape work.
+  //
+  // MAX_TOKENS below binds on LLM_BACKEND=api only. The live backend is `cli`,
+  // which has no per-call output cap, so on the path this actually runs the
+  // ceiling is the model's own limit and the real constraint is the timeout.
+  // An earlier version of this comment called 16384 "the real scaling limit
+  // here"; a run under that nominal cap emitted 50,304 output tokens without
+  // truncating, which is what makes #296's 8.5x budget gap look the way it does.
   ({ text, stopReason } = await callClaude({
     prompt,
     maxTokens: MAX_TOKENS,
@@ -406,9 +412,15 @@ try {
 
 // Fail fast if truncated — a partial JSON response will always cause a parse error downstream
 if (stopReason === 'max_tokens') {
-  console.error(
-    `Claude response truncated (stop_reason=max_tokens). Raise max_tokens in generate-impl.mjs.`
-  );
+  // Both backends surface this, so the advice has to name a lever that exists
+  // on the one in use. Raising MAX_TOKENS does nothing under `cli`: it is never
+  // forwarded, and the response was bounded by the model's own limit.
+  const remedy =
+    (process.env.LLM_BACKEND || 'api') === 'cli'
+      ? `LLM_BACKEND=cli ignores MAX_TOKENS, so raising it will not help. The response hit the ` +
+        `model's own output limit: narrow the spec's declared file set, or split the issue.`
+      : `Raise MAX_TOKENS in generate-impl.mjs (currently ${MAX_TOKENS}).`;
+  console.error(`Claude response truncated (stop_reason=max_tokens). ${remedy}`);
   process.exit(1);
 }
 

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -353,6 +353,22 @@ async function callViaCli({ prompt, timeoutMs, model }) {
 // before this option existed.
 export async function callClaude({ prompt, maxTokens, timeoutMs, model }) {
   if (LLM_BACKEND === 'cli') {
+    // Say so rather than dropping it silently. All four generators pass a
+    // maxTokens they believe bounds the response, and on this backend none of
+    // them do - which is how `generate-impl.mjs` came to reason about a "16384
+    // cap" that was never in force, and how a run emitting 50,304 output tokens
+    // against that nominal cap did not look anomalous (#296, #313).
+    //
+    // Warn, do not throw: the parameter is correct for the API backend, callers
+    // are right to pass it, and this module must never be the reason a pipeline
+    // run fails.
+    if (maxTokens != null) {
+      console.warn(
+        `llm-client: maxTokens=${maxTokens} is ignored on LLM_BACKEND=cli ` +
+          `(the CLI has no per-call output cap). Output length is unbounded here; ` +
+          `budget and timeouts accordingly.`
+      );
+    }
     return callViaCli({ prompt, timeoutMs, model });
   }
   return callViaApi({ prompt, maxTokens, timeoutMs, model });

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -365,8 +365,9 @@ export async function callClaude({ prompt, maxTokens, timeoutMs, model }) {
     if (maxTokens != null) {
       console.warn(
         `llm-client: maxTokens=${maxTokens} is ignored on LLM_BACKEND=cli ` +
-          `(the CLI has no per-call output cap). Output length is unbounded here; ` +
-          `budget and timeouts accordingly.`
+          `(the CLI has no per-call output cap). The model's own output limit still ` +
+          `applies, so a response can still stop at stop_reason=max_tokens - it just ` +
+          `will not stop at ${maxTokens}. Budget and time out accordingly.`
       );
     }
     return callViaCli({ prompt, timeoutMs, model });

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -439,6 +439,11 @@ test('callClaude warns that maxTokens is ignored on the CLI backend', async () =
   assert.match(hit, /16384/, 'the warning names the value that was discarded');
   assert.match(hit, /ignored/);
   assert.match(hit, /LLM_BACKEND=cli/);
+  // Not "unbounded": generate-impl.mjs's truncation guard tells the reader the
+  // response hit the model's own limit, and a warning claiming no limit exists
+  // would contradict it. Two places, one fact.
+  assert.doesNotMatch(hit, /unbounded/);
+  assert.match(hit, /model's own output limit still applies/);
 });
 
 test('callClaude stays quiet when no maxTokens was passed', async () => {

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -405,3 +405,52 @@ test('callViaApi falls back to the hardcoded default model when none is supplied
     globalThis.fetch = originalFetch;
   }
 });
+
+// --- maxTokens visibility on the CLI backend (#313) ---
+//
+// All four generators pass a maxTokens they believe bounds the response, and
+// callViaCli cannot honour it. Dropping it silently is how generate-impl.mjs
+// came to reason about a "16384 cap" that was never in force, and how a run
+// emitting 50,304 output tokens against that nominal cap did not look
+// anomalous (#296). These assert the drop is announced, and only when it
+// actually happens.
+
+async function captureWarnings(fn) {
+  const original = console.warn;
+  const seen = [];
+  console.warn = (...args) => seen.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return seen;
+}
+
+test('callClaude warns that maxTokens is ignored on the CLI backend', async () => {
+  process.env.FAKE_CLAUDE_MODE = 'success';
+
+  const warnings = await captureWarnings(() =>
+    callClaude({ prompt: 'hi', maxTokens: 16384, timeoutMs: 10000 })
+  );
+
+  const hit = warnings.find((w) => w.includes('maxTokens'));
+  assert.ok(hit, 'a silently-dropped parameter must say so');
+  assert.match(hit, /16384/, 'the warning names the value that was discarded');
+  assert.match(hit, /ignored/);
+  assert.match(hit, /LLM_BACKEND=cli/);
+});
+
+test('callClaude stays quiet when no maxTokens was passed', async () => {
+  // Not vacuous: without this the warning could be unconditional, which would
+  // train the reader to ignore it.
+  process.env.FAKE_CLAUDE_MODE = 'success';
+
+  const warnings = await captureWarnings(() => callClaude({ prompt: 'hi', timeoutMs: 10000 }));
+
+  assert.equal(
+    warnings.filter((w) => w.includes('maxTokens')).length,
+    0,
+    'nothing was dropped, so there is nothing to report'
+  );
+});


### PR DESCRIPTION
`callClaude` routes to `callViaCli`, which takes no `maxTokens` because the CLI has no per-call output cap. All four generators pass one anyway, believing it bounds the response, and nothing said otherwise at runtime.

`generate-impl.mjs` shows the cost: it states the caveat correctly at its output-budget block and then contradicts itself twice - a comment calling 16384 "the real scaling limit here", and a truncation guard advising you to raise a number that is never forwarded. That guard does still fire under `cli`, so it was wrong advice at the one moment it matters.

`callClaude` now warns when the parameter is dropped, the truncation message names a lever that exists on the backend in use, and the comment attributes the cap to the API backend. Warning rather than throwing: the parameter is right for the API backend and this module must never be why a run fails. Two tests, checked to fail without the fix.

Refs #313

Assisted-by: claude-opus-5 (agent)
