### PR TITLE
chore(ci): drop the duplicate Claude commit attribution trailer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "attribution": {
+    "commit": ""
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -445,6 +445,11 @@ Rules:
 - This trailer is the attribution key for the code-metrics layer
   (agent-vs-human change-failure rate). It cannot be backfilled onto old
   history, so start using it now.
+- `Assisted-by` is the **only** attribution trailer this repo reads - nothing
+  here consumes `Co-Authored-By:`, which appears above purely as an example of
+  trailer syntax. `.claude/settings.json` therefore clears Claude Code's own
+  commit attribution (`attribution.commit`), so agent commits carry one
+  format-checked line instead of two that can drift apart.
 
 ## ❓ Questions?
 


### PR DESCRIPTION
Refs #321

`Assisted-by` is the only commit trailer anything here reads: format-checked by `check-commit-trailers.mjs`, and the join key `bugspotter-metrics`' `classifyAuthor` uses to classify agent vs. human commits. `Co-Authored-By` is unvalidated and has already drifted across four spellings in recent history, and its `noreply@anthropic.com` address links to no GitHub profile.

Adds a tracked `.claude/settings.json` clearing `attribution.commit`, so agent commits carry one trailer instead of two that can disagree. Also notes the convention in `CONTRIBUTING.md`.

Assisted-by: claude-opus-5 (agent)