### PR TITLE
fix(ai-sdlc): switch impl-agent CLI calls to stream-json telemetry

### DIFF
--- a/scripts/ai-sdlc/generate-impl.test.mjs
+++ b/scripts/ai-sdlc/generate-impl.test.mjs
@@ -66,7 +66,7 @@ writeFileSync(
     "    files: [{ path: 'packages/generated.ts', content: 'export const generated = true;\\n' }],",
     "    summary: 'fake impl',",
     '  };',
-    "  process.stdout.write(JSON.stringify({ result: JSON.stringify(payload), stop_reason: 'end_turn' }));",
+    "  process.stdout.write(JSON.stringify({ type: 'result', result: JSON.stringify(payload), stop_reason: 'end_turn' }) + '\\n');",
     '});',
     '',
   ].join('\n')

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -247,6 +247,20 @@ export function formatCliProgress({ elapsedMs, stdoutBytes, stderrBytes, thinkin
   return thinkingTokens === null ? base : `${base}, ~${thinkingTokens} thinking tokens so far`;
 }
 
+// Bounds a raw stdout/stderr dump before it lands in a thrown Error message.
+// Under `stream-json --verbose`, a failing or malformed call can have far
+// more in stdout by the time it dies than the old buffered `json` format
+// ever produced (every NDJSON event streamed so far, not one envelope
+// written once at the end), so the two dumps in callViaCli's close handler
+// need the same clipping discipline formatCliTimeout already applies to its
+// tails, or a single bad run can flood a CI log.
+function clipDump(text, tailChars = 1500) {
+  const trimmed = text.trim();
+  return trimmed.length > tailChars
+    ? `(showing last ${tailChars} of ${trimmed.length} chars)\n${trimmed.slice(-tailChars)}`
+    : trimmed;
+}
+
 // No `maxTokens` param here (deliberately) — the CLI has no per-call
 // output-token cap to forward it to. See the module header comment.
 async function callViaCli({ prompt, timeoutMs, model }) {
@@ -402,16 +416,19 @@ async function callViaCli({ prompt, timeoutMs, model }) {
       if (code !== 0 || signal) {
         const reason = code !== null ? `code ${code}` : `signal ${signal}`;
         // The claude CLI's error detail (e.g. a billing/auth failure) lands
-        // in the JSON on stdout, not stderr — include both.
+        // in the JSON on stdout, not stderr - include both, clipped (see
+        // clipDump above).
         const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n');
-        reject(new Error(`claude CLI exited with ${reason}${detail ? `: ${detail}` : ''}`));
+        reject(
+          new Error(`claude CLI exited with ${reason}${detail ? `: ${clipDump(detail)}` : ''}`)
+        );
         return;
       }
       if (!resultEvent) {
         reject(
           new Error(
             `claude CLI exited cleanly but no "result" event was found in its stream-json ` +
-              `output:\n${stdout}`
+              `output:\n${clipDump(stdout)}`
           )
         );
         return;

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -168,9 +168,11 @@ const CLI_HEARTBEAT_MS = 60_000;
 // buffered `json` output — `stdout 0B` after 780s meant the CLI never
 // emitted its envelope, and nothing distinguished "still working" from
 // "wedged". Under `stream-json`, a non-null `thinkingTokens` closes most of
-// that gap directly: a growing count is direct evidence of a working call,
-// not a parsing or sizing problem. Zero bytes of any kind remains the one
-// case this still can't fully explain (nothing streamed yet at all).
+// that gap directly: it's evidence the call produced real output at some
+// point, not a parsing or sizing problem — though it's a last-known
+// snapshot, not proof the call was still active at the moment of the kill.
+// Zero bytes of any kind remains the one case this still can't fully
+// explain (nothing streamed yet at all).
 //
 // Tails are bounded because stderr can carry progress spew and this string
 // goes into an Error message that lands in a CI log.
@@ -200,13 +202,17 @@ export function formatCliTimeout({
   // 2026-08-13 diagnostic reproduction of a real dead-at-780s run found the
   // model was still in extended thinking for 59% of its (successful) 337s
   // total wall time, invisible under the buffered `json` format this
-  // function was originally written for. Under `stream-json`, a growing
-  // thinking-token count observed right up to the kill is direct evidence
-  // the call was progressing, not wedged.
+  // function was originally written for. Under `stream-json`, a
+  // thinking-token count is evidence the call produced real output at some
+  // point — but this is a single last-known snapshot, not a trend: nothing
+  // here tracks event timing or prior counts, so one early event followed by
+  // total silence for the rest of the timeout looks identical to one
+  // received seconds before the kill. Don't claim "still climbing" or "not
+  // a hang" from this alone.
   if (thinkingTokens !== null) {
     message +=
-      `\n  last known thinking-token count: ~${thinkingTokens} (still climbing when killed — ` +
-      `this was a working call, not a hang)`;
+      `\n  last known thinking-token count: ~${thinkingTokens} ` +
+      `(thinking progress was observed before termination)`;
   }
 
   if (stdoutBytes === 0 && stderrBytes === 0) {

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -92,7 +92,8 @@ async function callViaApi({ prompt, maxTokens, timeoutMs, model }) {
   return { text: data.content[0].text, stopReason: data.stop_reason };
 }
 
-// The CLI's `--output-format json` envelope carries operational fields this
+// The CLI's terminal `result` event (now under `--output-format stream-json`,
+// originally the whole `json` envelope) carries operational fields this
 // module used to discard: turn count, wall time, and token usage. Without them
 // a slow call is a black box. impl-agent run 30761885485 spent its entire 780s
 // timeout on a response the script itself had measured at ~6594 output tokens,
@@ -119,11 +120,22 @@ export function logCliTelemetry(data, log = console) {
   if (typeof data?.duration_api_ms === 'number') {
     parts.push(`api=${Math.round(data.duration_api_ms / 1000)}s`);
   }
+  // Time to first (visible, non-thinking) token — only carried in the
+  // `stream-json` envelope, not the buffered `json` one this function
+  // originally supported. The 2026-08-13 diagnostic found this split matters:
+  // a real reproduction spent 59% of its total wall time in extended thinking
+  // before ttft, a proportion no other field here can show on its own.
+  if (typeof data?.ttft_ms === 'number') {
+    parts.push(`ttft=${Math.round(data.ttft_ms / 1000)}s`);
+  }
   if (typeof data?.usage?.input_tokens === 'number') {
     parts.push(`in=${data.usage.input_tokens}`);
   }
   if (typeof data?.usage?.output_tokens === 'number') {
     parts.push(`out=${data.usage.output_tokens}`);
+  }
+  if (typeof data?.usage?.output_tokens_details?.thinking_tokens === 'number') {
+    parts.push(`thinking=${data.usage.output_tokens_details.thinking_tokens}`);
   }
   if (typeof data?.total_cost_usd === 'number') {
     parts.push(`cost=$${data.total_cost_usd.toFixed(4)}`);
@@ -139,9 +151,10 @@ export function logCliTelemetry(data, log = console) {
   }
 }
 
-// How often callViaCli reports that a call is still in flight. The CLI buffers
-// its whole `--output-format json` envelope to the end, so a long call is
-// otherwise indistinguishable from a hung one until the timeout fires.
+// How often callViaCli reports that a call is still in flight. Under
+// `stream-json`, thinking-token progress events arrive throughout the call
+// (see consumeLine below), so this heartbeat can now show real signs of
+// life instead of just elapsed time and silence.
 const CLI_HEARTBEAT_MS = 60_000;
 
 // logCliTelemetry only ever runs on the success path — it needs a parsed
@@ -151,12 +164,13 @@ const CLI_HEARTBEAT_MS = 60_000;
 // logged exactly one line, `claude CLI timed out after 780000ms`, discarding
 // every byte the child had written.
 //
-// The byte counts are the load-bearing part, not the tails. `stdout 0B` after
-// 780s means the CLI never emitted its envelope — it was still working, or
-// wedged, and the timeout is the symptom rather than the cause. Non-zero
-// stdout means it produced something we then threw away, which is a parsing
-// or size problem instead. Those need opposite fixes, and today's log cannot
-// tell them apart.
+// The byte counts were the load-bearing part when this only ran against
+// buffered `json` output — `stdout 0B` after 780s meant the CLI never
+// emitted its envelope, and nothing distinguished "still working" from
+// "wedged". Under `stream-json`, a non-null `thinkingTokens` closes most of
+// that gap directly: a growing count is direct evidence of a working call,
+// not a parsing or sizing problem. Zero bytes of any kind remains the one
+// case this still can't fully explain (nothing streamed yet at all).
 //
 // Tails are bounded because stderr can carry progress spew and this string
 // goes into an Error message that lands in a CI log.
@@ -166,6 +180,7 @@ export function formatCliTimeout({
   stdout = '',
   stderr = '',
   tailChars = 1500,
+  thinkingTokens = null,
 }) {
   // Keep this exact prefix: it is the string the run logs have been
   // identified by across every timeout so far.
@@ -180,6 +195,19 @@ export function formatCliTimeout({
   const stderrBytes = Buffer.byteLength(stderr, 'utf8');
 
   message += `\n  received: stdout ${stdoutBytes}B, stderr ${stderrBytes}B`;
+
+  // The single most direct answer to "was this a hang or genuine work": a
+  // 2026-08-13 diagnostic reproduction of a real dead-at-780s run found the
+  // model was still in extended thinking for 59% of its (successful) 337s
+  // total wall time, invisible under the buffered `json` format this
+  // function was originally written for. Under `stream-json`, a growing
+  // thinking-token count observed right up to the kill is direct evidence
+  // the call was progressing, not wedged.
+  if (thinkingTokens !== null) {
+    message +=
+      `\n  last known thinking-token count: ~${thinkingTokens} (still climbing when killed — ` +
+      `this was a working call, not a hang)`;
+  }
 
   if (stdoutBytes === 0 && stderrBytes === 0) {
     message +=
@@ -208,12 +236,15 @@ export function formatCliTimeout({
 // Emitted every CLI_HEARTBEAT_MS while a call is in flight. Byte counts make
 // the difference between "streaming, just slow" and "silent since the first
 // second" visible while the run is still happening, instead of only in the
-// post-mortem.
-export function formatCliProgress({ elapsedMs, stdoutBytes, stderrBytes }) {
-  return (
+// post-mortem. `thinkingTokens` (from the most recent `stream-json`
+// thinking_tokens event, if any have arrived yet) adds the one signal that
+// distinguishes "extended thinking, genuinely still working" from every
+// other kind of silence.
+export function formatCliProgress({ elapsedMs, stdoutBytes, stderrBytes, thinkingTokens = null }) {
+  const base =
     `claude CLI: still running after ${Math.round(elapsedMs / 1000)}s ` +
-    `(stdout ${stdoutBytes}B, stderr ${stderrBytes}B)`
-  );
+    `(stdout ${stdoutBytes}B, stderr ${stderrBytes}B)`;
+  return thinkingTokens === null ? base : `${base}, ~${thinkingTokens} thinking tokens so far`;
 }
 
 // No `maxTokens` param here (deliberately) — the CLI has no per-call
@@ -250,10 +281,23 @@ async function callViaCli({ prompt, timeoutMs, model }) {
       // Confirmed empirically on both Windows (shell: true) and POSIX
       // (shell: false, tested under WSL) that '--tools=' parses correctly
       // and disables tools, so one token form is used unconditionally.
+      //
+      // stream-json (not json): buffered `json` output means a healthy-but-
+      // slow call and a genuinely wedged one both look like silence until
+      // the timeout fires — impl-agent runs 30761885485/31039877104/#297 all
+      // died this way, 0 bytes received. A 2026-08-13 diagnostic reproducing
+      // #297's exact prompt under stream-json found the call was NOT stuck —
+      // it finished in 337s, 443s under budget — but 59% of that was extended
+      // thinking with no visible output token yet, a phase `json` cannot
+      // show at all. `--verbose` is not optional alongside `stream-json`
+      // under `-p`: confirmed empirically, omitting it fails outright with
+      // "Error: When using --print, --output-format=stream-json requires
+      // --verbose".
       [
         '-p',
         '--output-format',
-        'json',
+        'stream-json',
+        '--verbose',
         '--model',
         model || CLI_MODEL,
         '--tools=',
@@ -268,7 +312,37 @@ async function callViaCli({ prompt, timeoutMs, model }) {
 
     let stdout = '';
     let stderr = '';
+    let lineBuf = '';
+    let resultEvent = null;
+    // Most recent estimated_tokens from a `system`/`thinking_tokens` event —
+    // the one number that distinguishes "still working" from "wedged" while
+    // a call is in flight or right up to the moment it's killed.
+    let lastThinkingTokens = null;
     const startedAt = Date.now();
+
+    function consumeLine(line) {
+      if (!line.trim()) {
+        return;
+      }
+      let evt;
+      try {
+        evt = JSON.parse(line);
+      } catch {
+        // --verbose can interleave non-JSON debug output on some CLI
+        // versions; a line that isn't a JSON event is not fatal, the byte
+        // count already reflects it either way.
+        return;
+      }
+      if (
+        evt?.type === 'system' &&
+        evt.subtype === 'thinking_tokens' &&
+        typeof evt.estimated_tokens === 'number'
+      ) {
+        lastThinkingTokens = evt.estimated_tokens;
+      } else if (evt?.type === 'result') {
+        resultEvent = evt;
+      }
+    }
 
     // unref'd so a stray interval can never hold the process open on a path
     // that forgets to clear it; every exit path below clears it anyway.
@@ -278,6 +352,7 @@ async function callViaCli({ prompt, timeoutMs, model }) {
           elapsedMs: Date.now() - startedAt,
           stdoutBytes: Buffer.byteLength(stdout, 'utf8'),
           stderrBytes: Buffer.byteLength(stderr, 'utf8'),
+          thinkingTokens: lastThinkingTokens,
         })
       );
     }, CLI_HEARTBEAT_MS);
@@ -288,7 +363,13 @@ async function callViaCli({ prompt, timeoutMs, model }) {
       child.kill('SIGKILL');
       reject(
         new Error(
-          formatCliTimeout({ timeoutMs, elapsedMs: Date.now() - startedAt, stdout, stderr })
+          formatCliTimeout({
+            timeoutMs,
+            elapsedMs: Date.now() - startedAt,
+            stdout,
+            stderr,
+            thinkingTokens: lastThinkingTokens,
+          })
         )
       );
     }, timeoutMs);
@@ -297,6 +378,12 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (d) => {
       stdout += d;
+      lineBuf += d;
+      let idx;
+      while ((idx = lineBuf.indexOf('\n')) !== -1) {
+        consumeLine(lineBuf.slice(0, idx));
+        lineBuf = lineBuf.slice(idx + 1);
+      }
     });
     child.stderr.on('data', (d) => {
       stderr += d;
@@ -309,6 +396,9 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     child.on('close', (code, signal) => {
       clearTimeout(timer);
       clearInterval(heartbeat);
+      if (lineBuf.trim()) {
+        consumeLine(lineBuf); // a final line with no trailing newline
+      }
       if (code !== 0 || signal) {
         const reason = code !== null ? `code ${code}` : `signal ${signal}`;
         // The claude CLI's error detail (e.g. a billing/auth failure) lands
@@ -317,27 +407,25 @@ async function callViaCli({ prompt, timeoutMs, model }) {
         reject(new Error(`claude CLI exited with ${reason}${detail ? `: ${detail}` : ''}`));
         return;
       }
-      let data;
-      try {
-        data = JSON.parse(stdout);
-      } catch (err) {
-        reject(new Error(`Failed to parse claude CLI JSON output: ${err.message}\n${stdout}`));
+      if (!resultEvent) {
+        reject(
+          new Error(
+            `claude CLI exited cleanly but no "result" event was found in its stream-json ` +
+              `output:\n${stdout}`
+          )
+        );
         return;
       }
-      if (!data || typeof data !== 'object') {
-        reject(new Error(`Unexpected claude CLI JSON output (not an object): ${stdout}`));
+      if (resultEvent.is_error) {
+        reject(new Error(`claude CLI reported an error: ${JSON.stringify(resultEvent)}`));
         return;
       }
-      if (data.is_error) {
-        reject(new Error(`claude CLI reported an error: ${JSON.stringify(data)}`));
+      if (typeof resultEvent.result !== 'string') {
+        reject(new Error(`Unexpected claude CLI response shape: ${JSON.stringify(resultEvent)}`));
         return;
       }
-      if (typeof data.result !== 'string') {
-        reject(new Error(`Unexpected claude CLI response shape: ${JSON.stringify(data)}`));
-        return;
-      }
-      logCliTelemetry(data);
-      resolve({ text: data.result, stopReason: data.stop_reason });
+      logCliTelemetry(resultEvent);
+      resolve({ text: resultEvent.result, stopReason: resultEvent.stop_reason });
     });
 
     child.stdin.on('error', () => {});

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -44,10 +44,14 @@ writeFileSync(
     // (['-p', '--output-format', ...]).
     'if (argvDumpPath) fs.writeFileSync(argvDumpPath, JSON.stringify(process.argv.slice(2)));',
     "const mode = process.env.FAKE_CLAUDE_MODE || 'success';",
-    // Writes a partial (unparseable) envelope and then never finishes, so the
-    // parent's timeout path fires with real bytes already buffered. `return`
-    // is legal here: CommonJS wraps the module body in a function.
+    // Writes one real NDJSON thinking_tokens event (so callViaCli's line
+    // parser has something to pick up), then a partial/unparseable trailing
+    // envelope and never finishes — the parent's timeout path fires with
+    // both a known thinking-token count AND raw undecodable bytes already
+    // buffered. `return` is legal here: CommonJS wraps the module body in a
+    // function.
     "if (mode === 'hang') {",
+    "  process.stdout.write(JSON.stringify({ type: 'system', subtype: 'thinking_tokens', estimated_tokens: 42 }) + '\\n');",
     "  process.stdout.write('PARTIAL_ENVELOPE_MARKER');",
     "  process.stderr.write('FAKE_STDERR_PROGRESS');",
     '  setTimeout(function () { process.exit(0); }, 5000);',
@@ -57,7 +61,10 @@ writeFileSync(
     "  process.stdout.write('FAKE_STDOUT_MARKER: upstream billing failure detail');",
     '  process.exit(2);',
     '}',
-    "process.stdout.write(JSON.stringify({ result: 'fake cli response', stop_reason: 'end_turn' }));",
+    // stream-json shape: one or more NDJSON lines, the terminal one typed
+    // "result" — mirrors the real CLI's `--output-format stream-json` output.
+    "process.stdout.write(JSON.stringify({ type: 'system', subtype: 'thinking_tokens', estimated_tokens: 7 }) + '\\n');",
+    "process.stdout.write(JSON.stringify({ type: 'result', result: 'fake cli response', stop_reason: 'end_turn' }) + '\\n');",
     'process.exit(0);',
     '',
   ].join('\n')
@@ -117,6 +124,34 @@ test('logCliTelemetry surfaces turns, wall time, tokens and cost from the CLI en
   assert.match(lines.log[0], /out=6594/);
   assert.match(lines.log[0], /cost=\$0\.1234/);
   assert.equal(lines.warn.length, 0, 'a single-turn call must not warn');
+});
+
+test('logCliTelemetry surfaces ttft and the thinking/output token split when present', () => {
+  const { lines, logger } = captureLog();
+
+  logCliTelemetry(
+    {
+      num_turns: 1,
+      duration_ms: 337_000,
+      ttft_ms: 198_642,
+      usage: { output_tokens: 23_209, output_tokens_details: { thinking_tokens: 12_954 } },
+    },
+    logger
+  );
+
+  assert.equal(lines.log.length, 1);
+  assert.match(lines.log[0], /ttft=199s/);
+  assert.match(lines.log[0], /out=23209/);
+  assert.match(lines.log[0], /thinking=12954/);
+});
+
+test('logCliTelemetry omits ttft/thinking fields when the envelope lacks them', () => {
+  const { lines, logger } = captureLog();
+
+  logCliTelemetry({ num_turns: 1, duration_ms: 1000, usage: { output_tokens: 4 } }, logger);
+
+  assert.doesNotMatch(lines.log[0], /ttft=/);
+  assert.doesNotMatch(lines.log[0], /thinking=/);
 });
 
 test('logCliTelemetry warns when the CLI reports more than one turn despite --tools=', () => {
@@ -197,17 +232,52 @@ test('formatCliProgress reports elapsed time and bytes received so far', () => {
   assert.match(line, /stdout 0B, stderr 42B/);
 });
 
+test('formatCliProgress includes the thinking-token count when known', () => {
+  const withTokens = formatCliProgress({
+    elapsedMs: 60_000,
+    stdoutBytes: 500,
+    stderrBytes: 0,
+    thinkingTokens: 1200,
+  });
+  assert.match(withTokens, /~1200 thinking tokens so far/);
+
+  // Not vacuous: the field must actually be omittable, not just non-throwing.
+  const withoutTokens = formatCliProgress({ elapsedMs: 60_000, stdoutBytes: 0, stderrBytes: 0 });
+  assert.doesNotMatch(withoutTokens, /thinking tokens/);
+});
+
+test('formatCliTimeout reports the last known thinking-token count when present', () => {
+  const message = formatCliTimeout({
+    timeoutMs: 780_000,
+    elapsedMs: 780_050,
+    stdout: '{"type":"system","subtype":"thinking_tokens","estimated_tokens":900}\n',
+    thinkingTokens: 900,
+  });
+
+  assert.match(message, /last known thinking-token count: ~900/);
+  assert.match(message, /this was a working call, not a hang/);
+});
+
+test('formatCliTimeout omits the thinking-token line when none arrived', () => {
+  const message = formatCliTimeout({ timeoutMs: 780_000, elapsedMs: 780_050 });
+  assert.doesNotMatch(message, /thinking-token count/);
+});
+
 test('callViaCli timeout error carries what the child actually wrote before the kill', async () => {
   process.env.FAKE_CLAUDE_MODE = 'hang';
   process.env.FAKE_CLAUDE_ENV_DUMP = '';
 
   // Proves the forensics reach the real rejection path, not just the pure
   // formatter: without them this error message is the bare one-liner that
-  // made impl-agent runs 30761885485 and 31039877104 undiagnosable.
+  // made impl-agent runs 30761885485 and 31039877104 undiagnosable. The
+  // thinking-token assertion proves callViaCli's own NDJSON line parser
+  // (not just formatCliTimeout in isolation) picked up the real event the
+  // fake CLI streamed before hanging.
   await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 2500 }), (err) => {
     assert.match(err.message, /claude CLI timed out after 2500ms/);
     assert.match(err.message, /received: stdout \d+B, stderr \d+B/);
     assert.match(err.message, /PARTIAL_ENVELOPE_MARKER/);
+    assert.match(err.message, /last known thinking-token count: ~42/);
     assert.doesNotMatch(err.message, /wrote nothing at all/);
     return true;
   });
@@ -294,7 +364,8 @@ test('callViaCli invokes claude with --tools= and --strict-mcp-config, not --all
     assert.deepEqual(argv, [
       '-p',
       '--output-format',
-      'json',
+      'stream-json',
+      '--verbose',
       '--model',
       'claude-sonnet-4-6',
       '--tools=',

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -255,7 +255,7 @@ test('formatCliTimeout reports the last known thinking-token count when present'
   });
 
   assert.match(message, /last known thinking-token count: ~900/);
-  assert.match(message, /this was a working call, not a hang/);
+  assert.match(message, /thinking progress was observed before termination/);
 });
 
 test('formatCliTimeout omits the thinking-token line when none arrived', () => {


### PR DESCRIPTION
`callViaCli` used `--output-format json`, which buffers the whole response until the call finishes - a healthy-but-slow call and a genuinely wedged one both look like silence until the timeout fires. Three impl-agent runs (#237, #269, #297) have died at their timeout with 0 bytes received, completely undiagnosable.

A diagnostic reproduction of #297's exact prompt under `stream-json --verbose` found the call was not stuck - it finished in 337s, 443s under budget - but 59% of that was extended thinking with no visible output yet, a phase the buffered format hides entirely.

Switches to `stream-json`, parses the NDJSON stream, and surfaces the running thinking-token count in the heartbeat log and any timeout error, plus `ttft_ms` and the thinking/output token split on success. Same return contract, same timeout/kill logic, no changes to `generate-impl.mjs`, `verify-spec.mjs`, or the workflow YAML.

101/101 ai-sdlc tests pass, prettier/eslint clean, pre-push backend suite green.

Refs #327

Assisted-by: claude-opus-5 (agent)