### PR TITLE
fix(ai-sdlc): surface the model's visible text on CLI timeout, not just raw bytes

### DIFF
--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -289,7 +289,16 @@ export function formatCliProgress({
       visibleText.length > visibleTextTailChars
         ? `…${visibleText.slice(-visibleTextTailChars)}`
         : visibleText;
-    line += `, last text: "${snippet.replace(/\s+/g, ' ').trim()}"`;
+    // JSON.stringify, not manual `"${...}"` interpolation: real transcripts
+    // (#353, 2026-08-18) show the model's "text" blocks routinely contain
+    // literal `"` (e.g. embedded `<invoke name="Bash">`-style content, since
+    // --tools= makes it narrate tool calls as plain text instead of issuing
+    // real tool_use blocks) - a raw quote inside a manually `"..."`-wrapped
+    // snippet visually closes the string early and makes the log line look
+    // truncated/corrupted even though nothing was lost. JSON.stringify
+    // escapes embedded quotes/backslashes/control chars correctly and still
+    // reads as a quoted string.
+    line += `, last text: ${JSON.stringify(snippet.replace(/\s+/g, ' ').trim())}`;
   }
   return line;
 }

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -184,6 +184,7 @@ export function formatCliTimeout({
   stderr = '',
   tailChars = 1500,
   thinkingTokens = null,
+  visibleText = null,
 }) {
   // Keep this exact prefix: it is the string the run logs have been
   // identified by across every timeout so far.
@@ -214,6 +215,25 @@ export function formatCliTimeout({
     message +=
       `\n  last known thinking-token count: ~${thinkingTokens} ` +
       `(thinking progress was observed before termination)`;
+  }
+
+  // The raw stdout tail below is the NDJSON wire format - mostly field names,
+  // event envelopes, and (for thinking blocks) a base64 signature, not
+  // anything a human reads quickly. `visibleText` is the model's own most
+  // recently seen text content block, extracted as it streams (see
+  // consumeLine's assistant-event branch) - the one thing that actually let
+  // a human spot a real failure shape once: three consecutive #353
+  // spec-agent timeouts (2026-08-18) all showed the model narrating the same
+  // intention on repeat ("I'll read the relevant source files... Let me read
+  // the key files... Let me read the relevant source files...") before being
+  // killed, a qualitatively different shape than every prior timeout this
+  // pipeline had hit, and invisible in the raw tail alone - finding it took
+  // manually downloading the transcript artifact and parsing it by hand.
+  if (visibleText) {
+    const clipped = visibleText.length > tailChars;
+    message +=
+      `\n  last visible assistant text${clipped ? ` (last ${tailChars} chars of ${visibleText.length})` : ''}:\n` +
+      (clipped ? visibleText.slice(-tailChars) : visibleText);
   }
 
   if (stdoutBytes === 0 && stderrBytes === 0) {
@@ -247,11 +267,31 @@ export function formatCliTimeout({
 // thinking_tokens event, if any have arrived yet) adds the one signal that
 // distinguishes "extended thinking, genuinely still working" from every
 // other kind of silence.
-export function formatCliProgress({ elapsedMs, stdoutBytes, stderrBytes, thinkingTokens = null }) {
+export function formatCliProgress({
+  elapsedMs,
+  stdoutBytes,
+  stderrBytes,
+  thinkingTokens = null,
+  visibleText = null,
+  visibleTextTailChars = 120,
+}) {
   const base =
     `claude CLI: still running after ${Math.round(elapsedMs / 1000)}s ` +
     `(stdout ${stdoutBytes}B, stderr ${stderrBytes}B)`;
-  return thinkingTokens === null ? base : `${base}, ~${thinkingTokens} thinking tokens so far`;
+  let line = thinkingTokens === null ? base : `${base}, ~${thinkingTokens} thinking tokens so far`;
+  // A short live snippet of the model's own most recent visible text, so a
+  // human watching the run (or reading the log after the fact, before ever
+  // touching the transcript artifact) can see AT A GLANCE whether it's
+  // producing new spec content or repeating itself - the second is a real,
+  // observed failure shape (#353, 2026-08-18), not a hypothetical.
+  if (visibleText) {
+    const snippet =
+      visibleText.length > visibleTextTailChars
+        ? `…${visibleText.slice(-visibleTextTailChars)}`
+        : visibleText;
+    line += `, last text: "${snippet.replace(/\s+/g, ' ').trim()}"`;
+  }
+  return line;
 }
 
 // Bounds a raw stdout/stderr dump before it lands in a thrown Error message.
@@ -372,6 +412,17 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     // the one number that distinguishes "still working" from "wedged" while
     // a call is in flight or right up to the moment it's killed.
     let lastThinkingTokens = null;
+    // The model's own most recently seen visible text content block, kept
+    // as a single overwritten snapshot (not appended/accumulated) — under
+    // stream-json, an assistant event's content block already carries the
+    // block's own text as known so far, so keeping only the latest one
+    // avoids both unbounded growth and double-counting, whether the CLI is
+    // emitting growing partial blocks or one event per completed block.
+    // Exists specifically so a timeout or heartbeat can show what the model
+    // was actually writing, not just how many bytes arrived - see
+    // formatCliTimeout's own comment for the failure this was built to
+    // stop requiring manual transcript archaeology to diagnose.
+    let latestVisibleText = null;
     const startedAt = Date.now();
 
     function consumeLine(line) {
@@ -395,6 +446,12 @@ async function callViaCli({ prompt, timeoutMs, model }) {
         lastThinkingTokens = evt.estimated_tokens;
       } else if (evt?.type === 'result') {
         resultEvent = evt;
+      } else if (evt?.type === 'assistant' && Array.isArray(evt.message?.content)) {
+        for (const block of evt.message.content) {
+          if (block?.type === 'text' && typeof block.text === 'string' && block.text.trim()) {
+            latestVisibleText = block.text;
+          }
+        }
       }
     }
 
@@ -407,6 +464,7 @@ async function callViaCli({ prompt, timeoutMs, model }) {
           stdoutBytes: Buffer.byteLength(stdout, 'utf8'),
           stderrBytes: Buffer.byteLength(stderr, 'utf8'),
           thinkingTokens: lastThinkingTokens,
+          visibleText: latestVisibleText,
         })
       );
     }, CLI_HEARTBEAT_MS);
@@ -424,6 +482,7 @@ async function callViaCli({ prompt, timeoutMs, model }) {
             stdout,
             stderr,
             thinkingTokens: lastThinkingTokens,
+            visibleText: latestVisibleText,
           })
         )
       );

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -489,14 +489,6 @@ async function callViaCli({ prompt, timeoutMs, model }) {
       // showed, tens of KB per block). Without this, thinkingTokens/
       // latestVisibleText below would be systematically one event stale at
       // the worst possible moment: the instant of the kill itself.
-      // Mirrors the close handler below: a complete NDJSON record can be
-      // sitting in lineBuf without its trailing newline yet (the child's
-      // last stdout chunk before the kill need not end on a line boundary -
-      // more likely than it sounds for a large text block arriving across
-      // several 'data' events, exactly the shape #353's real transcripts
-      // showed, tens of KB per block). Without this, thinkingTokens/
-      // latestVisibleText below would be systematically one event stale at
-      // the worst possible moment: the instant of the kill itself.
       if (lineBuf.trim()) {
         consumeLine(lineBuf);
       }

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -481,6 +481,25 @@ async function callViaCli({ prompt, timeoutMs, model }) {
 
     const timer = setTimeout(() => {
       clearInterval(heartbeat);
+      // Mirrors the close handler below: a complete NDJSON record can be
+      // sitting in lineBuf without its trailing newline yet (the child's
+      // last stdout chunk before the kill need not end on a line boundary -
+      // more likely than it sounds for a large text block arriving across
+      // several 'data' events, exactly the shape #353's real transcripts
+      // showed, tens of KB per block). Without this, thinkingTokens/
+      // latestVisibleText below would be systematically one event stale at
+      // the worst possible moment: the instant of the kill itself.
+      // Mirrors the close handler below: a complete NDJSON record can be
+      // sitting in lineBuf without its trailing newline yet (the child's
+      // last stdout chunk before the kill need not end on a line boundary -
+      // more likely than it sounds for a large text block arriving across
+      // several 'data' events, exactly the shape #353's real transcripts
+      // showed, tens of KB per block). Without this, thinkingTokens/
+      // latestVisibleText below would be systematically one event stale at
+      // the worst possible moment: the instant of the kill itself.
+      if (lineBuf.trim()) {
+        consumeLine(lineBuf);
+      }
       child.kill('SIGKILL');
       dumpCliTranscriptOnFailure(stdout, stderr);
       reject(

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -337,6 +337,27 @@ test('formatCliProgress omits the visible-text field entirely when none was seen
   assert.doesNotMatch(line, /last text/);
 });
 
+test('formatCliProgress safely escapes a visible-text snippet that itself contains double quotes', () => {
+  // Real transcripts (#353, 2026-08-18 timeouts) show the model's "text"
+  // content routinely contains literal `"` - e.g. `<invoke name="Bash">` -
+  // since --tools= makes it narrate would-be tool calls as plain text
+  // instead of issuing real tool_use blocks. A naive `"${snippet}"` wrap
+  // would let that embedded quote visually close the string early.
+  const line = formatCliProgress({
+    elapsedMs: 60_000,
+    stdoutBytes: 500,
+    stderrBytes: 0,
+    visibleText: '<invoke name="Bash"><parameter name="command">echo hi</parameter></invoke>',
+  });
+
+  // The embedded quotes must come through escaped, not as a bare `"` that
+  // prematurely ends the `last text: "..."` quoting.
+  assert.match(line, /last text: "<invoke name=\\"Bash\\">/);
+  // The line must still end with a single closing quote for the whole
+  // snippet, not one left dangling mid-string by an unescaped `"`.
+  assert.ok(line.endsWith('</invoke>"'), `expected a cleanly closed quoted string, got: ${line}`);
+});
+
 test('callViaCli timeout error carries what the child actually wrote before the kill', async () => {
   process.env.FAKE_CLAUDE_MODE = 'hang';
   process.env.FAKE_CLAUDE_ENV_DUMP = '';

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -58,6 +58,21 @@ writeFileSync(
     '  setTimeout(function () { process.exit(0); }, 5000);',
     '  return;',
     '}',
+    // Same as 'hang', except the final assistant event is a genuinely
+    // *complete* NDJSON record that simply has not been followed by its
+    // trailing newline yet when the kill fires - a real, plausible shape
+    // for a large content block (the #353 transcripts this PR was built
+    // around had single text blocks up to ~77KB, arriving across several
+    // stdout chunks) whose closing '\\n' just hasn't landed by the time the
+    // timeout timer fires. consumeLine only runs on '\\n'-delimited slices
+    // as data arrives, so this line is deliberately left sitting in
+    // callViaCli's internal lineBuf, unconsumed, unless the timeout path
+    // flushes it the same way the close handler already does.
+    "if (mode === 'hang_no_trailing_newline') {",
+    "  process.stdout.write(JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'FAKE_UNFLUSHED_TEXT: no trailing newline yet' }] } }));",
+    '  setTimeout(function () { process.exit(0); }, 5000);',
+    '  return;',
+    '}',
     "if (mode === 'error') {",
     "  process.stdout.write('FAKE_STDOUT_MARKER: upstream billing failure detail');",
     '  process.exit(2);',
@@ -382,6 +397,28 @@ test('callViaCli timeout error carries what the child actually wrote before the 
     assert.match(err.message, /last visible assistant text/);
     assert.match(err.message, /FAKE_VISIBLE_TEXT: drafting the spec/);
     assert.doesNotMatch(err.message, /wrote nothing at all/);
+    return true;
+  });
+});
+
+test('callViaCli flushes a complete-but-not-yet-newline-terminated NDJSON record before timing out', async () => {
+  // CodeRabbit finding on PR #361: the close handler flushes a trailing
+  // unterminated line from lineBuf (`if (lineBuf.trim()) consumeLine(lineBuf)`)
+  // but, before this fix, the timeout path did not - it killed the child
+  // and built the error straight from lastThinkingTokens/latestVisibleText
+  // as last updated by the 'data' handler, silently dropping any complete
+  // record still sitting in lineBuf without its trailing '\n'. That is a
+  // real, plausible race for a large content block (real #353 transcripts
+  // had single text blocks up to ~77KB spanning several stdout chunks)
+  // whose closing newline just hasn't arrived by the moment the timer
+  // fires - exactly the case this diagnostic exists to cover.
+  process.env.FAKE_CLAUDE_MODE = 'hang_no_trailing_newline';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+
+  await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 2500 }), (err) => {
+    assert.match(err.message, /claude CLI timed out after 2500ms/);
+    assert.match(err.message, /last visible assistant text/);
+    assert.match(err.message, /FAKE_UNFLUSHED_TEXT: no trailing newline yet/);
     return true;
   });
 });

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -52,6 +52,7 @@ writeFileSync(
     // function.
     "if (mode === 'hang') {",
     "  process.stdout.write(JSON.stringify({ type: 'system', subtype: 'thinking_tokens', estimated_tokens: 42 }) + '\\n');",
+    "  process.stdout.write(JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'FAKE_VISIBLE_TEXT: drafting the spec' }] } }) + '\\n');",
     "  process.stdout.write('PARTIAL_ENVELOPE_MARKER');",
     "  process.stderr.write('FAKE_STDERR_PROGRESS');",
     '  setTimeout(function () { process.exit(0); }, 5000);',
@@ -263,6 +264,79 @@ test('formatCliTimeout omits the thinking-token line when none arrived', () => {
   assert.doesNotMatch(message, /thinking-token count/);
 });
 
+test('formatCliTimeout includes the visible-text tail, separate from the raw stdout tail', () => {
+  const message = formatCliTimeout({
+    timeoutMs: 420_000,
+    elapsedMs: 420_030,
+    stdout:
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"I will read the files."}]}}\n',
+    visibleText: 'I will read the files.',
+  });
+
+  assert.match(message, /last visible assistant text/);
+  assert.match(message, /I will read the files\./);
+  // Must appear as its own labeled section, not just incidentally present
+  // because it also happens to be inside the raw stdout tail.
+  assert.match(message, /last visible assistant text[\s\S]*I will read the files\./);
+});
+
+test('formatCliTimeout omits the visible-text section when nothing was extracted', () => {
+  const message = formatCliTimeout({ timeoutMs: 780_000, elapsedMs: 780_050, stdout: 'raw bytes' });
+  assert.doesNotMatch(message, /last visible assistant text/);
+});
+
+test('formatCliTimeout clips the visible-text tail independently of the raw stdout tail length', () => {
+  const longText = 'y'.repeat(5000);
+  const message = formatCliTimeout({
+    timeoutMs: 5000,
+    stdout: 'short',
+    visibleText: longText,
+    tailChars: 100,
+  });
+
+  assert.match(message, /last visible assistant text \(last 100 chars of 5000\)/);
+  assert.ok(
+    !message.includes(longText),
+    'the full 5000-char text must not appear verbatim, only its clipped tail'
+  );
+});
+
+test('formatCliProgress includes a short visible-text snippet when known', () => {
+  const line = formatCliProgress({
+    elapsedMs: 60_000,
+    stdoutBytes: 500,
+    stderrBytes: 0,
+    visibleText: 'I will read the relevant source files before drafting the spec.',
+  });
+
+  assert.match(
+    line,
+    /last text: "I will read the relevant source files before drafting the spec\."/
+  );
+});
+
+test('formatCliProgress clips a long visible-text snippet to a short tail', () => {
+  const longText = `${'a'.repeat(200)}TAIL_MARKER`;
+  const line = formatCliProgress({
+    elapsedMs: 60_000,
+    stdoutBytes: 500,
+    stderrBytes: 0,
+    visibleText: longText,
+    visibleTextTailChars: 20,
+  });
+
+  assert.match(line, /last text: "…\w*TAIL_MARKER"/);
+  assert.ok(
+    !line.includes('a'.repeat(50)),
+    'expected the snippet clipped, not the full 200-char run'
+  );
+});
+
+test('formatCliProgress omits the visible-text field entirely when none was seen yet', () => {
+  const line = formatCliProgress({ elapsedMs: 60_000, stdoutBytes: 0, stderrBytes: 0 });
+  assert.doesNotMatch(line, /last text/);
+});
+
 test('callViaCli timeout error carries what the child actually wrote before the kill', async () => {
   process.env.FAKE_CLAUDE_MODE = 'hang';
   process.env.FAKE_CLAUDE_ENV_DUMP = '';
@@ -278,6 +352,14 @@ test('callViaCli timeout error carries what the child actually wrote before the 
     assert.match(err.message, /received: stdout \d+B, stderr \d+B/);
     assert.match(err.message, /PARTIAL_ENVELOPE_MARKER/);
     assert.match(err.message, /last known thinking-token count: ~42/);
+    // Proves callViaCli's own consumeLine (not just formatCliTimeout in
+    // isolation) actually parses the assistant event's text content block
+    // out of the real NDJSON stream and carries it through to the
+    // rejection - the whole point of this addition, since the raw stdout
+    // tail alone (PARTIAL_ENVELOPE_MARKER, asserted above) is not
+    // human-readable prose.
+    assert.match(err.message, /last visible assistant text/);
+    assert.match(err.message, /FAKE_VISIBLE_TEXT: drafting the spec/);
     assert.doesNotMatch(err.message, /wrote nothing at all/);
     return true;
   });


### PR DESCRIPTION
Refs #360.

A repeated-narration timeout on #353's spec generation (three consecutive failures, unprecedented for this pipeline) could only be diagnosed by manually downloading the CLI transcript artifact and parsing it by hand - the existing timeout error's stdout tail is the raw NDJSON wire format (field names, event envelopes, base64 thinking-block signatures), not readable prose.

Extracts the model's own most recently seen text content block as it streams (mirroring how thinking-token counts are already tracked) and surfaces it in both the heartbeat log (a short live snippet, visible while a run is still in flight) and the timeout error message (a longer tail, clearly labeled and separate from the raw stdout tail). Verified end-to-end against the real `callViaCli` path, not just the pure formatters, via the existing fake-CLI test harness.

`node --test scripts/ai-sdlc/llm-client.test.mjs`: 33/33 pass. Full backend unit suite: 126 files / 3126 tests pass.
