### PR TITLE
feat(deploy): production runbook + wire the API deploy step

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -262,17 +262,18 @@ jobs:
           echo "Image: ${{ needs.build.outputs.image_tag }}"
           echo "Digest: ${{ needs.build.outputs.image_digest }}"
 
-      # SSH to the single production host and recreate `api` + `worker` from
-      # the image this run just pushed - pinned to the run's sha tag, never
+      # SSH to the single production host as a dedicated `deploy` account
+      # restricted by a forced SSH command (see DEPLOY-SECRETS-ROTATION.md) -
+      # the key can run exactly one operation, not a shell. All this step
+      # does is send the image ref as the "command"; the host-side script
+      # validates it, pulls, retags :latest (keeping the previous tag for
+      # instant rollback), and recreates `api` + `worker` - both, since they
+      # share one image and rebuilding it without recreating both leaves them
+      # on different code (found the hard way during the manual deploy this
+      # replaces, see RUNBOOK.md). Pinned to the run's sha tag, never
       # `latest`, so "deployed" and "the health check below passed" refer to
-      # the same build. Mirrors the manual procedure in RUNBOOK.md: pull,
-      # retag :latest (keeping the previous tag for instant rollback), then
-      # `compose up -d --no-build` both services that share the image.
-      #
-      # `api` and `worker` MUST be recreated together - they share one image,
-      # and rebuilding it without recreating both leaves them on different
-      # code (found the hard way during the first manual deploy this
-      # replaces, see RUNBOOK.md).
+      # the same build. GHCR packages here are public, so no registry login
+      # is needed to pull.
       #
       # Known gap vs #318's stated acceptance bar: this verifies the deployed
       # container answers healthy, not that its image digest equals the one
@@ -291,15 +292,7 @@ jobs:
 
           echo "Deploying $IMAGE_REF to $DEPLOY_HOST"
           ssh -i "$RUNNER_TEMP/deploy_key" -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
-            "$DEPLOY_USER@$DEPLOY_HOST" "
-              set -euo pipefail
-              echo '${{ secrets.GITHUB_TOKEN }}' | docker login ${{ env.REGISTRY }} -u '${{ github.actor }}' --password-stdin
-              docker pull '$IMAGE_REF'
-              docker tag bugspotter-api:latest bugspotter-api:pre-${{ github.sha }} || true
-              docker tag '$IMAGE_REF' bugspotter-api:latest
-              cd /opt/bugspotter
-              docker compose up -d --no-build api worker
-            "
+            "$DEPLOY_USER@$DEPLOY_HOST" "$IMAGE_REF"
 
       - name: Verify deployment health
         if: vars.PRODUCTION_API_URL != ''

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -210,39 +210,18 @@ jobs:
           echo "Image: ${{ needs.build.outputs.image_tag }}"
           echo "Digest: ${{ needs.build.outputs.image_digest }}"
 
-      # ⚠️ REQUIRED: Add your actual deployment steps here
-      # The workflow builds and pushes Docker images, but YOU must deploy them.
-      # Without deployment steps, the health check below verifies the OLD deployment!
-      #
-      # Example deployment steps:
-      #
-      # - Railway:
-      #   - name: Deploy to Railway
-      #     run: |
-      #       railway service update bugspotter-api \
-      #         --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
-      #     env:
-      #       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-      #
-      # - Kubernetes:
-      #   - name: Deploy to Kubernetes
-      #     run: |
-      #       kubectl set image deployment/api \
-      #         api=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }} \
-      #         --namespace=staging
-      #
-      # - Docker Swarm:
-      #   - name: Deploy to Swarm
-      #     run: |
-      #       docker service update \
-      #         --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }} \
-      #         bugspotter_api
-
-      - name: ⚠️ Deployment Step Missing
+      # There is no staging environment. Production (see the job below) is a
+      # single Docker Compose host - see RUNBOOK.md. A second host for staging
+      # has never been provisioned; this job exists (kept for the
+      # workflow_dispatch environment choice, and to gate deploy-production
+      # via `needs:`) but has nothing to deploy to. Wiring a fake deploy step
+      # here would either target the SAME production host under a misleading
+      # label, or silently no-op - the exact "fired, passed, protected
+      # nothing" shape #318 exists to fix, not repeat.
+      - name: ℹ️ No staging environment
         run: |
-          echo "::warning::No deployment step configured - health check will verify existing deployment"
-          echo "::warning::Add deployment steps above this step to deploy the new Docker image"
-          echo "::warning::See comments above for platform-specific examples"
+          echo "::notice::There is no staging host - production is a single Docker Compose VM (see RUNBOOK.md)."
+          echo "::notice::This job intentionally deploys nothing. See deploy-production for the real deploy step."
 
       - name: Verify deployment health
         if: vars.STAGING_API_URL != ''
@@ -283,15 +262,44 @@ jobs:
           echo "Image: ${{ needs.build.outputs.image_tag }}"
           echo "Digest: ${{ needs.build.outputs.image_digest }}"
 
-      # ⚠️ REQUIRED: Add your actual deployment steps here
-      # Should mirror staging deployment with production credentials/namespace.
-      # See staging deployment section above for platform-specific examples.
-
-      - name: ⚠️ Deployment Step Missing
+      # SSH to the single production host and recreate `api` + `worker` from
+      # the image this run just pushed - pinned to the run's sha tag, never
+      # `latest`, so "deployed" and "the health check below passed" refer to
+      # the same build. Mirrors the manual procedure in RUNBOOK.md: pull,
+      # retag :latest (keeping the previous tag for instant rollback), then
+      # `compose up -d --no-build` both services that share the image.
+      #
+      # `api` and `worker` MUST be recreated together - they share one image,
+      # and rebuilding it without recreating both leaves them on different
+      # code (found the hard way during the first manual deploy this
+      # replaces, see RUNBOOK.md).
+      #
+      # Known gap vs #318's stated acceptance bar: this verifies the deployed
+      # container answers healthy, not that its image digest equals the one
+      # this run pushed - /ready exposes no build identifier yet. Tracked,
+      # not silently declared done.
+      - name: Deploy to production host
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
-          echo "::warning::No deployment step configured - health check will verify existing deployment"
-          echo "::warning::Add deployment steps above this step to deploy the new Docker image"
-          echo "::warning::Use production credentials/namespace (not staging)"
+          install -m 600 /dev/null "$RUNNER_TEMP/deploy_key"
+          printf '%s\n' "${{ secrets.SSH_DEPLOY_KEY }}" > "$RUNNER_TEMP/deploy_key"
+          install -m 600 /dev/null "$RUNNER_TEMP/known_hosts"
+          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" > "$RUNNER_TEMP/known_hosts"
+
+          echo "Deploying $IMAGE_REF to $DEPLOY_HOST"
+          ssh -i "$RUNNER_TEMP/deploy_key" -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+            "$DEPLOY_USER@$DEPLOY_HOST" "
+              set -euo pipefail
+              echo '${{ secrets.GITHUB_TOKEN }}' | docker login ${{ env.REGISTRY }} -u '${{ github.actor }}' --password-stdin
+              docker pull '$IMAGE_REF'
+              docker tag bugspotter-api:latest bugspotter-api:pre-${{ github.sha }} || true
+              docker tag '$IMAGE_REF' bugspotter-api:latest
+              cd /opt/bugspotter
+              docker compose up -d --no-build api worker
+            "
 
       - name: Verify deployment health
         if: vars.PRODUCTION_API_URL != ''

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -281,10 +281,21 @@ jobs:
       # not silently declared done.
       - name: Deploy to production host
         env:
-          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          # docker/metadata-action's `type=sha` uses git's abbreviated (7-char)
+          # sha by default - `github.sha` is the full 40-char sha, so
+          # reconstructing the tag from it produces a ref that was never
+          # pushed. Extract the real tag from the same output the build step
+          # actually used, instead of a second, divergent computation of it.
+          ALL_TAGS: ${{ needs.build.outputs.image_tag }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
+          IMAGE_REF=$(printf '%s\n' "$ALL_TAGS" | grep -- ':sha-')
+          if [ -z "$IMAGE_REF" ]; then
+            echo "::error::No sha-tagged image found in: $ALL_TAGS" >&2
+            exit 1
+          fi
+
           install -m 600 /dev/null "$RUNNER_TEMP/deploy_key"
           printf '%s\n' "${{ secrets.SSH_DEPLOY_KEY }}" > "$RUNNER_TEMP/deploy_key"
           install -m 600 /dev/null "$RUNNER_TEMP/known_hosts"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -289,6 +289,12 @@ jobs:
           ALL_TAGS: ${{ needs.build.outputs.image_tag }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          # Passed through env, not interpolated into the run: script text
+          # below, so a secret value containing shell metacharacters can't
+          # become shell syntax at execution time - the same injection shape
+          # GitHub's hardening docs warn against for untrusted `run:` input.
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
           # `|| true` matters: this shell runs with -e (GitHub Actions'
           # default), so a no-match grep inside the assignment would abort
@@ -300,9 +306,9 @@ jobs:
           fi
 
           install -m 600 /dev/null "$RUNNER_TEMP/deploy_key"
-          printf '%s\n' "${{ secrets.SSH_DEPLOY_KEY }}" > "$RUNNER_TEMP/deploy_key"
+          printf '%s\n' "$SSH_DEPLOY_KEY" > "$RUNNER_TEMP/deploy_key"
           install -m 600 /dev/null "$RUNNER_TEMP/known_hosts"
-          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" > "$RUNNER_TEMP/known_hosts"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$RUNNER_TEMP/known_hosts"
 
           echo "Deploying $IMAGE_REF to $DEPLOY_HOST"
           ssh -i "$RUNNER_TEMP/deploy_key" -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -290,7 +290,10 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
-          IMAGE_REF=$(printf '%s\n' "$ALL_TAGS" | grep -- ':sha-')
+          # `|| true` matters: this shell runs with -e (GitHub Actions'
+          # default), so a no-match grep inside the assignment would abort
+          # the step right here and skip the message below.
+          IMAGE_REF=$(printf '%s\n' "$ALL_TAGS" | grep -- ':sha-' || true)
           if [ -z "$IMAGE_REF" ]; then
             echo "::error::No sha-tagged image found in: $ALL_TAGS" >&2
             exit 1
@@ -303,6 +306,7 @@ jobs:
 
           echo "Deploying $IMAGE_REF to $DEPLOY_HOST"
           ssh -i "$RUNNER_TEMP/deploy_key" -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+            -o StrictHostKeyChecking=yes -o BatchMode=yes -o ConnectTimeout=15 \
             "$DEPLOY_USER@$DEPLOY_HOST" "$IMAGE_REF"
 
       - name: Verify deployment health

--- a/DEPLOY-SECRETS-ROTATION.md
+++ b/DEPLOY-SECRETS-ROTATION.md
@@ -4,6 +4,13 @@
 "Verifying" below for what was actually tested rather than only planned.
 Kept as the reference for the next time this key needs rotating.
 
+**Correction, 2026-08-12:** a later hardening pass (merged in PR #323) added
+`chown root:root` on `.ssh`/`authorized_keys`, citing general OpenSSH
+guidance. Applying it to the live host broke authentication outright -
+caught immediately by re-running the same benign-command check this doc
+already prescribes, exactly why that check exists. Reverted on the host and
+in this doc; see the notes under steps 2 and 5 below.
+
 `DEPLOY_HOST`, `DEPLOY_USER`, `SSH_DEPLOY_KEY`, `SSH_KNOWN_HOSTS` in
 `apex-bridge/bugspotter` were set 2026-04-09, four months before the
 2026-08-04 netcup migration. They hold Yandex-era values and will fail
@@ -55,20 +62,23 @@ useradd -m -s /bin/bash deploy
 # exits, silently breaking every deploy - the forced-command restriction
 # below is what actually limits this account, not the shell.
 usermod -aG docker deploy
-# root:root, not deploy:deploy: the forced command below is what restricts
-# this key to one script, not file permissions - but if `deploy` could write
-# its own .ssh, anything that ever runs as `deploy` (docker-group membership
-# is already root-equivalent, see above) could replace authorized_keys or
-# the script and remove that restriction. StrictModes (sshd's default)
-# rejects group/world-writable auth files, not root ownership - a root-owned,
-# non-writable-by-deploy authorized_keys is a standard hardening pattern, not
-# a login blocker. Still: this touches the auth path directly, so repeat the
-# same "benign command over the new key" check described under "Verifying,
-# either path" below after applying this, the same way the current live
-# setup was verified before being trusted.
 mkdir -p /home/deploy/.ssh && chmod 700 /home/deploy/.ssh
-chown root:root /home/deploy/.ssh
+chown deploy:deploy /home/deploy/.ssh
 ```
+
+**Do not `chown root:root` this directory**, despite it being a documented
+hardening pattern in general OpenSSH guidance (StrictModes is supposed to
+reject only group/world-writable auth files, not root ownership). Tried it
+here on 2026-08-12 and it broke authentication outright - `ssh -vvv` showed
+the client correctly offering the key, but sshd rejected it at the
+`publickey` stage every time (`Authentications that can continue: publickey`
+looping, never accepted), on this host's OpenSSH_10.0p2 (Debian 13). Reverting
+to `deploy:deploy` fixed it immediately, reproduced twice. Whatever the exact
+mechanism, treat the general guidance as wrong for this specific host until
+proven otherwise - verify empirically, don't cite documentation for a claim
+this easy to test. `ci-deploy.sh` itself staying `root:root` (below) is a
+separate, unaffected mechanism - that regression was isolated specifically
+to `.ssh`/`authorized_keys` ownership, not the script.
 
 ### 3. Write the forced-command script
 
@@ -137,8 +147,13 @@ simplest option then.
 echo 'command="/opt/bugspotter/scripts/ci-deploy.sh",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 AAAA...<paste public key>... ci-deploy@bugspotter' \
   >> /home/deploy/.ssh/authorized_keys
 chmod 600 /home/deploy/.ssh/authorized_keys
-chown root:root /home/deploy/.ssh/authorized_keys
+chown deploy:deploy /home/deploy/.ssh/authorized_keys
 ```
+
+`deploy:deploy`, not `root:root` - see the note under step 2. The forced
+command is what actually restricts this key to one script; ownership here
+only needs to satisfy StrictModes (not group/world-writable), which
+`deploy:deploy` at these permissions already does.
 
 ### 6. Workflow step (already matches Path A, shown for reference)
 

--- a/DEPLOY-SECRETS-ROTATION.md
+++ b/DEPLOY-SECRETS-ROTATION.md
@@ -15,12 +15,12 @@ to leave as-is, since that job only runs on `workflow_dispatch` with
 Two ways to rotate. They produce a materially different security posture,
 not just different secret values - read both before picking.
 
-|                                  | Path A: dedicated deploy user (recommended)                                                                                                             | Path B: reuse the admin key                            |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| Setup                            | New user, new keypair, a forced SSH command                                                                                                             | None - use what already exists                         |
-| A leaked `SSH_DEPLOY_KEY` grants | Exactly one operation: pull + redeploy `api`/`worker` from a validated GHCR image ref. Nothing else - not a shell, not other commands, not other hosts. | Full root on the production host                       |
-| Workflow change needed           | Yes - simplify `deploy-api.yml`'s SSH step (shown below)                                                                                                | No - the step already committed in PR #323 works as-is |
-| Time                             | ~20 minutes                                                                                                                                             | ~2 minutes                                             |
+|                                  | Path A: dedicated deploy user (recommended)                                                                                                             | Path B: reuse the admin key                                                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Setup                            | New user, new keypair, a forced SSH command                                                                                                             | None - use what already exists                                                                                                              |
+| A leaked `SSH_DEPLOY_KEY` grants | Exactly one operation: pull + redeploy `api`/`worker` from a validated GHCR image ref. Nothing else - not a shell, not other commands, not other hosts. | Full root on the production host                                                                                                            |
+| Workflow change needed           | No - `deploy-api.yml` as committed in this PR already sends only the image ref (step 6 documents the shape it's already in)                             | Yes - revert the SSH step to run the full login/pull/tag/compose sequence inline; a bare image ref sent to an unrestricted shell just fails |
+| Time                             | ~20 minutes                                                                                                                                             | ~2 minutes                                                                                                                                  |
 
 **Why "add the deploy user to the `docker` group" alone is not real scoping**,
 if you've seen this pattern before and are tempted to stop there: Docker group
@@ -55,8 +55,19 @@ useradd -m -s /bin/bash deploy
 # exits, silently breaking every deploy - the forced-command restriction
 # below is what actually limits this account, not the shell.
 usermod -aG docker deploy
+# root:root, not deploy:deploy: the forced command below is what restricts
+# this key to one script, not file permissions - but if `deploy` could write
+# its own .ssh, anything that ever runs as `deploy` (docker-group membership
+# is already root-equivalent, see above) could replace authorized_keys or
+# the script and remove that restriction. StrictModes (sshd's default)
+# rejects group/world-writable auth files, not root ownership - a root-owned,
+# non-writable-by-deploy authorized_keys is a standard hardening pattern, not
+# a login blocker. Still: this touches the auth path directly, so repeat the
+# same "benign command over the new key" check described under "Verifying,
+# either path" below after applying this, the same way the current live
+# setup was verified before being trusted.
 mkdir -p /home/deploy/.ssh && chmod 700 /home/deploy/.ssh
-chown deploy:deploy /home/deploy/.ssh
+chown root:root /home/deploy/.ssh
 ```
 
 ### 3. Write the forced-command script
@@ -80,15 +91,34 @@ case "$sha" in
   *[!0-9a-f]*|"") echo "rejected: malformed sha" >&2; exit 1 ;;
 esac
 
+# Same lock poll-deploy.sh uses - both paths retag the same
+# bugspotter-api:latest and recreate the same containers, so they must not
+# run concurrently. See RUNBOOK.md's "Interaction with path (2)".
+exec 9>/opt/bugspotter/scripts/.poll-deploy.lock
+flock -n 9 || { echo "rejected: poll-deploy.sh is mid-run, retry" >&2; exit 1; }
+
 docker pull "$IMAGE_REF"
-docker tag bugspotter-api:latest "bugspotter-api:pre-$sha" 2>/dev/null || true
+new_id=$(docker image inspect --format '{{.Id}}' "$IMAGE_REF")
+old_id=$(docker image inspect --format '{{.Id}}' bugspotter-api:latest 2>/dev/null || true)
+# Only back up an existing :latest, and only when it isn't already this same
+# content - a retried run would otherwise clobber the real pre-<sha> rollback
+# target with itself. No `|| true` on the tag itself: a genuine failure here
+# should abort the deploy, not be silently swallowed.
+if [ -n "$old_id" ] && [ "$new_id" != "$old_id" ]; then
+  docker tag bugspotter-api:latest "bugspotter-api:pre-$sha"
+fi
 docker tag "$IMAGE_REF" bugspotter-api:latest
 cd /opt/bugspotter
 docker compose up -d --no-build api worker
 SCRIPT
 
-chmod +x /opt/bugspotter/scripts/ci-deploy.sh
-chown deploy:deploy /opt/bugspotter/scripts/ci-deploy.sh
+chmod 755 /opt/bugspotter/scripts/ci-deploy.sh
+chown root:root /opt/bugspotter/scripts/ci-deploy.sh
+# /opt/bugspotter/scripts/ is itself deploy-owned (poll-deploy.sh's cron job
+# needs to create its own state/lock/log files there) - without the sticky
+# bit, that directory-write access would let `deploy` delete and replace
+# this root-owned script outright, regardless of the file's own permissions.
+chmod +t /opt/bugspotter/scripts
 ```
 
 ### 4. Registry auth - not needed
@@ -107,13 +137,14 @@ simplest option then.
 echo 'command="/opt/bugspotter/scripts/ci-deploy.sh",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 AAAA...<paste public key>... ci-deploy@bugspotter' \
   >> /home/deploy/.ssh/authorized_keys
 chmod 600 /home/deploy/.ssh/authorized_keys
+chown root:root /home/deploy/.ssh/authorized_keys
 ```
 
-### 6. Simplify the workflow step (Path A only)
+### 6. Workflow step (already matches Path A, shown for reference)
 
-`deploy-api.yml`'s SSH step currently sends the whole deploy sequence as the
-command - a forced command ignores that and always runs the script above
-instead, so the step only needs to send the image ref:
+`deploy-api.yml`'s SSH step, as committed in this PR, already sends only the
+image ref - a forced command ignores whatever it's sent and always runs the
+script above instead, so there's nothing left to simplify:
 
 ```yaml
 - name: Deploy to production host
@@ -134,28 +165,45 @@ instead, so the step only needs to send the image ref:
 ### 7. Set the secrets
 
 ```bash
-gh secret set DEPLOY_HOST --repo apex-bridge/bugspotter --body "159.195.212.239"
-gh secret set DEPLOY_USER --repo apex-bridge/bugspotter --body "deploy"
-gh secret set SSH_DEPLOY_KEY --repo apex-bridge/bugspotter --body "$(cat ~/.ssh/bugspotter-ci-deploy)"
-gh secret set SSH_KNOWN_HOSTS --repo apex-bridge/bugspotter --body "$(ssh-keyscan -t ed25519 159.195.212.239 2>/dev/null)"
+gh secret set DEPLOY_HOST --repo apex-bridge/bugspotter --env production --body "159.195.212.239"
+gh secret set DEPLOY_USER --repo apex-bridge/bugspotter --env production --body "deploy"
+gh secret set SSH_DEPLOY_KEY --repo apex-bridge/bugspotter --env production --body "$(cat ~/.ssh/bugspotter-ci-deploy)"
+# ssh-keyscan collects whatever key the host presents - it does not verify
+# it. Before trusting the output, compare its fingerprint
+# (ssh-keygen -lf <(ssh-keyscan -t ed25519 159.195.212.239)) against netcup's
+# console or another trusted channel, not just what came back over this
+# connection.
+gh secret set SSH_KNOWN_HOSTS --repo apex-bridge/bugspotter --env production --body "$(ssh-keyscan -t ed25519 159.195.212.239 2>/dev/null)"
 ```
 
 (Windows git-bash: always `--body "$VAR"`, never pipe to stdin - a pipe
 silently corrupts multi-line values.)
 
+`--env production` scopes these to the `production` environment `deploy-api.yml`
+declares on the `deploy-production` job - without it, `gh secret set` creates
+repository-level secrets that any workflow in the repo can read via
+`secrets.<NAME>`, regardless of environment gating.
+
 ---
 
 ## Path B: reuse the existing admin key
 
-No new user, no script, no workflow change - the SSH step already
-committed in PR #323 runs `docker login`/`pull`/`tag`/`compose up` directly
-as whatever user these secrets name.
+No new user, no script - but not a drop-in with the workflow as currently
+committed either. `deploy-api.yml`'s SSH step now sends only the bare image
+ref (Path A's forced-command contract, see step 6 above); a plain,
+unrestricted SSH session doesn't interpret that specially and just fails
+trying to execute it as a command. Using Path B requires reverting that step
+to run the full `docker login`/`pull`/`tag`/`compose up` sequence inline -
+the shape it had before Path A's scoping replaced it - not "works as-is."
 
 ```bash
-gh secret set DEPLOY_HOST --repo apex-bridge/bugspotter --body "159.195.212.239"
-gh secret set DEPLOY_USER --repo apex-bridge/bugspotter --body "root"
-gh secret set SSH_DEPLOY_KEY --repo apex-bridge/bugspotter --body "$(cat ~/.ssh/bugspotter-netcup)"
-gh secret set SSH_KNOWN_HOSTS --repo apex-bridge/bugspotter --body "$(ssh-keyscan -t ed25519 159.195.212.239 2>/dev/null)"
+gh secret set DEPLOY_HOST --repo apex-bridge/bugspotter --env production --body "159.195.212.239"
+gh secret set DEPLOY_USER --repo apex-bridge/bugspotter --env production --body "root"
+gh secret set SSH_DEPLOY_KEY --repo apex-bridge/bugspotter --env production --body "$(cat ~/.ssh/bugspotter-netcup)"
+# ssh-keyscan collects whatever key the host presents - it does not verify
+# it. Compare the fingerprint against netcup's console or another trusted
+# channel before trusting this.
+gh secret set SSH_KNOWN_HOSTS --repo apex-bridge/bugspotter --env production --body "$(ssh-keyscan -t ed25519 159.195.212.239 2>/dev/null)"
 ```
 
 Accept this only with the tradeoff in the table above in mind: any workflow
@@ -172,10 +220,17 @@ production deploy. Reduce first-run risk by dispatching against a commit
 that's already running, so a failure means "the step doesn't work," not
 "bad code just shipped":
 
+Without `--ref`, `gh workflow run` uses the default branch (`main`), which
+can be ahead of what's actually live - pin it to the commit currently
+serving production so a "just verify the step works" run can't
+accidentally deploy newer, unreviewed code:
+
 ```bash
-gh workflow run deploy-api.yml --repo apex-bridge/bugspotter -f environment=production
+gh workflow run deploy-api.yml --repo apex-bridge/bugspotter \
+  --ref <commit-or-tag-currently-serving-production> \
+  -f environment=production
 gh run watch --repo apex-bridge/bugspotter
-curl -s -o /dev/null -w 'HTTP %{http_code}\n' https://app.kz.bugspotter.io/ready
+curl -fsS -o /dev/null -w 'HTTP %{http_code}\n' https://app.kz.bugspotter.io/ready
 ```
 
 **What was actually verified for Path A (2026-08-11):** before wiring the
@@ -192,10 +247,18 @@ externally. Only after that did the four GitHub secrets get set. The
 that's the one remaining step to close the loop end-to-end through Actions
 itself rather than a direct SSH test.
 
-Rollback is the same either way - re-tag and recreate, per `RUNBOOK.md`:
+Rollback needs the **admin key** (`~/.ssh/bugspotter-netcup`, `root@...`),
+not the Path A deploy key - `ci-deploy.sh`'s forced command only accepts a
+validated `sha-<hex>` image ref as `$SSH_ORIGINAL_COMMAND`, so this
+multi-line command would be rejected outright over the restricted key.
+Otherwise the same re-tag-and-recreate as `RUNBOOK.md`, with `set -e` added
+so a failed `docker tag` (no such rollback tag, typo'd sha, etc.) stops the
+command instead of silently falling through to a `compose up` that
+"succeeds" without having restored anything:
 
 ```bash
-ssh -i <key> <user>@159.195.212.239 "
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
+  set -e
   docker tag bugspotter-api:pre-<sha> bugspotter-api:latest
   cd /opt/bugspotter && docker compose up -d --no-build api worker
 "

--- a/DEPLOY-SECRETS-ROTATION.md
+++ b/DEPLOY-SECRETS-ROTATION.md
@@ -1,0 +1,202 @@
+# Rotating the API deploy secrets
+
+**Status: done, 2026-08-11.** Path A, executed live and verified - see
+"Verifying" below for what was actually tested rather than only planned.
+Kept as the reference for the next time this key needs rotating.
+
+`DEPLOY_HOST`, `DEPLOY_USER`, `SSH_DEPLOY_KEY`, `SSH_KNOWN_HOSTS` in
+`apex-bridge/bugspotter` were set 2026-04-09, four months before the
+2026-08-04 netcup migration. They hold Yandex-era values and will fail
+cleanly (SSH auth/host-key failure) against the current host. Until
+rotated, PR #323's `deploy-production` job cannot succeed - which is safe
+to leave as-is, since that job only runs on `workflow_dispatch` with
+`environment: production`, never on push.
+
+Two ways to rotate. They produce a materially different security posture,
+not just different secret values - read both before picking.
+
+|                                  | Path A: dedicated deploy user (recommended)                                                                                                             | Path B: reuse the admin key                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Setup                            | New user, new keypair, a forced SSH command                                                                                                             | None - use what already exists                         |
+| A leaked `SSH_DEPLOY_KEY` grants | Exactly one operation: pull + redeploy `api`/`worker` from a validated GHCR image ref. Nothing else - not a shell, not other commands, not other hosts. | Full root on the production host                       |
+| Workflow change needed           | Yes - simplify `deploy-api.yml`'s SSH step (shown below)                                                                                                | No - the step already committed in PR #323 works as-is |
+| Time                             | ~20 minutes                                                                                                                                             | ~2 minutes                                             |
+
+**Why "add the deploy user to the `docker` group" alone is not real scoping**,
+if you've seen this pattern before and are tempted to stop there: Docker group
+membership lets you bind-mount the host root filesystem into a container and
+`chroot` into it - it is root-equivalent by design, not a Docker bug. The
+actual scoping in Path A comes from the SSH **forced command**, which makes
+the key unable to run anything except one fixed, validated script -
+regardless of what command the connecting client asks for. Docker-group
+membership is still required (the script needs to run `docker`), but the key
+itself can never be used to reach a shell.
+
+---
+
+## Path A: dedicated deploy user + forced command
+
+### 1. Generate a new keypair (do not reuse `bugspotter-netcup`)
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/bugspotter-ci-deploy -N "" -C "ci-deploy@bugspotter"
+```
+
+No passphrase - this key runs unattended in GitHub Actions.
+
+### 2. Create the user on the host
+
+```bash
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239
+
+useradd -m -s /bin/bash deploy
+# NOT /usr/sbin/nologin: sshd invokes a forced command through the user's
+# login shell (`<shell> -c "<command>"`). nologin just prints a message and
+# exits, silently breaking every deploy - the forced-command restriction
+# below is what actually limits this account, not the shell.
+usermod -aG docker deploy
+mkdir -p /home/deploy/.ssh && chmod 700 /home/deploy/.ssh
+chown deploy:deploy /home/deploy/.ssh
+```
+
+### 3. Write the forced-command script
+
+`$SSH_ORIGINAL_COMMAND` is the only untrusted input that reaches this
+script - the workflow will send an image ref as the "command"; validate it
+strictly before it touches anything.
+
+```bash
+cat > /opt/bugspotter/scripts/ci-deploy.sh <<'SCRIPT'
+#!/bin/sh
+set -eu
+
+IMAGE_REF="${SSH_ORIGINAL_COMMAND:-}"
+case "$IMAGE_REF" in
+  ghcr.io/apex-bridge/bugspotter/api:sha-*) ;;
+  *) echo "rejected: not a recognized image ref" >&2; exit 1 ;;
+esac
+sha="${IMAGE_REF#ghcr.io/apex-bridge/bugspotter/api:sha-}"
+case "$sha" in
+  *[!0-9a-f]*|"") echo "rejected: malformed sha" >&2; exit 1 ;;
+esac
+
+docker pull "$IMAGE_REF"
+docker tag bugspotter-api:latest "bugspotter-api:pre-$sha" 2>/dev/null || true
+docker tag "$IMAGE_REF" bugspotter-api:latest
+cd /opt/bugspotter
+docker compose up -d --no-build api worker
+SCRIPT
+
+chmod +x /opt/bugspotter/scripts/ci-deploy.sh
+chown deploy:deploy /opt/bugspotter/scripts/ci-deploy.sh
+```
+
+### 4. Registry auth - not needed
+
+Checked before assuming: `docker manifest inspect
+ghcr.io/apex-bridge/bugspotter/api:sha-cb02c35` succeeded with zero
+credentials. These packages are public, so `docker pull` in the script needs
+no login and no PAT. If that ever changes (package made private), the
+script needs a `docker login` added back, and something has to supply the
+credential - a PAT cached via `docker login` as the `deploy` user is the
+simplest option then.
+
+### 5. Install the public key with the forced command
+
+```bash
+echo 'command="/opt/bugspotter/scripts/ci-deploy.sh",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 AAAA...<paste public key>... ci-deploy@bugspotter' \
+  >> /home/deploy/.ssh/authorized_keys
+chmod 600 /home/deploy/.ssh/authorized_keys
+```
+
+### 6. Simplify the workflow step (Path A only)
+
+`deploy-api.yml`'s SSH step currently sends the whole deploy sequence as the
+command - a forced command ignores that and always runs the script above
+instead, so the step only needs to send the image ref:
+
+```yaml
+- name: Deploy to production host
+  env:
+    IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+    DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+    DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+  run: |
+    install -m 600 /dev/null "$RUNNER_TEMP/deploy_key"
+    printf '%s\n' "${{ secrets.SSH_DEPLOY_KEY }}" > "$RUNNER_TEMP/deploy_key"
+    install -m 600 /dev/null "$RUNNER_TEMP/known_hosts"
+    printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" > "$RUNNER_TEMP/known_hosts"
+
+    ssh -i "$RUNNER_TEMP/deploy_key" -o UserKnownHostsFile="$RUNNER_TEMP/known_hosts" \
+      "$DEPLOY_USER@$DEPLOY_HOST" "$IMAGE_REF"
+```
+
+### 7. Set the secrets
+
+```bash
+gh secret set DEPLOY_HOST --repo apex-bridge/bugspotter --body "159.195.212.239"
+gh secret set DEPLOY_USER --repo apex-bridge/bugspotter --body "deploy"
+gh secret set SSH_DEPLOY_KEY --repo apex-bridge/bugspotter --body "$(cat ~/.ssh/bugspotter-ci-deploy)"
+gh secret set SSH_KNOWN_HOSTS --repo apex-bridge/bugspotter --body "$(ssh-keyscan -t ed25519 159.195.212.239 2>/dev/null)"
+```
+
+(Windows git-bash: always `--body "$VAR"`, never pipe to stdin - a pipe
+silently corrupts multi-line values.)
+
+---
+
+## Path B: reuse the existing admin key
+
+No new user, no script, no workflow change - the SSH step already
+committed in PR #323 runs `docker login`/`pull`/`tag`/`compose up` directly
+as whatever user these secrets name.
+
+```bash
+gh secret set DEPLOY_HOST --repo apex-bridge/bugspotter --body "159.195.212.239"
+gh secret set DEPLOY_USER --repo apex-bridge/bugspotter --body "root"
+gh secret set SSH_DEPLOY_KEY --repo apex-bridge/bugspotter --body "$(cat ~/.ssh/bugspotter-netcup)"
+gh secret set SSH_KNOWN_HOSTS --repo apex-bridge/bugspotter --body "$(ssh-keyscan -t ed25519 159.195.212.239 2>/dev/null)"
+```
+
+Accept this only with the tradeoff in the table above in mind: any workflow
+run with access to these secrets - and any compromise of the secret itself -
+now has unrestricted root on the box serving production traffic.
+
+---
+
+## Verifying, either path
+
+There is no staging environment to rehearse against (see PR #323's
+"no staging" note) - the first real trigger of this step **is** a
+production deploy. Reduce first-run risk by dispatching against a commit
+that's already running, so a failure means "the step doesn't work," not
+"bad code just shipped":
+
+```bash
+gh workflow run deploy-api.yml --repo apex-bridge/bugspotter -f environment=production
+gh run watch --repo apex-bridge/bugspotter
+curl -s -o /dev/null -w 'HTTP %{http_code}\n' https://app.kz.bugspotter.io/ready
+```
+
+**What was actually verified for Path A (2026-08-11):** before wiring the
+workflow secrets at all, the forced command was tested directly over SSH
+with the new key - first a benign arbitrary command
+(`ssh -i ~/.ssh/bugspotter-ci-deploy deploy@159.195.212.239 "echo test"`),
+which correctly printed `rejected: not a recognized image ref` instead of
+running it, proving the key cannot escape the script. Then a real deploy
+against `ghcr.io/apex-bridge/bugspotter/api:sha-cb02c35` - the commit
+already running - which pulled, tagged, recreated `api` + `worker`, and
+returned exit 0 with both containers healthy. `curl /ready` confirmed 200
+externally. Only after that did the four GitHub secrets get set. The
+`gh workflow run` trigger above was not yet exercised as of this writing -
+that's the one remaining step to close the loop end-to-end through Actions
+itself rather than a direct SSH test.
+
+Rollback is the same either way - re-tag and recreate, per `RUNBOOK.md`:
+
+```bash
+ssh -i <key> <user>@159.195.212.239 "
+  docker tag bugspotter-api:pre-<sha> bugspotter-api:latest
+  cd /opt/bugspotter && docker compose up -d --no-build api worker
+"
+```

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -54,12 +54,16 @@ leaves them on different code.
 #    and "build". Archiving into a fresh directory and swapping, rather than
 #    extracting straight into the existing src/, also removes files deleted
 #    from the repo since the last sync (a plain tar -x into src/ would not).
+#    The previous src/ is kept as src.bak, not deleted outright - if the
+#    build in step 2 or the deploy in step 4 fails, the last-known-good
+#    source tree is still there. Remove src.bak only after step 5 confirms
+#    the new deploy is healthy.
 ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
-  "rm -rf /opt/bugspotter/src.new && mkdir -p /opt/bugspotter/src.new"
+  "rm -rf /opt/bugspotter/src.new /opt/bugspotter/src.bak && mkdir -p /opt/bugspotter/src.new"
 git archive <ref> | ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
   "tar -x -C /opt/bugspotter/src.new"
 ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
-  "rm -rf /opt/bugspotter/src && mv /opt/bugspotter/src.new /opt/bugspotter/src"
+  "mv /opt/bugspotter/src /opt/bugspotter/src.bak 2>/dev/null; mv /opt/bugspotter/src.new /opt/bugspotter/src"
 
 # 2. Build. The image is built directly with `docker build`, NOT `docker
 #    compose build` - the live docker-compose.yml's `build.context: .` can't
@@ -75,11 +79,18 @@ ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
 # 3. Tag the OLD image for rollback before overwriting :latest. This
 #    pre-<ref>/build-<ref> convention already existed on the host (pre-290,
 #    build-290, pre-292, build-292) before this runbook documented it.
-#    Skip this on a retry of the same deploy: if :latest is already
-#    build-<short-ref>, re-running it overwrites the real rollback target
-#    with the thing you'd be rolling back from.
-ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
-  "docker tag bugspotter-api:latest bugspotter-api:pre-<short-ref>"
+#    Guarded, not just noted: skips the tag when :latest already IS
+#    build-<short-ref> (a retry of this same deploy) - otherwise it would
+#    overwrite the real rollback target with the thing you'd be rolling back
+#    from. Mirrors the check ci-deploy.sh/poll-deploy.sh apply automatically
+#    (see DEPLOY-SECRETS-ROTATION.md).
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 '
+  new_id=$(docker image inspect --format "{{.Id}}" bugspotter-api:build-<short-ref>)
+  old_id=$(docker image inspect --format "{{.Id}}" bugspotter-api:latest 2>/dev/null || true)
+  if [ -n "$old_id" ] && [ "$new_id" != "$old_id" ]; then
+    docker tag bugspotter-api:latest bugspotter-api:pre-<short-ref>
+  fi
+'
 
 # 4. Retag the new build as :latest and recreate both containers that use it.
 ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
@@ -93,6 +104,11 @@ ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
 curl -s -o /dev/null -w 'HTTP %{http_code}\n' https://app.kz.bugspotter.io/ready
 ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
   "docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' | grep -E 'bugspotter-api|bugspotter-worker'"
+
+# Only now, with the new deploy confirmed healthy, drop the source backup
+# from step 1 - if anything above failed instead, src.bak is the last-known-
+# good tree to recover from.
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "rm -rf /opt/bugspotter/src.bak"
 
 # 6. Record what's deployed.
 ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -12,14 +12,14 @@ reconstructing it from memory.
 
 `/opt/bugspotter/`:
 
-| Path                                                                                | What                                                                            | Origin                                                                                                              |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `src/`                                                                              | Application source at the last-synced commit                                    | `git archive <ref> \| ssh ... tar -x` from a local clone - **not** a git clone on the host, there is no `.git` here |
-| `docker-compose.yml`, `docker-compose.monitoring.yml`, `docker-compose.storage.yml` | The compose files actually in effect                                            | Synced from the repo **by hand**, separately from `src/` - see "Compose file drift" below                           |
-| `.env`                                                                              | Runtime config + secrets                                                        | Hand-maintained on the host; never committed                                                                        |
-| `monitoring/`                                                                       | Grafana/Prometheus/Alertmanager config, including hand-provisioned secret files | Partly synced, partly hand-created - see below                                                                      |
-| `scripts/`                                                                          | `init-minio.sh`, `reset-demo-data.sh`, `seed-demo-data.sh`                      | Synced from repo                                                                                                    |
-| `intelligence-src/`                                                                 | Separate source tree for the `bugspotter-intelligence` service                  | Same pattern as `src/`, different repo                                                                              |
+| Path                                                                                | What                                                                                                                                                                                   | Origin                                                                                                              |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/`                                                                              | Application source at the last-synced commit                                                                                                                                           | `git archive <ref> \| ssh ... tar -x` from a local clone - **not** a git clone on the host, there is no `.git` here |
+| `docker-compose.yml`, `docker-compose.monitoring.yml`, `docker-compose.storage.yml` | The compose files actually in effect                                                                                                                                                   | Synced from the repo **by hand**, separately from `src/` - see "Compose file drift" below                           |
+| `.env`                                                                              | Runtime config + secrets                                                                                                                                                               | Hand-maintained on the host; never committed                                                                        |
+| `monitoring/`                                                                       | Grafana/Prometheus/Alertmanager config, including hand-provisioned secret files                                                                                                        | Partly synced, partly hand-created - see below                                                                      |
+| `scripts/`                                                                          | `init-minio.sh`, `reset-demo-data.sh`, `seed-demo-data.sh` (synced) plus `ci-deploy.sh`, `poll-deploy.sh` and their state/lock/log files (host-only, `deploy`-owned - not in the repo) | Mixed: repo-synced files and hand-created ops tooling share this directory                                          |
+| `intelligence-src/`                                                                 | Separate source tree for the `bugspotter-intelligence` service                                                                                                                         | Same pattern as `src/`, different repo                                                                              |
 
 `docker-compose.yandex.yml` no longer applies - it carried managed-Postgres
 TLS/pooler plumbing for the decommissioned Yandex host and has no netcup
@@ -110,6 +110,106 @@ actually changed:
 | `apps/admin/**`                                                                                                      | `admin` (separate image, separate Dockerfile - **not covered by this runbook**, no automated path exists for it either)                       |
 | `docker-compose*.yml` only, no code change                                                                           | `docker compose up -d` for the affected service, no rebuild                                                                                   |
 | `.env` only                                                                                                          | Depends on the variable - compose bakes interpolated env at container-**create** time, so most changes need `up -d` (recreate), not `restart` |
+
+## Three deploy paths now exist - which one actually runs
+
+The manual procedure above is one of three. As of 2026-08-11/12, in order of
+how automatic each is:
+
+1. **Manual** (above) - a human runs it by hand. Always works, always current.
+2. **SSH forced-command, CI-triggered** - `deploy-api.yml`'s `deploy-production`
+   job SSHes in as a dedicated `deploy` account restricted to one script
+   (`ci-deploy.sh`); see `DEPLOY-SECRETS-ROTATION.md`. **Currently non-functional**:
+   GitHub-hosted runner IPs time out reaching `159.195.212.239:22`, blocked
+   somewhere upstream of the host's own firewall (`ufw` allows it; the block
+   isn't visible from inside the VM). `workflow_dispatch`-only, never fires on
+   push, so this is safe to leave broken - it just means it isn't doing
+   anything, not that it's doing the wrong thing.
+3. **Poll-based, host-side** (`poll-deploy.sh`, this section) - the fix for
+   (2)'s blocker: instead of GitHub reaching in, the host reaches out. No
+   inbound network dependency at all.
+
+### Poll-based auto-deploy
+
+`ghcr.io/apex-bridge/bugspotter/api` is a **public** package - confirmed
+2026-08-11 via `docker manifest inspect` with zero credentials. Combined with
+the host already having working outbound internet (proven the same day: it
+pulled from GHCR fine during manual testing), there is no reason to fight the
+inbound-firewall problem at all for routine deploys. The host can just check
+the registry itself.
+
+`/opt/bugspotter/scripts/poll-deploy.sh`, owned by `deploy`, run every 3
+minutes via that user's crontab:
+
+```sh
+#!/bin/sh
+set -eu
+
+IMAGE="ghcr.io/apex-bridge/bugspotter/api:main"
+STATE_FILE="/opt/bugspotter/scripts/.last-deployed-digest"
+LOCK_FILE="/opt/bugspotter/scripts/.poll-deploy.lock"
+LOG_FILE="/opt/bugspotter/scripts/.poll-deploy.log"
+
+exec 9>"$LOCK_FILE"
+flock -n 9 || exit 0
+
+pull_output=$(docker pull "$IMAGE")
+new_digest=$(printf '%s\n' "$pull_output" | awk '/^Digest: sha256:/{print $2}')
+
+if [ -z "$new_digest" ]; then
+  echo "$(date -Iseconds) could not parse a digest from docker pull output, skipping" >> "$LOG_FILE"
+  exit 1
+fi
+
+old_digest=$(cat "$STATE_FILE" 2>/dev/null || true)
+
+[ "$new_digest" = "$old_digest" ] && exit 0
+
+echo "$(date -Iseconds) deploying $new_digest (was: ${old_digest:-none})" >> "$LOG_FILE"
+
+short=$(printf '%s' "$new_digest" | cut -c1-12)
+docker tag bugspotter-api:latest "bugspotter-api:pre-$short" 2>/dev/null || true
+docker tag "$IMAGE" bugspotter-api:latest
+cd /opt/bugspotter
+docker compose up -d --no-build api worker
+
+printf '%s' "$new_digest" > "$STATE_FILE"
+echo "$(date -Iseconds) deployed $new_digest" >> "$LOG_FILE"
+```
+
+Crontab (installed for the `deploy` user, not root):
+
+```
+*/3 * * * * /opt/bugspotter/scripts/poll-deploy.sh
+```
+
+**Two bugs found and fixed while building this, both worth knowing if this
+script is ever touched again:**
+
+- `deploy` cannot create files directly in `/opt/bugspotter/` - that
+  directory is `root:root` mode `755`. State/lock/log files live in
+  `/opt/bugspotter/scripts/` instead, which `deploy` owns (same directory
+  `ci-deploy.sh` already lives in).
+- The digest **must** come from `docker pull`'s own `Digest: sha256:...`
+  output line, not from `docker inspect --format='{{index .RepoDigests 0}}'`.
+  `RepoDigests` is an unordered list of every repo@digest pairing a locally
+  cached image is known under - if the same image content is ever reachable
+  through more than one tag, index `0` is not guaranteed to be the one
+  belonging to `$IMAGE`. Caught this the hard way: a second run that should
+  have been a silent no-op instead redeployed, because the wrong list entry
+  won the race.
+
+Deploying `:main` specifically (not `:latest`) means only pushes that
+actually rebuild the backend move it - `docker/metadata-action`'s
+`type=ref,event=branch` only retags `:main` when a real build runs, same
+gating as everything else in `deploy-api.yml`.
+
+**Interaction with path (2):** unaffected. If netcup's firewall question ever
+gets resolved, both paths can run side by side - the SSH path deploys
+on-demand and immediately; the poller deploys automatically within its
+interval. They converge on the same state (`bugspotter-api:latest`) via the
+same underlying tag-and-recreate pattern, so there's no conflict between
+them, only redundancy.
 
 ## Full stack bring-up / restore
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -12,14 +12,14 @@ reconstructing it from memory.
 
 `/opt/bugspotter/`:
 
-| Path                                                                                | What                                                                                                                                                                                   | Origin                                                                                                              |
-| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `src/`                                                                              | Application source at the last-synced commit                                                                                                                                           | `git archive <ref> \| ssh ... tar -x` from a local clone - **not** a git clone on the host, there is no `.git` here |
-| `docker-compose.yml`, `docker-compose.monitoring.yml`, `docker-compose.storage.yml` | The compose files actually in effect                                                                                                                                                   | Synced from the repo **by hand**, separately from `src/` - see "Compose file drift" below                           |
-| `.env`                                                                              | Runtime config + secrets                                                                                                                                                               | Hand-maintained on the host; never committed                                                                        |
-| `monitoring/`                                                                       | Grafana/Prometheus/Alertmanager config, including hand-provisioned secret files                                                                                                        | Partly synced, partly hand-created - see below                                                                      |
-| `scripts/`                                                                          | `init-minio.sh`, `reset-demo-data.sh`, `seed-demo-data.sh` (synced) plus `ci-deploy.sh`, `poll-deploy.sh` and their state/lock/log files (host-only, `deploy`-owned - not in the repo) | Mixed: repo-synced files and hand-created ops tooling share this directory                                          |
-| `intelligence-src/`                                                                 | Separate source tree for the `bugspotter-intelligence` service                                                                                                                         | Same pattern as `src/`, different repo                                                                              |
+| Path                                                                                | What                                                                                                                                                                                                                                                                                                             | Origin                                                                                                              |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/`                                                                              | Application source at the last-synced commit                                                                                                                                                                                                                                                                     | `git archive <ref> \| ssh ... tar -x` from a local clone - **not** a git clone on the host, there is no `.git` here |
+| `docker-compose.yml`, `docker-compose.monitoring.yml`, `docker-compose.storage.yml` | The compose files actually in effect                                                                                                                                                                                                                                                                             | Synced from the repo **by hand**, separately from `src/` - see "Compose file drift" below                           |
+| `.env`                                                                              | Runtime config + secrets                                                                                                                                                                                                                                                                                         | Hand-maintained on the host; never committed                                                                        |
+| `monitoring/`                                                                       | Grafana/Prometheus/Alertmanager config, including hand-provisioned secret files                                                                                                                                                                                                                                  | Partly synced, partly hand-created - see below                                                                      |
+| `scripts/`                                                                          | `init-minio.sh`, `reset-demo-data.sh`, `seed-demo-data.sh` (synced) plus `poll-deploy.sh` and its state/lock/log files (`deploy`-owned), and `ci-deploy.sh` (`root:root` - directory has the sticky bit so `deploy`'s own write access can't be used to replace it) - none of the host-only ones are in the repo | Mixed: repo-synced files and hand-created ops tooling share this directory                                          |
+| `intelligence-src/`                                                                 | Separate source tree for the `bugspotter-intelligence` service                                                                                                                                                                                                                                                   | Same pattern as `src/`, different repo                                                                              |
 
 `docker-compose.yandex.yml` no longer applies - it carried managed-Postgres
 TLS/pooler plumbing for the decommissioned Yandex host and has no netcup
@@ -48,11 +48,18 @@ one image (`bugspotter-api:latest`); rebuilding it without recreating both
 leaves them on different code.
 
 ```bash
-# 1. From a local clone at the target commit, sync source to the host.
-#    git archive only includes tracked files - untracked cruft never leaks in.
-#    This does NOT delete files removed from the repo since the last sync.
-git archive main | ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
-  "tar -x -C /opt/bugspotter/src"
+# 1. From a local clone at the target commit, sync source to the host into a
+#    clean temp directory, then swap it in. <ref> must be the actual target
+#    commit/tag - not a branch name that can move under you between "sync"
+#    and "build". Archiving into a fresh directory and swapping, rather than
+#    extracting straight into the existing src/, also removes files deleted
+#    from the repo since the last sync (a plain tar -x into src/ would not).
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
+  "rm -rf /opt/bugspotter/src.new && mkdir -p /opt/bugspotter/src.new"
+git archive <ref> | ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
+  "tar -x -C /opt/bugspotter/src.new"
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
+  "rm -rf /opt/bugspotter/src && mv /opt/bugspotter/src.new /opt/bugspotter/src"
 
 # 2. Build. The image is built directly with `docker build`, NOT `docker
 #    compose build` - the live docker-compose.yml's `build.context: .` can't
@@ -68,6 +75,9 @@ ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
 # 3. Tag the OLD image for rollback before overwriting :latest. This
 #    pre-<ref>/build-<ref> convention already existed on the host (pre-290,
 #    build-290, pre-292, build-292) before this runbook documented it.
+#    Skip this on a retry of the same deploy: if :latest is already
+#    build-<short-ref>, re-running it overwrites the real rollback target
+#    with the thing you'd be rolling back from.
 ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
   "docker tag bugspotter-api:latest bugspotter-api:pre-<short-ref>"
 
@@ -95,6 +105,7 @@ ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
 
 ```bash
 ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
+  set -e
   docker tag bugspotter-api:pre-<short-ref> bugspotter-api:latest
   cd /opt/bugspotter && docker compose up -d --no-build api worker
 "
@@ -168,10 +179,41 @@ old_digest=$(cat "$STATE_FILE" 2>/dev/null || true)
 echo "$(date -Iseconds) deploying $new_digest (was: ${old_digest:-none})" >> "$LOG_FILE"
 
 short=$(printf '%s' "$new_digest" | cut -c1-12)
-docker tag bugspotter-api:latest "bugspotter-api:pre-$short" 2>/dev/null || true
+new_id=$(docker image inspect --format '{{.Id}}' "$IMAGE")
+old_id=$(docker image inspect --format '{{.Id}}' bugspotter-api:latest 2>/dev/null || true)
+# Only back up an existing :latest, and only when it isn't already this same
+# content - a retry that lands here with :latest already == $IMAGE would
+# otherwise clobber the real pre-<sha> rollback target with itself. No
+# `|| true` on the tag itself: a genuine failure here should abort the
+# deploy, not be silently swallowed the way "no previous image yet" is.
+if [ -n "$old_id" ] && [ "$new_id" != "$old_id" ]; then
+  docker tag bugspotter-api:latest "bugspotter-api:pre-$short"
+fi
 docker tag "$IMAGE" bugspotter-api:latest
 cd /opt/bugspotter
 docker compose up -d --no-build api worker
+
+# `docker compose up -d` returns once containers are started, not once
+# they're healthy - nothing gates on worker's own healthcheck the way worker
+# gates on api's, so a clean `up -d` exit does not mean the rollout is good.
+# Poll both before recording this digest as deployed; on timeout, leave
+# STATE_FILE untouched so the next poll retries instead of treating a broken
+# rollout as done.
+ok=0
+for _ in $(seq 1 15); do
+  api_health=$(docker inspect --format '{{.State.Health.Status}}' bugspotter-api 2>/dev/null || echo unknown)
+  worker_health=$(docker inspect --format '{{.State.Health.Status}}' bugspotter-worker 2>/dev/null || echo unknown)
+  if [ "$api_health" = healthy ] && [ "$worker_health" = healthy ]; then
+    ok=1
+    break
+  fi
+  sleep 10
+done
+
+if [ "$ok" -ne 1 ]; then
+  echo "$(date -Iseconds) deployed $new_digest but api/worker did not report healthy (api=$api_health worker=$worker_health), not recording as deployed" >> "$LOG_FILE"
+  exit 1
+fi
 
 printf '%s' "$new_digest" > "$STATE_FILE"
 echo "$(date -Iseconds) deployed $new_digest" >> "$LOG_FILE"
@@ -179,7 +221,7 @@ echo "$(date -Iseconds) deployed $new_digest" >> "$LOG_FILE"
 
 Crontab (installed for the `deploy` user, not root):
 
-```
+```text
 */3 * * * * /opt/bugspotter/scripts/poll-deploy.sh
 ```
 
@@ -189,7 +231,9 @@ script is ever touched again:**
 - `deploy` cannot create files directly in `/opt/bugspotter/` - that
   directory is `root:root` mode `755`. State/lock/log files live in
   `/opt/bugspotter/scripts/` instead, which `deploy` owns (same directory
-  `ci-deploy.sh` already lives in).
+  `ci-deploy.sh` lives in, though that specific file is `root:root` with the
+  directory's sticky bit set - see `DEPLOY-SECRETS-ROTATION.md` - so `deploy`
+  can create its own files there but can't touch that one).
 - The digest **must** come from `docker pull`'s own `Digest: sha256:...`
   output line, not from `docker inspect --format='{{index .RepoDigests 0}}'`.
   `RepoDigests` is an unordered list of every repo@digest pairing a locally
@@ -204,12 +248,18 @@ actually rebuild the backend move it - `docker/metadata-action`'s
 `type=ref,event=branch` only retags `:main` when a real build runs, same
 gating as everything else in `deploy-api.yml`.
 
-**Interaction with path (2):** unaffected. If netcup's firewall question ever
-gets resolved, both paths can run side by side - the SSH path deploys
-on-demand and immediately; the poller deploys automatically within its
-interval. They converge on the same state (`bugspotter-api:latest`) via the
-same underlying tag-and-recreate pattern, so there's no conflict between
-them, only redundancy.
+**Interaction with path (2):** serialized, not conflict-free by accident -
+both paths retag the same `bugspotter-api:latest` and recreate the same
+containers, so running them concurrently could interleave. `ci-deploy.sh` now
+takes the same `.poll-deploy.lock` this script holds (`flock -n`, see
+`DEPLOY-SECRETS-ROTATION.md`); if a poll and an on-demand SSH deploy land in
+the same window, whichever loses the lock exits with a "try again" rejection
+instead of racing - just retry it. What's still separate on purpose: `ci-deploy.sh`
+does not write `.last-deployed-digest`, so a deploy through path (2) doesn't
+change what this poller considers current - the next poll still compares
+against `:main`'s digest independently, which is correct given the two paths
+track different image references (`:main` vs a specific `sha-<hex>`), not a
+gap.
 
 ## Full stack bring-up / restore
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,197 @@
+# Production Runbook (netcup SaaS host)
+
+Covers the single production host at `app.kz.bugspotter.io` / `api.kz.bugspotter.io`
+(netcup, `159.195.212.239`). This is **not** the self-hosted path - see
+`DEPLOY-UPGRADE.md` for that. Written after the first fully-verified manual
+deploy following the 2026-08-04 host move ([#309](https://github.com/apex-bridge/bugspotter/issues/309)),
+recovering the sequence from the deleted `deploy-yandex.yml`
+(`git show 97ccdec~1:.github/workflows/deploy-yandex.yml`) rather than
+reconstructing it from memory.
+
+## Host layout
+
+`/opt/bugspotter/`:
+
+| Path                                                                                | What                                                                            | Origin                                                                                                              |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/`                                                                              | Application source at the last-synced commit                                    | `git archive <ref> \| ssh ... tar -x` from a local clone - **not** a git clone on the host, there is no `.git` here |
+| `docker-compose.yml`, `docker-compose.monitoring.yml`, `docker-compose.storage.yml` | The compose files actually in effect                                            | Synced from the repo **by hand**, separately from `src/` - see "Compose file drift" below                           |
+| `.env`                                                                              | Runtime config + secrets                                                        | Hand-maintained on the host; never committed                                                                        |
+| `monitoring/`                                                                       | Grafana/Prometheus/Alertmanager config, including hand-provisioned secret files | Partly synced, partly hand-created - see below                                                                      |
+| `scripts/`                                                                          | `init-minio.sh`, `reset-demo-data.sh`, `seed-demo-data.sh`                      | Synced from repo                                                                                                    |
+| `intelligence-src/`                                                                 | Separate source tree for the `bugspotter-intelligence` service                  | Same pattern as `src/`, different repo                                                                              |
+
+`docker-compose.yandex.yml` no longer applies - it carried managed-Postgres
+TLS/pooler plumbing for the decommissioned Yandex host and has no netcup
+equivalent (Postgres runs as a container here, not a managed service).
+
+## Compose file drift is real, not hypothetical
+
+Checked 2026-08-11: the live `docker-compose.yml` and the copy already sitting
+in a freshly-synced `src/` differed by **2253 diff lines** - looked like a
+total rewrite. It wasn't: the live file has CRLF line endings (picked up from
+some earlier Windows-side edit or transfer) while `git archive` always
+produces LF, so every single line register as changed. `diff -B -b
+--strip-trailing-cr` cuts through it. The _real_ diff was 2 comment lines (a
+stale doc reference) in `docker-compose.yml`, a stale comment in
+`docker-compose.monitoring.yml` - and one genuine functional difference in
+`docker-compose.storage.yml`: the live file publishes the MinIO console to
+`127.0.0.1:${MINIO_CONSOLE_PORT:-9001}:9001` for SSH-tunnel access; the
+repo's copy does not. **Do not blindly overwrite the live storage compose
+file from a fresh sync** - it would silently drop console access. Diff with
+`--strip-trailing-cr` first, always.
+
+## Update procedure (API/worker) - live-tested 2026-08-11
+
+This is what actually ran to deploy PR #317's fix. `api` and `worker` share
+one image (`bugspotter-api:latest`); rebuilding it without recreating both
+leaves them on different code.
+
+```bash
+# 1. From a local clone at the target commit, sync source to the host.
+#    git archive only includes tracked files - untracked cruft never leaks in.
+#    This does NOT delete files removed from the repo since the last sync.
+git archive main | ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
+  "tar -x -C /opt/bugspotter/src"
+
+# 2. Build. The image is built directly with `docker build`, NOT `docker
+#    compose build` - the live docker-compose.yml's `build.context: .` can't
+#    resolve `packages/backend/Dockerfile` from /opt/bugspotter (there is no
+#    /opt/bugspotter/packages). Compose only ever recreates containers from
+#    an already-built, already-tagged image via `--no-build`.
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
+  cd /opt/bugspotter/src
+  docker build -f packages/backend/Dockerfile --target production \
+    -t bugspotter-api:build-<short-ref> .
+"
+
+# 3. Tag the OLD image for rollback before overwriting :latest. This
+#    pre-<ref>/build-<ref> convention already existed on the host (pre-290,
+#    build-290, pre-292, build-292) before this runbook documented it.
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
+  "docker tag bugspotter-api:latest bugspotter-api:pre-<short-ref>"
+
+# 4. Retag the new build as :latest and recreate both containers that use it.
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
+  docker tag bugspotter-api:build-<short-ref> bugspotter-api:latest
+  cd /opt/bugspotter
+  docker compose up -d --no-build api worker
+"
+
+# 5. Verify - external, not just container status (a green healthcheck can
+#    still be checking the OLD deployment if step 4 silently no-oped).
+curl -s -o /dev/null -w 'HTTP %{http_code}\n' https://app.kz.bugspotter.io/ready
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 \
+  "docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' | grep -E 'bugspotter-api|bugspotter-worker'"
+
+# 6. Record what's deployed.
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
+  cp /opt/bugspotter/.env /opt/bugspotter/.env.bak-gitcommit-<short-ref>
+  sed -i 's/^GIT_COMMIT=.*/GIT_COMMIT=<short-ref>/' /opt/bugspotter/.env
+"
+```
+
+**Rollback** (any step after 4 goes wrong):
+
+```bash
+ssh -i ~/.ssh/bugspotter-netcup root@159.195.212.239 "
+  docker tag bugspotter-api:pre-<short-ref> bugspotter-api:latest
+  cd /opt/bugspotter && docker compose up -d --no-build api worker
+"
+```
+
+**Which containers need recreating for a given change** - `docker compose up
+-d --no-build <service>` only touches containers whose image or config
+actually changed:
+
+| Change touches                                                                                                       | Recreate                                                                                                                                      |
+| -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/backend/**`, `packages/types/**`, `packages/utils/**`, `packages/billing/**`, `packages/message-broker/**` | `api`, `worker` (shared image)                                                                                                                |
+| `apps/admin/**`                                                                                                      | `admin` (separate image, separate Dockerfile - **not covered by this runbook**, no automated path exists for it either)                       |
+| `docker-compose*.yml` only, no code change                                                                           | `docker compose up -d` for the affected service, no rebuild                                                                                   |
+| `.env` only                                                                                                          | Depends on the variable - compose bakes interpolated env at container-**create** time, so most changes need `up -d` (recreate), not `restart` |
+
+## Full stack bring-up / restore
+
+Recovered from the deleted `deploy-yandex.yml`, adapted for netcup (drop the
+`docker-compose.yandex.yml` overlay - no managed-DB TLS/pooler plumbing
+needed here). **Not re-tested end-to-end during this session** - the update
+procedure above was; this section is the recovered historical sequence, not
+freshly verified.
+
+```bash
+COMPOSE="docker compose -f docker-compose.yml -f docker-compose.monitoring.yml"
+
+# Monitoring first - avoids port contention with core services, and pulling
+# it alongside app images means --remove-orphans below won't mistake
+# monitoring containers for orphans.
+$COMPOSE --profile monitoring --profile host-metrics pull
+$COMPOSE --profile monitoring --profile host-metrics up -d --no-build
+
+# Core. --profile demo names the profile explicitly - a bare `up -d` silently
+# skips every profiled service, including demo.
+$COMPOSE --profile demo up -d --no-build --remove-orphans
+
+# Intelligence, if used.
+$COMPOSE --profile intelligence pull
+$COMPOSE --profile intelligence up -d --no-build
+
+# Health gate - internal first, then external (catches DNS/TLS-only breaks
+# the internal check can't see).
+for i in $(seq 1 15); do curl -sf http://127.0.0.1:3000/ready && break; sleep 10; done
+curl -sf https://app.kz.bugspotter.io/ready
+```
+
+**Database / object storage restore**: see `BACKUP.md`'s restore drill for
+fetching and validating a dump - that document deliberately restores into a
+**scratch** database, not prod. For a live restore: stop `api` and `worker`
+first (`docker compose stop api worker`), restore the dump into the running
+`postgres` container, verify row counts before restarting, then `docker
+compose up -d api worker`. MinIO/object-storage restore is not yet
+documented anywhere - open gap, not covered by this runbook or by `BACKUP.md`.
+
+## Hand-provisioned files (gitignored, not covered by any test)
+
+- **`monitoring/telegram_token`** - must be owned `65534:65534` (the
+  `nobody` user the alertmanager image runs as) with mode `600`. A
+  root-owned file left by `cp`/`scp` as root is unreadable to the container -
+  the healthcheck still passes and nothing logs until an alert actually
+  fires and delivery silently fails. This exact failure was live in
+  production after the 2026-08-04 move. Verified healthy on this host as of
+  2026-08-11 (`nobody:nogroup`, mode `600`). Provision:
+  ```bash
+  printf '%s' '<bot-token>' > /opt/bugspotter/monitoring/telegram_token
+  chown 65534:65534 /opt/bugspotter/monitoring/telegram_token
+  chmod 600 /opt/bugspotter/monitoring/telegram_token
+  ```
+  Verify it's actually readable, not just present:
+  ```bash
+  docker exec bugspotter-alertmanager wc -c < /etc/alertmanager/telegram_token
+  ```
+- **`monitoring/alertmanager.yml`**'s `chat_id` field - substituted by hand
+  from the deleted workflow's `TELEGRAM_ALERT_CHAT_ID`; no longer automated.
+
+## Production env surface
+
+`.env` on the host currently carries 87 variables. `.env.example` in the repo
+does not enumerate all of them - these six in particular are load-bearing in
+production and absent from `.env.example` (verified 2026-08-11, still true):
+
+| Variable                      | Why it matters                                                                                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEPLOYMENT_MODE`             | `saas` vs `selfhosted` - gates multi-tenancy, billing, signup                                                                         |
+| `DATA_RESIDENCY_REGION`       | Sets the residency column on new organisations at creation time                                                                       |
+| `COOKIE_DOMAIN`               | Unset silently breaks cross-subdomain SSO                                                                                             |
+| `SELF_SERVICE_SIGNUP_ENABLED` | Gates the signup endpoint in `saas` mode                                                                                              |
+| `POSTGRES_HOST`               | Points at the in-network `postgres` container - required since there's no managed DB here                                             |
+| `NODE_EXTRA_CA_CERTS`         | Was needed for the old managed-Postgres TLS chain; **not set on this host** - confirms it's Yandex-era-only, not a netcup requirement |
+
+Full production var set is not reproduced here (values are secrets); this
+table is the delta between what's live and what the repo documents.
+
+## Related
+
+- `BACKUP.md` - off-site backup mechanics and the scratch-DB restore drill
+- `DEPLOY-UPGRADE.md` - self-hosted image pinning and upgrade order (different scope)
+- [#309](https://github.com/apex-bridge/bugspotter/issues/309) - the issue this runbook closes
+- [#318](https://github.com/apex-bridge/bugspotter/issues/318) - `deploy-api.yml` never actually deploying; this runbook is its documented input


### PR DESCRIPTION
Closes #318
Refs #309

Two commits:

1. **RUNBOOK.md** - the production ops runbook #309 asked for, recovered from
   the deleted `deploy-yandex.yml` rather than reconstructed from memory. The
   update procedure in it is what actually ran today, live, to deploy #317's
   fix - not a guess.
2. **deploy-api.yml** - wires a real SSH deploy step into `deploy-production`,
   gated on `workflow_dispatch` + `environment: production` (a plain push
   cannot satisfy that). `deploy-staging` now says plainly that no staging
   host exists instead of implying one should be added there.

## What today's manual deploy found

`#237` and `#269` were already live before this PR - their fix commits were
ancestors of the commit already running in production. The `needs-deploy`
label was just never cleared. Both closed with the verification command in
the closing comment.

The live `docker-compose.yml` has CRLF endings, so a naive diff against a
fresh `git archive` sync shows the whole file as changed. The real delta was
2 comment lines. `docker-compose.storage.yml` has genuine drift though: a
MinIO console port binding that's live but not in the repo - don't blindly
resync it.

## Not done here, flagged not hidden

- `DEPLOY_HOST` / `DEPLOY_USER` / `SSH_DEPLOY_KEY` / `SSH_KNOWN_HOSTS` predate
  the 2026-08-04 netcup migration and still hold Yandex-era values. This
  workflow cannot succeed until they're rotated - separate question below.
- No build-identifier in `/ready`, so the health check confirms the container
  answers, not that its digest matches what the run pushed. #318's own
  Acceptance section asks for the latter.
- `apps/admin` half of #317 (the edit-dialog fix) is undeployed - separate
  image, separate Dockerfile, `deploy-admin.yml` has the same missing-step
  problem and isn't touched by this PR.

## Before this can actually run

The four deploy secrets need rotating to the netcup host. Open question: reuse
the existing root key (`~/.ssh/bugspotter-netcup`, fast, but means a leaked CI
secret is full root) or provision a dedicated deploy user scoped to just the
docker commands this step needs (more setup, safer secret). Not decided in
this PR - didn't want to silently pick the less secure option, or spend
follow-up work on the more secure one, without your call.

Assisted-by: claude-opus-5 (agent)
