### PR TITLE
ci(ai-sdlc): run the spec guards on PRs, not only inside the agent

### DIFF
--- a/.github/workflows/ai-sdlc-guards.yml
+++ b/.github/workflows/ai-sdlc-guards.yml
@@ -1,0 +1,105 @@
+name: AI-SDLC Guards
+
+# The scope and ownership guards used to run ONLY inside spec-agent.yml and
+# impl-agent.yml, which meant they guarded the machine path and not the change.
+# ci.yml runs `node --test scripts/ai-sdlc/*.test.mjs` - it tests the guards, it
+# never invokes them. Consequences, all real:
+#
+#  - the spec ratification PR (Gate 1) did not re-run ownership on the version a
+#    human edits and merges;
+#  - PR #283, the delivery for issue #269, was written by hand and therefore
+#    passed through none of them, as did 13b3f6b and c0af5ec.
+#
+# The guardrails were attached to the machine path; the delivery went down the
+# human path. This puts the spec-side guards on the PR, where the change is.
+#
+# Scope, stated honestly: spec-side only. The impl-side equivalent needs a
+# PR-diff-level comparison that check-impl-scope.mjs explicitly does not attempt
+# (see its own header) plus spec resolution from the linked issue. That is new
+# logic rather than a relocation, and it is filed separately.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'docs/specs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ai-sdlc-guards-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  spec-guards:
+    name: Spec guards
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout PR merge result
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect spec files changed by this PR
+        id: specs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Added or modified only. A deleted spec has nothing to verify, and
+          # feeding a deleted path to the guards would fail on the read rather
+          # than on the rule, which is a misleading way to go red.
+          files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- 'docs/specs/*.md' || true)
+          if [ -z "$files" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No added or modified spec files; nothing to check."
+            exit 0
+          fi
+          echo "count=$(printf '%s\n' "$files" | wc -l)" >> "$GITHUB_OUTPUT"
+          # Multi-line value needs a heredoc delimiter, or the runner rejects
+          # the whole step.
+          {
+            echo 'files<<SPECS_EOF'
+            printf '%s\n' "$files"
+            echo 'SPECS_EOF'
+          } >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$files" | sed 's/^/  /'
+
+      - name: Verify spec path ownership (deterministic, hard)
+        if: steps.specs.outputs.count != '0'
+        env:
+          SPECS: ${{ steps.specs.outputs.files }}
+        run: |
+          set -euo pipefail
+          failed=0
+          while IFS= read -r spec; do
+            [ -n "$spec" ] || continue
+            echo "::group::verify-spec-ownership $spec"
+            # Run every spec before failing, so one PR touching two specs
+            # reports both rather than only the first.
+            SPEC_FILE="$spec" node scripts/ai-sdlc/verify-spec-ownership.mjs || failed=1
+            echo "::endgroup::"
+          done <<< "$SPECS"
+          [ "$failed" -eq 0 ] || {
+            echo "::error::Spec path ownership check failed. A spec declares files owned by an ADR it does not cite."
+            exit 1
+          }
+
+      - name: Check spec scope (advisory)
+        if: steps.specs.outputs.count != '0'
+        env:
+          SPECS: ${{ steps.specs.outputs.files }}
+        run: |
+          set -euo pipefail
+          # Advisory by design - the cap is uncalibrated. It runs here rather
+          # than in the agent job specifically so its output lands on the PR the
+          # reviewer is reading, instead of in a step summary nobody opens.
+          while IFS= read -r spec; do
+            [ -n "$spec" ] || continue
+            echo "::group::check-spec-scope $spec"
+            SPEC_FILE="$spec" node scripts/ai-sdlc/check-spec-scope.mjs || true
+            echo "::endgroup::"
+          done <<< "$SPECS"

--- a/.github/workflows/ai-sdlc-guards.yml
+++ b/.github/workflows/ai-sdlc-guards.yml
@@ -43,6 +43,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Collect spec files changed by this PR
         id: specs
         env:

--- a/.github/workflows/ai-sdlc-guards.yml
+++ b/.github/workflows/ai-sdlc-guards.yml
@@ -8,7 +8,7 @@ name: AI-SDLC Guards
 #  - the spec ratification PR (Gate 1) did not re-run ownership on the version a
 #    human edits and merges;
 #  - PR #283, the delivery for issue #269, was written by hand and therefore
-#    passed through none of them, as did 13b3f6b and c0af5ec.
+#    passed through none of them, as did 13bf6b3 and c0af5ec.
 #
 # The guardrails were attached to the machine path; the delivery went down the
 # human path. This puts the spec-side guards on the PR, where the change is.
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Collect spec files changed by this PR
         id: specs
@@ -49,13 +50,16 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Added or modified only. A deleted spec has nothing to verify, and
-          # feeding a deleted path to the guards would fail on the read rather
-          # than on the rule, which is a misleading way to go red.
-          files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- 'docs/specs/*.md' || true)
+          # Added, modified, or renamed only. A deleted spec has nothing to
+          # verify, and feeding a deleted path to the guards would fail on the
+          # read rather than on the rule, which is a misleading way to go red.
+          # R is included because a rename that also edits content (e.g. a
+          # spec renumbered alongside a wording fix) would otherwise be
+          # invisible to AM and skip both guards silently.
+          files=$(git diff --name-only --diff-filter=AMR "$BASE_SHA" "$HEAD_SHA" -- 'docs/specs/*.md')
           if [ -z "$files" ]; then
             echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "No added or modified spec files; nothing to check."
+            echo "No added, modified, or renamed spec files; nothing to check."
             exit 0
           fi
           echo "count=$(printf '%s\n' "$files" | wc -l)" >> "$GITHUB_OUTPUT"
@@ -84,12 +88,12 @@ jobs:
             echo "::endgroup::"
           done <<< "$SPECS"
           [ "$failed" -eq 0 ] || {
-            echo "::error::Spec path ownership check failed. A spec declares files owned by an ADR it does not cite."
+            echo "::error::Spec path ownership check failed. A spec declares a new path under a component name that docs/adr/README.md attributes to a different repo. See the group log above for the specific path(s)."
             exit 1
           }
 
       - name: Check spec scope (advisory)
-        if: steps.specs.outputs.count != '0'
+        if: ${{ !cancelled() && steps.specs.outputs.count != '0' }}
         env:
           SPECS: ${{ steps.specs.outputs.files }}
         run: |
@@ -100,6 +104,8 @@ jobs:
           while IFS= read -r spec; do
             [ -n "$spec" ] || continue
             echo "::group::check-spec-scope $spec"
-            SPEC_FILE="$spec" node scripts/ai-sdlc/check-spec-scope.mjs || true
+            if ! SPEC_FILE="$spec" node scripts/ai-sdlc/check-spec-scope.mjs; then
+              echo "::warning::check-spec-scope crashed for $spec instead of reporting advisory output - this is a launch/script failure, not a scope finding"
+            fi
             echo "::endgroup::"
           done <<< "$SPECS"


### PR DESCRIPTION
`verify-spec-ownership.mjs` and `check-spec-scope.mjs` ran only inside `spec-agent.yml`. `ci.yml` runs `node --test scripts/ai-sdlc/*.test.mjs` - it **tests** the guards, it never **invokes** them.

So they guarded the machine path and not the change:

- the spec ratification PR (Gate 1) never re-ran ownership on the version a human edits and merges
- **PR #283, the delivery for issue #269, was written by hand and passed through none of them.** So did `13bf6b3` and `c0af5ec`

The guardrails were attached to the machine path while the delivery went down the human path. This is the second appearance of that inversion - the first is `impl-agent.yml` hardcoding `Refs #%s`, which makes *agent* PRs structurally incapable of skipping Gate 4 while hand-written ones can.

## What this does

Runs on `docs/specs/**` PRs only, so it costs nothing on the rest. Ownership is hard; scope stays advisory. Moving scope here is most of its value on its own: its warning previously landed in the spec-agent run's step summary, a surface the person ratifying the spec never opens.

Both guards run against every changed spec before failing, so a PR touching two specs reports both rather than only the first.

## Verified, not assumed

| spec | result |
|---|---|
| `0237-...` | ownership lint passed, 4 declared paths checked; scope 4 files, within cap (6) |
| `0226-...` | no `Files touched:` line, both guards skip, exit 0 |

That second row is a pre-existing fail-open path, not something this PR introduces - `verify-spec-ownership.mjs` exits 0 on four separate paths (unreadable spec, missing `docs/adr/README.md`, zero foreign tokens parsed, no `Files touched:` line). It is named in the follow-up rather than quietly relied on here.

## Deliberately spec-side only

The impl equivalent is not a relocation. `check-impl-scope.mjs` says so itself:

> this only checks the scaffold at generation time ... It does not re-check later commits a human pushes to the same PR before merge - that's a different, PR-diff-level check this script does not attempt.

That needs new logic plus spec resolution from the linked issue, so it is filed separately.

`actionlint` clean. Additive - no existing workflow changes behaviour.


Refs #320

Assisted-by: claude-opus-5 (agent)
Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
