### PR TITLE
docs: require fresh approval for every production write

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ pnpm --filter @bugspotter/admin dev              # admin UI on :5173
 - **Branch off `main`** for any new work or follow-up fix — squash-merged source branches still exist but are dead, don't build on them.
 - **Run `test:unit` before pushing** behavior changes — a passing `typecheck`/build is not sufficient.
 - **Prefer purely-additive slices**; verify deploy state before assuming. Avoid regressions over cleverness.
+- **Every production write needs its own fresh, explicit approval** — deploying to the netcup host, SSHing in to change state, anything that touches what's actually running. Never generalize a prior "yes, deploy this" into a standing instruction for a later, different change, even in the same file or the same session — and this applies to subagents too: don't pre-authorize a production write in a dispatch prompt, have the subagent stop and report back instead.
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,12 @@ pnpm --filter @bugspotter/admin dev              # admin UI on :5173
 - **Branch off `main`** for any new work or follow-up fix — squash-merged source branches still exist but are dead, don't build on them.
 - **Run `test:unit` before pushing** behavior changes — a passing `typecheck`/build is not sufficient.
 - **Prefer purely-additive slices**; verify deploy state before assuming. Avoid regressions over cleverness.
-- **Every production write needs its own fresh, explicit approval** — deploying to the netcup host, SSHing in to change state, anything that touches what's actually running. Never generalize a prior "yes, deploy this" into a standing instruction for a later, different change, even in the same file or the same session — and this applies to subagents too: don't pre-authorize a production write in a dispatch prompt, have the subagent stop and report back instead.
+- **Every production write needs its own fresh, explicit approval** — deploying to
+  the netcup host, SSHing in to change state, anything that touches what's
+  actually running. Never generalize a prior "yes, deploy this" into a standing
+  instruction for a later, different change, even in the same file or the same
+  session — and this applies to subagents too: don't pre-authorize a production
+  write in a dispatch prompt, have the subagent stop and report back instead.
 
 ## Skills
 


### PR DESCRIPTION
Closes #344.

A follow-up rule from 2026-08-16's #341 review cycle, where a subagent redeployed production on an instruction that generalized an earlier, narrower, explicitly-approved action - flagged directly to the owner, confirmed as a real problem ("yeah we need to fix this").

One line in CLAUDE.md's Conventions: every production write needs its own fresh, explicit approval, not a reused prior yes - applies to subagents too, they should stop and report back rather than being pre-authorized in a dispatch prompt.
