### PR TITLE
feat(intelligence-worker): honour Retry-After from llm_unavailable

### DIFF
--- a/packages/backend/src/queue/workers/intelligence-worker.ts
+++ b/packages/backend/src/queue/workers/intelligence-worker.ts
@@ -13,6 +13,7 @@
 
 import type { IJobHandle } from '@bugspotter/message-broker';
 import type { Redis } from 'ioredis';
+import { DelayedError } from 'bullmq';
 import { getLogger } from '../../logger.js';
 import {
   validateIntelligenceJobData,
@@ -128,10 +129,16 @@ async function resolveClient(
 }
 
 /**
- * Process intelligence analysis job
+ * Process intelligence analysis job.
+ *
+ * `token` is BullMQ's worker lock token, threaded through from the processor
+ * registration below. It is only used on the `llm_unavailable` reschedule
+ * path, where it proves this call still holds the job's lock before asking
+ * BullMQ to delay it (issue #297).
  */
-async function processIntelligenceJob(
+export async function processIntelligenceJob(
   job: IJobHandle<IntelligenceJobData, IntelligenceJobResult>,
+  token: string | undefined,
   clientFactory: IntelligenceClientFactory,
   db: DatabaseClient,
   ruleExecutor: DedupRuleExecutor
@@ -158,27 +165,40 @@ async function processIntelligenceJob(
 
   const { client, orgId } = await resolveClient(job, clientFactory, db);
 
-  if (type === 'analyze') {
-    return processAnalyzeJob(job, client, db, orgId, startTime, ruleExecutor);
-  }
+  try {
+    if (type === 'analyze') {
+      return await processAnalyzeJob(job, client, db, orgId, startTime, ruleExecutor);
+    }
 
-  if (type === 'resolution') {
-    return processResolutionJob(job, client, startTime);
-  }
+    if (type === 'resolution') {
+      return await processResolutionJob(job, client, startTime);
+    }
 
-  if (type === 'enrich') {
-    return processEnrichJob(job, client, db, orgId, startTime);
-  }
+    if (type === 'enrich') {
+      return await processEnrichJob(job, client, db, orgId, startTime);
+    }
 
-  if (type === 'mitigation') {
-    return processMitigationJob(job, client, db, startTime);
-  }
+    if (type === 'mitigation') {
+      return await processMitigationJob(job, client, db, startTime);
+    }
 
-  // Unsupported type — shouldn't happen if validation is correct
-  throw new JobProcessingError(job.id || 'unknown', `Unsupported intelligence job type: ${type}`, {
-    type,
-    bugReportId,
-  });
+    // Unsupported type — shouldn't happen if validation is correct
+    throw new JobProcessingError(
+      job.id || 'unknown',
+      `Unsupported intelligence job type: ${type}`,
+      { type, bugReportId }
+    );
+  } catch (err) {
+    if (err instanceof IntelligenceError && err.code === 'llm_unavailable') {
+      // `||`, not `??` — retryAfter can be an explicit 0, and `0 ?? 30`
+      // evaluates to `0` since `0` is not nullish. `||` treats `0` as falsy
+      // and falls through to the 30s floor as intended.
+      const ms = (err.retryAfter || 30) * 1000;
+      await job.moveToDelayed(Date.now() + ms, token);
+      throw new DelayedError();
+    }
+    throw err;
+  }
 }
 
 /**
@@ -585,7 +605,8 @@ export function createIntelligenceWorker(
     typeof QUEUE_NAMES.INTELLIGENCE
   >({
     name: QUEUE_NAMES.INTELLIGENCE,
-    processor: async (job) => processIntelligenceJob(job, clientFactory, db, ruleExecutor),
+    processor: async (job, token) =>
+      processIntelligenceJob(job, token, clientFactory, db, ruleExecutor),
     connection,
     workerType: QUEUE_NAMES.INTELLIGENCE,
   });

--- a/packages/backend/src/queue/workers/worker-factory.ts
+++ b/packages/backend/src/queue/workers/worker-factory.ts
@@ -42,8 +42,12 @@ interface CreateWorkerOptions<D = unknown, R = unknown, N extends QueueName = Qu
   /** Queue name (must match job name) */
   name: N;
 
-  /** Job processor function */
-  processor: (job: IJobHandle<D, R>) => Promise<R>;
+  /**
+   * Job processor function. `token` is BullMQ's worker lock token, present
+   * whenever a registered processor is invoked - only needed by processors
+   * that call `job.moveToDelayed`.
+   */
+  processor: (job: IJobHandle<D, R>, token?: string) => Promise<R>;
 
   /** Redis connection */
   connection: Redis;

--- a/packages/backend/src/services/intelligence/intelligence-client.ts
+++ b/packages/backend/src/services/intelligence/intelligence-client.ts
@@ -432,10 +432,12 @@ export class IntelligenceClient {
  */
 export class IntelligenceError extends Error {
   /**
-   * Seconds the upstream asked us to wait, parsed from `Retry-After`. Metadata
-   * only: no caller reads it yet. `IntelligenceClient` is shared by a queue
-   * worker that could absorb the wait and by request-path routes that cannot,
-   * so honouring the hint belongs to the caller, not to the client.
+   * Seconds the upstream asked us to wait, parsed from `Retry-After`.
+   * `IntelligenceClient` is shared by a queue worker that can absorb the
+   * wait and by request-path routes that cannot, so honouring the hint
+   * belongs to the caller, not to the client - `intelligence-worker.ts`
+   * reads it on `llm_unavailable` to reschedule via `job.moveToDelayed`
+   * instead of consuming a retry attempt (issue #297).
    */
   public readonly retryAfter?: number;
   /**

--- a/packages/backend/tests/queue/intelligence-worker.test.ts
+++ b/packages/backend/tests/queue/intelligence-worker.test.ts
@@ -13,9 +13,17 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { processAnalyzeJob } from '../../src/queue/workers/intelligence-worker.js';
+import { DelayedError } from 'bullmq';
+import {
+  processAnalyzeJob,
+  processIntelligenceJob,
+} from '../../src/queue/workers/intelligence-worker.js';
 import type { DatabaseClient } from '../../src/db/client.js';
-import type { IntelligenceClient } from '../../src/services/intelligence/intelligence-client.js';
+import {
+  IntelligenceError,
+  type IntelligenceClient,
+} from '../../src/services/intelligence/intelligence-client.js';
+import type { IntelligenceClientFactory } from '../../src/services/intelligence/tenant-config.js';
 import type { DedupRuleExecutor } from '../../src/services/rules/executor.js';
 
 describe('Intelligence Worker - processAnalyzeJob org threshold', () => {
@@ -147,5 +155,116 @@ describe('Intelligence Worker - processAnalyzeJob org threshold', () => {
     ).rejects.toThrow('db unavailable');
 
     expect(mockClient.getSimilarBugs).not.toHaveBeenCalled();
+  });
+});
+
+describe('Intelligence Worker - processIntelligenceJob llm_unavailable rescheduling', () => {
+  let mockJob: any;
+  let mockClient: any;
+  let mockClientFactory: IntelligenceClientFactory;
+  let mockDb: DatabaseClient;
+  let mockRuleExecutor: DedupRuleExecutor;
+
+  beforeEach(() => {
+    mockJob = {
+      id: 'job-1',
+      data: {
+        type: 'analyze',
+        bugReportId: 'bug-1',
+        projectId: 'proj-1',
+        payload: { bug_id: 'bug-1' },
+      },
+      updateProgress: vi.fn(),
+      moveToDelayed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockClient = {
+      analyzeBug: vi.fn(),
+      getSimilarBugs: vi.fn().mockResolvedValue({ is_duplicate: false, similar_bugs: [] }),
+    };
+
+    // resolveClient falls through to getGlobalClient() when the project has
+    // no organization_id (self-hosted path).
+    mockClientFactory = {
+      getGlobalClient: vi.fn().mockReturnValue(mockClient),
+      getClientForOrg: vi.fn(),
+    } as unknown as IntelligenceClientFactory;
+
+    mockDb = {
+      projects: {
+        findById: vi.fn().mockResolvedValue({ id: 'proj-1', organization_id: null }),
+      },
+    } as unknown as DatabaseClient;
+
+    mockRuleExecutor = {} as DedupRuleExecutor;
+  });
+
+  // AC #1 — retryAfter present reschedules at the server-supplied delay
+  it('moves job to delayed using retryAfter when llm_unavailable', async () => {
+    const retryAfter = 45;
+    mockClient.analyzeBug.mockRejectedValueOnce(
+      new IntelligenceError('LLM unavailable', 'llm_unavailable', 503, { retryAfter })
+    );
+
+    const before = Date.now();
+    await expect(
+      processIntelligenceJob(mockJob, 'test-token', mockClientFactory, mockDb, mockRuleExecutor)
+    ).rejects.toBeInstanceOf(DelayedError);
+    const after = Date.now();
+
+    expect(mockJob.moveToDelayed).toHaveBeenCalledOnce();
+    const [calledAt, calledToken] = mockJob.moveToDelayed.mock.calls[0];
+    expect(calledAt).toBeGreaterThanOrEqual(before + retryAfter * 1000);
+    expect(calledAt).toBeLessThanOrEqual(after + retryAfter * 1000);
+    expect(calledToken).toBe('test-token');
+  });
+
+  // AC #2 — retryAfter absent falls back to the 30s floor
+  it('falls back to 30s delay when retryAfter is absent', async () => {
+    mockClient.analyzeBug.mockRejectedValueOnce(
+      new IntelligenceError('LLM unavailable', 'llm_unavailable', 503)
+    );
+
+    const before = Date.now();
+    await expect(
+      processIntelligenceJob(mockJob, 'test-token', mockClientFactory, mockDb, mockRuleExecutor)
+    ).rejects.toBeInstanceOf(DelayedError);
+    const after = Date.now();
+
+    const [calledAt] = mockJob.moveToDelayed.mock.calls[0];
+    expect(calledAt).toBeGreaterThanOrEqual(before + 30_000);
+    expect(calledAt).toBeLessThanOrEqual(after + 30_000);
+  });
+
+  // AC #3 — retryAfter explicitly 0 also falls back to the 30s floor.
+  // Distinct from the absent case: proves `||` handles an explicit falsy 0
+  // where `??` would not (`0 ?? 30` evaluates to `0`).
+  it('falls back to 30s delay when retryAfter is explicitly 0', async () => {
+    mockClient.analyzeBug.mockRejectedValueOnce(
+      new IntelligenceError('LLM unavailable', 'llm_unavailable', 503, { retryAfter: 0 })
+    );
+
+    const before = Date.now();
+    await expect(
+      processIntelligenceJob(mockJob, 'test-token', mockClientFactory, mockDb, mockRuleExecutor)
+    ).rejects.toBeInstanceOf(DelayedError);
+    const after = Date.now();
+
+    const [calledAt] = mockJob.moveToDelayed.mock.calls[0];
+    expect(calledAt).toBeGreaterThanOrEqual(before + 30_000);
+    expect(calledAt).toBeLessThanOrEqual(after + 30_000);
+  });
+
+  // AC #4 — a non-llm_unavailable error propagates normally, no reschedule
+  it('does not call moveToDelayed for non-llm_unavailable errors', async () => {
+    mockClient.analyzeBug.mockRejectedValueOnce(
+      new IntelligenceError('Service error', 'server_error', 500)
+    );
+
+    await expect(
+      processIntelligenceJob(mockJob, 'test-token', mockClientFactory, mockDb, mockRuleExecutor)
+    ).rejects.not.toBeInstanceOf(DelayedError);
+
+    expect(mockJob.moveToDelayed).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/tests/queue/intelligence-worker.test.ts
+++ b/packages/backend/tests/queue/intelligence-worker.test.ts
@@ -172,7 +172,10 @@ describe('Intelligence Worker - processIntelligenceJob llm_unavailable reschedul
         type: 'analyze',
         bugReportId: 'bug-1',
         projectId: 'proj-1',
-        payload: { bug_id: 'bug-1' },
+        // validateIntelligenceJobData requires title for type 'analyze', not
+        // just bug_id - omitting it fails validation before the job ever
+        // reaches client.analyzeBug, let alone the reschedule path.
+        payload: { bug_id: 'bug-1', title: 'Test bug' },
       },
       updateProgress: vi.fn(),
       moveToDelayed: vi.fn().mockResolvedValue(undefined),

--- a/packages/message-broker/src/adapters/bullmq/worker-host.ts
+++ b/packages/message-broker/src/adapters/bullmq/worker-host.ts
@@ -9,7 +9,12 @@ import { BullMQJobHandle } from './job-handle.js';
 
 export interface BullMQWorkerHostConfig<D, R> extends WorkerHostOptions {
   queue: string;
-  processor: (job: IJobHandle<D, R>) => Promise<R>;
+  /**
+   * BullMQ's own processor callback receives `(job, token)` - `token` is the
+   * worker lock token, required to call `job.moveToDelayed`. Optional so
+   * existing processors that ignore it keep compiling unchanged.
+   */
+  processor: (job: IJobHandle<D, R>, token?: string) => Promise<R>;
   connection: Redis;
   customOptions?: Partial<WorkerOptions>;
 }
@@ -27,9 +32,9 @@ export class BullMQWorkerHost<D = unknown, R = unknown> implements IWorkerHost<D
 
     this.worker = new Worker<D, R>(
       config.queue,
-      async (job) => {
+      async (job, token) => {
         const handle = new BullMQJobHandle<D, R>(job);
-        return config.processor(handle);
+        return config.processor(handle, token);
       },
       opts
     );

--- a/packages/message-broker/tests/worker-host.test.ts
+++ b/packages/message-broker/tests/worker-host.test.ts
@@ -116,7 +116,8 @@ describe('BullMQWorkerHost', () => {
           name: 'test-job',
           data: { key: 'value' },
           attemptsMade: 1,
-        })
+        }),
+        undefined
       );
     });
 
@@ -132,6 +133,25 @@ describe('BullMQWorkerHost', () => {
 
       const result = await capturedProcessor(mockBullJob);
       expect(result).toEqual({ result: 'done' });
+    });
+
+    it('should forward BullMQ-supplied token as the processor second argument', async () => {
+      // BullMQ's own Processor type is (job, token?) => Promise<R> - the
+      // worker's real callback receives a lock token, and a wrapper that
+      // drops it silently breaks any processor calling job.moveToDelayed,
+      // which requires that exact token (issue #297).
+      const mockBullJob = {
+        id: 'j2',
+        name: 'n',
+        data: { key: 'k' },
+        attemptsMade: 0,
+        updateProgress: vi.fn(),
+        log: vi.fn(),
+      };
+
+      await capturedProcessor(mockBullJob, 'lock-token-abc');
+
+      expect(processor).toHaveBeenCalledWith(expect.anything(), 'lock-token-abc');
     });
   });
 


### PR DESCRIPTION
Implements #297 by hand, per the ratified spec (PR #324, amended by PR #328).

When the intelligence service responds `llm_unavailable` with a `Retry-After` hint, the worker now reschedules via `job.moveToDelayed` instead of falling through to BullMQ's standard backoff (5s/10s/20s, exhausted in ~35s) and hammering an already-overloaded LLM backend.

Two prerequisite fixes the spec never declared a path for, found by an actual `impl-agent` pipeline retry hitting a real `tsc` error (see AI-SDLC log for 2026-08-13):
- `createWorker`'s processor type (`worker-factory.ts`) only ever accepted a single `job` argument.
- `BullMQWorkerHost`'s wrapper (`worker-host.ts`) silently discarded the `token` BullMQ passes to a real processor callback - a type-only fix would have left every reschedule calling `moveToDelayed` with `token: undefined`, which BullMQ rejects.

30s floor when `retryAfter` is absent or explicitly `0` (`err.retryAfter || 30`, not `??` - `0` is a valid explicit value that must not survive as the delay). Non-`llm_unavailable` errors are unaffected.

Attempt-accounting: `moveToDelayed` does not consume a `job.opts.attempts` slot - a persistently unavailable LLM backend reschedules indefinitely rather than dead-lettering. Deliberate: the alternative (exhausting retries and dead-lettering) loses the analysis entirely, and `Retry-After` is a signal the backend expects to recover.

Verified locally: `typecheck` clean, `message-broker` test suite (59/59, including a new test proving the token now actually reaches the processor - not just a type change), backend `test:unit` (3120/3120). `tests/queue/intelligence-worker.test.ts` itself needs a real Postgres via testcontainers, which times out on this Windows/Docker Desktop setup independent of this change (`tests/queue` runs in CI's "Backend Services Tests" job, not local `test:unit`) - watching that job on this PR.

Refs #297

Assisted-by: claude-opus-5 (agent)