### PR TITLE
fix(ai-sdlc): raise generate-spec's CLI timeout from 420s to 450s

### DIFF
--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Generate spec
         id: gen
-        # 8m > generate-spec.mjs's own 420s (7m) LLM timeout, so the script's
-        # error message wins over a silent step kill.
+        # 8m > generate-spec.mjs's own 450s (7.5m) LLM timeout, so the
+        # script's error message wins over a silent step kill.
         timeout-minutes: 8
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -33,9 +33,9 @@ jobs:
     name: Draft spec
     if: github.event.label.name == 'needs-spec'
     runs-on: ubuntu-latest
-    # 22m. This job makes TWO sequential LLM calls - generate-spec.mjs (420s)
-    # and verify-spec.mjs (420s) - so the job cap has to contain 840s of model
-    # budget plus setup. At 15m (900s) it did not: worst case was ~840s of LLM
+    # 22m. This job makes TWO sequential LLM calls - generate-spec.mjs (450s)
+    # and verify-spec.mjs (420s) - so the job cap has to contain 870s of model
+    # budget plus setup. At 15m (900s) it did not: worst case was ~870s of LLM
     # plus checkout, setup-node, `npm install -g @anthropic-ai/claude-code`,
     # prettier, git push and two `gh` calls. The failure mode was the worst
     # available - GitHub cancels the job mid-call, so a spec that generate-spec

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -163,21 +163,25 @@ Rules:
 
 let specContent;
 try {
-  // 420s, matching verify-spec.mjs. 180_000 was set when this prompt was
-  // just TEMPLATE.md + the issue body; it has grown a lot since and the
-  // budget was never revisited: PR #240 added the BFS source-tree scanner
-  // and PR #260 added the ~10KB ADR index. Two independent reasons the old
-  // number was wrong:
-  //   1. verify-spec.mjs measured 283.9s for a comparable call on the CLI
-  //      backend and set 420s off that. 180s was below an already-measured
-  //      duration for similar work.
-  //   2. It failed in practice - run 30752527569 (issue #269) died at
-  //      exactly 180000ms having produced nothing.
-  // spec-agent.yml caps this step at 8m, above this 420s, so the error above
-  // wins over a silent step kill. Note the job also runs verify-spec.mjs
-  // (another 420s), so raising either number means re-checking that job's
-  // 22m cap still contains both plus setup - see that file's comments.
-  ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 420_000 }));
+  // 450s. Was 420s (originally raised from 180_000, matching
+  // verify-spec.mjs's own measured 283.9s for comparable work) - but that
+  // number was itself never revisited after the prompt grew twice more
+  // since (PR #240's BFS source-tree scanner, PR #260's ~10KB ADR index,
+  // which grew again 2026-08-16 when a new ADR era table was added to
+  // docs/adr/README.md). Issue #360 (2026-08-18): three consecutive
+  // identical 420s timeouts on issue #353's spec, each killed while still
+  // actively producing output - not #269's kind of failure (180s below an
+  // already-measured duration), a genuinely larger/harder task than this
+  // number has ever been checked against. spec-agent.yml's own step cap is
+  // 480s; 450s keeps a 30s buffer under it so this timeout's own error
+  // message still wins over GitHub's silent step kill, same reasoning as
+  // the original 420s-under-the-old-480s-cap gap, just narrower - there is
+  // no more headroom to give without also raising the workflow's own step
+  // and job caps, which is a bigger change #360 leaves open if this still
+  // isn't enough. Note the job also runs verify-spec.mjs (its own 420s,
+  // unchanged), so raising either further means re-checking the job's 22m
+  // cap still contains both plus setup - see that file's comments.
+  ({ text: specContent } = await callClaude({ prompt, maxTokens: 4096, timeoutMs: 450_000 }));
 } catch (err) {
   console.error(err.message);
   process.exit(1);


### PR DESCRIPTION
Refs #360.

Three consecutive identical 420s timeouts on issue #353's spec, each killed while still actively producing output - genuinely different from every prior timeout this pipeline has hit (all pure variance, resolved on retry). The 420s number was itself never revisited since being set against a different script's measured duration, and the prompt has grown twice since (the source-tree scanner, the ADR index - which grew again this session).

450s uses the currently-idle headroom under the step's own 480s cap - zero workflow-file changes - keeping a 30s buffer so this timeout's own error message still wins over GitHub's silent step kill, same reasoning the original 420s-under-480s gap already used.

Not claimed to fully resolve #360 - retrying #353 next with #361's new visible-text diagnostics live, so a fourth failure (if it happens) will be far more informative than the first three were.
