### PR TITLE
ci(ai-sdlc): capture full CLI transcript on failure as a build artifact

### DIFF
--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -79,7 +79,23 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           SPEC_CONTENT: ${{ steps.spec.outputs.spec_content }}
+          # llm-client.mjs writes the CLI's full raw NDJSON stream here on any
+          # failed call (never on success) - the "Upload CLI transcript"
+          # step below attaches it as a build artifact.
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-adr.ndjson
         run: node scripts/ai-sdlc/generate-adr.mjs
+
+      # `always()`: llm-client.mjs writes this file whenever its own call
+      # rejects, independent of whether the surrounding script exits 0 or
+      # not. if-no-files-found: ignore makes the normal case a no-op.
+      - name: Upload CLI transcript if one was written
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-transcript-adr-issue-${{ github.event.issue.number }}
+          path: cli-transcript-adr.ndjson
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Format generated files
         env:

--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -79,21 +79,24 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           SPEC_CONTENT: ${{ steps.spec.outputs.spec_content }}
-          # llm-client.mjs writes the CLI's full raw NDJSON stream here on any
+          # llm-client.mjs writes the CLI's full raw stdout/stderr here on any
           # failed call (never on success) - the "Upload CLI transcript"
           # step below attaches it as a build artifact.
-          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-adr.ndjson
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-adr.log
         run: node scripts/ai-sdlc/generate-adr.mjs
 
       # `always()`: llm-client.mjs writes this file whenever its own call
       # rejects, independent of whether the surrounding script exits 0 or
       # not. if-no-files-found: ignore makes the normal case a no-op.
+      # .log, not .ndjson: dumpCliTranscriptOnFailure wraps the raw stdout in
+      # human-readable "=== stdout/stderr ===" headers and appends stderr, so
+      # the file as a whole is not valid NDJSON even though stdout itself is.
       - name: Upload CLI transcript if one was written
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cli-transcript-adr-issue-${{ github.event.issue.number }}
-          path: cli-transcript-adr.ndjson
+          path: cli-transcript-adr.log
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -104,7 +104,7 @@ jobs:
           IMPL_MODEL_HIGH: ${{ vars.IMPL_MODEL_HIGH }}
           IMPL_MODEL_DEFAULT: ${{ vars.IMPL_MODEL_DEFAULT }}
           IMPL_MODEL_LOW: ${{ vars.IMPL_MODEL_LOW }}
-          # llm-client.mjs writes the CLI's full raw NDJSON stream here on any
+          # llm-client.mjs writes the CLI's full raw stdout/stderr here on any
           # failure (timeout, non-zero exit, malformed envelope) - never on
           # success. formatCliTimeout's own error message clips to 1500 chars
           # to keep this log readable, which is exactly what makes a real
@@ -112,7 +112,7 @@ jobs:
           # count jump in the final 60s that the clipped tail alone couldn't
           # explain). The "Upload CLI transcript on failure" step below
           # attaches the full file as a build artifact.
-          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-impl.ndjson
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-impl.log
         run: node scripts/ai-sdlc/generate-impl.mjs
 
       # `always()`, not `failure()`: llm-client.mjs writes this file whenever
@@ -121,12 +121,15 @@ jobs:
       # spec-agent.yml). Tying the upload to this step's own pass/fail would
       # silently miss those cases. if-no-files-found: ignore makes the normal
       # (no failure, no file) case a no-op instead of an error.
+      # .log, not .ndjson: dumpCliTranscriptOnFailure wraps the raw stdout in
+      # human-readable "=== stdout/stderr ===" headers and appends stderr, so
+      # the file as a whole is not valid NDJSON even though stdout itself is.
       - name: Upload CLI transcript if one was written
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cli-transcript-impl-issue-${{ github.event.issue.number }}
-          path: cli-transcript-impl.ndjson
+          path: cli-transcript-impl.log
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -104,7 +104,31 @@ jobs:
           IMPL_MODEL_HIGH: ${{ vars.IMPL_MODEL_HIGH }}
           IMPL_MODEL_DEFAULT: ${{ vars.IMPL_MODEL_DEFAULT }}
           IMPL_MODEL_LOW: ${{ vars.IMPL_MODEL_LOW }}
+          # llm-client.mjs writes the CLI's full raw NDJSON stream here on any
+          # failure (timeout, non-zero exit, malformed envelope) - never on
+          # success. formatCliTimeout's own error message clips to 1500 chars
+          # to keep this log readable, which is exactly what makes a real
+          # post-mortem impossible (2026-08-14, issue #227: a thinking-token
+          # count jump in the final 60s that the clipped tail alone couldn't
+          # explain). The "Upload CLI transcript on failure" step below
+          # attaches the full file as a build artifact.
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-impl.ndjson
         run: node scripts/ai-sdlc/generate-impl.mjs
+
+      # `always()`, not `failure()`: llm-client.mjs writes this file whenever
+      # its own call rejects, but a caller can swallow that rejection and
+      # still exit 0 (verify-spec.mjs does exactly this on purpose - see
+      # spec-agent.yml). Tying the upload to this step's own pass/fail would
+      # silently miss those cases. if-no-files-found: ignore makes the normal
+      # (no failure, no file) case a no-op instead of an error.
+      - name: Upload CLI transcript if one was written
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-transcript-impl-issue-${{ github.event.issue.number }}
+          path: cli-transcript-impl.ndjson
+          if-no-files-found: ignore
+          retention-days: 14
 
       # Hard gate: the scaffold's file list and the ratified spec's "Files
       # touched" list must match EXACTLY - no file written that the spec

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -66,6 +66,9 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          # See "Upload CLI transcript(s) if any were written" below - the
+          # full raw stream llm-client.mjs saves on any failed call.
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-generate-spec.ndjson
         run: node scripts/ai-sdlc/generate-spec.mjs
 
       - name: Verify and patch spec (adversarial factual check)
@@ -80,7 +83,22 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-verify-spec.ndjson
         run: node scripts/ai-sdlc/verify-spec.mjs
+
+      # `always()`, not `failure()`: verify-spec.mjs deliberately exits 0 on
+      # its own LLM call failing (see above), so a transcript can exist even
+      # though every step in this job reported success. if-no-files-found:
+      # ignore makes the normal (no failure, no file) case a no-op. One
+      # upload step covers both possible files via a glob.
+      - name: Upload CLI transcript(s) if any were written
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-transcript-spec-issue-${{ github.event.issue.number }}
+          path: cli-transcript-*.ndjson
+          if-no-files-found: ignore
+          retention-days: 14
 
       # Deterministic follow-up to the LLM pass above: no model call, no
       # attention/instruction-following failure mode. Fails the workflow

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -67,8 +67,8 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           # See "Upload CLI transcript(s) if any were written" below - the
-          # full raw stream llm-client.mjs saves on any failed call.
-          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-generate-spec.ndjson
+          # full raw stdout/stderr llm-client.mjs saves on any failed call.
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-generate-spec.log
         run: node scripts/ai-sdlc/generate-spec.mjs
 
       - name: Verify and patch spec (adversarial factual check)
@@ -83,7 +83,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
-          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-verify-spec.ndjson
+          AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-verify-spec.log
         run: node scripts/ai-sdlc/verify-spec.mjs
 
       # `always()`, not `failure()`: verify-spec.mjs deliberately exits 0 on
@@ -91,12 +91,15 @@ jobs:
       # though every step in this job reported success. if-no-files-found:
       # ignore makes the normal (no failure, no file) case a no-op. One
       # upload step covers both possible files via a glob.
+      # .log, not .ndjson: dumpCliTranscriptOnFailure wraps the raw stdout in
+      # human-readable "=== stdout/stderr ===" headers and appends stderr, so
+      # the file as a whole is not valid NDJSON even though stdout itself is.
       - name: Upload CLI transcript(s) if any were written
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cli-transcript-spec-issue-${{ github.event.issue.number }}
-          path: cli-transcript-*.ndjson
+          path: cli-transcript-*.log
           if-no-files-found: ignore
           retention-days: 14
 

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -36,6 +36,7 @@
 //   detectable via stopReason === 'max_tokens' regardless of backend.
 
 import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
 import { Buffer } from 'node:buffer';
 
 const LLM_BACKEND = process.env.LLM_BACKEND || 'api';
@@ -267,6 +268,39 @@ function clipDump(text, tailChars = 1500) {
     : trimmed;
 }
 
+// The tails formatCliTimeout/clipDump put in an Error message are themselves
+// clipped to keep a CI log readable - which is exactly what makes a real
+// post-mortem impossible. A 2026-08-14 timeout (impl-agent, issue #227) had a
+// visible anomaly (thinking-token count jumping ~1690 -> ~21857 in the final
+// 60s) that could not be explained from the 1500-char tail alone: is that a
+// new long thinking segment starting late, or the CLI's own estimate
+// catching up on one continuous segment? Answering that needs the full
+// NDJSON stream, not a fragment.
+//
+// Writes only on a failure path (see call sites in callViaCli) - a
+// successful call needs no forensics, and dumping every run's full stream
+// would make the artifact noise instead of signal. Best-effort: a write
+// failure must never be the reason the real error from callViaCli is lost,
+// so this only warns and returns.
+function dumpCliTranscriptOnFailure(stdout, stderr) {
+  const path = process.env.AI_SDLC_CLI_TRANSCRIPT_PATH;
+  if (!path) {
+    return;
+  }
+  try {
+    const stdoutBytes = Buffer.byteLength(stdout, 'utf8');
+    const stderrBytes = Buffer.byteLength(stderr, 'utf8');
+    writeFileSync(
+      path,
+      `=== stdout (${stdoutBytes} bytes, raw NDJSON stream) ===\n${stdout}\n\n` +
+        `=== stderr (${stderrBytes} bytes) ===\n${stderr}\n`,
+      'utf8'
+    );
+  } catch (err) {
+    console.warn(`llm-client: could not write CLI transcript to ${path}: ${err.message}`);
+  }
+}
+
 // No `maxTokens` param here (deliberately) — the CLI has no per-call
 // output-token cap to forward it to. See the module header comment.
 async function callViaCli({ prompt, timeoutMs, model }) {
@@ -381,6 +415,7 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     const timer = setTimeout(() => {
       clearInterval(heartbeat);
       child.kill('SIGKILL');
+      dumpCliTranscriptOnFailure(stdout, stderr);
       reject(
         new Error(
           formatCliTimeout({
@@ -411,6 +446,7 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     child.on('error', (err) => {
       clearTimeout(timer);
       clearInterval(heartbeat);
+      dumpCliTranscriptOnFailure(stdout, stderr);
       reject(err);
     });
     child.on('close', (code, signal) => {
@@ -425,12 +461,14 @@ async function callViaCli({ prompt, timeoutMs, model }) {
         // in the JSON on stdout, not stderr - include both, clipped (see
         // clipDump above).
         const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n');
+        dumpCliTranscriptOnFailure(stdout, stderr);
         reject(
           new Error(`claude CLI exited with ${reason}${detail ? `: ${clipDump(detail)}` : ''}`)
         );
         return;
       }
       if (!resultEvent) {
+        dumpCliTranscriptOnFailure(stdout, stderr);
         reject(
           new Error(
             `claude CLI exited cleanly but no "result" event was found in its stream-json ` +
@@ -440,10 +478,12 @@ async function callViaCli({ prompt, timeoutMs, model }) {
         return;
       }
       if (resultEvent.is_error) {
+        dumpCliTranscriptOnFailure(stdout, stderr);
         reject(new Error(`claude CLI reported an error: ${JSON.stringify(resultEvent)}`));
         return;
       }
       if (typeof resultEvent.result !== 'string') {
+        dumpCliTranscriptOnFailure(stdout, stderr);
         reject(new Error(`Unexpected claude CLI response shape: ${JSON.stringify(resultEvent)}`));
         return;
       }

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -20,7 +20,7 @@
 
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { writeFileSync, mkdtempSync, rmSync, chmodSync, readFileSync } from 'node:fs';
+import { writeFileSync, mkdtempSync, rmSync, chmodSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -281,6 +281,74 @@ test('callViaCli timeout error carries what the child actually wrote before the 
     assert.doesNotMatch(err.message, /wrote nothing at all/);
     return true;
   });
+});
+
+test('callViaCli writes the full raw stdout/stderr to AI_SDLC_CLI_TRANSCRIPT_PATH on a timeout', async () => {
+  // formatCliTimeout's tail is clipped to keep a CI log readable, which is
+  // exactly what makes a real post-mortem impossible (2026-08-14, impl-agent
+  // issue #227: the thinking-token count jumped ~1690 -> ~21857 in the final
+  // 60s and the clipped tail alone couldn't say why). This is the escape
+  // hatch: the full stream, not a fragment.
+  const transcriptPath = join(DIR, 'transcript-timeout.txt');
+  process.env.FAKE_CLAUDE_MODE = 'hang';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+  process.env.AI_SDLC_CLI_TRANSCRIPT_PATH = transcriptPath;
+
+  try {
+    await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 2500 }));
+
+    const transcript = readFileSync(transcriptPath, 'utf8');
+    // Full content, not the 1500-char-tail-clipped version formatCliTimeout
+    // puts in the Error message.
+    assert.match(transcript, /PARTIAL_ENVELOPE_MARKER/);
+    assert.match(transcript, /FAKE_STDERR_PROGRESS/);
+    assert.match(transcript, /=== stdout \(\d+ bytes, raw NDJSON stream\) ===/);
+    assert.match(transcript, /=== stderr \(\d+ bytes\) ===/);
+  } finally {
+    delete process.env.AI_SDLC_CLI_TRANSCRIPT_PATH;
+  }
+});
+
+test('callViaCli writes a transcript on a non-zero exit too, not just a timeout', async () => {
+  const transcriptPath = join(DIR, 'transcript-error.txt');
+  process.env.FAKE_CLAUDE_MODE = 'error';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+  process.env.AI_SDLC_CLI_TRANSCRIPT_PATH = transcriptPath;
+
+  try {
+    await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 }));
+
+    const transcript = readFileSync(transcriptPath, 'utf8');
+    assert.match(transcript, /FAKE_STDOUT_MARKER: upstream billing failure detail/);
+  } finally {
+    delete process.env.AI_SDLC_CLI_TRANSCRIPT_PATH;
+  }
+});
+
+test('callViaCli never writes a transcript on success, even when AI_SDLC_CLI_TRANSCRIPT_PATH is set', async () => {
+  // A successful call needs no forensics — dumping every run's full stream
+  // would make the artifact noise instead of signal.
+  const transcriptPath = join(DIR, 'transcript-success.txt');
+  process.env.FAKE_CLAUDE_MODE = 'success';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+  process.env.AI_SDLC_CLI_TRANSCRIPT_PATH = transcriptPath;
+
+  try {
+    await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
+    assert.equal(existsSync(transcriptPath), false);
+  } finally {
+    delete process.env.AI_SDLC_CLI_TRANSCRIPT_PATH;
+  }
+});
+
+test('callViaCli writes no transcript file when AI_SDLC_CLI_TRANSCRIPT_PATH is unset, even on failure', async () => {
+  const transcriptPath = join(DIR, 'transcript-unset.txt');
+  process.env.FAKE_CLAUDE_MODE = 'error';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+  delete process.env.AI_SDLC_CLI_TRANSCRIPT_PATH;
+
+  await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 }));
+  assert.equal(existsSync(transcriptPath), false);
 });
 
 test('callViaCli strips ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN from the spawned child env, keeps other vars', async () => {


### PR DESCRIPTION
Adds forensic capture for AI-SDLC CLI-backend failures. \`formatCliTimeout\`'s own error message clips to a 1500-char tail to keep CI logs readable, which is exactly what makes a real post-mortem impossible - the 2026-08-14 impl-agent timeout on issue #227 showed a thinking-token count jumping ~1690 -> ~21857 in the final 60s that the clipped tail alone couldn't explain.

\`llm-client.mjs\` now writes the full raw NDJSON stream to \`AI_SDLC_CLI_TRANSCRIPT_PATH\` on any failed call (timeout, non-zero exit, malformed envelope) - never on success, so it stays signal not noise. \`spec-agent.yml\`, \`adr-agent.yml\`, and \`impl-agent.yml\` set the env var on each CLI-calling step and upload the file as a build artifact (\`if: always()\` + \`if-no-files-found: ignore\`, since \`verify-spec.mjs\` deliberately swallows its own LLM failures and exits 0).

Refs #227