### PR TITLE
feat(ai-sdlc): harden the pipeline against #367's completeness failures

### DIFF
--- a/.github/workflows/ai-sdlc-guards.yml
+++ b/.github/workflows/ai-sdlc-guards.yml
@@ -121,6 +121,6 @@ jobs:
             echo "::endgroup::"
           done <<< "$SPECS"
           [ "$failed" -eq 0 ] || {
-            echo "::error::Spec scope check failed. A spec declares more files than generate-impl.mjs's own 6-file generation limit - see the group log above for which one(s) and why this blocks merge, not just warns."
+            echo "::error::Spec scope check failed. A spec is unreadable, has no parseable \"Files touched:\" line, or declares more files than generate-impl.mjs's own 6-file generation limit - see the group log above for which spec(s), which reason, and why this blocks merge rather than just warning."
             exit 1
           }

--- a/.github/workflows/ai-sdlc-guards.yml
+++ b/.github/workflows/ai-sdlc-guards.yml
@@ -97,20 +97,30 @@ jobs:
             exit 1
           }
 
-      - name: Check spec scope (advisory)
+      - name: Check spec scope (hard)
         if: ${{ !cancelled() && steps.specs.outputs.count != '0' }}
         env:
           SPECS: ${{ steps.specs.outputs.files }}
+          # Hard here (unlike spec-agent.yml's own inline copy of this same
+          # check, which stays soft) - this step runs against the PR content
+          # a human actually reviews and merges, agent-authored or
+          # hand-written either way, so it's the one that should actually
+          # block ratifying a spec over generate-impl.mjs's own file-count
+          # limit. See check-spec-scope.mjs's header for the full reasoning
+          # and issue #367, the real incident that justified flipping this.
+          SPEC_SCOPE_HARD: 'true'
         run: |
           set -euo pipefail
-          # Advisory by design - the cap is uncalibrated. It runs here rather
-          # than in the agent job specifically so its output lands on the PR the
-          # reviewer is reading, instead of in a step summary nobody opens.
+          failed=0
           while IFS= read -r spec; do
             [ -n "$spec" ] || continue
             echo "::group::check-spec-scope $spec"
-            if ! SPEC_FILE="$spec" node scripts/ai-sdlc/check-spec-scope.mjs; then
-              echo "::warning::check-spec-scope crashed for $spec instead of reporting advisory output - this is a launch/script failure, not a scope finding"
-            fi
+            # Run every spec before failing, so one PR touching two specs
+            # reports both rather than only the first.
+            SPEC_FILE="$spec" node scripts/ai-sdlc/check-spec-scope.mjs || failed=1
             echo "::endgroup::"
           done <<< "$SPECS"
+          [ "$failed" -eq 0 ] || {
+            echo "::error::Spec scope check failed. A spec declares more files than generate-impl.mjs's own 6-file generation limit - see the group log above for which one(s) and why this blocks merge, not just warns."
+            exit 1
+          }

--- a/.github/workflows/impl-agent.yml
+++ b/.github/workflows/impl-agent.yml
@@ -141,18 +141,20 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      # Hard gate: the scaffold's file list and the ratified spec's "Files
-      # touched" list must match EXACTLY - no file written that the spec
-      # never declared, and no file declared that the scaffold never wrote.
-      # An unambiguous comparison, not a judgment call, so unlike
-      # check-spec-scope.mjs's advisory warning this fails the workflow
-      # outright. FILES_WRITTEN is passed even when empty: an empty value
-      # means the scaffold wrote nothing, which the gate must fail rather
-      # than skip.
+      # Hard gate, always: the scaffold's file list and the ratified spec's
+      # "Files touched" list must match EXACTLY - no file written that the
+      # spec never declared, and no file declared that the scaffold never
+      # wrote. An unambiguous comparison, not a judgment call - unlike
+      # check-spec-scope.mjs's cap check, which stays soft specifically in
+      # this workflow (spec-agent.yml runs its own hard copy against the PR
+      # instead; see that script's header). FILES_WRITTEN is passed even
+      # when empty: an empty value means the scaffold wrote nothing, which
+      # the gate must fail rather than skip.
       - name: Check impl scope against spec
         env:
           SPEC_FILE: ${{ steps.spec.outputs.spec_file }}
           FILES_WRITTEN: ${{ steps.gen.outputs.files_written }}
+          IMPL_SUMMARY: ${{ steps.gen.outputs.impl_summary }}
         run: node scripts/ai-sdlc/check-impl-scope.mjs
 
       - name: Install dependencies (required for ESLint)

--- a/.github/workflows/spec-agent.yml
+++ b/.github/workflows/spec-agent.yml
@@ -113,9 +113,13 @@ jobs:
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}
         run: node scripts/ai-sdlc/verify-spec-ownership.mjs
 
-      # Advisory only (see the script's own header for why this isn't a
-      # hard cap yet) - warns if the spec's declared scope is large enough
-      # to be worth a second look before ratifying.
+      # Deliberately kept soft here (SPEC_SCOPE_HARD unset) even though the
+      # cap is a real hard gate elsewhere: an over-scoped agent-generated
+      # spec should still produce a visible PR with a warning, rather than
+      # failing this whole job with nothing to show for it - a silently
+      # vanished generation run is worse than a PR a human has to react to.
+      # ai-sdlc-guards.yml runs the hard copy of this same check against the
+      # PR itself, where a reviewer will actually see it before merging.
       - name: Check spec scope (advisory)
         env:
           SPEC_FILE: ${{ steps.gen.outputs.spec_file }}

--- a/scripts/ai-sdlc/check-impl-scope.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.mjs
@@ -37,6 +37,7 @@
 // Exit 0 only when the comparison actually ran and came back clean.
 
 import { readFileSync } from 'node:fs';
+import { posix } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
 
@@ -44,16 +45,29 @@ import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
  * Canonicalize a repo-relative path for set comparison.
  *
  * The two sides of this comparison are produced very differently: written
- * paths come from generate-impl.mjs, already normalized by node's
- * `relative()` (no `./`, forward slashes); declared paths are lifted
- * verbatim out of backticks in human-ratified, LLM-drafted markdown. A
- * stray `./` or a stray space on the spec side would otherwise make the
- * SAME file show up in BOTH failure lists at once - reported as written-but-
- * undeclared and declared-but-unwritten simultaneously - which is a
- * confusing false failure that costs a full generation run.
+ * paths come from generate-impl.mjs, already canonicalized by node's
+ * `relative(base, resolve(base, p))` (no `./`, no `..` segments, forward
+ * slashes); declared paths are lifted verbatim out of backticks in
+ * human-ratified, LLM-drafted markdown. A stray `./`, a stray space, or a
+ * `packages/x/../y.ts`-shaped path on the spec side would otherwise make
+ * the SAME file show up in BOTH failure lists at once - reported as
+ * written-but-undeclared and declared-but-unwritten simultaneously - which
+ * is a confusing false failure that costs a full generation run.
+ * `posix.normalize()` (not the manual leading-"./"" strip this used to be)
+ * is what actually matches the written side's `..`-resolving behavior; a
+ * spec declaring a path with a literal `..` segment - unusual, but not
+ * impossible from a drafting model - would otherwise never match its own
+ * written file (found via generate-impl.mjs's self-correction feature
+ * reusing this same function; see issue #367's completeness-hardening PR).
+ *
+ * Empty input returns empty, not `posix.normalize('')`'s own `'.'` - every
+ * call site immediately `.filter(Boolean)`s its output, on the assumption
+ * that empty-in means empty-out (an empty `FILES_WRITTEN` env var must stay
+ * an empty writtenPaths array, not become the single bogus path `['.']`).
  */
 export function normalizePath(p) {
-  return p.trim().replaceAll('\\', '/').replace(/^\.\//, '');
+  const trimmed = p.trim().replaceAll('\\', '/');
+  return trimmed ? posix.normalize(trimmed) : '';
 }
 
 /** Returns the subset of writtenPaths not present in declaredPaths. */

--- a/scripts/ai-sdlc/check-impl-scope.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.mjs
@@ -28,6 +28,9 @@
 // check. It short-circuited to exit 0 until 2026-08-02, which left the most
 // extreme version of the #237 bug (zero of N declared files) passing green
 // through the gate built to catch it.
+// Optional env var: IMPL_SUMMARY (generate-impl.mjs's own impl_summary
+// output) - printed on a mismatch as an unverified lead, not trusted as a
+// completeness signal (see issue #367, where it disagreed with reality).
 // Exit 1 if the two lists disagree in either direction, OR if the ratified
 // spec can't be read or has no parseable "Files touched" line — a hard gate
 // that no-ops on a malformed baseline isn't a gate, it's a trap door.
@@ -75,7 +78,7 @@ export function findUnwrittenPaths(writtenPaths, declaredPaths) {
 }
 
 function main() {
-  const { SPEC_FILE, FILES_WRITTEN } = process.env;
+  const { SPEC_FILE, FILES_WRITTEN, IMPL_SUMMARY } = process.env;
   if (!SPEC_FILE) {
     console.error('Missing SPEC_FILE');
     process.exit(1);
@@ -153,6 +156,21 @@ function main() {
           '       without amending will fail identically, since the agent will keep\n' +
           '       (correctly) deciding that file needs no change.\n'
       );
+
+      // The model's own account of what it did, straight from its response -
+      // NOT verified against FILES_WRITTEN, and issue #367 (2026-08-20) found
+      // it can actively disagree: one run's summary claimed all 7 declared
+      // files were handled while the files array itself contained only 2.
+      // Surfaced anyway because it's still a fast lead on WHY something is
+      // missing (ran out of budget mid-file, decided a file needed no
+      // change, flagged its own gap) - a human just has to read it knowing
+      // it may be describing work that was never actually emitted.
+      if (IMPL_SUMMARY?.trim()) {
+        console.error(
+          `\n  Model's own summary (unverified - may describe work not actually written,\n` +
+            `  see issue #367): ${IMPL_SUMMARY.trim()}\n`
+        );
+      }
     }
 
     console.error(`Declared in ${SPEC_FILE}:\n${declaredPaths.map((p) => `  ${p}`).join('\n')}`);

--- a/scripts/ai-sdlc/check-impl-scope.test.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.test.mjs
@@ -146,6 +146,7 @@ function runCli(env) {
   const base = { ...process.env };
   delete base.SPEC_FILE;
   delete base.FILES_WRITTEN;
+  delete base.IMPL_SUMMARY;
   return spawnSync(process.execPath, [SCRIPT], { env: { ...base, ...env }, encoding: 'utf8' });
 }
 
@@ -185,6 +186,36 @@ describe('CLI', () => {
     assert.equal(r.status, 1);
     assert.match(r.stderr, /Did NOT write files the spec declared:\n {2}- packages\/b\.ts/);
     assert.doesNotMatch(r.stderr, /Wrote files the spec never declared/);
+  });
+
+  test('under-delivery surfaces IMPL_SUMMARY as an unverified lead when provided', () => {
+    const spec = writeSpec('under-with-summary.md', TWO_FILES);
+    const r = runCli({
+      SPEC_FILE: spec,
+      FILES_WRITTEN: 'packages/a.ts',
+      IMPL_SUMMARY: 'Wrote both files and the wiring.',
+    });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /Model's own summary \(unverified/);
+    assert.match(r.stderr, /Wrote both files and the wiring\./);
+  });
+
+  test('under-delivery omits the summary section when IMPL_SUMMARY is unset', () => {
+    const spec = writeSpec('under-no-summary.md', TWO_FILES);
+    const r = runCli({ SPEC_FILE: spec, FILES_WRITTEN: 'packages/a.ts' });
+    assert.equal(r.status, 1);
+    assert.doesNotMatch(r.stderr, /Model's own summary/);
+  });
+
+  test('a passing run never prints the summary section, even if IMPL_SUMMARY is set', () => {
+    const spec = writeSpec('match-with-summary.md', TWO_FILES);
+    const r = runCli({
+      SPEC_FILE: spec,
+      FILES_WRITTEN: 'packages/a.ts,packages/b.ts',
+      IMPL_SUMMARY: 'Wrote both files.',
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(r.stdout + r.stderr, /Model's own summary/);
   });
 
   test('exits 1 on over-delivery, naming only the undeclared path', () => {

--- a/scripts/ai-sdlc/check-impl-scope.test.mjs
+++ b/scripts/ai-sdlc/check-impl-scope.test.mjs
@@ -110,6 +110,23 @@ describe('normalizePath', () => {
   test('normalizes backslash separators to forward slashes', () => {
     assert.equal(normalizePath('packages\\backend\\src\\a.ts'), 'packages/backend/src/a.ts');
   });
+
+  test('resolves ".." segments the same way generate-impl.mjs\'s relative()-based toRepoRelative does', () => {
+    // A spec declaring a path this way is unusual, but the written side
+    // (relative(base, resolve(base, p))) always collapses it - without the
+    // same resolution here, a correctly-written file would show up as
+    // both written-but-undeclared AND declared-but-unwritten.
+    assert.equal(normalizePath('packages/x/../y.ts'), 'packages/y.ts');
+  });
+
+  test('empty input stays empty, not posix.normalize\'s own "."', () => {
+    // Every call site .filter(Boolean)s the result on the assumption that
+    // empty-in means empty-out. FILES_WRITTEN='' -> ''.split(',') -> ['']
+    // -> normalizePath('') must filter away, or an empty FILES_WRITTEN
+    // becomes the single bogus written path ['.'] instead of [].
+    assert.equal(normalizePath(''), '');
+    assert.equal(normalizePath('   '), '');
+  });
 });
 
 // --- CLI-level tests for main() -------------------------------------------

--- a/scripts/ai-sdlc/check-spec-scope.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.mjs
@@ -104,7 +104,12 @@ function main() {
   }
 
   const declaredPaths = extractDeclaredPaths(spec);
-  if (!declaredPaths) {
+  // extractDeclaredPaths returns null only when the "**Files touched:**"
+  // marker itself is absent - a marker present with no parseable backtick
+  // path returns [], which is truthy. Both are the same malformed-spec
+  // finding: `!declaredPaths` alone would let a hard-mode run see 0 files
+  // "within cap" and exit 0, silently bypassing the gate.
+  if (!declaredPaths || declaredPaths.length === 0) {
     const msg = 'Spec scope check: no "Files touched:" line found.';
     if (hard) {
       console.error(`::error::${msg} A malformed spec is a real finding in hard mode, not a skip.`);

--- a/scripts/ai-sdlc/check-spec-scope.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.mjs
@@ -88,13 +88,29 @@ function main() {
   try {
     spec = readFileSync(SPEC_FILE, 'utf8');
   } catch (err) {
-    console.warn(`Spec scope check: could not read spec file: ${err.message}`);
+    // In hard mode this is a real gate, and a gate that no-ops on a file it
+    // can't even read isn't a gate, it's a trap door (same reasoning
+    // check-impl-scope.mjs's own header states for the identical choice).
+    // Soft mode (spec-agent.yml's own inline copy) keeps waving this
+    // through: a caller-side plumbing bug there shouldn't fail the whole
+    // generation job over a check this soft to begin with.
+    const msg = `Spec scope check: could not read spec file: ${err.message}`;
+    if (hard) {
+      console.error(`::error::${msg}`);
+      process.exit(1);
+    }
+    console.warn(msg);
     process.exit(0);
   }
 
   const declaredPaths = extractDeclaredPaths(spec);
   if (!declaredPaths) {
-    console.warn('Spec scope check: no "Files touched:" line found — skipping.');
+    const msg = 'Spec scope check: no "Files touched:" line found.';
+    if (hard) {
+      console.error(`::error::${msg} A malformed spec is a real finding in hard mode, not a skip.`);
+      process.exit(1);
+    }
+    console.warn(`${msg} Skipping.`);
     process.exit(0);
   }
 

--- a/scripts/ai-sdlc/check-spec-scope.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.mjs
@@ -1,20 +1,36 @@
 #!/usr/bin/env node
-// Advisory fan-out check for generated specs: warns (does not fail the
-// build) when a spec's declared "Files touched" list is large enough to be
-// a structural tell that a new package/subsystem is being born rather than
-// a scoped change - spec #238 declared 10 files, 7 of them new, including a
-// from-scratch package.json/tsconfig.json/vitest.config.ts trio.
+// Fan-out check for generated specs: fires when a spec's declared "Files
+// touched" list is larger than DEFAULT_CAP (6). Two independent reasons the
+// same number matters:
 //
-// This is deliberately SOFT, unlike verify-spec-ownership.mjs's hard gate:
-// there is no real historical distribution to calibrate a hard cap against
-// yet (bugspotter-metrics did not track files_changed until schema 4).
-// Flip DEFAULT_CAP's enforcement to a hard exit(1) once enough real spec
-// PRs have shipped through it to know what "large" actually means for this
-// repo, rather than guessing a number now and blocking legitimate work on
-// a guess.
+//   1. A structural tell that a new package/subsystem is being born rather
+//      than a scoped change - spec #238 declared 10 files, 7 of them new,
+//      including a from-scratch package.json/tsconfig.json/vitest.config.ts
+//      trio. This half stayed a judgment call for a long time (see below).
+//   2. generate-impl.mjs's own prompt hard-codes "Do NOT generate more than
+//      6 files total" - a spec over that isn't just "worth a second look",
+//      it is asking impl-agent to violate its own instructions. Issue #367
+//      (2026-08-20) is the real data point this was missing: a spec grew
+//      from 4 to 7 files during legitimate review fixes, nobody re-checked
+//      it against this cap, and impl-agent silently dropped 5 of 7 files
+//      rather than erroring - twice, at two different declared counts,
+//      before the spec was manually reduced back under 6.
 //
-// Required env var: SPEC_FILE. Optional: SPEC_SCOPE_CAP (default 6).
-// Always exits 0 - this is advisory only.
+// Two call sites, two enforcement modes, same script:
+//   - spec-agent.yml's own inline step runs SOFT (SPEC_SCOPE_HARD unset):
+//     an over-scoped agent-generated spec still produces a visible PR with
+//     a warning, rather than failing the whole generation job with nothing
+//     to show - a silently-vanished run is worse than a PR a human has to
+//     react to (see ai-sdlc-guards.yml's own comment on why it runs the
+//     hard copy of this check where a reviewer will actually see it).
+//   - ai-sdlc-guards.yml runs HARD (SPEC_SCOPE_HARD=true): this is the copy
+//     that runs against the actual PR content a human reviews and merges,
+//     agent-authored or hand-written either way, so it's the one that
+//     should actually block ratifying an over-scoped spec.
+//
+// Required env var: SPEC_FILE. Optional: SPEC_SCOPE_CAP (default 6),
+// SPEC_SCOPE_HARD ('true' to exit 1 on a finding; anything else, including
+// unset, stays soft and always exits 0).
 
 import { readFileSync, appendFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
@@ -42,24 +58,27 @@ export function resolveCap(rawCap, defaultCap = DEFAULT_CAP) {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : defaultCap;
 }
 
-/** Returns a warning string if declaredPaths.length exceeds cap, else null. */
+/** Returns a finding string if declaredPaths.length exceeds cap, else null. */
 export function checkFanOut(declaredPaths, cap = DEFAULT_CAP) {
   if (declaredPaths.length <= cap) {
     return null;
   }
   return (
-    `Spec declares ${declaredPaths.length} files touched (advisory cap: ${cap}). ` +
-    `A spec this large is worth a second look before ratifying - it's the same shape ` +
-    `spec #238 had (10 files, 7 new, including a from-scratch package scaffold) right ` +
-    `before it turned out to be hallucinating an entire package. Not a hard block: a ` +
-    `genuinely large, coherent change is sometimes correct - but if this is several ` +
-    `unrelated things stapled together, splitting it into multiple issues/specs is ` +
-    `usually the better call.`
+    `Spec declares ${declaredPaths.length} files touched (cap: ${cap}). Two independent ` +
+    `reasons this matters: it's the same shape spec #238 had (10 files, 7 new, including ` +
+    `a from-scratch package scaffold) right before it turned out to be hallucinating an ` +
+    `entire package - AND generate-impl.mjs's own prompt hard-codes "do not generate more ` +
+    `than 6 files total", so a spec over that cap is asking impl-agent to violate its own ` +
+    `instructions, not just "worth a second look". Issue #367 hit this for real: impl-agent ` +
+    `silently dropped 5 of 7 declared files rather than erroring. A genuinely large, ` +
+    `coherent change is sometimes still correct - but the fix is splitting it into ` +
+    `multiple issues/specs (see #367/#368 for a worked example), not ratifying it as-is.`
   );
 }
 
 function main() {
-  const { SPEC_FILE, SPEC_SCOPE_CAP } = process.env;
+  const { SPEC_FILE, SPEC_SCOPE_CAP, SPEC_SCOPE_HARD } = process.env;
+  const hard = SPEC_SCOPE_HARD === 'true';
   if (!SPEC_FILE) {
     console.error('Missing SPEC_FILE');
     process.exit(1);
@@ -86,18 +105,19 @@ function main() {
     console.warn(`Spec scope check: ignoring invalid SPEC_SCOPE_CAP="${SPEC_SCOPE_CAP}".`);
   }
   const cap = resolveCap(SPEC_SCOPE_CAP);
-  const warning = checkFanOut(declaredPaths, cap);
-  if (warning) {
-    console.warn(`::warning::${warning}`);
-    // Advisory output that only lands in run-log annotations is easy for a
-    // spec reviewer to miss — they see the PR, not the Action run. Surface
-    // it in the job summary too, when running under GitHub Actions.
+  const finding = checkFanOut(declaredPaths, cap);
+  if (finding) {
+    const label = hard ? 'Spec scope check FAILED' : 'Spec scope warning';
+    console[hard ? 'error' : 'warn'](`::${hard ? 'error' : 'warning'}::${finding}`);
+    // Run-log annotations are easy for a spec reviewer to miss — they see
+    // the PR, not the Action run. Surface it in the job summary too, when
+    // running under GitHub Actions.
     if (process.env.GITHUB_STEP_SUMMARY) {
-      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n**Spec scope warning:** ${warning}\n`);
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n**${label}:** ${finding}\n`);
     }
-  } else {
-    console.log(`Spec scope check: ${declaredPaths.length} file(s) declared, within cap (${cap}).`);
+    process.exit(hard ? 1 : 0);
   }
+  console.log(`Spec scope check: ${declaredPaths.length} file(s) declared, within cap (${cap}).`);
   process.exit(0);
 }
 

--- a/scripts/ai-sdlc/check-spec-scope.test.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.test.mjs
@@ -130,4 +130,34 @@ describe('CLI: SPEC_SCOPE_HARD dispatch', () => {
     assert.equal(r.status, 0, r.stderr);
     assert.match(r.stdout, /within cap/);
   });
+
+  test('unreadable spec file, SPEC_SCOPE_HARD unset: exits 0 (soft waves it through)', () => {
+    const r = runCli({ SPEC_FILE: join(DIR, 'does-not-exist.md') });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /could not read spec file/);
+  });
+
+  test('unreadable spec file, SPEC_SCOPE_HARD=true: exits 1 (hard gate cannot be bypassed by an I/O error)', () => {
+    const r = runCli({ SPEC_FILE: join(DIR, 'does-not-exist.md'), SPEC_SCOPE_HARD: 'true' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /::error::/);
+    assert.match(r.stderr, /could not read spec file/);
+  });
+
+  test('no parseable "Files touched:" line, SPEC_SCOPE_HARD unset: exits 0 (soft skips)', () => {
+    const path = join(DIR, 'no-files-touched-soft.md');
+    writeFileSync(path, '# Spec: fixture\n\n## Problem\n\nNo files field.\n', 'utf8');
+    const r = runCli({ SPEC_FILE: path });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /no "Files touched:" line found/);
+  });
+
+  test('no parseable "Files touched:" line, SPEC_SCOPE_HARD=true: exits 1 (a malformed spec is a real finding, not a skip)', () => {
+    const path = join(DIR, 'no-files-touched-hard.md');
+    writeFileSync(path, '# Spec: fixture\n\n## Problem\n\nNo files field.\n', 'utf8');
+    const r = runCli({ SPEC_FILE: path, SPEC_SCOPE_HARD: 'true' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /::error::/);
+    assert.match(r.stderr, /no "Files touched:" line found/);
+  });
 });

--- a/scripts/ai-sdlc/check-spec-scope.test.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.test.mjs
@@ -160,4 +160,33 @@ describe('CLI: SPEC_SCOPE_HARD dispatch', () => {
     assert.match(r.stderr, /::error::/);
     assert.match(r.stderr, /no "Files touched:" line found/);
   });
+
+  test('"Files touched:" marker present but empty, SPEC_SCOPE_HARD=true: exits 1, not "0 files within cap"', () => {
+    // extractDeclaredPaths returns [] (not null) for a marker with no
+    // parseable backtick path - truthy, so `!declaredPaths` alone would
+    // silently pass this as "0 files declared, within cap" in hard mode.
+    const path = join(DIR, 'empty-marker-hard.md');
+    writeFileSync(
+      path,
+      '# Spec: fixture\n\n**Files touched:**\n\n## Problem\n\nFixture.\n',
+      'utf8'
+    );
+    const r = runCli({ SPEC_FILE: path, SPEC_SCOPE_HARD: 'true' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /::error::/);
+    assert.match(r.stderr, /no "Files touched:" line found/);
+    assert.doesNotMatch(r.stdout, /within cap/);
+  });
+
+  test('"Files touched:" marker present but empty, SPEC_SCOPE_HARD unset: exits 0 (soft skips, same as no marker at all)', () => {
+    const path = join(DIR, 'empty-marker-soft.md');
+    writeFileSync(
+      path,
+      '# Spec: fixture\n\n**Files touched:**\n\n## Problem\n\nFixture.\n',
+      'utf8'
+    );
+    const r = runCli({ SPEC_FILE: path });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /no "Files touched:" line found/);
+  });
 });

--- a/scripts/ai-sdlc/check-spec-scope.test.mjs
+++ b/scripts/ai-sdlc/check-spec-scope.test.mjs
@@ -1,8 +1,15 @@
-// Tests for check-spec-scope.mjs's pure logic. Zero-dependency, run with
-// `node --test`.
+// Tests for check-spec-scope.mjs's pure logic, plus a CLI block for the
+// hard/soft dispatch in main() (SPEC_SCOPE_HARD), which isn't pure logic
+// and can only be exercised by actually running the script. Zero-dependency,
+// run with `node --test`.
 
-import { test, describe } from 'node:test';
+import { test, describe, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { checkFanOut, resolveCap, DEFAULT_CAP } from './check-spec-scope.mjs';
 
 describe('resolveCap', () => {
@@ -58,5 +65,69 @@ describe('checkFanOut', () => {
 
   test('empty list never warns', () => {
     assert.equal(checkFanOut([]), null);
+  });
+});
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'check-spec-scope.mjs');
+const DIR = mkdtempSync(join(tmpdir(), 'check-spec-scope-test-'));
+after(() => rmSync(DIR, { recursive: true, force: true }));
+
+function writeSpec(name, fileCount) {
+  const path = join(DIR, name);
+  const files = Array.from({ length: fileCount }, (_, i) => `\`packages/a/${i}.ts\``).join(', ');
+  writeFileSync(
+    path,
+    [
+      '# Spec: fixture',
+      '',
+      `**Files touched:** ${files}`,
+      '',
+      '## Problem',
+      '',
+      'Fixture.',
+      '',
+    ].join('\n'),
+    'utf8'
+  );
+  return path;
+}
+
+/** Runs the real CLI with a clean slate for the env vars under test. */
+function runCli(env) {
+  const base = { ...process.env };
+  delete base.SPEC_FILE;
+  delete base.SPEC_SCOPE_CAP;
+  delete base.SPEC_SCOPE_HARD;
+  return spawnSync(process.execPath, [SCRIPT], { env: { ...base, ...env }, encoding: 'utf8' });
+}
+
+describe('CLI: SPEC_SCOPE_HARD dispatch', () => {
+  test('over cap, SPEC_SCOPE_HARD unset: exits 0, still warns', () => {
+    const spec = writeSpec('over-soft.md', DEFAULT_CAP + 1);
+    const r = runCli({ SPEC_FILE: spec });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /::warning::/);
+    assert.match(r.stderr, /files touched \(cap: 6\)/);
+  });
+
+  test('over cap, SPEC_SCOPE_HARD=true: exits 1', () => {
+    const spec = writeSpec('over-hard.md', DEFAULT_CAP + 1);
+    const r = runCli({ SPEC_FILE: spec, SPEC_SCOPE_HARD: 'true' });
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /::error::/);
+    assert.match(r.stderr, /files touched \(cap: 6\)/);
+  });
+
+  test('over cap, SPEC_SCOPE_HARD set to something other than "true": stays soft', () => {
+    const spec = writeSpec('over-hard-typo.md', DEFAULT_CAP + 1);
+    const r = runCli({ SPEC_FILE: spec, SPEC_SCOPE_HARD: 'yes' });
+    assert.equal(r.status, 0, r.stderr);
+  });
+
+  test('within cap, SPEC_SCOPE_HARD=true: exits 0, no finding', () => {
+    const spec = writeSpec('within-hard.md', DEFAULT_CAP);
+    const r = runCli({ SPEC_FILE: spec, SPEC_SCOPE_HARD: 'true' });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /within cap/);
   });
 });

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -483,8 +483,18 @@ if (!parsed || !Array.isArray(parsed.files) || parsed.files.length === 0) {
 // var alongside the workflow change rather than relying on remembering to
 // edit this file's own hard-coded default too.
 function parsePositiveMs(envValue, fallback) {
-  const n = Number(envValue);
-  return envValue !== undefined && Number.isFinite(n) && n >= 0 ? n : fallback;
+  // Trim-then-check-empty BEFORE Number(), same reasoning as
+  // check-spec-scope.mjs's resolveCap: Number('') is 0, not NaN, and
+  // GitHub Actions resolves an unconfigured `vars.*` reference to an empty
+  // string rather than leaving the env var unset - so `envValue !==
+  // undefined` alone would let an empty override silently collapse the
+  // budget to 0 instead of falling back.
+  const trimmed = typeof envValue === 'string' ? envValue.trim() : envValue;
+  if (trimmed === undefined || trimmed === '') {
+    return fallback;
+  }
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
 }
 const STEP_BUDGET_MS = parsePositiveMs(process.env.IMPL_STEP_BUDGET_MS, 21 * 60_000);
 // Headroom for validation/write/downstream steps after the model call(s) return.

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -31,6 +31,7 @@ import { dirname, resolve, relative, isAbsolute } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { callClaude, requireLlmCredentials } from './llm-client.mjs';
 import { extractDeclaredPaths } from './verify-spec-ownership.mjs';
+import { normalizePath, findUnwrittenPaths } from './check-impl-scope.mjs';
 
 const { ISSUE_NUMBER, ISSUE_TITLE, ISSUE_LABELS = '', SPEC_CONTENT, GITHUB_OUTPUT } = process.env;
 
@@ -370,6 +371,7 @@ RULES:
 // correctness — see the header comment above.
 const prompt = staticContext ? `${staticContext}\n\n${userPrompt}` : userPrompt;
 
+const scriptStartedAt = Date.now();
 let text, stopReason;
 try {
   // 600s: this is the largest of the four ai-sdlc Claude calls — max_tokens
@@ -454,6 +456,98 @@ try {
 if (!parsed || !Array.isArray(parsed.files) || parsed.files.length === 0) {
   console.error('No files in response:', JSON.stringify(parsed, null, 2));
   process.exit(1);
+}
+
+// Self-correction: compare the response's own declared paths against the
+// spec's "Files touched" list BEFORE writing anything, and make ONE
+// corrective follow-up call for exactly the missing files if there's a
+// gap. check-impl-scope.mjs's hard gate downstream still has the final
+// say - this is a pre-emptive attempt to not need it, not a replacement.
+// Deliberately asks for ONLY the missing files, not a full re-generation:
+// the response schema's cost driver is re-emitting whole files, so a
+// broad "try again" risks dropping a *different* file under the same
+// pressure that caused this one. Verified against `parsed.files`, never
+// against `parsed.summary` - issue #367 (2026-08-20) found a real run
+// whose summary claimed all declared files were written while the files
+// array itself held only 2 of 7, so the summary cannot be trusted as a
+// completeness signal here any more than check-impl-scope.mjs trusts it.
+//
+// Time-budgeted, not unconditional: STEP_BUDGET_MS mirrors impl-agent.yml's
+// "Generate scaffold" step cap (currently 21m) - keep the two in sync if
+// that step's timeout-minutes ever changes. Turn 1 alone can legitimately
+// use most of that budget, so a second call only fires with a real,
+// bounded amount of time actually left; otherwise this skips straight to
+// check-impl-scope.mjs reporting the gap to a human, same as before this
+// existed.
+const STEP_BUDGET_MS = 21 * 60_000;
+const SAFETY_BUFFER_MS = 4 * 60_000; // headroom for validation/write/downstream steps
+const RETRY_MIN_BUDGET_MS = 90_000; // not worth attempting a corrective call below this
+const declaredPathsForRetry = (extractDeclaredPaths(SPEC_CONTENT) ?? [])
+  .map(normalizePath)
+  .filter(Boolean);
+const respondedPaths = parsed.files
+  .map((f) => (typeof f?.path === 'string' ? normalizePath(f.path) : null))
+  .filter(Boolean);
+const missingPaths = findUnwrittenPaths(respondedPaths, declaredPathsForRetry);
+
+if (missingPaths.length > 0 && declaredPathsForRetry.length > 0) {
+  const remainingMs = STEP_BUDGET_MS - SAFETY_BUFFER_MS - (Date.now() - scriptStartedAt);
+  if (remainingMs < RETRY_MIN_BUDGET_MS) {
+    console.log(
+      `Response is missing ${missingPaths.length} declared file(s) (${missingPaths.join(', ')}), ` +
+        `but only ~${Math.round(remainingMs / 1000)}s remain in the step budget - not enough for ` +
+        `a safe corrective call. Proceeding without it; check-impl-scope.mjs will report the gap.`
+    );
+  } else {
+    const retryTimeoutMs = Math.min(300_000, remainingMs);
+    console.log(
+      `Response covered ${respondedPaths.length}/${declaredPathsForRetry.length} declared files; ` +
+        `missing: ${missingPaths.join(', ')}. Requesting exactly the missing file(s) in one ` +
+        `corrective follow-up turn (timeout ${Math.round(retryTimeoutMs / 1000)}s).`
+    );
+    const correctionPrompt =
+      `${prompt}\n\n` +
+      `--- CORRECTIVE FOLLOW-UP ---\n` +
+      `Your previous response's "files" array covered: ${respondedPaths.join(', ') || '(none)'}.\n` +
+      `The spec's "Files touched" list also declares these paths, which your response did ` +
+      `NOT include: ${missingPaths.join(', ')}.\n` +
+      `Return ONLY these missing file(s) now, in the exact same JSON schema ` +
+      `({ "files": [...], "summary": "..." }) - do not re-emit files you already provided.`;
+
+    let retryText, retryStopReason;
+    try {
+      ({ text: retryText, stopReason: retryStopReason } = await callClaude({
+        prompt: correctionPrompt,
+        maxTokens: MAX_TOKENS,
+        timeoutMs: retryTimeoutMs,
+        model: MODEL,
+      }));
+    } catch (err) {
+      // Not fatal - fall through with what turn 1 gave us and let
+      // check-impl-scope.mjs report the (still-real) gap to a human.
+      console.warn(`Corrective follow-up call failed, proceeding without it: ${err.message}`);
+      retryText = null;
+    }
+
+    if (retryText && retryStopReason !== 'max_tokens') {
+      try {
+        const retryFenceMatch = retryText.match(/```json\s*([\s\S]*?)\s*```/i);
+        const retryRaw = retryFenceMatch ? retryFenceMatch[1].trim() : retryText.trim();
+        const retryParsed = JSON.parse(retryRaw);
+        if (Array.isArray(retryParsed?.files) && retryParsed.files.length > 0) {
+          parsed.files = [...parsed.files, ...retryParsed.files];
+          parsed.summary =
+            `${parsed.summary ?? ''} [corrective follow-up added ${retryParsed.files.length} ` +
+            `file(s): ${missingPaths.join(', ')}]`;
+          console.log(`Corrective follow-up added ${retryParsed.files.length} file(s).`);
+        }
+      } catch (e) {
+        console.warn(
+          `Corrective follow-up response was not parseable JSON, proceeding without it: ${e.message}`
+        );
+      }
+    }
+  }
 }
 
 // Write files (repoRoot + FORBIDDEN_PATH_PATTERNS are declared above, shared

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -473,15 +473,24 @@ if (!parsed || !Array.isArray(parsed.files) || parsed.files.length === 0) {
 // completeness signal here any more than check-impl-scope.mjs trusts it.
 //
 // Time-budgeted, not unconditional: STEP_BUDGET_MS mirrors impl-agent.yml's
-// "Generate scaffold" step cap (currently 21m) - keep the two in sync if
-// that step's timeout-minutes ever changes. Turn 1 alone can legitimately
-// use most of that budget, so a second call only fires with a real,
-// bounded amount of time actually left; otherwise this skips straight to
-// check-impl-scope.mjs reporting the gap to a human, same as before this
-// existed.
-const STEP_BUDGET_MS = 21 * 60_000;
-const SAFETY_BUFFER_MS = 4 * 60_000; // headroom for validation/write/downstream steps
-const RETRY_MIN_BUDGET_MS = 90_000; // not worth attempting a corrective call below this
+// "Generate scaffold" step cap (currently 21m). Turn 1 alone can
+// legitimately use most of that budget, so a second call only fires with
+// a real, bounded amount of time actually left; otherwise this skips
+// straight to check-impl-scope.mjs reporting the gap to a human, same as
+// before this existed. All three are overridable via env vars specifically
+// so a future change to that workflow step's timeout-minutes can't
+// silently desync from the number this script assumes - update the env
+// var alongside the workflow change rather than relying on remembering to
+// edit this file's own hard-coded default too.
+function parsePositiveMs(envValue, fallback) {
+  const n = Number(envValue);
+  return envValue !== undefined && Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+const STEP_BUDGET_MS = parsePositiveMs(process.env.IMPL_STEP_BUDGET_MS, 21 * 60_000);
+// Headroom for validation/write/downstream steps after the model call(s) return.
+const SAFETY_BUFFER_MS = parsePositiveMs(process.env.IMPL_SAFETY_BUFFER_MS, 4 * 60_000);
+// Not worth attempting a corrective call below this much remaining budget.
+const RETRY_MIN_BUDGET_MS = parsePositiveMs(process.env.IMPL_RETRY_MIN_BUDGET_MS, 90_000);
 const declaredPathsForRetry = (extractDeclaredPaths(SPEC_CONTENT) ?? [])
   .map(normalizePath)
   .filter(Boolean);
@@ -489,6 +498,7 @@ const respondedPaths = parsed.files
   .map((f) => (typeof f?.path === 'string' ? normalizePath(f.path) : null))
   .filter(Boolean);
 const missingPaths = findUnwrittenPaths(respondedPaths, declaredPathsForRetry);
+let correctionAttempted = false;
 
 if (missingPaths.length > 0 && declaredPathsForRetry.length > 0) {
   const remainingMs = STEP_BUDGET_MS - SAFETY_BUFFER_MS - (Date.now() - scriptStartedAt);
@@ -535,11 +545,21 @@ if (missingPaths.length > 0 && declaredPathsForRetry.length > 0) {
         const retryRaw = retryFenceMatch ? retryFenceMatch[1].trim() : retryText.trim();
         const retryParsed = JSON.parse(retryRaw);
         if (Array.isArray(retryParsed?.files) && retryParsed.files.length > 0) {
+          // Merge the candidate files in, but do NOT claim success here.
+          // retryParsed.files is what the retry SAYS it returned, not what
+          // survives the write loop below (path-traversal/forbidden-path/
+          // control-char rejection, or a duplicate of a turn-1 path) -
+          // claiming these specific paths were "added" before that loop
+          // has run would repeat the exact confabulation issue #367 is
+          // about, just in this script's own log instead of the model's.
+          // correctionAttempted + missingPaths (captured above) are what
+          // let the post-write-loop block report what ACTUALLY landed.
           parsed.files = [...parsed.files, ...retryParsed.files];
-          parsed.summary =
-            `${parsed.summary ?? ''} [corrective follow-up added ${retryParsed.files.length} ` +
-            `file(s): ${missingPaths.join(', ')}]`;
-          console.log(`Corrective follow-up added ${retryParsed.files.length} file(s).`);
+          correctionAttempted = true;
+          console.log(
+            `Corrective follow-up returned ${retryParsed.files.length} file(s) - verifying ` +
+              `after the write loop which of them actually land before updating the summary.`
+          );
         }
       } catch (e) {
         console.warn(
@@ -583,6 +603,34 @@ for (const { path, content } of parsed.files) {
 if (writtenPaths.length === 0) {
   console.error('No valid files were written after validation - aborting.');
   process.exit(1);
+}
+
+// Now that writtenPaths reflects what actually survived the write loop
+// (path-traversal/forbidden-path/control-char rejection and dedup all
+// included), report what the corrective follow-up ACTUALLY recovered -
+// the intersection of what it was missing and what's now really on disk -
+// not what it was asked for or what retryParsed.files claimed. Getting
+// this wrong here would be the same confabulation issue #367 flagged in
+// the model's own summary, just relocated into this script's log instead
+// of fixed.
+if (correctionAttempted) {
+  const recovered = missingPaths.filter((p) => writtenPaths.includes(p));
+  const stillMissing = missingPaths.filter((p) => !writtenPaths.includes(p));
+  if (recovered.length > 0) {
+    parsed.summary =
+      `${parsed.summary ?? ''} [corrective follow-up recovered ${recovered.length} of ` +
+      `${missingPaths.length} missing file(s): ${recovered.join(', ')}` +
+      (stillMissing.length > 0 ? `; still missing: ${stillMissing.join(', ')}` : '') +
+      `]`;
+    console.log(
+      `Corrective follow-up recovered ${recovered.length}/${missingPaths.length} file(s).`
+    );
+  } else {
+    parsed.summary =
+      `${parsed.summary ?? ''} [corrective follow-up attempted but recovered none of the ` +
+      `${missingPaths.length} missing file(s): ${missingPaths.join(', ')}]`;
+    console.log('Corrective follow-up recovered none of the missing file(s).');
+  }
 }
 
 console.log(`\nSummary: ${parsed.summary}`);

--- a/scripts/ai-sdlc/generate-impl.test.mjs
+++ b/scripts/ai-sdlc/generate-impl.test.mjs
@@ -137,9 +137,10 @@ let runSeq = 0;
 /**
  * Runs the real generate-impl.mjs against the temp repo.
  * @param {string} specContent
- * @param {{files?: object[], retryFiles?: object[]}} [fakeResponses] - what
- *   the fake `claude` returns on the first call and, if a self-correction
- *   round-trip fires, the corrective follow-up call.
+ * @param {{files?: object[], retryFiles?: object[], env?: object}} [fakeResponses] -
+ *   what the fake `claude` returns on the first call and, if a
+ *   self-correction round-trip fires, the corrective follow-up call, plus
+ *   any extra env vars to set on the child (e.g. the IMPL_*_MS overrides).
  */
 function runImpl(specContent, fakeResponses = {}) {
   const promptDump = join(BIN_DIR, `prompt-${runSeq++}.txt`);
@@ -162,6 +163,7 @@ function runImpl(specContent, fakeResponses = {}) {
       ...(fakeResponses.retryFiles
         ? { FAKE_CLAUDE_RETRY_FILES: JSON.stringify(fakeResponses.retryFiles) }
         : {}),
+      ...(fakeResponses.env ?? {}),
     },
   });
   const dump = existsSync(promptDump) ? readFileSync(promptDump, 'utf8') : null;
@@ -237,8 +239,11 @@ describe('self-correction on a missing declared file', () => {
     assert.match(r.stdout, /corrective follow-up turn/);
     assert.match(r.stdout, /Wrote packages\/a\.ts/);
     assert.match(r.stdout, /Wrote packages\/b\.ts/);
-    assert.match(r.stdout, /Corrective follow-up added 1 file\(s\)/);
-    assert.match(r.stdout, /corrective follow-up added 1 file\(s\): packages\/b\.ts/);
+    assert.match(r.stdout, /Corrective follow-up recovered 1\/1 file\(s\)/);
+    assert.match(
+      r.stdout,
+      /corrective follow-up recovered 1 of 1 missing file\(s\): packages\/b\.ts/
+    );
     // The retry prompt must actually tell the model what's missing and
     // what was already covered - not just repeat the original prompt blind.
     assert.match(r.retryPrompt, /packages\/b\.ts/);
@@ -269,6 +274,24 @@ describe('self-correction on a missing declared file', () => {
     // check-impl-scope.mjs's job to report, not this script's to loop on.
   });
 
+  test('does not claim a file was recovered when the retry returns the wrong path', () => {
+    // The confabulation this whole self-correction feature must not repeat:
+    // the retry DOES return a file (so it looks superficially successful),
+    // but it's not the path that was actually missing. The summary must
+    // report reality (nothing recovered), not the retry's own claim.
+    const r = runImpl(spec('packages/a.ts', 'packages/b.ts'), {
+      files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
+      retryFiles: [{ path: 'packages/wrong-file.ts', content: 'export const w = 1;\n' }],
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 2);
+    assert.match(r.stdout, /Wrote packages\/a\.ts/);
+    assert.match(r.stdout, /Wrote packages\/wrong-file\.ts/);
+    assert.doesNotMatch(r.stdout, /Wrote packages\/b\.ts/);
+    assert.match(r.stdout, /Corrective follow-up recovered none of the missing file\(s\)/);
+    assert.match(r.stdout, /recovered none of the.*missing file\(s\): packages\/b\.ts/);
+  });
+
   test('over-delivery (an undeclared extra file) does not trigger a retry', () => {
     // Self-correction targets under-delivery specifically; an extra file
     // is a different problem (drift, not a gap) that check-impl-scope.mjs
@@ -281,5 +304,25 @@ describe('self-correction on a missing declared file', () => {
     });
     assert.equal(r.status, 0, r.stderr);
     assert.equal(r.modelCallCount, 1);
+  });
+
+  test('skips the retry when IMPL_STEP_BUDGET_MS leaves no safe headroom', () => {
+    // A file's worth of headroom is missing but the env override collapses
+    // the step budget to less than the safety buffer alone, so remainingMs
+    // goes negative - the retry must not fire even though it otherwise
+    // would for this exact spec/response pair (see the first test above).
+    const r = runImpl(spec('packages/a.ts', 'packages/b.ts'), {
+      files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
+      retryFiles: [{ path: 'packages/b.ts', content: 'export const b = 2;\n' }],
+      env: { IMPL_STEP_BUDGET_MS: '1000' },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(
+      r.modelCallCount,
+      1,
+      'a collapsed budget must prevent the corrective call entirely'
+    );
+    assert.match(r.stdout, /not enough for a safe corrective call/);
+    assert.doesNotMatch(r.stdout, /Wrote packages\/b\.ts/);
   });
 });

--- a/scripts/ai-sdlc/generate-impl.test.mjs
+++ b/scripts/ai-sdlc/generate-impl.test.mjs
@@ -51,6 +51,23 @@ after(() => {
 // --- fake `claude` on PATH -------------------------------------------------
 // Drains stdin before answering: callViaCli writes the whole prompt to the
 // child's stdin, and the prompt here carries a ~1000-line fixture.
+//
+// Configurable via env vars so the same fake can play both turns of a
+// self-correction round-trip:
+//   FAKE_CLAUDE_FILES       - JSON array of {path, content} for a normal
+//                             (first-turn) call. Defaults to the single
+//                             packages/generated.ts fixture the original
+//                             over-cap tests depend on.
+//   FAKE_CLAUDE_RETRY_FILES - JSON array of {path, content} returned ONLY
+//                             when the received prompt contains the literal
+//                             "--- CORRECTIVE FOLLOW-UP ---" marker
+//                             generate-impl.mjs's own retry prompt always
+//                             includes - this is what lets the fake tell
+//                             the two turns apart without any shared state
+//                             across the two separate child-process spawns.
+//                             Defaults to an empty files array (a corrective
+//                             call that still can't produce the files) when
+//                             unset.
 const IMPL = join(BIN_DIR, 'fake-claude-impl.cjs');
 writeFileSync(
   IMPL,
@@ -61,11 +78,19 @@ writeFileSync(
     "process.stdin.on('data', (d) => { input += d; });",
     "process.stdin.on('end', () => {",
     '  const dump = process.env.FAKE_CLAUDE_PROMPT_DUMP;',
-    '  if (dump) fs.writeFileSync(dump, input);',
-    '  const payload = {',
-    "    files: [{ path: 'packages/generated.ts', content: 'export const generated = true;\\n' }],",
-    "    summary: 'fake impl',",
-    '  };',
+    // Appended, not overwritten: a self-correction round-trip spawns this
+    // fake twice in one generate-impl.mjs run, and both prompts need to
+    // reach the test, in order, separated so neither can be mistaken for
+    // a substring of the other.
+    "  if (dump) fs.appendFileSync(dump, input + '\\n===FAKE_CLAUDE_CALL_BOUNDARY===\\n');",
+    "  const isRetry = input.includes('--- CORRECTIVE FOLLOW-UP ---');",
+    '  const files = isRetry',
+    "    ? JSON.parse(process.env.FAKE_CLAUDE_RETRY_FILES || '[]')",
+    '    : JSON.parse(',
+    '        process.env.FAKE_CLAUDE_FILES ||',
+    '          \'[{"path":"packages/generated.ts","content":"export const generated = true;\\\\n"}]\'',
+    '      );',
+    "  const payload = { files, summary: isRetry ? 'fake retry' : 'fake impl' };",
     "  process.stdout.write(JSON.stringify({ type: 'result', result: JSON.stringify(payload), stop_reason: 'end_turn' }) + '\\n');",
     '});',
     '',
@@ -109,8 +134,14 @@ function spec(...paths) {
 }
 
 let runSeq = 0;
-/** Runs the real generate-impl.mjs against the temp repo. */
-function runImpl(specContent) {
+/**
+ * Runs the real generate-impl.mjs against the temp repo.
+ * @param {string} specContent
+ * @param {{files?: object[], retryFiles?: object[]}} [fakeResponses] - what
+ *   the fake `claude` returns on the first call and, if a self-correction
+ *   round-trip fires, the corrective follow-up call.
+ */
+function runImpl(specContent, fakeResponses = {}) {
   const promptDump = join(BIN_DIR, `prompt-${runSeq++}.txt`);
   const env = { ...process.env };
   delete env.GITHUB_OUTPUT;
@@ -127,12 +158,20 @@ function runImpl(specContent) {
       ISSUE_TITLE: 'fixture issue',
       SPEC_CONTENT: specContent,
       FAKE_CLAUDE_PROMPT_DUMP: promptDump,
+      ...(fakeResponses.files ? { FAKE_CLAUDE_FILES: JSON.stringify(fakeResponses.files) } : {}),
+      ...(fakeResponses.retryFiles
+        ? { FAKE_CLAUDE_RETRY_FILES: JSON.stringify(fakeResponses.retryFiles) }
+        : {}),
     },
   });
+  const dump = existsSync(promptDump) ? readFileSync(promptDump, 'utf8') : null;
+  const calls = dump ? dump.split('===FAKE_CLAUDE_CALL_BOUNDARY===').filter((s) => s.trim()) : [];
   return {
     ...result,
-    modelWasCalled: existsSync(promptDump),
-    prompt: existsSync(promptDump) ? readFileSync(promptDump, 'utf8') : null,
+    modelWasCalled: calls.length > 0,
+    modelCallCount: calls.length,
+    prompt: calls[0] ?? null,
+    retryPrompt: calls[1] ?? null,
   };
 }
 
@@ -183,5 +222,64 @@ describe('over-cap preflight', () => {
     // At-cap and under-cap siblings must not be listed as offenders.
     assert.doesNotMatch(r.stderr, /packages\/at-cap\.ts/);
     assert.doesNotMatch(r.stderr, /packages\/small\.ts/);
+  });
+});
+
+describe('self-correction on a missing declared file', () => {
+  test('makes one corrective follow-up call and writes the recovered file', () => {
+    const r = runImpl(spec('packages/a.ts', 'packages/b.ts'), {
+      files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
+      retryFiles: [{ path: 'packages/b.ts', content: 'export const b = 2;\n' }],
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 2, 'expected exactly one corrective follow-up call');
+    assert.match(r.stdout, /missing: packages\/b\.ts/);
+    assert.match(r.stdout, /corrective follow-up turn/);
+    assert.match(r.stdout, /Wrote packages\/a\.ts/);
+    assert.match(r.stdout, /Wrote packages\/b\.ts/);
+    assert.match(r.stdout, /Corrective follow-up added 1 file\(s\)/);
+    assert.match(r.stdout, /corrective follow-up added 1 file\(s\): packages\/b\.ts/);
+    // The retry prompt must actually tell the model what's missing and
+    // what was already covered - not just repeat the original prompt blind.
+    assert.match(r.retryPrompt, /packages\/b\.ts/);
+    assert.match(r.retryPrompt, /packages\/a\.ts/);
+  });
+
+  test('does not retry when the first response already covers every declared file', () => {
+    const r = runImpl(spec('packages/a.ts'), {
+      files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 1, 'no declared file was missing, so no retry should fire');
+    assert.doesNotMatch(r.stdout, /corrective follow-up/);
+  });
+
+  test('falls through cleanly when the corrective call also fails to produce the file', () => {
+    // FAKE_CLAUDE_RETRY_FILES left unset -> the fake's corrective-turn
+    // default is an empty files array, simulating a retry that still
+    // doesn't recover the gap.
+    const r = runImpl(spec('packages/a.ts', 'packages/b.ts'), {
+      files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 2);
+    assert.match(r.stdout, /Wrote packages\/a\.ts/);
+    assert.doesNotMatch(r.stdout, /Wrote packages\/b\.ts/);
+    // Turn 1 still succeeded and wrote what it had - the remaining gap is
+    // check-impl-scope.mjs's job to report, not this script's to loop on.
+  });
+
+  test('over-delivery (an undeclared extra file) does not trigger a retry', () => {
+    // Self-correction targets under-delivery specifically; an extra file
+    // is a different problem (drift, not a gap) that check-impl-scope.mjs
+    // already reports on its own.
+    const r = runImpl(spec('packages/a.ts'), {
+      files: [
+        { path: 'packages/a.ts', content: 'export const a = 1;\n' },
+        { path: 'packages/sneaky.ts', content: 'export const sneaky = 1;\n' },
+      ],
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 1);
   });
 });

--- a/scripts/ai-sdlc/generate-impl.test.mjs
+++ b/scripts/ai-sdlc/generate-impl.test.mjs
@@ -325,4 +325,20 @@ describe('self-correction on a missing declared file', () => {
     assert.match(r.stdout, /not enough for a safe corrective call/);
     assert.doesNotMatch(r.stdout, /Wrote packages\/b\.ts/);
   });
+
+  test('an empty-string IMPL_STEP_BUDGET_MS falls back to the default, not a collapsed 0 budget', () => {
+    // GitHub Actions resolves an unconfigured `vars.*` reference to an
+    // empty string, not an unset env var - Number('') is 0, not NaN, so a
+    // naive `envValue !== undefined` check would silently disable every
+    // future corrective call the moment this ever gets wired to a repo
+    // variable that isn't configured yet.
+    const r = runImpl(spec('packages/a.ts', 'packages/b.ts'), {
+      files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
+      retryFiles: [{ path: 'packages/b.ts', content: 'export const b = 2;\n' }],
+      env: { IMPL_STEP_BUDGET_MS: '' },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 2, 'an empty override must not collapse the budget to 0');
+    assert.match(r.stdout, /Wrote packages\/b\.ts/);
+  });
 });


### PR DESCRIPTION
Refs #367.

Three independent improvements, all responses to the same real incident (issue #367: impl-agent silently dropped files twice, at two different declared counts, one run's own summary claiming work it never wrote):

1. **`check-spec-scope.mjs`'s 6-file cap becomes a real hard gate** - but only in `ai-sdlc-guards.yml`, which runs against the actual PR a human reviews and merges. `spec-agent.yml`'s own inline copy stays soft deliberately: an over-scoped agent-generated spec should still produce a visible PR with a warning, not fail the whole generation job with nothing to show for it. New `SPEC_SCOPE_HARD` env var dispatches between the two modes from one script.

2. **`check-impl-scope.mjs` now surfaces `generate-impl.mjs`'s own `impl_summary`** on a mismatch, clearly labeled unverified (issue #367 showed it can actively disagree with the real files array) - a fast lead instead of a 10-minute log-spelunking exercise for the next person diagnosing this.

3. **`generate-impl.mjs` attempts one corrective follow-up call**, asking for ONLY the missing files, when its own response doesn't cover every spec-declared path - time-budgeted against the step's real remaining cap so it can't itself blow the timeout. Falls through cleanly to `check-impl-scope.mjs`'s existing hard gate if the correction can't run or doesn't fully close the gap.

154/154 ai-sdlc tests pass (11 new), actionlint clean on all three touched workflow files.
