### PR TITLE
fix(ai-sdlc): raise generate-impl's CLI timeout from 780s to 1140s

### DIFF
--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -40,14 +40,15 @@ jobs:
     name: Generate implementation scaffold
     if: github.event.label.name == 'agent-working'
     runs-on: ubuntu-latest
-    # Must exceed the "Generate scaffold" step budget (18m) plus everything
+    # Must exceed the "Generate scaffold" step budget (21m) plus everything
     # around it, or a slow-but-successful generation gets killed after paying
     # for the model call. Measured on run 30149093922 (the last fully green
     # run): ~17s of setup before the step, ~64s for scope check + install +
     # build + prettier + eslint + commit/push (which runs the pre-push unit
-    # suite) + PR + comment after it. 18m + ~1.5m left no margin under a 20m
-    # cap; 25m leaves ~6m for a slower runner or a larger scaffold.
-    timeout-minutes: 25
+    # suite) + PR + comment after it, ~1.5m total. Raised 25m -> 28m alongside
+    # the step's 18m -> 21m (issue #365) to keep roughly the same ~5-6m
+    # margin this job has always carried, not let it thin out to nothing.
+    timeout-minutes: 28
 
     steps:
       - uses: actions/checkout@v4
@@ -86,11 +87,14 @@ jobs:
 
       - name: Generate scaffold
         id: gen
-        # 18m, under the job's 25m cap. Raised from 15m alongside
+        # 21m, under the job's 28m cap. Raised from 15m to 18m alongside
         # generate-impl.mjs's CLI timeout (600s -> 780s): a real run on
         # issue #237 took 9m08s and another timed out at exactly 10m, so the
-        # old budget had no useful margin.
-        timeout-minutes: 18
+        # old budget had no useful margin. Raised again 18m -> 21m alongside
+        # 780s -> 1140s (issue #365): three identical timeouts on issue #353,
+        # each killed mid-way through a second extended-thinking pass that
+        # never got room to finish.
+        timeout-minutes: 21
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -108,10 +112,14 @@ jobs:
           # failure (timeout, non-zero exit, malformed envelope) - never on
           # success. formatCliTimeout's own error message clips to 1500 chars
           # to keep this log readable, which is exactly what makes a real
-          # post-mortem impossible (2026-08-14, issue #227: a thinking-token
-          # count jump in the final 60s that the clipped tail alone couldn't
-          # explain). The "Upload CLI transcript on failure" step below
-          # attaches the full file as a build artifact.
+          # post-mortem impossible from the step log alone (2026-08-14, issue
+          # #227: a thinking-token count jump in the final 60s the clipped
+          # tail alone couldn't explain). The "Upload CLI transcript on
+          # failure" step below attaches the full file as a build artifact -
+          # issue #365 (2026-08-19) used exactly that artifact to explain
+          # #227's jump: it's Claude's extended-thinking signature field
+          # (100K+ chars, emitted atomically once a thinking block completes,
+          # not streamed), not a stall or a loop.
           AI_SDLC_CLI_TRANSCRIPT_PATH: ${{ github.workspace }}/cli-transcript-impl.log
         run: node scripts/ai-sdlc/generate-impl.mjs
 

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -385,7 +385,8 @@ try {
   // (548s) — a 9% margin. Raised to 780_000ms (13m), which still sits under
   // impl-agent.yml's "Generate scaffold" step timeout with room for node
   // startup and file I/O (that step's budget was raised to 18m in the same
-  // change, and the job cap to 25m so the post-generation steps still fit).
+  // change, and the job cap to 25m so the post-generation steps still fit -
+  // both raised again below, so read those as historical, not current).
   //
   // 780_000ms proved too thin too: issue #365 (2026-08-19), three identical
   // timeouts on issue #353's OIDC login/callback task, each killed still
@@ -394,8 +395,9 @@ try {
   // pass, then starting a SECOND one immediately after - all three runs were
   // killed partway through that second pass, having spent nearly the whole
   // budget on thinking twice without ever reaching real output. Raised to
-  // 1_140_000ms (19m) to give a second thinking pass of similar length room
-  // to actually finish, not just start. Not claimed to be enough - #365
+  // 1_140_000ms (19m) - and impl-agent.yml's step/job caps to 21m/28m, up
+  // from 18m/25m - to give a second thinking pass of similar length room to
+  // actually finish, not just start. Not claimed to be enough - #365
   // isn't closed, this is one measured step against it, same as #360/#362's
   // relationship for generate-spec.mjs's timeout.
   //

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -387,6 +387,18 @@ try {
   // startup and file I/O (that step's budget was raised to 18m in the same
   // change, and the job cap to 25m so the post-generation steps still fit).
   //
+  // 780_000ms proved too thin too: issue #365 (2026-08-19), three identical
+  // timeouts on issue #353's OIDC login/callback task, each killed still
+  // producing output. Hand-parsing the raw CLI transcript (see #365 for the
+  // full diagnosis) found the model doing one ~420-450s extended-thinking
+  // pass, then starting a SECOND one immediately after - all three runs were
+  // killed partway through that second pass, having spent nearly the whole
+  // budget on thinking twice without ever reaching real output. Raised to
+  // 1_140_000ms (19m) to give a second thinking pass of similar length room
+  // to actually finish, not just start. Not claimed to be enough - #365
+  // isn't closed, this is one measured step against it, same as #360/#362's
+  // relationship for generate-spec.mjs's timeout.
+  //
   // The deeper cost driver is the response schema: {path, content} means the
   // model re-emits every declared file IN FULL, so editing three ~500-line
   // files costs ~15K output tokens of mostly-unchanged text. A diff/patch-shaped
@@ -402,7 +414,7 @@ try {
   ({ text, stopReason } = await callClaude({
     prompt,
     maxTokens: MAX_TOKENS,
-    timeoutMs: 780_000,
+    timeoutMs: 1_140_000,
     model: MODEL,
   }));
 } catch (err) {


### PR DESCRIPTION
Refs #365. Fixes the timeout half of it - the two-pass-extended-thinking root cause itself may still need addressing separately.

Three identical timeouts on issue #353's impl generation (runs 32260206124, 32268157017, 32278494382), each killed still producing output. Hand-parsed the raw CLI transcript artifact from the third run: the model does one ~420-450s extended-thinking pass, then starts a second one immediately after - all three runs were killed partway through that second pass, never reaching real output.

Raised generate-impl.mjs's CLI timeout (780s -> 1140s) using previously-unused headroom, and the workflow's step/job caps (18m/25m -> 21m/28m) to preserve the same margin the job has always carried.

Bonus: this also solves a two-incident-old mystery. impl-agent.yml's own comment (issue #227, 2026-08-14) flagged "a thinking-token count jump in the final 60s the clipped tail alone couldn't explain." The transcript shows exactly what it is - Claude's extended-thinking signature field (100K+ chars, emitted atomically once a thinking block completes, not streamed), not a stall or a loop. Comment updated to record the answer.

Not claimed to fully resolve #365 - retrying #353's impl-agent next once this merges.
