### PR TITLE
Add getAndDelete to the cache layer for one-time-use payloads

### DIFF
--- a/packages/backend/src/cache/cache-service.ts
+++ b/packages/backend/src/cache/cache-service.ts
@@ -139,6 +139,49 @@ export class CacheService {
   }
 
   /**
+   * Atomically get a value and delete it in one operation, for one-time-use
+   * payloads (e.g. OIDC/OAuth state) where reading the same value twice
+   * must not both succeed.
+   *
+   * Unlike `get()`, this does NOT try L1 first: L1 (memory) is per-instance,
+   * so behind a load balancer, one instance's L1 copy has no idea whether a
+   * different instance already consumed the value via L2 (Redis). Redis is
+   * the cross-instance source of truth here - it alone decides hit/miss.
+   * Any L1 copy is cleaned up best-effort alongside it, never queried as an
+   * independent read, so a stale L1 entry can't be replayed as a second
+   * "hit" after Redis has already forgotten the key.
+   */
+  async getAndDelete<T>(key: string): Promise<T | null> {
+    if (this.redisCache) {
+      const value = await this.redisCache.getAndDelete<T>(key);
+      if (this.memoryCache) {
+        await this.memoryCache.delete(key);
+      }
+      if (this.debug) {
+        logger.debug(value !== null ? 'Cache getAndDelete L2 hit' : 'Cache getAndDelete miss', {
+          key,
+        });
+      }
+      return value;
+    }
+
+    // No Redis tier configured - memory is the only cache, so it's the
+    // sole (and therefore authoritative) source for a single-instance
+    // deployment.
+    if (this.memoryCache) {
+      const value = await this.memoryCache.getAndDelete<T>(key);
+      if (this.debug) {
+        logger.debug(value !== null ? 'Cache getAndDelete L1 hit' : 'Cache getAndDelete miss', {
+          key,
+        });
+      }
+      return value;
+    }
+
+    return null;
+  }
+
+  /**
    * Delete a key from all cache tiers
    */
   async delete(key: string): Promise<void> {

--- a/packages/backend/src/cache/cache-service.ts
+++ b/packages/backend/src/cache/cache-service.ts
@@ -155,7 +155,18 @@ export class CacheService {
     if (this.redisCache) {
       const value = await this.redisCache.getAndDelete<T>(key);
       if (this.memoryCache) {
-        await this.memoryCache.delete(key);
+        // Best-effort per the doc comment above: Redis has already
+        // authoritatively consumed the value by this point, so a failure
+        // cleaning up the local L1 copy must not surface as a failure of
+        // the overall consumption.
+        try {
+          await this.memoryCache.delete(key);
+        } catch (error) {
+          logger.warn('Cache getAndDelete L1 cleanup failed (best-effort)', {
+            key,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
       }
       if (this.debug) {
         logger.debug(value !== null ? 'Cache getAndDelete L2 hit' : 'Cache getAndDelete miss', {

--- a/packages/backend/src/cache/memory-cache.ts
+++ b/packages/backend/src/cache/memory-cache.ts
@@ -159,17 +159,43 @@ export class MemoryCache implements ICacheProvider {
   }
 
   /**
-   * Atomically get a value and delete it in one operation. Single-threaded
-   * Node has no interleaving concern here (unlike Redis, which needs its
-   * own native GETDEL) - a plain get-then-delete is already atomic from
-   * every caller's point of view.
+   * Atomically get a value and delete it in one operation.
+   *
+   * This does NOT delegate to `get()` - even though `get()` has no internal
+   * `await`, calling it as `await this.get(key)` still suspends to a
+   * microtask at the call site (that's just how `await` works, regardless of
+   * whether the callee itself awaited anything). Two concurrent
+   * `getAndDelete(sameKey)` calls could then both resolve their `get()` before
+   * either runs `this.cache.delete(key)`, breaking the one-time-use
+   * guarantee. Reading and deleting directly against `this.cache` with no
+   * `await` anywhere in this method body means it runs to completion
+   * synchronously once invoked, with no interleaving point - that's what
+   * makes it atomic on single-threaded Node.
    */
   async getAndDelete<T>(key: string): Promise<T | null> {
-    const value = await this.get<T>(key);
-    if (value !== null) {
-      this.cache.delete(key);
+    const entry = this.cache.get(key);
+
+    if (!entry) {
+      if (this.enableMetrics) {
+        this.misses++;
+      }
+      return null;
     }
-    return value;
+
+    if (this.isExpired(entry)) {
+      this.cache.delete(key);
+      if (this.enableMetrics) {
+        this.misses++;
+      }
+      return null;
+    }
+
+    this.cache.delete(key);
+    if (this.enableMetrics) {
+      this.hits++;
+    }
+
+    return entry.value as T;
   }
 
   /**

--- a/packages/backend/src/cache/memory-cache.ts
+++ b/packages/backend/src/cache/memory-cache.ts
@@ -159,6 +159,20 @@ export class MemoryCache implements ICacheProvider {
   }
 
   /**
+   * Atomically get a value and delete it in one operation. Single-threaded
+   * Node has no interleaving concern here (unlike Redis, which needs its
+   * own native GETDEL) - a plain get-then-delete is already atomic from
+   * every caller's point of view.
+   */
+  async getAndDelete<T>(key: string): Promise<T | null> {
+    const value = await this.get<T>(key);
+    if (value !== null) {
+      this.cache.delete(key);
+    }
+    return value;
+  }
+
+  /**
    * Set a value in cache
    */
   async set<T>(key: string, value: T, ttl?: number): Promise<void> {

--- a/packages/backend/src/cache/redis-cache.ts
+++ b/packages/backend/src/cache/redis-cache.ts
@@ -117,19 +117,47 @@ export class RedisCache implements ICacheProvider {
    * the one-shot invariant this method exists to provide). Same capability
    * check + Lua script as `consumePasswordResetToken()` in
    * `services/auth/password-reset-token.ts`.
+   *
+   * The `typeof redis.getdel === 'function'` check only tells us the
+   * *client library* has GETDEL support - ioredis compiles every Redis
+   * command method in statically at build time, independent of which
+   * Redis *server* version it's actually connected to. So we still have
+   * to attempt the call and fall back on the server's own rejection
+   * (`unknown command 'GETDEL'`) rather than trusting the client-side
+   * capability check alone. Any other error from `getdel` is a real
+   * failure and is left to propagate to the outer catch below, same as
+   * every other error path in this method.
    */
   async getAndDelete<T>(key: string): Promise<T | null> {
     try {
       const redis = await this.getConnection();
       const fullKey = this.buildKey(key);
-      const data =
-        typeof (redis as { getdel?: unknown }).getdel === 'function'
-          ? await redis.getdel(fullKey)
-          : ((await redis.eval(
+      let data: string | null;
+
+      if (typeof (redis as { getdel?: unknown }).getdel === 'function') {
+        try {
+          data = await redis.getdel(fullKey);
+        } catch (getdelError) {
+          if (
+            getdelError instanceof Error &&
+            /unknown command.*getdel/i.test(getdelError.message)
+          ) {
+            data = (await redis.eval(
               "local v = redis.call('GET', KEYS[1]); if v then redis.call('DEL', KEYS[1]) end; return v",
               1,
               fullKey
-            )) as string | null);
+            )) as string | null;
+          } else {
+            throw getdelError;
+          }
+        }
+      } else {
+        data = (await redis.eval(
+          "local v = redis.call('GET', KEYS[1]); if v then redis.call('DEL', KEYS[1]) end; return v",
+          1,
+          fullKey
+        )) as string | null;
+      }
 
       if (data === null) {
         if (this.enableMetrics) {

--- a/packages/backend/src/cache/redis-cache.ts
+++ b/packages/backend/src/cache/redis-cache.ts
@@ -131,9 +131,12 @@ export class RedisCache implements ICacheProvider {
       try {
         return JSON.parse(data) as T;
       } catch (parseError) {
-        logger.error('Redis cache JSON parse error', {
+        // Unlike the general-purpose get(), this cache is for one-time-use
+        // secrets (OIDC state, PKCE values) - never log any part of the
+        // actual value, just enough to debug the parse failure.
+        logger.error('Redis cache JSON parse error in getAndDelete', {
           key,
-          rawValue: data.substring(0, 100), // Log first 100 chars for debugging
+          dataLength: data.length,
           error: parseError instanceof Error ? parseError.message : 'Unknown error',
         });
         return null; // Safer than type assertion

--- a/packages/backend/src/cache/redis-cache.ts
+++ b/packages/backend/src/cache/redis-cache.ts
@@ -110,12 +110,26 @@ export class RedisCache implements ICacheProvider {
    * Atomically get a value and delete it in one operation, via Redis's
    * native GETDEL (Redis 6.2+) rather than a get-then-delete pair, which
    * would leave a window for the same value to be read twice.
+   *
+   * On older/self-hosted Redis (< 6.2) where GETDEL doesn't exist, falls
+   * back to an atomic Lua eval - a plain GET+DEL pipeline isn't safe under
+   * concurrency (two consumers can both read before either DELs, breaking
+   * the one-shot invariant this method exists to provide). Same capability
+   * check + Lua script as `consumePasswordResetToken()` in
+   * `services/auth/password-reset-token.ts`.
    */
   async getAndDelete<T>(key: string): Promise<T | null> {
     try {
       const redis = await this.getConnection();
       const fullKey = this.buildKey(key);
-      const data = await redis.getdel(fullKey);
+      const data =
+        typeof (redis as { getdel?: unknown }).getdel === 'function'
+          ? await redis.getdel(fullKey)
+          : ((await redis.eval(
+              "local v = redis.call('GET', KEYS[1]); if v then redis.call('DEL', KEYS[1]) end; return v",
+              1,
+              fullKey
+            )) as string | null);
 
       if (data === null) {
         if (this.enableMetrics) {

--- a/packages/backend/src/cache/redis-cache.ts
+++ b/packages/backend/src/cache/redis-cache.ts
@@ -107,6 +107,50 @@ export class RedisCache implements ICacheProvider {
   }
 
   /**
+   * Atomically get a value and delete it in one operation, via Redis's
+   * native GETDEL (Redis 6.2+) rather than a get-then-delete pair, which
+   * would leave a window for the same value to be read twice.
+   */
+  async getAndDelete<T>(key: string): Promise<T | null> {
+    try {
+      const redis = await this.getConnection();
+      const fullKey = this.buildKey(key);
+      const data = await redis.getdel(fullKey);
+
+      if (data === null) {
+        if (this.enableMetrics) {
+          this.misses++;
+        }
+        return null;
+      }
+
+      if (this.enableMetrics) {
+        this.hits++;
+      }
+
+      try {
+        return JSON.parse(data) as T;
+      } catch (parseError) {
+        logger.error('Redis cache JSON parse error', {
+          key,
+          rawValue: data.substring(0, 100), // Log first 100 chars for debugging
+          error: parseError instanceof Error ? parseError.message : 'Unknown error',
+        });
+        return null; // Safer than type assertion
+      }
+    } catch (error) {
+      logger.error('Redis cache getAndDelete error', {
+        key,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      if (this.enableMetrics) {
+        this.misses++;
+      }
+      return null;
+    }
+  }
+
+  /**
    * Set a value in cache
    */
   async set<T>(key: string, value: T, ttl?: number): Promise<void> {

--- a/packages/backend/src/cache/types.ts
+++ b/packages/backend/src/cache/types.ts
@@ -76,6 +76,16 @@ export interface ICacheProvider {
   get<T>(key: string): Promise<T | null>;
 
   /**
+   * Atomically get a value and delete it in one operation.
+   * Use for one-time-use payloads (e.g. OIDC/OAuth state) where a caller
+   * reading the value twice — once to validate, once to consume — would
+   * open a window for the same value to be replayed between the two calls.
+   * @param key - Cache key
+   * @returns Cached value or null if not found/expired
+   */
+  getAndDelete<T>(key: string): Promise<T | null>;
+
+  /**
    * Set a value in cache
    * @param key - Cache key
    * @param value - Value to cache (must be JSON-serializable)

--- a/packages/backend/tests/cache/cache-service.test.ts
+++ b/packages/backend/tests/cache/cache-service.test.ts
@@ -22,6 +22,7 @@ describe('CacheService', () => {
     // Create mock instances
     mockMemoryCache = {
       get: vi.fn(),
+      getAndDelete: vi.fn(),
       set: vi.fn(),
       delete: vi.fn(),
       deletePattern: vi.fn(),
@@ -36,6 +37,7 @@ describe('CacheService', () => {
 
     mockRedisCache = {
       get: vi.fn(),
+      getAndDelete: vi.fn(),
       set: vi.fn(),
       delete: vi.fn(),
       deletePattern: vi.fn(),
@@ -169,6 +171,78 @@ describe('CacheService', () => {
 
       expect(result).toEqual(testValue);
       expect(mockMemoryCache.get).toHaveBeenCalledWith('test-key');
+    });
+  });
+
+  describe('getAndDelete (one-time-use payloads)', () => {
+    beforeEach(() => {
+      cacheService = new CacheService();
+      // @ts-expect-error - Accessing private property for testing
+      cacheService.memoryCache = mockMemoryCache;
+      // @ts-expect-error - Accessing private property for testing
+      cacheService.redisCache = mockRedisCache;
+    });
+
+    it('should read from Redis (L2), not L1, when both tiers are enabled', async () => {
+      const testValue = { state: 'abc123' };
+      vi.mocked(mockRedisCache.getAndDelete).mockResolvedValue(testValue);
+
+      const result = await cacheService.getAndDelete('oidc-state-key');
+
+      expect(result).toEqual(testValue);
+      expect(mockRedisCache.getAndDelete).toHaveBeenCalledWith('oidc-state-key');
+      // L1 is never treated as an independent read for this operation - a
+      // stale L1 copy on this instance must not be returned as if it were
+      // a fresh consumption when another instance already consumed it via
+      // Redis.
+      expect(mockMemoryCache.get).not.toHaveBeenCalled();
+    });
+
+    it('should also clear the L1 copy alongside a Redis hit', async () => {
+      vi.mocked(mockRedisCache.getAndDelete).mockResolvedValue('value');
+
+      await cacheService.getAndDelete('key');
+
+      expect(mockMemoryCache.delete).toHaveBeenCalledWith('key');
+    });
+
+    it('should also clear the L1 copy alongside a Redis miss', async () => {
+      vi.mocked(mockRedisCache.getAndDelete).mockResolvedValue(null);
+
+      const result = await cacheService.getAndDelete('key');
+
+      expect(result).toBeNull();
+      expect(mockMemoryCache.delete).toHaveBeenCalledWith('key');
+    });
+
+    it('should not let a second call see the value Redis already consumed', async () => {
+      vi.mocked(mockRedisCache.getAndDelete)
+        .mockResolvedValueOnce('value')
+        .mockResolvedValueOnce(null);
+
+      expect(await cacheService.getAndDelete('key')).toBe('value');
+      expect(await cacheService.getAndDelete('key')).toBeNull();
+    });
+
+    it('should fall back to memory cache when Redis is disabled', async () => {
+      const service = new CacheService({ enableRedisCache: false });
+      // @ts-expect-error - Accessing private property for testing
+      service.memoryCache = mockMemoryCache;
+
+      vi.mocked(mockMemoryCache.getAndDelete).mockResolvedValue('memory-only-value');
+
+      const result = await service.getAndDelete('key');
+
+      expect(result).toBe('memory-only-value');
+      expect(mockMemoryCache.getAndDelete).toHaveBeenCalledWith('key');
+    });
+
+    it('should return null when neither cache tier is enabled', async () => {
+      const service = new CacheService({ enableMemoryCache: false, enableRedisCache: false });
+
+      const result = await service.getAndDelete('key');
+
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/backend/tests/cache/cache-service.test.ts
+++ b/packages/backend/tests/cache/cache-service.test.ts
@@ -244,6 +244,16 @@ describe('CacheService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should not let a failing best-effort L1 cleanup surface as a getAndDelete failure', async () => {
+      // Redis has already authoritatively consumed the value by the time
+      // the L1 cleanup runs; a thrown error there must be swallowed, not
+      // propagated, per the method's own "best-effort" doc comment.
+      vi.mocked(mockRedisCache.getAndDelete).mockResolvedValue('consumed-value');
+      vi.mocked(mockMemoryCache.delete).mockRejectedValue(new Error('L1 cleanup failed'));
+
+      await expect(cacheService.getAndDelete('key')).resolves.toBe('consumed-value');
+    });
   });
 
   describe('Set Operation', () => {

--- a/packages/backend/tests/cache/memory-cache.test.ts
+++ b/packages/backend/tests/cache/memory-cache.test.ts
@@ -51,6 +51,24 @@ describe('MemoryCache', () => {
       expect(await cache.has('key1')).toBe(true);
       expect(await cache.has('non-existent')).toBe(false);
     });
+
+    it('should get and delete a value in one operation', async () => {
+      await cache.set('key1', { foo: 'bar' }, 60);
+      const result = await cache.getAndDelete<{ foo: string }>('key1');
+      expect(result).toEqual({ foo: 'bar' });
+      expect(await cache.get('key1')).toBeNull();
+    });
+
+    it('should return null from getAndDelete for a non-existent key', async () => {
+      const result = await cache.getAndDelete('non-existent');
+      expect(result).toBeNull();
+    });
+
+    it('should not allow a second getAndDelete to see the same value', async () => {
+      await cache.set('key1', 'value1', 60);
+      expect(await cache.getAndDelete('key1')).toBe('value1');
+      expect(await cache.getAndDelete('key1')).toBeNull();
+    });
   });
 
   describe('TTL expiration', () => {

--- a/packages/backend/tests/cache/memory-cache.test.ts
+++ b/packages/backend/tests/cache/memory-cache.test.ts
@@ -69,6 +69,27 @@ describe('MemoryCache', () => {
       expect(await cache.getAndDelete('key1')).toBe('value1');
       expect(await cache.getAndDelete('key1')).toBeNull();
     });
+
+    it('should only let one of two concurrent getAndDelete calls see the value', async () => {
+      await cache.set('key1', 'value1', 60);
+
+      // Fire both calls without awaiting either individually first, so their
+      // promises are genuinely in flight at the same time - this is what
+      // reproduces the race if getAndDelete ever regresses to awaiting an
+      // internal get() before deleting.
+      const [first, second] = await Promise.all([
+        cache.getAndDelete('key1'),
+        cache.getAndDelete('key1'),
+      ]);
+
+      const results = [first, second];
+      const values = results.filter((r) => r !== null);
+      const nulls = results.filter((r) => r === null);
+
+      expect(values).toEqual(['value1']);
+      expect(nulls).toHaveLength(1);
+      expect(await cache.get('key1')).toBeNull();
+    });
   });
 
   describe('TTL expiration', () => {

--- a/packages/backend/tests/cache/redis-cache.test.ts
+++ b/packages/backend/tests/cache/redis-cache.test.ts
@@ -321,10 +321,37 @@ describe('RedisCache', () => {
       expect(result).toBeNull();
     });
 
-    it('should not throw on Redis errors', async () => {
+    it('should not throw on Redis errors, and should not fall back to eval for unrelated errors', async () => {
+      // A generic/unrelated error (e.g. a network blip) is NOT the
+      // "server doesn't support GETDEL" case - it must propagate to the
+      // outer catch like every other error in this method, not trigger
+      // the Lua eval fallback.
       mockRedis.getdel.mockRejectedValue(new Error('Redis down'));
 
       await expect(cache.getAndDelete('key')).resolves.toBeNull();
+      expect(mockRedis.eval).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the Lua eval when the Redis SERVER rejects GETDEL as unknown (Redis < 6.2)', async () => {
+      // ioredis exposes a `getdel` method on the client regardless of
+      // which Redis server version it's talking to (it's compiled into
+      // the library at build time), so `typeof redis.getdel === 'function'`
+      // is always true and can't be used to detect server support. The
+      // real signal is the server rejecting the command at runtime.
+      mockRedis.getdel.mockRejectedValue(
+        new Error("ERR unknown command 'GETDEL', with args beginning with: ")
+      );
+      mockRedis.eval.mockResolvedValue('{"name":"test"}');
+
+      const result = await cache.getAndDelete<{ name: string }>('key');
+
+      expect(mockRedis.getdel).toHaveBeenCalledWith('test:key');
+      expect(mockRedis.eval).toHaveBeenCalledWith(
+        "local v = redis.call('GET', KEYS[1]); if v then redis.call('DEL', KEYS[1]) end; return v",
+        1,
+        'test:key'
+      );
+      expect(result).toEqual({ name: 'test' });
     });
 
     it('should track metrics on hit and miss', async () => {

--- a/packages/backend/tests/cache/redis-cache.test.ts
+++ b/packages/backend/tests/cache/redis-cache.test.ts
@@ -16,6 +16,7 @@ const mockRedis = {
   setex: vi.fn(),
   del: vi.fn(),
   getdel: vi.fn(),
+  eval: vi.fn(),
   exists: vi.fn(),
   scan: vi.fn(),
   ping: vi.fn(),
@@ -44,6 +45,7 @@ describe('RedisCache', () => {
     mockRedis.setex.mockReset();
     mockRedis.del.mockReset();
     mockRedis.getdel.mockReset();
+    mockRedis.eval.mockReset();
     mockRedis.exists.mockReset();
     mockRedis.scan.mockReset();
     mockRedis.ping.mockReset();
@@ -334,6 +336,46 @@ describe('RedisCache', () => {
       const stats = await cache.getStats();
       expect(stats.hits).toBe(1);
       expect(stats.misses).toBe(1);
+    });
+
+    it('should fall back to an atomic Lua eval when GETDEL is unavailable (Redis < 6.2)', async () => {
+      // Simulate an older/self-hosted Redis where ioredis has no `getdel`
+      // method at all - the capability check in the implementation must
+      // detect this and use the Lua eval fallback instead, matching
+      // consumePasswordResetToken()'s pattern.
+      const originalGetdel = mockRedis.getdel;
+      // @ts-expect-error - simulating a Redis client without GETDEL support
+      delete mockRedis.getdel;
+      mockRedis.eval.mockResolvedValue('{"name":"test"}');
+
+      try {
+        const result = await cache.getAndDelete<{ name: string }>('key');
+
+        expect(mockRedis.eval).toHaveBeenCalledWith(
+          "local v = redis.call('GET', KEYS[1]); if v then redis.call('DEL', KEYS[1]) end; return v",
+          1,
+          'test:key'
+        );
+        expect(result).toEqual({ name: 'test' });
+      } finally {
+        mockRedis.getdel = originalGetdel;
+      }
+    });
+
+    it('should return null via the Lua eval fallback when the key does not exist', async () => {
+      const originalGetdel = mockRedis.getdel;
+      // @ts-expect-error - simulating a Redis client without GETDEL support
+      delete mockRedis.getdel;
+      mockRedis.eval.mockResolvedValue(null);
+
+      try {
+        const result = await cache.getAndDelete('nonexistent');
+
+        expect(mockRedis.eval).toHaveBeenCalled();
+        expect(result).toBeNull();
+      } finally {
+        mockRedis.getdel = originalGetdel;
+      }
     });
   });
 

--- a/packages/backend/tests/cache/redis-cache.test.ts
+++ b/packages/backend/tests/cache/redis-cache.test.ts
@@ -15,6 +15,7 @@ const mockRedis = {
   set: vi.fn(),
   setex: vi.fn(),
   del: vi.fn(),
+  getdel: vi.fn(),
   exists: vi.fn(),
   scan: vi.fn(),
   ping: vi.fn(),
@@ -42,6 +43,7 @@ describe('RedisCache', () => {
     mockRedis.set.mockReset();
     mockRedis.setex.mockReset();
     mockRedis.del.mockReset();
+    mockRedis.getdel.mockReset();
     mockRedis.exists.mockReset();
     mockRedis.scan.mockReset();
     mockRedis.ping.mockReset();
@@ -285,6 +287,52 @@ describe('RedisCache', () => {
 
       const stats = await cache.getStats();
       expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(1);
+    });
+  });
+
+  describe('getAndDelete', () => {
+    it('should use native GETDEL, not a separate get+del pair', async () => {
+      mockRedis.getdel.mockResolvedValue('{"name":"test"}');
+
+      const result = await cache.getAndDelete<{ name: string }>('key');
+
+      expect(mockRedis.getdel).toHaveBeenCalledWith('test:key');
+      expect(mockRedis.get).not.toHaveBeenCalled();
+      expect(mockRedis.del).not.toHaveBeenCalled();
+      expect(result).toEqual({ name: 'test' });
+    });
+
+    it('should return null for non-existent keys', async () => {
+      mockRedis.getdel.mockResolvedValue(null);
+
+      const result = await cache.getAndDelete('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for malformed JSON', async () => {
+      mockRedis.getdel.mockResolvedValue('plain-string');
+
+      const result = await cache.getAndDelete<string>('key');
+
+      expect(result).toBeNull();
+    });
+
+    it('should not throw on Redis errors', async () => {
+      mockRedis.getdel.mockRejectedValue(new Error('Redis down'));
+
+      await expect(cache.getAndDelete('key')).resolves.toBeNull();
+    });
+
+    it('should track metrics on hit and miss', async () => {
+      mockRedis.getdel.mockResolvedValueOnce('"value"').mockResolvedValueOnce(null);
+
+      await cache.getAndDelete('key1');
+      await cache.getAndDelete('key2');
+
+      const stats = await cache.getStats();
+      expect(stats.hits).toBe(1);
       expect(stats.misses).toBe(1);
     });
   });


### PR DESCRIPTION
Refs #368

Prerequisite for #368's OIDC callback state consumption (read once, never replayable). Split out as its own PR rather than folding into that spec — the combined change was 7 declared files, over `check-spec-scope.mjs`'s hard 6-file cap.

- `ICacheProvider.getAndDelete`: new interface method
- `RedisCache`: implemented via native `GETDEL` (Redis 6.2+), not a get+del pair
- `MemoryCache`: plain get-then-delete
- `CacheService`: reads from Redis (L2) only when both tiers are enabled, never L1 first like `get()` does — L1 is per-instance, so behind a load balancer it can't know whether a different instance already consumed the value. Falls back to memory-only when Redis is disabled.

Assisted-by: claude-opus-5 (agent)