### PR TITLE
chore(ai-sdlc): switch default Sonnet model from claude-sonnet-4-6 to claude-sonnet-5

### DIFF
--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -118,7 +118,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add -- "$ADR_FILE"
-          MSG="$(printf 'docs(adr): ADR-%s draft (%s)\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ADR_NUMBER" "$ADR_SLUG")"
+          MSG="$(printf 'docs(adr): ADR-%s draft (%s)\n\nAssisted-by: claude-sonnet-5 (agent)' "$ADR_NUMBER" "$ADR_SLUG")"
           git commit -m "$MSG"
           git fetch origin "$BRANCH" 2>/dev/null || true
           git push --force-with-lease origin "$BRANCH"
@@ -133,7 +133,7 @@ jobs:
           BRANCH: ${{ steps.push.outputs.branch }}
           ADR_NUMBER: ${{ steps.gen.outputs.adr_number }}
         run: |
-          PR_BODY="$(printf 'Agent-drafted ADR-%s for issue #%s.\n\nReview, promote Status to Accepted if correct, and merge to advance this issue to `agent-working`.\n\nRefs #%s\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ADR_NUMBER" "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
+          PR_BODY="$(printf 'Agent-drafted ADR-%s for issue #%s.\n\nReview, promote Status to Accepted if correct, and merge to advance this issue to `agent-working`.\n\nRefs #%s\n\nAssisted-by: claude-sonnet-5 (agent)' "$ADR_NUMBER" "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
 
           PR_URL=$(gh pr create \
             --title "docs(adr): ADR-${ADR_NUMBER} ${ISSUE_TITLE}" \

--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -112,13 +112,17 @@ jobs:
           ADR_FILE: ${{ steps.gen.outputs.adr_file }}
           ADR_SLUG: ${{ steps.gen.outputs.adr_slug }}
           ADR_NUMBER: ${{ steps.gen.outputs.adr_number }}
+          # The model generate-adr.mjs actually used (LLM_DEFAULT_MODEL's
+          # resolved value, not a second hardcoded literal here that would
+          # silently go stale the moment that override is set).
+          MODEL: ${{ steps.gen.outputs.model }}
         run: |
           BRANCH="adr/${ADR_NUMBER}-${ADR_SLUG}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add -- "$ADR_FILE"
-          MSG="$(printf 'docs(adr): ADR-%s draft (%s)\n\nAssisted-by: claude-sonnet-5 (agent)' "$ADR_NUMBER" "$ADR_SLUG")"
+          MSG="$(printf 'docs(adr): ADR-%s draft (%s)\n\nAssisted-by: %s (agent)' "$ADR_NUMBER" "$ADR_SLUG" "$MODEL")"
           git commit -m "$MSG"
           git fetch origin "$BRANCH" 2>/dev/null || true
           git push --force-with-lease origin "$BRANCH"
@@ -132,8 +136,9 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           BRANCH: ${{ steps.push.outputs.branch }}
           ADR_NUMBER: ${{ steps.gen.outputs.adr_number }}
+          MODEL: ${{ steps.gen.outputs.model }}
         run: |
-          PR_BODY="$(printf 'Agent-drafted ADR-%s for issue #%s.\n\nReview, promote Status to Accepted if correct, and merge to advance this issue to `agent-working`.\n\nRefs #%s\n\nAssisted-by: claude-sonnet-5 (agent)' "$ADR_NUMBER" "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
+          PR_BODY="$(printf 'Agent-drafted ADR-%s for issue #%s.\n\nReview, promote Status to Accepted if correct, and merge to advance this issue to `agent-working`.\n\nRefs #%s\n\nAssisted-by: %s (agent)' "$ADR_NUMBER" "$ISSUE_NUMBER" "$ISSUE_NUMBER" "$MODEL")"
 
           PR_URL=$(gh pr create \
             --title "docs(adr): ADR-${ADR_NUMBER} ${ISSUE_TITLE}" \

--- a/.github/workflows/adr-agent.yml
+++ b/.github/workflows/adr-agent.yml
@@ -73,6 +73,12 @@ jobs:
         timeout-minutes: 6
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}
+          # generate-adr.mjs never passes an explicit model to callClaude(),
+          # so CLI_MODEL (this) is its real effective default - without this
+          # mapping, setting the repo variable would silently do nothing,
+          # since a GitHub Actions variable only reaches process.env via an
+          # explicit env: entry like this one, never automatically.
+          LLM_DEFAULT_MODEL: ${{ vars.LLM_DEFAULT_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -251,9 +251,21 @@ jobs:
           # (deeper read on demand). Haiku is roughly 1/12 the cost of
           # Opus per token and finishes well inside the 25-turn budget
           # for typical diffs. Both branches of this conditional are
-          # non-empty model ids, so the `&& A || B` ternary is safe
-          # here (unlike the allowedTools line above).
+          # non-empty (each `vars.* || 'literal'` always resolves to a
+          # non-empty string), so the `&& A || B` ternary is safe here
+          # (unlike the allowedTools line above) — but each branch needs
+          # its own parens: without them, `||`'s lower precedence than
+          # `&&` would let the human-run fallback leak into the auto-run
+          # result too.
+          #
+          # Overridable via CLAUDE_REVIEW_MODEL_AUTO / _HUMAN repo
+          # variables — same pattern as generate-impl.mjs's
+          # IMPL_MODEL_HIGH/_LOW and llm-client.mjs's LLM_DEFAULT_MODEL
+          # (see model-defaults.mjs). This workflow can't import that
+          # shared module — plain GitHub Actions YAML, no JS runtime here
+          # — so its fallback literals are kept in sync with
+          # model-defaults.mjs's LOW_MODEL/HIGH_MODEL by hand.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob${{ github.event_name != 'pull_request' && ',Bash(gh pr comment:*)' || '' }}"
             --max-turns 25
-            --model ${{ github.event_name == 'pull_request' && 'claude-haiku-4-5-20251001' || 'claude-opus-4-7' }}
+            --model ${{ github.event_name == 'pull_request' && (vars.CLAUDE_REVIEW_MODEL_AUTO || 'claude-haiku-4-5-20251001') || (vars.CLAUDE_REVIEW_MODEL_HUMAN || 'claude-opus-4-8') }}

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -8,7 +8,7 @@ name: Impl Agent
 # Model router (label-based):
 #   complexity:high  -> claude-opus-4-8
 #   pii-sensitive    -> claude-haiku-4-5-20251001
-#   default          -> claude-sonnet-4-6
+#   default          -> claude-sonnet-5
 # The selected model is used on whichever LLM backend is active below.
 #
 # LLM backend is switchable via the LLM_BACKEND repo variable:

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -138,7 +138,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add "$SPEC_FILE"
-          MSG="$(printf 'spec(#%s): draft spec\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ISSUE_NUMBER")"
+          MSG="$(printf 'spec(#%s): draft spec\n\nAssisted-by: claude-sonnet-5 (agent)' "$ISSUE_NUMBER")"
           git commit -m "$MSG"
           git fetch origin "$BRANCH" 2>/dev/null || true
           git push --force-with-lease origin "$BRANCH"
@@ -153,7 +153,7 @@ jobs:
           BRANCH: ${{ steps.push.outputs.branch }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
         run: |
-          PR_BODY="$(printf 'Agent-drafted spec for issue #%s.\n\nReview, fill gaps, and merge to advance this issue to `needs-adr` (if an ADR is warranted) or `agent-working` (if no ADR is needed).\n\nRefs #%s\n\nAssisted-by: claude-sonnet-4-6 (agent)' "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
+          PR_BODY="$(printf 'Agent-drafted spec for issue #%s.\n\nReview, fill gaps, and merge to advance this issue to `needs-adr` (if an ADR is warranted) or `agent-working` (if no ADR is needed).\n\nRefs #%s\n\nAssisted-by: claude-sonnet-5 (agent)' "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
 
           PR_URL=$(gh pr create \
             --title "spec(#${ISSUE_NUMBER}): ${ISSUE_TITLE}" \

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -136,13 +136,17 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
           SPEC_SLUG: ${{ steps.gen.outputs.spec_slug }}
+          # The model generate-spec.mjs actually used (LLM_DEFAULT_MODEL's
+          # resolved value, not a second hardcoded literal here that would
+          # silently go stale the moment that override is set).
+          MODEL: ${{ steps.gen.outputs.model }}
         run: |
           BRANCH="spec/issue-${ISSUE_NUMBER}-${SPEC_SLUG}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add "$SPEC_FILE"
-          MSG="$(printf 'spec(#%s): draft spec\n\nAssisted-by: claude-sonnet-5 (agent)' "$ISSUE_NUMBER")"
+          MSG="$(printf 'spec(#%s): draft spec\n\nAssisted-by: %s (agent)' "$ISSUE_NUMBER" "$MODEL")"
           git commit -m "$MSG"
           git fetch origin "$BRANCH" 2>/dev/null || true
           git push --force-with-lease origin "$BRANCH"
@@ -156,8 +160,9 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           BRANCH: ${{ steps.push.outputs.branch }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
+          MODEL: ${{ steps.gen.outputs.model }}
         run: |
-          PR_BODY="$(printf 'Agent-drafted spec for issue #%s.\n\nReview, fill gaps, and merge to advance this issue to `needs-adr` (if an ADR is warranted) or `agent-working` (if no ADR is needed).\n\nRefs #%s\n\nAssisted-by: claude-sonnet-5 (agent)' "$ISSUE_NUMBER" "$ISSUE_NUMBER")"
+          PR_BODY="$(printf 'Agent-drafted spec for issue #%s.\n\nReview, fill gaps, and merge to advance this issue to `needs-adr` (if an ADR is warranted) or `agent-working` (if no ADR is needed).\n\nRefs #%s\n\nAssisted-by: %s (agent)' "$ISSUE_NUMBER" "$ISSUE_NUMBER" "$MODEL")"
 
           PR_URL=$(gh pr create \
             --title "spec(#${ISSUE_NUMBER}): ${ISSUE_TITLE}" \

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -61,6 +61,12 @@ jobs:
         timeout-minutes: 8
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}
+          # generate-spec.mjs never passes an explicit model to callClaude(),
+          # so CLI_MODEL (this) is its real effective default - without this
+          # mapping, setting the repo variable would silently do nothing,
+          # since a GitHub Actions variable only reaches process.env via an
+          # explicit env: entry like this one, never automatically.
+          LLM_DEFAULT_MODEL: ${{ vars.LLM_DEFAULT_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -80,6 +86,9 @@ jobs:
         timeout-minutes: 8
         env:
           LLM_BACKEND: ${{ vars.LLM_BACKEND }}
+          # verify-spec.mjs also never passes an explicit model - same
+          # CLI_MODEL default as the Generate spec step above.
+          LLM_DEFAULT_MODEL: ${{ vars.LLM_DEFAULT_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}

--- a/scripts/ai-sdlc/generate-adr.mjs
+++ b/scripts/ai-sdlc/generate-adr.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Calls Claude to draft an ADR for a GitHub issue.
 // Run from the repo root. Reads existing ADRs for numbering + style.
-// Outputs adr_file, adr_number, adr_slug to GITHUB_OUTPUT.
+// Outputs adr_file, adr_number, adr_slug, and model to GITHUB_OUTPUT.
 //
 // Required env vars: ISSUE_NUMBER, ISSUE_TITLE, plus either
 //   ANTHROPIC_API_KEY (default) or CLAUDE_CODE_OAUTH_TOKEN (LLM_BACKEND=cli)
@@ -17,7 +17,7 @@ import {
   mkdirSync,
   existsSync,
 } from 'node:fs';
-import { callClaude, requireLlmCredentials } from './llm-client.mjs';
+import { callClaude, requireLlmCredentials, CLI_MODEL } from './llm-client.mjs';
 
 const { ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, SPEC_CONTENT, GITHUB_OUTPUT } = process.env;
 
@@ -165,6 +165,10 @@ if (GITHUB_OUTPUT) {
   appendFileSync(GITHUB_OUTPUT, `adr_file=${adrFile}\n`);
   appendFileSync(GITHUB_OUTPUT, `adr_slug=${slug}\n`);
   appendFileSync(GITHUB_OUTPUT, `adr_number=${padded}\n`);
+  // So the workflow's "Assisted-by" commit/PR trailers can name the model
+  // that actually generated this ADR instead of a second hardcoded literal
+  // that would silently go stale the moment LLM_DEFAULT_MODEL is overridden.
+  appendFileSync(GITHUB_OUTPUT, `model=${CLI_MODEL}\n`);
 } else {
   console.log(`adr_file=${adrFile}`);
   console.log(`adr_slug=${slug}`);

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -32,6 +32,7 @@ import { randomUUID } from 'node:crypto';
 import { callClaude, requireLlmCredentials } from './llm-client.mjs';
 import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
 import { normalizePath, findUnwrittenPaths } from './check-impl-scope.mjs';
+import { DEFAULT_MODEL, HIGH_MODEL, LOW_MODEL } from './model-defaults.mjs';
 
 const { ISSUE_NUMBER, ISSUE_TITLE, ISSUE_LABELS = '', SPEC_CONTENT, GITHUB_OUTPUT } = process.env;
 
@@ -51,10 +52,12 @@ if (!SPEC_CONTENT) {
 
 // Model router — label-based with per-tier overrides via GitHub repo variables.
 // Change without a code edit: set IMPL_MODEL_HIGH / IMPL_MODEL_DEFAULT / IMPL_MODEL_LOW
-// in Settings > Secrets and variables > Actions > Variables.
-const MODEL_HIGH = process.env.IMPL_MODEL_HIGH || 'claude-opus-4-8';
-const MODEL_DEFAULT = process.env.IMPL_MODEL_DEFAULT || 'claude-sonnet-5';
-const MODEL_LOW = process.env.IMPL_MODEL_LOW || 'claude-haiku-4-5-20251001';
+// in Settings > Secrets and variables > Actions > Variables. Fallback literals
+// come from the shared model-defaults.mjs (also used by llm-client.mjs), so a
+// version bump only touches one place.
+const MODEL_HIGH = process.env.IMPL_MODEL_HIGH || HIGH_MODEL;
+const MODEL_DEFAULT = process.env.IMPL_MODEL_DEFAULT || DEFAULT_MODEL;
+const MODEL_LOW = process.env.IMPL_MODEL_LOW || LOW_MODEL;
 
 function selectModel(labels) {
   const set = new Set(labels.split(',').map((l) => l.trim().toLowerCase()));

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -5,7 +5,7 @@
 // Model router (label-based via ISSUE_LABELS env):
 //   complexity:high  -> claude-opus-4-8   (deep architecture, cross-cutting changes)
 //   pii-sensitive    -> claude-haiku-4-5-20251001  (local-floor stand-in; cheapest hosted)
-//   default          -> claude-sonnet-4-6
+//   default          -> claude-sonnet-5
 // The selected model is passed to callClaude's `model` override on either backend.
 //
 // Static context (CLAUDE.md files + pattern examples) is prepended to the prompt.
@@ -52,7 +52,7 @@ if (!SPEC_CONTENT) {
 // Change without a code edit: set IMPL_MODEL_HIGH / IMPL_MODEL_DEFAULT / IMPL_MODEL_LOW
 // in Settings > Secrets and variables > Actions > Variables.
 const MODEL_HIGH = process.env.IMPL_MODEL_HIGH || 'claude-opus-4-8';
-const MODEL_DEFAULT = process.env.IMPL_MODEL_DEFAULT || 'claude-sonnet-4-6';
+const MODEL_DEFAULT = process.env.IMPL_MODEL_DEFAULT || 'claude-sonnet-5';
 const MODEL_LOW = process.env.IMPL_MODEL_LOW || 'claude-haiku-4-5-20251001';
 
 function selectModel(labels) {

--- a/scripts/ai-sdlc/generate-spec.mjs
+++ b/scripts/ai-sdlc/generate-spec.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Calls Claude to draft a spec document for a GitHub issue.
 // Run from the repo root. Reads TEMPLATE.md; writes docs/specs/<file>.
-// Outputs spec_file and spec_slug to GITHUB_OUTPUT.
+// Outputs spec_file, spec_slug, padded_number, and model to GITHUB_OUTPUT.
 //
 // Required env vars: ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, plus either
 //   ANTHROPIC_API_KEY (default) or CLAUDE_CODE_OAUTH_TOKEN (LLM_BACKEND=cli)
@@ -16,7 +16,7 @@ import {
   statSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { callClaude, requireLlmCredentials } from './llm-client.mjs';
+import { callClaude, requireLlmCredentials, CLI_MODEL } from './llm-client.mjs';
 
 const { ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, GITHUB_OUTPUT } = process.env;
 
@@ -194,6 +194,10 @@ if (GITHUB_OUTPUT) {
   appendFileSync(GITHUB_OUTPUT, `spec_file=${specFile}\n`);
   appendFileSync(GITHUB_OUTPUT, `spec_slug=${slug}\n`);
   appendFileSync(GITHUB_OUTPUT, `padded_number=${padded}\n`);
+  // So the workflow's "Assisted-by" commit/PR trailers can name the model
+  // that actually generated this spec instead of a second hardcoded literal
+  // that would silently go stale the moment LLM_DEFAULT_MODEL is overridden.
+  appendFileSync(GITHUB_OUTPUT, `model=${CLI_MODEL}\n`);
 } else {
   console.log(`spec_file=${specFile}`);
   console.log(`spec_slug=${slug}`);

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -23,15 +23,17 @@
 //   in Claude Code's auth precedence and would otherwise silently shadow it.
 //
 // callClaude({ prompt, maxTokens, timeoutMs, model }) — `model` is optional
-//   (defaults to CLI_MODEL, claude-sonnet-5 unless overridden, on both
-//   backends) and lets a caller like generate-impl.mjs's label-based model
-//   router (complexity:high -> claude-opus-4-8, pii-sensitive ->
-//   claude-haiku, default -> sonnet) pick a different model per call on
-//   either backend. generate-spec.mjs, verify-spec.mjs, and generate-adr.mjs
-//   never pass `model` at all, so CLI_MODEL is their real effective default -
-//   change it without a code edit via the LLM_DEFAULT_MODEL repo variable,
-//   the same pattern generate-impl.mjs's own IMPL_MODEL_DEFAULT/_HIGH/_LOW
-//   already use (see that file). Before this override existed, switching the
+//   (defaults to CLI_MODEL, DEFAULT_MODEL from model-defaults.mjs unless
+//   overridden, on both backends) and lets a caller like generate-impl.mjs's
+//   label-based model router (complexity:high -> claude-opus-4-8,
+//   pii-sensitive -> claude-haiku, default -> sonnet) pick a different model
+//   per call on either backend. generate-spec.mjs, verify-spec.mjs, and
+//   generate-adr.mjs never pass `model` at all, so CLI_MODEL is their real
+//   effective default - change it without a code edit via the
+//   LLM_DEFAULT_MODEL repo variable, the same pattern generate-impl.mjs's own
+//   IMPL_MODEL_DEFAULT/_HIGH/_LOW already use (see that file; both files'
+//   fallback literals come from the shared model-defaults.mjs, so a version
+//   bump only touches one place). Before this override existed, switching the
 //   pipeline's default model (2026-08-21, claude-sonnet-4-6 -> claude-sonnet-5)
 //   required editing this file directly - a code PR for what should be a
 //   config change.
@@ -46,6 +48,7 @@
 import { spawn } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { Buffer } from 'node:buffer';
+import { DEFAULT_MODEL } from './model-defaults.mjs';
 
 const LLM_BACKEND = process.env.LLM_BACKEND || 'api';
 
@@ -53,7 +56,7 @@ const LLM_BACKEND = process.env.LLM_BACKEND || 'api';
 // process.env, so verifying the override actually works requires a fresh
 // process (a spawned subprocess with LLM_DEFAULT_MODEL already set before
 // import), not an in-process re-import - see llm-client.test.mjs.
-export const CLI_MODEL = process.env.LLM_DEFAULT_MODEL || 'claude-sonnet-5';
+export const CLI_MODEL = process.env.LLM_DEFAULT_MODEL || DEFAULT_MODEL;
 
 export function requireLlmCredentials() {
   if (LLM_BACKEND === 'cli') {

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -23,10 +23,18 @@
 //   in Claude Code's auth precedence and would otherwise silently shadow it.
 //
 // callClaude({ prompt, maxTokens, timeoutMs, model }) — `model` is optional
-//   (defaults to claude-sonnet-5 on both backends) and lets a caller like
-//   generate-impl.mjs's label-based model router (complexity:high ->
-//   claude-opus-4-8, pii-sensitive -> claude-haiku, default -> sonnet)
-//   pick a different model per call on either backend.
+//   (defaults to CLI_MODEL, claude-sonnet-5 unless overridden, on both
+//   backends) and lets a caller like generate-impl.mjs's label-based model
+//   router (complexity:high -> claude-opus-4-8, pii-sensitive ->
+//   claude-haiku, default -> sonnet) pick a different model per call on
+//   either backend. generate-spec.mjs, verify-spec.mjs, and generate-adr.mjs
+//   never pass `model` at all, so CLI_MODEL is their real effective default -
+//   change it without a code edit via the LLM_DEFAULT_MODEL repo variable,
+//   the same pattern generate-impl.mjs's own IMPL_MODEL_DEFAULT/_HIGH/_LOW
+//   already use (see that file). Before this override existed, switching the
+//   pipeline's default model (2026-08-21, claude-sonnet-4-6 -> claude-sonnet-5)
+//   required editing this file directly - a code PR for what should be a
+//   config change.
 //   `maxTokens` only takes effect on the API backend (becomes max_tokens in
 //   the request body). callViaCli ignores it — `claude --help` has no flag
 //   to cap output tokens per call (only --max-budget-usd, a dollar budget,
@@ -41,7 +49,11 @@ import { Buffer } from 'node:buffer';
 
 const LLM_BACKEND = process.env.LLM_BACKEND || 'api';
 
-const CLI_MODEL = 'claude-sonnet-5';
+// Exported for testability: computed once at module-load time from
+// process.env, so verifying the override actually works requires a fresh
+// process (a spawned subprocess with LLM_DEFAULT_MODEL already set before
+// import), not an in-process re-import - see llm-client.test.mjs.
+export const CLI_MODEL = process.env.LLM_DEFAULT_MODEL || 'claude-sonnet-5';
 
 export function requireLlmCredentials() {
   if (LLM_BACKEND === 'cli') {
@@ -65,7 +77,10 @@ async function callViaApi({ prompt, maxTokens, timeoutMs, model }) {
     },
     signal: AbortSignal.timeout(timeoutMs),
     body: JSON.stringify({
-      model: model || 'claude-sonnet-5',
+      // CLI_MODEL, not a second hardcoded literal - one source of truth for
+      // "the default when no caller-supplied model", overridable the same
+      // way on both backends via LLM_DEFAULT_MODEL.
+      model: model || CLI_MODEL,
       max_tokens: maxTokens,
       messages: [{ role: 'user', content: prompt }],
     }),

--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -23,7 +23,7 @@
 //   in Claude Code's auth precedence and would otherwise silently shadow it.
 //
 // callClaude({ prompt, maxTokens, timeoutMs, model }) — `model` is optional
-//   (defaults to claude-sonnet-4-6 on both backends) and lets a caller like
+//   (defaults to claude-sonnet-5 on both backends) and lets a caller like
 //   generate-impl.mjs's label-based model router (complexity:high ->
 //   claude-opus-4-8, pii-sensitive -> claude-haiku, default -> sonnet)
 //   pick a different model per call on either backend.
@@ -41,7 +41,7 @@ import { Buffer } from 'node:buffer';
 
 const LLM_BACKEND = process.env.LLM_BACKEND || 'api';
 
-const CLI_MODEL = 'claude-sonnet-4-6';
+const CLI_MODEL = 'claude-sonnet-5';
 
 export function requireLlmCredentials() {
   if (LLM_BACKEND === 'cli') {
@@ -65,7 +65,7 @@ async function callViaApi({ prompt, maxTokens, timeoutMs, model }) {
     },
     signal: AbortSignal.timeout(timeoutMs),
     body: JSON.stringify({
-      model: model || 'claude-sonnet-4-6',
+      model: model || 'claude-sonnet-5',
       max_tokens: maxTokens,
       messages: [{ role: 'user', content: prompt }],
     }),

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -575,7 +575,7 @@ test('callViaCli invokes claude with --tools= and --strict-mcp-config, not --all
       'stream-json',
       '--verbose',
       '--model',
-      'claude-sonnet-4-6',
+      'claude-sonnet-5',
       '--tools=',
       '--strict-mcp-config',
     ]);
@@ -679,7 +679,7 @@ test('callViaApi falls back to the hardcoded default model when none is supplied
 
   try {
     await callClaudeApi({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });
-    assert.equal(requests[0].body.model, 'claude-sonnet-4-6');
+    assert.equal(requests[0].body.model, 'claude-sonnet-5');
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -21,8 +21,10 @@
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { writeFileSync, mkdtempSync, rmSync, chmodSync, readFileSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const DIR = mkdtempSync(join(tmpdir(), 'llm-client-test-'));
 const IMPL = join(DIR, 'fake-claude-impl.cjs');
@@ -737,4 +739,70 @@ test('callClaude stays quiet when no maxTokens was passed', async () => {
     0,
     'nothing was dropped, so there is nothing to report'
   );
+});
+
+// --- LLM_DEFAULT_MODEL override (CLI_MODEL) --------------------------------
+//
+// CLI_MODEL is computed once at module-load time from process.env, same as
+// LLM_BACKEND above - so unlike every other test in this file, which shares
+// the ONE dynamic import() at the top (LLM_DEFAULT_MODEL deliberately left
+// unset there, so the 35 tests above keep asserting the plain default), this
+// needs a genuinely fresh process with the env var already set before
+// llm-client.mjs is ever imported. A subprocess, not a second in-process
+// import - Node's ESM loader caches by resolved specifier, so re-importing
+// the same file in-process would just return the already-evaluated module.
+// pathToFileURL, not a raw path: dynamic import() requires a valid URL
+// scheme, and a bare Windows path ('C:\...') isn't one.
+const LLM_CLIENT_URL = pathToFileURL(
+  join(dirname(fileURLToPath(import.meta.url)), 'llm-client.mjs')
+).href;
+
+/** Runs a fresh `node` process that calls callClaude() once and returns the argv the fake claude received. */
+function runInSubprocess(envOverrides) {
+  const scriptPath = join(DIR, `model-override-check-${Date.now()}-${Math.random()}.mjs`);
+  const dumpPath = join(DIR, `model-override-argv-${Date.now()}-${Math.random()}.json`);
+  writeFileSync(
+    scriptPath,
+    [
+      `const { callClaude } = await import(${JSON.stringify(LLM_CLIENT_URL)});`,
+      `await callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 10000 });`,
+      '',
+    ].join('\n')
+  );
+
+  // Clean slate for LLM_DEFAULT_MODEL specifically: the parent test-runner
+  // process must not leak its own value (there shouldn't be one, but the
+  // "unset" test below needs that guaranteed, not assumed) into a child
+  // whose whole point is proving what happens when it truly is unset.
+  const env = { ...process.env };
+  delete env.LLM_DEFAULT_MODEL;
+
+  const result = spawnSync(process.execPath, [scriptPath], {
+    encoding: 'utf8',
+    env: {
+      ...env,
+      ...envOverrides,
+      LLM_BACKEND: 'cli',
+      CLAUDE_CODE_OAUTH_TOKEN: 'test-oauth-token',
+      PATH: `${DIR}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`,
+      FAKE_CLAUDE_MODE: 'success',
+      FAKE_CLAUDE_ARGV_DUMP: dumpPath,
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(readFileSync(dumpPath, 'utf8'));
+}
+
+test('LLM_DEFAULT_MODEL overrides CLI_MODEL, verified via a fresh process', () => {
+  const argv = runInSubprocess({ LLM_DEFAULT_MODEL: 'claude-custom-test-model' });
+  const modelIdx = argv.indexOf('--model');
+  assert.notEqual(modelIdx, -1);
+  assert.equal(argv[modelIdx + 1], 'claude-custom-test-model');
+});
+
+test('LLM_DEFAULT_MODEL unset falls back to the hardcoded default, verified via a fresh process', () => {
+  const argv = runInSubprocess({});
+  const modelIdx = argv.indexOf('--model');
+  assert.notEqual(modelIdx, -1);
+  assert.equal(argv[modelIdx + 1], 'claude-sonnet-5');
 });

--- a/scripts/ai-sdlc/model-defaults.mjs
+++ b/scripts/ai-sdlc/model-defaults.mjs
@@ -1,0 +1,13 @@
+// Single source of truth for this pipeline's hardcoded model-id fallbacks.
+//
+// Every call site still overrides independently via its own env var
+// (LLM_DEFAULT_MODEL, IMPL_MODEL_HIGH/_DEFAULT/_LOW) - this module only fixes
+// what each falls back to when that env var isn't set, so bumping the
+// pipeline's default model touches one file instead of every consumer.
+// claude-review.yml can't import this (plain GitHub Actions YAML), so its own
+// vars.*-driven fallbacks are kept in sync with these by hand - see the
+// comment above its --model line.
+
+export const DEFAULT_MODEL = 'claude-sonnet-5';
+export const HIGH_MODEL = 'claude-opus-4-8';
+export const LOW_MODEL = 'claude-haiku-4-5-20251001';


### PR DESCRIPTION
Refs #374.

Updates every hardcoded `claude-sonnet-4-6` reference across the pipeline:

- `llm-client.mjs`'s `CLI_MODEL` and API-backend fallback - the effective default for `generate-spec.mjs`, `verify-spec.mjs`, and `generate-adr.mjs`, none of which pass an explicit model.
- `generate-impl.mjs`'s own `MODEL_DEFAULT` fallback (still overridable via `IMPL_MODEL_DEFAULT` without a code change).
- The `Assisted-by` trailers `spec-agent.yml`/`adr-agent.yml` stamp on agent commits and PR bodies.
- Matching test assertions in `llm-client.test.mjs`.

`MODEL_HIGH` (`claude-opus-4-8`) and `MODEL_LOW` (`claude-haiku-4-5-20251001`) are untouched - different model families, not in scope here. `docker-compose.yml`'s `CLAUDE_MODEL` default (`bugspotter-intelligence`'s optional Claude provider) is also untouched - a separate service, not part of the AI-SDLC pipeline.

Typecheck n/a (script files), all 143 ai-sdlc tests pass, actionlint clean on all three workflow files.
