### PR TITLE
ci(ai-sdlc): auto-advance gate labels when a stage PR merges

### DIFF
--- a/.github/workflows/pipeline-advance.yml
+++ b/.github/workflows/pipeline-advance.yml
@@ -1,0 +1,119 @@
+name: Pipeline Advance
+
+# Auto-advances a pipeline issue's gate label when one of the AI-SDLC stage
+# PRs (spec/, adr/, impl/) merges, so a human doesn't have to hand-run
+# `gh issue edit --remove-label X --add-label Y` after every merge - done by
+# hand for issues #297 and #227, an entire session each.
+#
+# Deliberately narrow: this only ever flips a label after a human has already
+# merged the stage PR - which IS the judgment call each gate exists to
+# require. It never opens a PR, never ratifies a spec or ADR, never decides
+# content is good enough. See scripts/ai-sdlc/advance-gate.mjs for the full
+# decision logic (and its tests) - fails closed (skips silently-ish, just
+# logs + no-ops) on anything it can't parse confidently, rather than guessing
+# at a label change.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: pipeline-advance-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  advance:
+    name: Advance pipeline gate
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Test the decision logic
+        run: node --test scripts/ai-sdlc/advance-gate.test.mjs
+
+      # The issue number for adr/ branches only comes from the PR body (their
+      # branch name is the ADR number, not the issue's) - resolved first so
+      # the next step knows which issue's labels to fetch.
+      - name: Resolve stage and issue number
+        id: resolve
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/ai-sdlc/advance-gate.mjs resolve-issue
+
+      - name: Read ADR field from the merged spec (spec-stage merges only)
+        id: adr_field
+        if: steps.resolve.outputs.stage == 'spec'
+        env:
+          ISSUE_NUMBER: ${{ steps.resolve.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          PADDED=$(printf '%04d' "$ISSUE_NUMBER")
+          SPEC_FILE=$(ls "docs/specs/${PADDED}-"*.md 2>/dev/null | head -1) || true
+          VALUE=""
+          if [ -n "$SPEC_FILE" ] && [ -f "$SPEC_FILE" ]; then
+            VALUE=$(grep -m1 -E '^ADR:' "$SPEC_FILE" | sed -E 's/^ADR:[[:space:]]*//') || true
+          fi
+          echo "value=$VALUE" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch the issue's current labels
+        id: current_labels
+        if: steps.resolve.outputs.issue_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.resolve.outputs.issue_number }}
+        run: |
+          set -euo pipefail
+          LABELS_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name]')
+          {
+            echo "json<<EOF_LABELS"
+            echo "$LABELS_JSON"
+            echo "EOF_LABELS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Decide
+        id: decide
+        if: steps.resolve.outputs.issue_number != ''
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          ISSUE_LABELS_JSON: ${{ steps.current_labels.outputs.json }}
+          ADR_FIELD: ${{ steps.adr_field.outputs.value }}
+        run: node scripts/ai-sdlc/advance-gate.mjs decide
+
+      - name: Advance the label
+        if: steps.decide.outputs.action == 'advance'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.decide.outputs.issue_number }}
+          FROM_LABELS: ${{ steps.decide.outputs.from_labels }}
+          TO_LABEL: ${{ steps.decide.outputs.to_label }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          set -euo pipefail
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label "$FROM_LABELS" --add-label "$TO_LABEL"
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "Auto-advanced to \`${TO_LABEL}\` (${REASON})."
+
+      - name: Log why nothing was advanced
+        if: steps.decide.outputs.action != 'advance'
+        env:
+          REASON: ${{ steps.decide.outputs.reason || 'not an AI-SDLC stage branch (spec/, adr/, impl/)' }}
+        run: |
+          echo "pipeline-advance: no-op - ${REASON}"

--- a/scripts/ai-sdlc/advance-gate.mjs
+++ b/scripts/ai-sdlc/advance-gate.mjs
@@ -104,7 +104,11 @@ export function parseStageAndBranchIssue(headRef) {
  * @returns {string|null} null if the file has no such line at all
  */
 export function readAdrField(specContent) {
-  const m = /^ADR:\s*(.+)$/m.exec(specContent ?? '');
+  // [ \t]* (not \s*) keeps the optional leading whitespace on the ADR line
+  // itself - \s matches a newline too, so \s* would happily skip a blank
+  // `ADR:` line and capture the next line's text as the value instead of
+  // reporting no value at all.
+  const m = /^ADR:[ \t]*(\S.*)$/m.exec(specContent ?? '');
   return m ? m[1].trim() : null;
 }
 
@@ -229,10 +233,19 @@ function writeOutputs(pairs) {
   if (!out) {
     return;
   }
-  const lines = Object.entries(pairs)
-    .map(([k, v]) => `${k}=${v ?? ''}`)
-    .join('\n');
-  appendFileSync(out, `${lines}\n`);
+  const lines = Object.entries(pairs).map(([k, v]) => {
+    const value = String(v ?? '');
+    if (!/[\r\n]/.test(value)) {
+      return `${k}=${value}`;
+    }
+    // Randomised delimiter, same reason as check-gate-4.mjs's comment output:
+    // `reason` carries the spec's own ADR field text today, which the bash
+    // step guarantees is single-line - but that guarantee lives outside this
+    // file, so the delimiter form is what actually holds if it ever doesn't.
+    const delimiter = `EOF_${k.toUpperCase()}_${Math.random().toString(36).slice(2)}`;
+    return `${k}<<${delimiter}\n${value}\n${delimiter}`;
+  });
+  appendFileSync(out, `${lines.join('\n')}\n`);
 }
 
 // Two modes because the issue number for adr/ branches is only knowable

--- a/scripts/ai-sdlc/advance-gate.mjs
+++ b/scripts/ai-sdlc/advance-gate.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+// Decides how a pipeline issue's gate label should move when one of the
+// AI-SDLC stage PRs (spec/, adr/, impl/) merges.
+//
+// Before this existed, every gate transition in the pipeline was a human
+// running `gh issue edit --remove-label X --add-label Y` by hand after
+// reading the merged PR - done manually for issues #297 and #227 across an
+// entire session each. That is pure mechanical work with an unambiguous
+// trigger (a stage PR merging) and, for two of the three stages, an
+// unambiguous destination:
+//
+//   spec/  merge -> needs-adr, OR agent-working directly if the spec itself
+//          declares no ADR is warranted (its own "ADR: n/a" line - a field
+//          a human/agent already set deliberately while drafting the spec,
+//          not a guess this script invents).
+//   adr/   merge -> agent-working, always (the branch only exists when an
+//          ADR was drafted, so there is no other place for it to go).
+//   impl/  merge -> needs-deploy, always (Gate 3 IS the merge - see
+//          impl-agent.yml's own header comment - so a merged impl/ PR has
+//          already cleared it).
+//
+// This module never substitutes for the human judgment the gates exist to
+// require: it only fires after a human has already merged the PR, and
+// merging IS that judgment. It fails closed - skip, not guess - on anything
+// it cannot parse confidently: an unrecognized branch prefix, no resolvable
+// issue number, an issue not currently sitting at the label this stage
+// expects (a person may have already moved it by hand), or a spec file
+// missing its ADR line.
+//
+// This module is the decision only - it performs no mutations and makes no
+// network calls. The workflow (.github/workflows/pipeline-advance.yml)
+// supplies the facts (branch name, PR body, the issue's current labels, the
+// merged spec's ADR field) and carries out the label edit, so the interesting
+// logic stays testable without a live GitHub - same split as
+// check-gate-4.mjs / gate-guard.yml.
+
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const GATE_LABELS = {
+  spec: 'needs-spec',
+  adr: 'needs-adr',
+  agentWorking: 'agent-working',
+  needsReview: 'needs-review',
+  needsDeploy: 'needs-deploy',
+};
+
+// Same reference pattern as scripts/check-pr-link.mjs's REFERENCE, narrowed
+// to capture the issue number: adr/ branches don't carry the issue number in
+// their name (they're named after the ADR number instead), so it has to come
+// from the agent-authored PR body's "Refs #NNN" instead. Word-bounded on both
+// sides for the identical reason check-pr-link.mjs is: reject partial tokens
+// like "#123abc", never false-match "discloses #123" as "closes".
+const REFERENCE_WITH_NUMBER =
+  /(?<!\p{L})(?:Closes|Refs|Fixes|Tracks|Resolves|References)\s+(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#([0-9]+)(?![0-9\p{L}])/iu;
+
+/**
+ * @param {string} body
+ * @returns {number|null}
+ */
+export function extractIssueNumber(body) {
+  for (const line of (body ?? '').split(/\r?\n/)) {
+    const m = REFERENCE_WITH_NUMBER.exec(line);
+    if (m) {
+      return Number(m[1]);
+    }
+  }
+  return null;
+}
+
+/**
+ * Which AI-SDLC stage a merged PR belongs to, and its issue number if the
+ * branch name carries one. adr/ branches are named after the ADR number
+ * (`adr/0043-slug`), not the issue, so their issueNumber is always null here
+ * - callers fall back to extractIssueNumber(prBody) for that stage.
+ *
+ * @param {string} headRef
+ * @returns {{stage: 'spec'|'adr'|'impl'|null, issueNumber: number|null}}
+ */
+export function parseStageAndBranchIssue(headRef) {
+  const ref = headRef ?? '';
+  let m = /^spec\/issue-(\d+)-/.exec(ref);
+  if (m) {
+    return { stage: 'spec', issueNumber: Number(m[1]) };
+  }
+  m = /^impl\/issue-(\d+)-/.exec(ref);
+  if (m) {
+    return { stage: 'impl', issueNumber: Number(m[1]) };
+  }
+  if (/^adr\/\d+-/.test(ref)) {
+    return { stage: 'adr', issueNumber: null };
+  }
+  return { stage: null, issueNumber: null };
+}
+
+/**
+ * Reads the `ADR: pending / docs/adr/NNNN-slug.md / n/a` line a ratified spec
+ * carries (see docs/specs/TEMPLATE.md). Returns the trimmed value verbatim
+ * (not just a boolean) so the decision below - and the resulting issue
+ * comment - can say what the spec actually declared, not just what was
+ * inferred from it.
+ *
+ * @param {string} specContent
+ * @returns {string|null} null if the file has no such line at all
+ */
+export function readAdrField(specContent) {
+  const m = /^ADR:\s*(.+)$/m.exec(specContent ?? '');
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * @param {object} input
+ * @param {string} input.headRef
+ * @param {string} input.prBody
+ * @param {string[]} input.issueLabels - the issue's labels *right now*, so a
+ *   label a person already changed by hand is respected rather than clobbered
+ * @param {string|null} input.adrField - only meaningful for stage 'spec'
+ * @returns {{action: 'advance'|'skip', stage: string|null, issueNumber: number|null,
+ *            fromLabels: string[], toLabel: string|null, reason: string}}
+ */
+export function decideAdvance({ headRef, prBody, issueLabels = [], adrField = null }) {
+  const { stage, issueNumber: branchIssueNumber } = parseStageAndBranchIssue(headRef);
+
+  if (!stage) {
+    return {
+      action: 'skip',
+      stage: null,
+      issueNumber: null,
+      fromLabels: [],
+      toLabel: null,
+      reason: 'not an AI-SDLC stage branch (spec/, adr/, impl/)',
+    };
+  }
+
+  const issueNumber = branchIssueNumber ?? extractIssueNumber(prBody);
+  if (!issueNumber) {
+    return {
+      action: 'skip',
+      stage,
+      issueNumber: null,
+      fromLabels: [],
+      toLabel: null,
+      reason: 'could not determine the linked issue number from the branch name or PR body',
+    };
+  }
+
+  if (stage === 'spec') {
+    if (!issueLabels.includes(GATE_LABELS.spec)) {
+      return {
+        action: 'skip',
+        stage,
+        issueNumber,
+        fromLabels: [],
+        toLabel: null,
+        reason: `issue #${issueNumber} is not currently at \`${GATE_LABELS.spec}\` - already advanced, or moved by a person`,
+      };
+    }
+    if (!adrField) {
+      return {
+        action: 'skip',
+        stage,
+        issueNumber,
+        fromLabels: [],
+        toLabel: null,
+        reason: 'could not read the ADR field from the merged spec file',
+      };
+    }
+    const toLabel = adrField.toLowerCase() === 'n/a' ? GATE_LABELS.agentWorking : GATE_LABELS.adr;
+    return {
+      action: 'advance',
+      stage,
+      issueNumber,
+      fromLabels: [GATE_LABELS.spec],
+      toLabel,
+      reason: `spec merged; its ADR field reads "${adrField}"`,
+    };
+  }
+
+  if (stage === 'adr') {
+    if (!issueLabels.includes(GATE_LABELS.adr)) {
+      return {
+        action: 'skip',
+        stage,
+        issueNumber,
+        fromLabels: [],
+        toLabel: null,
+        reason: `issue #${issueNumber} is not currently at \`${GATE_LABELS.adr}\` - already advanced, or moved by a person`,
+      };
+    }
+    return {
+      action: 'advance',
+      stage,
+      issueNumber,
+      fromLabels: [GATE_LABELS.adr],
+      toLabel: GATE_LABELS.agentWorking,
+      reason: 'ADR merged, gate 2 complete',
+    };
+  }
+
+  // stage === 'impl'. Either `agent-working` or `needs-review` may be
+  // present (nothing currently sets `needs-review` before merge, but
+  // check-gate-4.mjs's PRE_DEPLOY_GATES treats both as pre-deploy states, so
+  // this strips whichever is actually there rather than assuming one).
+  const present = [GATE_LABELS.agentWorking, GATE_LABELS.needsReview].filter((l) =>
+    issueLabels.includes(l)
+  );
+  if (present.length === 0) {
+    return {
+      action: 'skip',
+      stage,
+      issueNumber,
+      fromLabels: [],
+      toLabel: null,
+      reason: `issue #${issueNumber} carries neither \`${GATE_LABELS.agentWorking}\` nor \`${GATE_LABELS.needsReview}\` - already advanced, or moved by a person`,
+    };
+  }
+  return {
+    action: 'advance',
+    stage,
+    issueNumber,
+    fromLabels: present,
+    toLabel: GATE_LABELS.needsDeploy,
+    reason: 'implementation PR merged, gate 3 (human merge review) complete',
+  };
+}
+
+function writeOutputs(pairs) {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) {
+    return;
+  }
+  const lines = Object.entries(pairs)
+    .map(([k, v]) => `${k}=${v ?? ''}`)
+    .join('\n');
+  appendFileSync(out, `${lines}\n`);
+}
+
+// Two modes because the issue number for adr/ branches is only knowable
+// after parsing (branch name alone isn't enough), but fetching the issue's
+// current labels - needed for the real decision - requires that number
+// first. The workflow runs `resolve-issue` to get it, fetches labels with
+// plain `gh issue view`, then runs `decide` with everything assembled. Both
+// modes share this one module so the parsing logic is exercised by the same
+// tests either way.
+function main() {
+  const mode = process.argv[2];
+  const headRef = process.env.HEAD_REF ?? '';
+  const prBody = process.env.PR_BODY ?? '';
+
+  if (mode === 'resolve-issue') {
+    const { stage, issueNumber: branchIssueNumber } = parseStageAndBranchIssue(headRef);
+    const issueNumber = branchIssueNumber ?? (stage ? extractIssueNumber(prBody) : null);
+    console.log(
+      `advance-gate resolve-issue: stage=${stage ?? 'none'} issue=${issueNumber ?? 'none'}`
+    );
+    writeOutputs({ stage, issue_number: issueNumber });
+    return;
+  }
+
+  if (mode !== 'decide') {
+    console.error(`advance-gate: unknown mode "${mode ?? ''}" (expected resolve-issue or decide)`);
+    process.exit(2);
+  }
+
+  let issueLabels = [];
+  const rawLabels = process.env.ISSUE_LABELS_JSON;
+  if (rawLabels) {
+    try {
+      const parsed = JSON.parse(rawLabels);
+      if (Array.isArray(parsed)) {
+        issueLabels = parsed.map((l) => (typeof l === 'string' ? l : l?.name)).filter(Boolean);
+      }
+    } catch {
+      // Fail open, loudly - same reasoning as check-gate-4.mjs: a bad parse
+      // must never crash this workflow, worst case is a skip.
+      console.warn('advance-gate: could not parse ISSUE_LABELS_JSON, treating as no labels');
+    }
+  }
+
+  const decision = decideAdvance({
+    headRef,
+    prBody,
+    issueLabels,
+    adrField: process.env.ADR_FIELD || null,
+  });
+
+  console.log(`advance-gate decide: ${decision.action} (${decision.reason})`);
+
+  writeOutputs({
+    action: decision.action,
+    stage: decision.stage,
+    issue_number: decision.issueNumber,
+    // Our own label names, never arbitrary text - safe to comma-join, same
+    // reasoning as check-gate-4.mjs's remove_labels output.
+    from_labels: decision.fromLabels.join(','),
+    to_label: decision.toLabel,
+    reason: decision.reason,
+  });
+}
+
+// Only run when invoked directly, so the exports above stay importable by tests.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/scripts/ai-sdlc/advance-gate.test.mjs
+++ b/scripts/ai-sdlc/advance-gate.test.mjs
@@ -1,0 +1,170 @@
+// Tests for advance-gate.mjs. Zero-dependency: run with `node --test`.
+//
+// The point of this file is the fail-closed behavior: a gate advanced on a
+// wrong guess is worse than one left for a human to flip by hand, because it
+// silently moves an issue through a state nobody actually reviewed. Every
+// "skip" branch below is asserted as firmly as the three real advances are.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseStageAndBranchIssue,
+  extractIssueNumber,
+  readAdrField,
+  decideAdvance,
+  GATE_LABELS,
+} from './advance-gate.mjs';
+
+test('parses the issue number out of a spec/ branch name', () => {
+  const r = parseStageAndBranchIssue('spec/issue-227-intelligence-show-match-score-threshold-');
+  assert.equal(r.stage, 'spec');
+  assert.equal(r.issueNumber, 227);
+});
+
+test('parses the issue number out of an impl/ branch name', () => {
+  const r = parseStageAndBranchIssue('impl/issue-297-intelligence-worker-honour-retry-after');
+  assert.equal(r.stage, 'impl');
+  assert.equal(r.issueNumber, 297);
+});
+
+test('recognizes an adr/ branch but cannot get the issue number from its name', () => {
+  const r = parseStageAndBranchIssue('adr/0043-intelligence-show-match-score-threshold-');
+  assert.equal(r.stage, 'adr');
+  assert.equal(r.issueNumber, null);
+});
+
+test('does not treat an unrelated branch as an AI-SDLC stage', () => {
+  const r = parseStageAndBranchIssue('chore/bump-deps');
+  assert.equal(r.stage, null);
+});
+
+test('extracts the issue number from a "Refs #NNN" PR body', () => {
+  assert.equal(extractIssueNumber('Agent-drafted ADR-0043 for issue #227.\n\nRefs #227'), 227);
+});
+
+test('does not match a bare #NNN with no keyword', () => {
+  // Same reasoning as check-pr-link.mjs's REFERENCE: a bare number in prose
+  // (e.g. quoting an issue while describing something) must not count.
+  assert.equal(extractIssueNumber('See #227 for background.'), null);
+});
+
+test('reads the ADR field from a spec file', () => {
+  assert.equal(readAdrField('Linked issue: Refs #227\nADR: n/a\n\n## Problem'), 'n/a');
+  assert.equal(readAdrField('ADR: docs/adr/0043-slug.md\n'), 'docs/adr/0043-slug.md');
+  assert.equal(readAdrField('no ADR line here'), null);
+});
+
+test('spec merge with ADR: n/a advances straight to agent-working', () => {
+  const d = decideAdvance({
+    headRef: 'spec/issue-227-intelligence-show-match-score-threshold-',
+    prBody: 'Refs #227',
+    issueLabels: ['enhancement', GATE_LABELS.spec],
+    adrField: 'n/a',
+  });
+  assert.equal(d.action, 'advance');
+  assert.equal(d.issueNumber, 227);
+  assert.deepEqual(d.fromLabels, [GATE_LABELS.spec]);
+  assert.equal(d.toLabel, GATE_LABELS.agentWorking);
+});
+
+test('spec merge with an ADR still pending advances to needs-adr', () => {
+  const d = decideAdvance({
+    headRef: 'spec/issue-226-intelligence-wire-per-org-similarity-thr',
+    prBody: 'Refs #226',
+    issueLabels: [GATE_LABELS.spec],
+    adrField: 'pending',
+  });
+  assert.equal(d.action, 'advance');
+  assert.equal(d.toLabel, GATE_LABELS.adr);
+});
+
+test('spec merge is skipped, not guessed, when the ADR field could not be read', () => {
+  const d = decideAdvance({
+    headRef: 'spec/issue-227-intelligence-show-match-score-threshold-',
+    prBody: 'Refs #227',
+    issueLabels: [GATE_LABELS.spec],
+    adrField: null,
+  });
+  assert.equal(d.action, 'skip');
+});
+
+test('spec merge is skipped when the issue is no longer at needs-spec', () => {
+  // A person already moved it by hand - do not fight them.
+  const d = decideAdvance({
+    headRef: 'spec/issue-227-intelligence-show-match-score-threshold-',
+    prBody: 'Refs #227',
+    issueLabels: [GATE_LABELS.adr],
+    adrField: 'n/a',
+  });
+  assert.equal(d.action, 'skip');
+});
+
+test('adr merge advances to agent-working using the issue number from the PR body', () => {
+  const d = decideAdvance({
+    headRef: 'adr/0043-intelligence-show-match-score-threshold-',
+    prBody: 'Agent-drafted ADR-0043 for issue #227.\n\nRefs #227',
+    issueLabels: [GATE_LABELS.adr],
+    adrField: null,
+  });
+  assert.equal(d.action, 'advance');
+  assert.equal(d.issueNumber, 227);
+  assert.deepEqual(d.fromLabels, [GATE_LABELS.adr]);
+  assert.equal(d.toLabel, GATE_LABELS.agentWorking);
+});
+
+test('adr merge is skipped when the PR body has no resolvable issue reference', () => {
+  const d = decideAdvance({
+    headRef: 'adr/0043-intelligence-show-match-score-threshold-',
+    prBody: 'No reference in this body.',
+    issueLabels: [GATE_LABELS.adr],
+    adrField: null,
+  });
+  assert.equal(d.action, 'skip');
+  assert.equal(d.issueNumber, null);
+});
+
+test('impl merge advances agent-working to needs-deploy', () => {
+  const d = decideAdvance({
+    headRef: 'impl/issue-297-intelligence-worker-honour-retry-after',
+    prBody: 'Refs #297',
+    issueLabels: [GATE_LABELS.agentWorking],
+    adrField: null,
+  });
+  assert.equal(d.action, 'advance');
+  assert.deepEqual(d.fromLabels, [GATE_LABELS.agentWorking]);
+  assert.equal(d.toLabel, GATE_LABELS.needsDeploy);
+});
+
+test('impl merge strips needs-review too if present alongside agent-working', () => {
+  // Defensive: nothing sets needs-review today, but check-gate-4.mjs already
+  // treats it as a pre-deploy state a human could apply by hand.
+  const d = decideAdvance({
+    headRef: 'impl/issue-297-intelligence-worker-honour-retry-after',
+    prBody: 'Refs #297',
+    issueLabels: [GATE_LABELS.agentWorking, GATE_LABELS.needsReview],
+    adrField: null,
+  });
+  assert.equal(d.action, 'advance');
+  assert.deepEqual(d.fromLabels, [GATE_LABELS.agentWorking, GATE_LABELS.needsReview]);
+});
+
+test('impl merge is skipped when the issue already reached needs-deploy', () => {
+  const d = decideAdvance({
+    headRef: 'impl/issue-297-intelligence-worker-honour-retry-after',
+    prBody: 'Refs #297',
+    issueLabels: [GATE_LABELS.needsDeploy],
+    adrField: null,
+  });
+  assert.equal(d.action, 'skip');
+});
+
+test('an ordinary PR merge on an unrelated branch is skipped entirely', () => {
+  const d = decideAdvance({
+    headRef: 'chore/bump-deps',
+    prBody: 'Refs #227',
+    issueLabels: [GATE_LABELS.spec],
+    adrField: 'n/a',
+  });
+  assert.equal(d.action, 'skip');
+  assert.equal(d.stage, null);
+});

--- a/scripts/ai-sdlc/advance-gate.test.mjs
+++ b/scripts/ai-sdlc/advance-gate.test.mjs
@@ -48,10 +48,21 @@ test('does not match a bare #NNN with no keyword', () => {
   assert.equal(extractIssueNumber('See #227 for background.'), null);
 });
 
+test('accepts an owner/repo-qualified reference and keeps the number', () => {
+  assert.equal(extractIssueNumber('Refs some-org/some-repo#227'), 227);
+});
+
 test('reads the ADR field from a spec file', () => {
   assert.equal(readAdrField('Linked issue: Refs #227\nADR: n/a\n\n## Problem'), 'n/a');
   assert.equal(readAdrField('ADR: docs/adr/0043-slug.md\n'), 'docs/adr/0043-slug.md');
   assert.equal(readAdrField('no ADR line here'), null);
+});
+
+test('a blank ADR line reports no value, not the next line', () => {
+  // Regression: \s* in the old pattern matched the newline too, so a blank
+  // `ADR:` line captured whatever text followed it on the next line.
+  assert.equal(readAdrField('ADR:\n\n## Problem'), null);
+  assert.equal(readAdrField('ADR: \nSome unrelated text'), null);
 });
 
 test('spec merge with ADR: n/a advances straight to agent-working', () => {
@@ -64,6 +75,17 @@ test('spec merge with ADR: n/a advances straight to agent-working', () => {
   assert.equal(d.action, 'advance');
   assert.equal(d.issueNumber, 227);
   assert.deepEqual(d.fromLabels, [GATE_LABELS.spec]);
+  assert.equal(d.toLabel, GATE_LABELS.agentWorking);
+});
+
+test('treats an uppercase ADR: N/A the same as n/a', () => {
+  const d = decideAdvance({
+    headRef: 'spec/issue-227-intelligence-show-match-score-threshold-',
+    prBody: 'Refs #227',
+    issueLabels: [GATE_LABELS.spec],
+    adrField: 'N/A',
+  });
+  assert.equal(d.action, 'advance');
   assert.equal(d.toLabel, GATE_LABELS.agentWorking);
 });
 


### PR DESCRIPTION
Automates the label flip that's been done by hand after every spec/adr/impl PR merge (issues #297, #227). `pipeline-advance.yml` fires on `pull_request: closed` when merged; `scripts/ai-sdlc/advance-gate.mjs` decides the destination label deterministically:

- spec/ merge -> `needs-adr` or `agent-working`, based on the merged spec's own `ADR: n/a/pending/path` line (not guessed)
- adr/ merge -> always `agent-working`
- impl/ merge -> always `needs-deploy` (Gate 3 is the merge itself)

Fails closed (skips, logs why) on anything it can't parse confidently: unrecognized branch, no resolvable issue number, or the issue already moved off the expected label by a person. Never touches gate content or approves anything - only fires after a human has already merged.

Refs #227