### PR TITLE
fix(#367): install openid-client, reduce spec to the 3 files the model writes reliably

### DIFF
--- a/docs/specs/0367-sso-2a-oidc-login-initiation.md
+++ b/docs/specs/0367-sso-2a-oidc-login-initiation.md
@@ -34,7 +34,7 @@ Split off #353 as its smaller, lower-risk half (see #367 for why). BugSpotter ha
 
 ## Constraints
 
-1. `openid-client@5.7.1` is now installed (see "Blocking prerequisites" above) — v5 ships a functional API as its primary surface, not the class-based `Issuer.discover()`; verify the installed version's real exported surface before finalizing imports, and use `Issuer.discover`, `issuer.Client`, and `generators.*` consistently as shown below if that's what 5.7.1 actually exposes.
+1. `openid-client@5.7.1` is now installed (see "Blocking prerequisites" above) — verified against the installed version: it exposes the class-based v5 API (`Issuer.discover`, `issuer.Client`, `generators.codeVerifier`, `generators.codeChallenge` are all functions), not the v6 functional API (`discovery()`, `randomPKCECodeVerifier()`, which 5.7.1 does not export). Use `Issuer.discover`, `issuer.Client`, and `generators.*` consistently as shown below.
 2. PKCE `code_challenge_method: 'S256'` on every authorization request; no implicit flow, no bare authorization code grant without a verifier.
 3. `issuerUrl` from saved config AND both `token_endpoint` and `jwks_uri` from the discovery response each validated with `validateSSRFProtection()` immediately before every connection — not cached as pre-approved after first discovery. Verify the exact export name in `packages/backend/src/integrations/security/ssrf-validator.ts` before use; it is ASSUMED to match the name this constraint quotes.
 4. CSRF state payload `{ nonce, codeVerifier, redirectUri, tenantId, issuer }` stored via `getCacheService().set()` with ≤10-minute TTL — no new cache method needed for this slice (atomic consumption via `getAndDelete` is #368's concern, added to `CacheService` there).
@@ -58,9 +58,9 @@ New file. Owns IdP interaction logic so the route handler stays thin. `consumeOi
 
 ```ts
 // New file — packages/backend/src/api/services/oidc-service.ts
-// IMPORTANT: verify the openid-client v5 import surface before finalizing these imports.
-// If the package exposes a functional API (discovery(), randomPKCECodeVerifier(), etc.)
-// rather than the class-based Issuer.discover(), rewrite discoverIssuerValidated accordingly.
+// openid-client@5.7.1 exposes the class-based v5 API (Issuer.discover, issuer.Client,
+// generators.*), not the v6 functional API (discovery(), randomPKCECodeVerifier()) —
+// verified against the installed version.
 import { Issuer, generators } from 'openid-client';
 // validateSSRFProtection is a synchronous function returning URL (throws on blocked addresses)
 import { validateSSRFProtection } from '../../integrations/security/ssrf-validator.js';
@@ -114,7 +114,7 @@ export function oidcRoutes(fastify: FastifyInstance): void {
       const redirectUri = `${request.protocol}://${request.hostname}/api/v1/auth/oidc/${tenantId}/callback`;
       const issuer = await discoverIssuerValidated(config.issuerUrl);
 
-      // ASSUMED: openid-client v5 Client construction — verify v5 class vs functional API
+      // Verified against openid-client@5.7.1: class-based construction, not the v6 functional API.
       const client = new issuer.Client({ client_id: config.clientId, response_types: ['code'] });
       const state = generators.state();
       const nonce = generators.nonce();

--- a/docs/specs/0367-sso-2a-oidc-login-initiation.md
+++ b/docs/specs/0367-sso-2a-oidc-login-initiation.md
@@ -5,16 +5,18 @@ ADR: docs/adr/0044-sso-oidc-account-linking-and-tenant-boundary.md
 
 **Files touched:**
 
-- `packages/backend/package.json`, `pnpm-lock.yaml` — add `openid-client` v5 as a real dependency; the workspace has no reference to it at all today (confirmed: zero hits in either manifest or the lockfile)
 - `packages/backend/src/api/services/oidc-service.ts` — new file; IdP discovery + SSRF gating, PKCE/state generation, state storage
 - `packages/backend/src/api/routes/auth-oidc.ts` — new file; route module with `GET /api/v1/auth/oidc/:tenantId/login`, registered by direct function call (matching `authRoutes`), not as a Fastify plugin
-- `packages/backend/src/api/server.ts` — call `oidcRoutes(fastify)` alongside the other route-module calls
 - `packages/backend/tests/api/auth-oidc.test.ts` — new file; test case A/B below
+
+**Out of scope, follow-up after this merges:** wiring `oidcRoutes(fastify)` into `packages/backend/src/api/server.ts` — a single import + one function call, but it can only be written once this slice's `auth-oidc.ts` actually exists to import from, so it's a small hand-implemented follow-up immediately after this lands, not part of this slice's own scope.
 
 **Blocking prerequisites:**
 
 - #352 — `OidcIdpConfigRepository` and its schema must exist (they do)
-- **DI wiring already landed** (2026-08-20, hand-implemented outside the pipeline): `oidcIdpConfigs: OidcIdpConfigRepository` is now in `RepositoryRegistry`/`createRepositories()` (`factory.ts`) and `DatabaseClient` (`client.ts`) — `fastify.container.db.oidcIdpConfigs` is real and usable. Originally part of this slice's own Files-touched list, but that pushed the declared file count to 7, over `generate-impl.mjs`'s own hard "do not generate more than 6 files" instruction — the first impl-agent run silently dropped 5 of the 7 declared files rather than erroring, which `check-impl-scope.mjs` correctly caught. Since the wiring is small, mechanical, and follows an exact existing pattern with zero ambiguity, it was hand-implemented directly and removed from this slice's scope rather than filed as yet another pipeline cycle.
+- **DI wiring already landed** (2026-08-20, hand-implemented outside the pipeline): `oidcIdpConfigs: OidcIdpConfigRepository` is now in `RepositoryRegistry`/`createRepositories()` (`factory.ts`) and `DatabaseClient` (`client.ts`) — `fastify.container.db.oidcIdpConfigs` is real and usable.
+- **`openid-client` v5 already installed** (2026-08-20, hand-implemented outside the pipeline): `packages/backend/package.json`/`pnpm-lock.yaml` now carry `openid-client@5.7.1` (`pnpm --filter @bugspotter/backend add openid-client@^5`), typecheck confirmed clean.
+- **Why hand-implemented, twice:** this slice's declared file count reached 7 during review fixes (DI wiring + the missing dependency), over `generate-impl.mjs`'s own hard "do not generate more than 6 files" instruction. The first impl-agent run silently dropped 5 of 7 files rather than erroring; reducing to 5 (removing the already-landed DI wiring) still dropped 2 of 5 on the second run (`package.json`, `server.ts` — always the smallest/most mechanical entries, core logic written correctly both times). Reduced further to exactly 3 files - the core logic the model has now proven it writes reliably - by hand-landing both remaining mechanical pieces (this dependency add, and moving `server.ts`'s wiring to a post-merge follow-up) rather than gambling on a third full retry.
 
 ## Problem
 
@@ -32,7 +34,7 @@ Split off #353 as its smaller, lower-risk half (see #367 for why). BugSpotter ha
 
 ## Constraints
 
-1. `openid-client` is not a dependency of this workspace at all today (confirmed: zero hits in `package.json`, `packages/backend/package.json`, and `pnpm-lock.yaml`) — add it pinned to v5 before writing any code against it. v5 ships a functional API as its primary surface, not the class-based `Issuer.discover()`; use `Issuer.discover`, `issuer.Client`, and `generators.*` consistently as shown below once the package is actually installed and its real exported surface is confirmed against the installed version.
+1. `openid-client@5.7.1` is now installed (see "Blocking prerequisites" above) — v5 ships a functional API as its primary surface, not the class-based `Issuer.discover()`; verify the installed version's real exported surface before finalizing imports, and use `Issuer.discover`, `issuer.Client`, and `generators.*` consistently as shown below if that's what 5.7.1 actually exposes.
 2. PKCE `code_challenge_method: 'S256'` on every authorization request; no implicit flow, no bare authorization code grant without a verifier.
 3. `issuerUrl` from saved config AND both `token_endpoint` and `jwks_uri` from the discovery response each validated with `validateSSRFProtection()` immediately before every connection — not cached as pre-approved after first discovery. Verify the exact export name in `packages/backend/src/integrations/security/ssrf-validator.ts` before use; it is ASSUMED to match the name this constraint quotes.
 4. CSRF state payload `{ nonce, codeVerifier, redirectUri, tenantId, issuer }` stored via `getCacheService().set()` with ≤10-minute TTL — no new cache method needed for this slice (atomic consumption via `getAndDelete` is #368's concern, added to `CacheService` there).
@@ -48,15 +50,7 @@ Split off #353 as its smaller, lower-risk half (see #367 for why). BugSpotter ha
 
 ## Changes
 
-### `packages/backend/package.json`, `pnpm-lock.yaml`
-
-Add `openid-client` (pinned to v5) as an actual dependency — Constraint 1 above.
-
-```bash
-pnpm --filter @bugspotter/backend add openid-client@^5
-```
-
-`oidcIdpConfigs` is already real on `fastify.container.db` — see "Blocking prerequisites" above. No changes needed to `factory.ts`/`client.ts` in this slice.
+`openid-client` is already installed and `oidcIdpConfigs` is already real on `fastify.container.db` — see "Blocking prerequisites" above. No changes needed to `package.json`/`pnpm-lock.yaml`/`factory.ts`/`client.ts` in this slice.
 
 ### `packages/backend/src/api/services/oidc-service.ts`
 
@@ -152,22 +146,30 @@ export function oidcRoutes(fastify: FastifyInstance): void {
 }
 ```
 
-### `packages/backend/src/api/server.ts`
-
-Call `oidcRoutes(fastify)` alongside the other route-module calls (e.g. next to `authRoutes(fastify, db)`), not via `fastify.register(...)` — this backend wires its own route modules by direct function call, reserving `fastify.register` for actual Fastify plugins (`@fastify/cors`, `@fastify/jwt`, etc.).
-
-```ts
-// Append after the existing authRoutes(fastify, db) call (verify insertion point):
-import { oidcRoutes } from './routes/auth-oidc.js';
-// ...
-oidcRoutes(fastify);
-```
+`server.ts` wiring is out of scope for this slice — see "Out of scope, follow-up after this merges" above. Once this merges, `oidcRoutes(fastify)` gets called alongside the other route-module calls (e.g. next to `authRoutes(fastify, db)`), not via `fastify.register(...)` — this backend wires its own route modules by direct function call, reserving `fastify.register` for actual Fastify plugins (`@fastify/cors`, `@fastify/jwt`, etc.).
 
 ## Tests
 
 ### `packages/backend/tests/api/auth-oidc.test.ts`
 
 New file — #368 extends it with callback test cases.
+
+**Test harness — do NOT use `createServer()`.** `server.ts` wiring is out of scope for this slice (see above), so this file must build its own minimal Fastify instance and register `oidcRoutes` directly — the same pattern `tests/api/routes/signup.route.test.ts` already uses (`Fastify()`, register only the plugins actually needed, call the route module function directly, `fastify.decorate('container', mockContainer)` to satisfy `fastify.container.db.oidcIdpConfigs`, matching how `server.ts` itself does `fastify.decorate('container', container)`).
+
+```ts
+import Fastify, { type FastifyInstance } from 'fastify';
+import { oidcRoutes } from '../../../src/api/routes/auth-oidc.js';
+
+async function buildServer(): Promise<FastifyInstance> {
+  const server = Fastify();
+  server.decorate('container', {
+    db: { oidcIdpConfigs: mockOidcIdpConfigs },
+  });
+  oidcRoutes(server);
+  await server.ready();
+  return server;
+}
+```
 
 **Mock/fixture updates required:**
 
@@ -231,12 +233,25 @@ mockAuthorizationUrlFn.mockReturnValue('https://idp.example.com/auth?mock=1');
 ```
 
 ```ts
-// Shared fixture setup inside beforeEach — extend the existing container mock:
+// Module scope: buildServer() (defined above) reads mockOidcIdpConfigs by closure.
 const mockOidcIdpConfigs = {
   findByTenantId: vi.fn(),
 };
-// container.db.oidcIdpConfigs = mockOidcIdpConfigs (wire into whatever container-mock
-// helper this test suite already uses for `db`)
+
+describe('OIDC login initiation', () => {
+  let server: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    server = await buildServer();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  // test cases below go inside this describe block
+});
 ```
 
 **Test case A — login redirects with S256 PKCE and stores state (AC #1):**
@@ -249,7 +264,7 @@ it('redirects to IdP with S256 PKCE challenge and stores state in cache', async 
     allowedDomains: ['corp.example.com'],
   });
 
-  const res = await fastify.inject({
+  const res = await server.inject({
     method: 'GET',
     url: '/api/v1/auth/oidc/tenant-abc/login',
   });
@@ -276,7 +291,7 @@ it('redirects to IdP with S256 PKCE challenge and stores state in cache', async 
 it('returns 404 for a tenant with no SSO configuration, without touching SSRF validation', async () => {
   mockOidcIdpConfigs.findByTenantId.mockResolvedValue(null);
 
-  const res = await fastify.inject({
+  const res = await server.inject({
     method: 'GET',
     url: '/api/v1/auth/oidc/unknown-tenant/login',
   });

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -65,6 +65,7 @@
     "md-to-adf": "^0.6.4",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.10.1",
+    "openid-client": "^5",
     "pg": "^8.13.1",
     "prom-client": "^15.1.3",
     "sharp": "^0.34.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
       nodemailer:
         specifier: ^6.10.1
         version: 6.10.1
+      openid-client:
+        specifier: ^5
+        version: 5.7.1
       pg:
         specifier: ^8.13.1
         version: 8.16.3
@@ -4649,6 +4652,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   js-md5@0.8.3:
     resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
@@ -4804,16 +4810,16 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.2:
-    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
-    engines: {node: 20 || >=22}
-
   lru-cache@11.3.3:
     resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lucide-react@0.363.0:
     resolution: {integrity: sha512-AlsfPCsXQyQx7wwsIgzcKOL9LwC498LIMAo+c0Es5PkHJa33xwmYAkkSoKoJWWWSYQEStqu58/jT4tL2gi32uQ==}
@@ -5243,6 +5249,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
+
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
@@ -5256,6 +5266,10 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  oidc-token-hash@5.2.0:
+    resolution: {integrity: sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==}
+    engines: {node: ^10.13.0 || >=12.0.0}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -5275,6 +5289,9 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   opn@5.3.0:
     resolution: {integrity: sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==}
@@ -10276,7 +10293,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jsdom@24.1.0)(msw@2.11.6(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jsdom@27.0.0)(msw@2.11.6(@types/node@20.19.19)(typescript@5.9.3))(terser@5.44.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11962,6 +11979,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@4.15.9: {}
+
   js-md5@0.8.3: {}
 
   js-tokens@4.0.0: {}
@@ -12152,14 +12171,15 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.2: {}
-
-  lru-cache@11.3.3:
-    optional: true
+  lru-cache@11.3.3: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lucide-react@0.363.0(react@18.3.1):
     dependencies:
@@ -12834,6 +12854,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@2.2.0: {}
+
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
@@ -12841,6 +12863,8 @@ snapshots:
   obliterator@2.0.5: {}
 
   obug@2.1.1: {}
+
+  oidc-token-hash@5.2.0: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -12859,6 +12883,13 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openid-client@5.7.1:
+    dependencies:
+      jose: 4.15.9
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.2.0
 
   opn@5.3.0:
     dependencies:
@@ -12931,7 +12962,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.3.3
       minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}


### PR DESCRIPTION
Refs #367.

Second impl-agent run (5 declared files, after PR #371's DI-wiring removal) still dropped 2: `package.json` and `server.ts` - both times the smallest, most mechanical entries, while the actual core logic (`oidc-service.ts`, `auth-oidc.ts`, the test file) was written correctly both runs. Rather than gamble on a third full retry:

- `openid-client@5.7.1` installed directly, typecheck clean.
- `server.ts` wiring moved to a documented post-merge follow-up - it can only be written once `auth-oidc.ts` exists to import from anyway, so deferring it is the more correct dependency order, not just a workaround.
- Test harness rewritten to not depend on `server.ts`: builds its own minimal Fastify instance and registers `oidcRoutes` directly, same pattern `tests/api/routes/signup.route.test.ts` already uses.

Spec now declares exactly 3 files - the set the model has proven twice it writes reliably.
