### PR TITLE
fix(ci): allow claude-review.yml to run on github-actions[bot] PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -156,6 +156,23 @@ jobs:
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
         with:
+          # Every PR this workflow needs to review that's opened by
+          # spec-agent.yml/adr-agent.yml/impl-agent.yml is authored by
+          # github-actions[bot] (gh pr create under github.token). The action
+          # refuses to run for ANY bot actor by default - "Workflow initiated
+          # by non-human actor... Add bot to allowed_bots list" - which meant
+          # this review had silently never run on a single bot-authored PR
+          # since this workflow was introduced (#346). CodeRabbit/Copilot
+          # aren't gated by this (separate Apps), so bot PRs still got some
+          # review; this repo's own tuned reviewer just wasn't contributing
+          # to exactly the PRs it matters most for.
+          #
+          # Deliberately the specific login, not '*' - the action's own
+          # security doc warns a public repo with '*' lets any external App
+          # invoke this action with an attacker-controlled prompt. This repo
+          # is private today, but naming the one actor that actually needs
+          # this is also just correct, not merely cautious.
+          allowed_bots: 'github-actions[bot]'
           # Only pass the OAuth token. The action does NOT arbitrate between
           # anthropic_api_key and claude_code_oauth_token when both are set -
           # it maps both straight into env vars unconditionally, and the


### PR DESCRIPTION
Closes #346.

Every spec/adr/impl-agent PR is authored by `github-actions[bot]` (`gh pr create` under `github.token`). `anthropics/claude-code-action@v1` refuses to run for any bot actor by default, so this reviewer had silently never run on a single bot-authored PR since the workflow was introduced (2026-08-08) - confirmed against the action's own source (`anthropics/claude-code-action`: `action.yml`, `docs/security.md`, `docs/usage.md`) and empirically on PR #345, where the step exits immediately with `Workflow initiated by non-human actor: github-actions (type: Bot)`.

CodeRabbit/Copilot are separate GitHub Apps, not gated by this - they kept reviewing bot PRs the whole time, so this wasn't a silent zero-review gap, just a missing layer on exactly the PRs it matters most for. Not a required branch-protection check either, so it never blocked merges - purely reduced coverage with no visible signal anything was skipped.

Fix: `allowed_bots: 'github-actions[bot]'` on the review step. Scoped to the exact login, not `'*'` - the action's own security doc warns a public repo with `'*'` lets any external App invoke it with an attacker-controlled prompt; this repo is private today, but naming the one actor that actually needs this is also just correct, not merely cautious.

`actionlint` clean. Full backend unit suite (3120 tests) passed via the pre-push hook (one transient failure on the first attempt, reran clean - unrelated pre-existing flake, not caused by this change).
