### PR TITLE
fix(ai-sdlc): expand {a,b,c} brace groups in extractDeclaredPaths

### DIFF
--- a/scripts/ai-sdlc/verify-spec-ownership.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.mjs
@@ -122,7 +122,14 @@ export function expandBraceGroup(path) {
   if (close === -1) {
     return [path];
   }
-  if (path.indexOf('{', close + 1) !== -1) {
+  // A second `{` anywhere after the first one — not just after its close —
+  // catches both a separate second group ("{a,b}/{c,d}") AND a nested one
+  // ("{en,{ru,kk}}"). The latter matters because `close` above is the FIRST
+  // `}`, which for a nested group is the inner one: checking only after
+  // `close` would miss the nested `{` sitting between `open` and `close`,
+  // slice a malformed alternative list, and silently emit garbled paths
+  // instead of failing closed on a shape this function doesn't handle.
+  if (path.indexOf('{', open + 1) !== -1) {
     return [path];
   }
   const alternatives = path

--- a/scripts/ai-sdlc/verify-spec-ownership.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.mjs
@@ -98,6 +98,46 @@ function allBacktickSpans(text) {
   return spans;
 }
 
+// Expands a single {a,b,c} brace-alternation group into multiple concrete
+// paths - shorthand a spec can reach for when several files get the same
+// one-line edit (e.g. i18n locale bundles:
+// `apps/admin/src/i18n/locales/{en,ru,kk}.json`). Without this,
+// extractDeclaredPaths returned that string as one literal, unexpanded path -
+// which check-impl-scope.mjs then compared byte-for-byte against the three
+// real files the model correctly wrote, and failed a scaffold that was
+// actually right (issue #227, 2026-08-15: three genuinely-declared locale
+// edits flagged as "not declared", plus a phantom "declared but never
+// written" file for the literal brace string itself).
+//
+// Only one group per path, no nesting - that covers every real spec seen so
+// far. A path with more than one brace group, or a `{...}` that turns out not
+// to be a >=2-way alternation (no comma), is returned unexpanded rather than
+// guessing at a shape this hasn't seen.
+export function expandBraceGroup(path) {
+  const open = path.indexOf('{');
+  if (open === -1) {
+    return [path];
+  }
+  const close = path.indexOf('}', open + 1);
+  if (close === -1) {
+    return [path];
+  }
+  if (path.indexOf('{', close + 1) !== -1) {
+    return [path];
+  }
+  const alternatives = path
+    .slice(open + 1, close)
+    .split(',')
+    .map((a) => a.trim())
+    .filter(Boolean);
+  if (alternatives.length < 2) {
+    return [path];
+  }
+  const prefix = path.slice(0, open);
+  const suffix = path.slice(close + 1);
+  return alternatives.map((alt) => `${prefix}${alt}${suffix}`);
+}
+
 export function extractDeclaredPaths(specText) {
   const marker = '**Files touched:**';
   const markerIdx = specText.indexOf(marker);
@@ -116,7 +156,9 @@ export function extractDeclaredPaths(specText) {
       // The inline form puts every path on the marker's own line, comma-
       // separated ("**Files touched:** `a.ts`, `b.ts`") - nothing precedes
       // them to be a trailing description, so every span here is a path.
-      paths.push(...allBacktickSpans(line));
+      for (const span of allBacktickSpans(line)) {
+        paths.push(...expandBraceGroup(span));
+      }
       continue;
     }
 
@@ -142,7 +184,7 @@ export function extractDeclaredPaths(specText) {
     // has its own backtick-quoted terms.
     const path = firstBacktickSpan(line);
     if (path !== null) {
-      paths.push(path);
+      paths.push(...expandBraceGroup(path));
       sawBullet = true;
     }
   }

--- a/scripts/ai-sdlc/verify-spec-ownership.test.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.test.mjs
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import {
   parseAdrOwnership,
   extractDeclaredPaths,
+  expandBraceGroup,
   extractOutOfScopeText,
   checkOwnership,
 } from './verify-spec-ownership.mjs';
@@ -37,6 +38,36 @@ describe('parseAdrOwnership', () => {
 
   test('empty index yields an empty map', () => {
     assert.equal(parseAdrOwnership('no table here').size, 0);
+  });
+});
+
+describe('expandBraceGroup', () => {
+  test('expands a brace-alternation group into one path per alternative', () => {
+    assert.deepEqual(expandBraceGroup('apps/admin/src/i18n/locales/{en,ru,kk}.json'), [
+      'apps/admin/src/i18n/locales/en.json',
+      'apps/admin/src/i18n/locales/ru.json',
+      'apps/admin/src/i18n/locales/kk.json',
+    ]);
+  });
+
+  test('trims whitespace inside the group', () => {
+    assert.deepEqual(expandBraceGroup('a/{one, two}.ts'), ['a/one.ts', 'a/two.ts']);
+  });
+
+  test('leaves a path with no braces unchanged', () => {
+    assert.deepEqual(expandBraceGroup('packages/a/b.ts'), ['packages/a/b.ts']);
+  });
+
+  test('leaves a path with a single-element group unchanged (not a real alternation)', () => {
+    assert.deepEqual(expandBraceGroup('a/{en}.json'), ['a/{en}.json']);
+  });
+
+  test('leaves a path with more than one brace group unchanged rather than guessing', () => {
+    assert.deepEqual(expandBraceGroup('a/{en,ru}/{v1,v2}.json'), ['a/{en,ru}/{v1,v2}.json']);
+  });
+
+  test('leaves an unclosed brace unchanged', () => {
+    assert.deepEqual(expandBraceGroup('a/{en,ru.json'), ['a/{en,ru.json']);
   });
 });
 
@@ -121,6 +152,29 @@ describe('extractDeclaredPaths', () => {
       '**Blocking prerequisites:** none',
     ].join('\n');
     assert.deepEqual(extractDeclaredPaths(spec), ['packages/a/one.ts', 'packages/a/two.ts']);
+  });
+
+  test('expands a brace-alternation path into its concrete files (issue #227)', () => {
+    // Real shape from docs/specs/0227-*.md: one bullet declaring an i18n
+    // edit across three locale files via `{en,ru,kk}.json` shorthand. Before
+    // expandBraceGroup, this returned the literal unexpanded string as a
+    // single "path" - check-impl-scope.mjs then flagged the three real files
+    // the model correctly wrote as undeclared, and the literal brace string
+    // as declared-but-never-written, failing a scaffold that was right.
+    const spec = [
+      '**Files touched:**',
+      '',
+      '- `apps/admin/src/components/bug-reports/similar-bugs-widget.tsx`',
+      '- `apps/admin/src/i18n/locales/{en,ru,kk}.json` — add `intelligence.duplicateDetails.{title,score}` keys.',
+      '',
+      '**Blocking prerequisites:** none',
+    ].join('\n');
+    assert.deepEqual(extractDeclaredPaths(spec), [
+      'apps/admin/src/components/bug-reports/similar-bugs-widget.tsx',
+      'apps/admin/src/i18n/locales/en.json',
+      'apps/admin/src/i18n/locales/ru.json',
+      'apps/admin/src/i18n/locales/kk.json',
+    ]);
   });
 });
 

--- a/scripts/ai-sdlc/verify-spec-ownership.test.mjs
+++ b/scripts/ai-sdlc/verify-spec-ownership.test.mjs
@@ -69,6 +69,15 @@ describe('expandBraceGroup', () => {
   test('leaves an unclosed brace unchanged', () => {
     assert.deepEqual(expandBraceGroup('a/{en,ru.json'), ['a/{en,ru.json']);
   });
+
+  test('leaves a nested brace group unchanged rather than emitting malformed paths', () => {
+    // Regression: the first `}` in a nested group like {en,{ru,kk}} is the
+    // INNER close, so a second-group check that only looked *after* that
+    // close missed the nested `{` sitting between open and close, sliced
+    // "en,{ru,kk" as if it were flat, and emitted garbled paths like
+    // "a/en}.json" and "a/{ru}.json" instead of failing closed.
+    assert.deepEqual(expandBraceGroup('a/{en,{ru,kk}}.json'), ['a/{en,{ru,kk}}.json']);
+  });
 });
 
 describe('extractDeclaredPaths', () => {


### PR DESCRIPTION
The impl-agent retry for #227 finished successfully (no timeout, ~9.5min) and correctly wrote three separate locale files for the spec's \`apps/admin/src/i18n/locales/{en,ru,kk}.json\` bullet - but \`extractDeclaredPaths\` returned that brace-alternation shorthand as one unexpanded literal path. \`check-impl-scope.mjs\` then compared it byte-for-byte against the three real files and failed a scaffold that was actually correct.

\`extractDeclaredPaths\` now expands a single \`{a,b,c}\` group into its N concrete paths wherever it appears, so \`generate-impl.mjs\`'s prompt context and the deterministic scope check agree on what the spec declared. Verified against the exact failed run's file list - passes now.

Refs #227