### PR TITLE
fix(ai-sdlc): stop extractDeclaredPaths from leaking prose into file paths

### DIFF
--- a/scripts/ai-sdlc/verify-spec-ownership.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.mjs
@@ -61,12 +61,93 @@ export function parseAdrOwnership(adrIndexText) {
  * the same line, so this must capture the whole block up to the next
  * "**"-prefixed field or "##" heading, not just the first line.
  */
-export function extractDeclaredPaths(specText) {
-  const filesTouchedMatch = specText.match(/\*\*Files touched:\*\*\s*([\s\S]*?)(?=\n\*\*|\n##|$)/);
-  if (!filesTouchedMatch) {
+// First backtick-quoted span in `text`, or null if there isn't a complete
+// pair. Pure string scanning, no regex - a lookahead-based section boundary
+// is exactly what let #297's real spec leak 14 extra "paths" (IJobHandle,
+// moveToDelayed, id, name, log()...) out of a prose paragraph sitting
+// between the bullet list and the next `**` field, because the boundary
+// pattern only knew to stop at the next heading, not at the end of the list.
+function firstBacktickSpan(text) {
+  const start = text.indexOf('`');
+  if (start === -1) {
     return null;
   }
-  return [...filesTouchedMatch[1].matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+  const end = text.indexOf('`', start + 1);
+  if (end === -1) {
+    return null;
+  }
+  return text.slice(start + 1, end);
+}
+
+// Every backtick-quoted span in `text`, left to right.
+function allBacktickSpans(text) {
+  const spans = [];
+  let i = 0;
+  for (;;) {
+    const start = text.indexOf('`', i);
+    if (start === -1) {
+      break;
+    }
+    const end = text.indexOf('`', start + 1);
+    if (end === -1) {
+      break;
+    }
+    spans.push(text.slice(start + 1, end));
+    i = end + 1;
+  }
+  return spans;
+}
+
+export function extractDeclaredPaths(specText) {
+  const marker = '**Files touched:**';
+  const markerIdx = specText.indexOf(marker);
+  if (markerIdx === -1) {
+    return null;
+  }
+
+  const lines = specText.slice(markerIdx + marker.length).split('\n');
+  const paths = [];
+  let sawBullet = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    if (i === 0) {
+      // The inline form puts every path on the marker's own line, comma-
+      // separated ("**Files touched:** `a.ts`, `b.ts`") - nothing precedes
+      // them to be a trailing description, so every span here is a path.
+      paths.push(...allBacktickSpans(line));
+      continue;
+    }
+
+    if (line.startsWith('**') || line.startsWith('##')) {
+      break; // the next field or section heading - the list is over
+    }
+    if (line === '') {
+      if (sawBullet) {
+        break; // a blank line after the list ends it
+      }
+      continue; // a blank line before the list starts - keep scanning
+    }
+    if (!line.startsWith('- ') && !line.startsWith('* ')) {
+      if (sawBullet) {
+        break; // prose after the list (e.g. a scope-explanation paragraph)
+      }
+      continue;
+    }
+
+    // A bullet line: only the FIRST backtick span is the declared path.
+    // Anything after it - " — `IJobHandle` has no `moveToDelayed`..." - is
+    // a trailing description, not another declared file, even though it
+    // has its own backtick-quoted terms.
+    const path = firstBacktickSpan(line);
+    if (path !== null) {
+      paths.push(path);
+      sawBullet = true;
+    }
+  }
+
+  return paths;
 }
 
 /** Extract the lowercased body text of the spec's "## Out of scope" section. */

--- a/scripts/ai-sdlc/verify-spec-ownership.test.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.test.mjs
@@ -103,6 +103,25 @@ describe('extractDeclaredPaths', () => {
     ].join('\n');
     assert.deepEqual(extractDeclaredPaths(spec), ['packages/a/one.ts', 'packages/a/two.ts']);
   });
+
+  test('stops the list at prose that follows a bullet with no blank line separator', () => {
+    // The previous test's prose paragraph is preceded by a blank line (the
+    // real docs/specs/0297 shape), so it's the "blank line after list"
+    // branch that ends the scan there, not the "prose after list" branch.
+    // This fixture drops that blank line so a non-bulleted, non-blank line
+    // immediately follows the bullets, exercising that second branch
+    // directly.
+    const spec = [
+      '**Files touched:**',
+      '',
+      '- `packages/a/one.ts`',
+      '- `packages/a/two.ts` — `IJobHandle` has no `moveToDelayed` member today; add one.',
+      'The scope grew beyond the original file: `job` is typed `IJobHandle<Data, Result>`,',
+      'not the raw `Job`, and it exposes only `id`, `name`, `log()`.',
+      '**Blocking prerequisites:** none',
+    ].join('\n');
+    assert.deepEqual(extractDeclaredPaths(spec), ['packages/a/one.ts', 'packages/a/two.ts']);
+  });
 });
 
 describe('extractOutOfScopeText', () => {

--- a/scripts/ai-sdlc/verify-spec-ownership.test.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.test.mjs
@@ -82,6 +82,27 @@ describe('extractDeclaredPaths', () => {
     const spec = '**Files touched:**\n\n- `packages/a/one.ts`';
     assert.deepEqual(extractDeclaredPaths(spec), ['packages/a/one.ts']);
   });
+
+  test('ignores backtick terms in a trailing description and in prose after the list', () => {
+    // Real shape from docs/specs/0297-*.md: each bullet's path is followed
+    // by " — <prose with its own `backtick` terms>", and the whole list is
+    // followed by a scope-explanation paragraph before the next `**` field
+    // - both used to leak into the result (19 "paths" instead of 5), because
+    // the old regex only knew to stop at the next heading, not at the end
+    // of the list itself.
+    const spec = [
+      '**Files touched:**',
+      '',
+      '- `packages/a/one.ts`',
+      '- `packages/a/two.ts` — `IJobHandle` has no `moveToDelayed` member today; add one.',
+      '',
+      'The scope grew beyond the original file: `job` is typed `IJobHandle<Data, Result>`,',
+      'not the raw `Job`, and it exposes only `id`, `name`, `log()`.',
+      '',
+      '**Blocking prerequisites:** none',
+    ].join('\n');
+    assert.deepEqual(extractDeclaredPaths(spec), ['packages/a/one.ts', 'packages/a/two.ts']);
+  });
 });
 
 describe('extractOutOfScopeText', () => {


### PR DESCRIPTION
Refs #297

Found while investigating why impl-agent kept timing out on #297: even setting the timeout aside, `check-impl-scope.mjs`'s hard gate would have rejected a perfect scaffold anyway. `extractDeclaredPaths` pulled 19 "paths" out of #297's real spec instead of 5 - `IJobHandle`, `moveToDelayed`, `id`, `name`, `log()` among them - because its regex captured everything up to the next `**`-prefixed line and grabbed every backtick span in that whole block, including per-bullet trailing descriptions and a prose paragraph sitting between the list and the next field.

Rewritten without regex - line-based scanning instead of a lookahead boundary pattern, since the boundary pattern hoping to catch every case was the actual failure mode. Verified against the real spec (19 -> 5) and locked in with a regression test.

Assisted-by: claude-opus-5 (agent)
