### PR TITLE
fix(ai-sdlc): use a real PAT for pipeline-advance's label edit

### DIFF
--- a/.github/workflows/pipeline-advance.yml
+++ b/.github/workflows/pipeline-advance.yml
@@ -96,10 +96,25 @@ jobs:
           ADR_FIELD: ${{ steps.adr_field.outputs.value }}
         run: node scripts/ai-sdlc/advance-gate.mjs decide
 
+      # GH_TOKEN here is deliberately NOT github.token. GitHub does not fire
+      # downstream workflow runs for events produced by the default
+      # GITHUB_TOKEN (its documented anti-recursion rule) - pull_request is
+      # explicitly exempted (so CI still runs on these agents' own PRs), but
+      # `issues.labeled` is not. Confirmed empirically on issue #337
+      # (2026-08-15): this step relabeled needs-spec -> agent-working as
+      # github-actions[bot] via github.token, the label event recorded
+      # correctly in the issue timeline, and impl-agent.yml still never
+      # fired - only a second, human-driven relabel triggered it. Using a
+      # real PAT here makes the label edit look like a normal user action,
+      # which does trigger agent-working's impl-agent.yml (and needs-adr's
+      # adr-agent.yml). METRICS_REPO_TOKEN is reused rather than minting a
+      # new secret: it's already a classic PAT (not repo-restricted like a
+      # fine-grained one) with `repo` scope, so it already has write access
+      # here too - see record-metrics.yml for its original purpose.
       - name: Advance the label
         if: steps.decide.outputs.action == 'advance'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
           ISSUE_NUMBER: ${{ steps.decide.outputs.issue_number }}
           FROM_LABELS: ${{ steps.decide.outputs.from_labels }}
           TO_LABEL: ${{ steps.decide.outputs.to_label }}


### PR DESCRIPTION
GitHub does not fire downstream workflow runs for events produced by the default \`GITHUB_TOKEN\` - \`pull_request\` is explicitly exempted (so CI still runs on these agents' own PRs), but \`issues.labeled\` is not. Confirmed empirically on issue #337: \`pipeline-advance.yml\` relabeled \`needs-spec\` -> \`agent-working\` as \`github-actions[bot]\` via \`github.token\`, the label event recorded correctly in the issue timeline (verified via the issue events API), but \`impl-agent.yml\` never fired - only a second, human-driven relabel triggered it.

Reuses \`METRICS_REPO_TOKEN\` rather than minting a new secret: it's already a classic PAT (not repo-restricted like a fine-grained one) with \`repo\` scope, so it already has write access here too.

Refs #337