### PR TITLE
fix(ai-sdlc): advance-gate skips needs-adr when the spec's ADR field is already ratified

### DIFF
--- a/.github/workflows/pipeline-advance.yml
+++ b/.github/workflows/pipeline-advance.yml
@@ -79,10 +79,14 @@ jobs:
           # docs/adr/NNNN-slug.md path that both exists AND is marked
           # Accepted counts - "pending" and made-up text still fall through
           # to needs-adr, and a Proposed/Draft ADR still needs its own gate.
+          # Matches "- Status: Accepted" whether or not it carries a trailing
+          # parenthetical (e.g. ADR-0010's "Accepted (legacy deprecation in
+          # progress)") - \b keeps it from also matching a different status
+          # that merely starts with "Accepted" as a word-fragment.
           RATIFIED="false"
           if [[ "$VALUE" =~ ^docs/adr/[0-9]{4}-[A-Za-z0-9._-]+\.md$ ]] \
             && [ -f "$VALUE" ] \
-            && grep -qm1 -E '^- Status: Accepted$' "$VALUE"; then
+            && grep -qm1 -E '^- Status: Accepted\b' "$VALUE"; then
             RATIFIED="true"
           fi
           echo "ratified=$RATIFIED" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pipeline-advance.yml
+++ b/.github/workflows/pipeline-advance.yml
@@ -71,6 +71,22 @@ jobs:
           fi
           echo "value=$VALUE" >> "$GITHUB_OUTPUT"
 
+          # #359: a spec's ADR field pointing at an already-ratified ADR (e.g.
+          # a child issue split off a decision ADR-0044 already settled) used
+          # to route to needs-adr just the same as "pending" or free text
+          # would - firing adr-agent.yml to draft a redundant ADR nobody
+          # asked for (hit for real on #352, PR #357/ADR-0045). Only an exact
+          # docs/adr/NNNN-slug.md path that both exists AND is marked
+          # Accepted counts - "pending" and made-up text still fall through
+          # to needs-adr, and a Proposed/Draft ADR still needs its own gate.
+          RATIFIED="false"
+          if [[ "$VALUE" =~ ^docs/adr/[0-9]{4}-[A-Za-z0-9._-]+\.md$ ]] \
+            && [ -f "$VALUE" ] \
+            && grep -qm1 -E '^- Status: Accepted$' "$VALUE"; then
+            RATIFIED="true"
+          fi
+          echo "ratified=$RATIFIED" >> "$GITHUB_OUTPUT"
+
       - name: Fetch the issue's current labels
         id: current_labels
         if: steps.resolve.outputs.issue_number != ''
@@ -94,6 +110,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           ISSUE_LABELS_JSON: ${{ steps.current_labels.outputs.json }}
           ADR_FIELD: ${{ steps.adr_field.outputs.value }}
+          ADR_ALREADY_RATIFIED: ${{ steps.adr_field.outputs.ratified }}
         run: node scripts/ai-sdlc/advance-gate.mjs decide
 
       # GH_TOKEN here is deliberately NOT github.token. GitHub does not fire

--- a/scripts/ai-sdlc/advance-gate.mjs
+++ b/scripts/ai-sdlc/advance-gate.mjs
@@ -12,7 +12,10 @@
 //   spec/  merge -> needs-adr, OR agent-working directly if the spec itself
 //          declares no ADR is warranted (its own "ADR: n/a" line - a field
 //          a human/agent already set deliberately while drafting the spec,
-//          not a guess this script invents).
+//          not a guess this script invents), OR the field already names an
+//          existing, Accepted ADR (#359 - a spec split off an already-
+//          ratified decision, e.g. a child issue under ADR-0044, still needs
+//          agent-working, not a redundant new ADR draft).
 //   adr/   merge -> agent-working, always (the branch only exists when an
 //          ADR was drafted, so there is no other place for it to go).
 //   impl/  merge -> needs-deploy, always (Gate 3 IS the merge - see
@@ -119,10 +122,22 @@ export function readAdrField(specContent) {
  * @param {string[]} input.issueLabels - the issue's labels *right now*, so a
  *   label a person already changed by hand is respected rather than clobbered
  * @param {string|null} input.adrField - only meaningful for stage 'spec'
+ * @param {boolean} [input.adrAlreadyRatified] - true when adrField names a
+ *   docs/adr/NNNN-slug.md file that exists on disk with `Status: Accepted` -
+ *   the workflow checks this (it has main checked out already), not this
+ *   module, so the decision here stays a pure function of its inputs and
+ *   testable without touching the filesystem. Only meaningful for stage
+ *   'spec'.
  * @returns {{action: 'advance'|'skip', stage: string|null, issueNumber: number|null,
  *            fromLabels: string[], toLabel: string|null, reason: string}}
  */
-export function decideAdvance({ headRef, prBody, issueLabels = [], adrField = null }) {
+export function decideAdvance({
+  headRef,
+  prBody,
+  issueLabels = [],
+  adrField = null,
+  adrAlreadyRatified = false,
+}) {
   const { stage, issueNumber: branchIssueNumber } = parseStageAndBranchIssue(headRef);
 
   if (!stage) {
@@ -169,14 +184,17 @@ export function decideAdvance({ headRef, prBody, issueLabels = [], adrField = nu
         reason: 'could not read the ADR field from the merged spec file',
       };
     }
-    const toLabel = adrField.toLowerCase() === 'n/a' ? GATE_LABELS.agentWorking : GATE_LABELS.adr;
+    const noAdrNeeded = adrField.toLowerCase() === 'n/a' || adrAlreadyRatified;
+    const toLabel = noAdrNeeded ? GATE_LABELS.agentWorking : GATE_LABELS.adr;
     return {
       action: 'advance',
       stage,
       issueNumber,
       fromLabels: [GATE_LABELS.spec],
       toLabel,
-      reason: `spec merged; its ADR field reads "${adrField}"`,
+      reason: adrAlreadyRatified
+        ? `spec merged; its ADR field "${adrField}" already exists and is Accepted - no new ADR needed`
+        : `spec merged; its ADR field reads "${adrField}"`,
     };
   }
 
@@ -295,6 +313,7 @@ function main() {
     prBody,
     issueLabels,
     adrField: process.env.ADR_FIELD || null,
+    adrAlreadyRatified: process.env.ADR_ALREADY_RATIFIED === 'true',
   });
 
   console.log(`advance-gate decide: ${decision.action} (${decision.reason})`);

--- a/scripts/ai-sdlc/advance-gate.test.mjs
+++ b/scripts/ai-sdlc/advance-gate.test.mjs
@@ -89,6 +89,35 @@ test('treats an uppercase ADR: N/A the same as n/a', () => {
   assert.equal(d.toLabel, GATE_LABELS.agentWorking);
 });
 
+test('spec merge whose ADR field names an already-ratified ADR advances straight to agent-working (#359)', () => {
+  const d = decideAdvance({
+    headRef: 'spec/issue-353-sso-2-4-oidc-login-callback-path-',
+    prBody: 'Refs #353',
+    issueLabels: [GATE_LABELS.spec],
+    adrField: 'docs/adr/0044-sso-oidc-account-linking-and-tenant-boundary.md',
+    adrAlreadyRatified: true,
+  });
+  assert.equal(d.action, 'advance');
+  assert.equal(d.issueNumber, 353);
+  assert.deepEqual(d.fromLabels, [GATE_LABELS.spec]);
+  assert.equal(d.toLabel, GATE_LABELS.agentWorking);
+  assert.match(d.reason, /already exists and is Accepted/);
+});
+
+test('a spec ADR field naming a real path still routes to needs-adr when the workflow did not confirm it is ratified', () => {
+  // adrAlreadyRatified defaults to false - the workflow only sets it true
+  // after actually checking the file exists AND is Accepted, so a stale or
+  // mistaken path (or a Proposed/Draft ADR) still gets its own gate.
+  const d = decideAdvance({
+    headRef: 'spec/issue-354-sso-3-4-enforce-sso-guards-',
+    prBody: 'Refs #354',
+    issueLabels: [GATE_LABELS.spec],
+    adrField: 'docs/adr/0044-sso-oidc-account-linking-and-tenant-boundary.md',
+  });
+  assert.equal(d.action, 'advance');
+  assert.equal(d.toLabel, GATE_LABELS.adr);
+});
+
 test('spec merge with an ADR still pending advances to needs-adr', () => {
   const d = decideAdvance({
     headRef: 'spec/issue-226-intelligence-wire-per-org-similarity-thr',


### PR DESCRIPTION
Fixes #359.

A spec's `ADR:` field naming an existing, Accepted ADR used to route to `needs-adr` the same as "pending" or free text would - firing `adr-agent.yml` to draft a redundant ADR nobody asked for. Hit for real on #352 (PR #357/ADR-0045, closed by hand after the fact); would have recurred on #353's just-merged spec (PR #363, cites ADR-0044) without this fix.

`pipeline-advance.yml`'s existing "Read ADR field" step now also checks the field is an exact `docs/adr/NNNN-slug.md` path, that file exists, and it's marked `- Status: Accepted`, passing the result as `ADR_ALREADY_RATIFIED`. `decideAdvance` takes it as a plain boolean so the decision logic stays a pure, disk-free function - two new test cases cover both the ratified-skip and the not-yet-confirmed fallback.
