### PR TITLE
Add two AI-SDLC pipeline guardrails from this session's incidents

### DIFF
--- a/.github/workflows/ai-sdlc-guards.yml
+++ b/.github/workflows/ai-sdlc-guards.yml
@@ -97,6 +97,39 @@ jobs:
             exit 1
           }
 
+      - name: Check spec-branch diff scope (advisory)
+        if: steps.specs.outputs.count != '0'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Advisory, not hard: a spec PR touching one incidental unrelated file
+        # (e.g. #376 bundled a spec fix with an unrelated flaky-test rewrite
+        # in the same PR) is legitimate and common enough that blocking on it
+        # would be a false-positive machine. What this catches instead is the
+        # SHAPE of a real 2026-08-21 incident - switching branches without
+        # returning to main first let `git pull` silently merge a whole
+        # OTHER feature branch (7 unrelated cache-layer files) into a spec
+        # PR, discovered only by manually running `gh pr diff --name-only`.
+        # A human glancing at this warning would have caught it immediately.
+        run: |
+          set -euo pipefail
+          outside=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- . ':!docs/specs/**' ':!docs/adr/**')
+          if [ -n "$outside" ]; then
+            echo "::warning::This PR touches docs/specs/** but also modifies files outside docs/specs/**/docs/adr/**. Often fine (a small incidental fix bundled in), but also the exact shape of an accidental cross-branch merge - double check these are intentional:"
+            printf '%s\n' "$outside" | sed 's/^/  /'
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+              {
+                echo ""
+                echo "**Spec-branch scope warning:** this PR modifies files outside \`docs/specs/**\`/\`docs/adr/**\`:"
+                echo '```'
+                printf '%s\n' "$outside"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "Spec-branch scope check: no files outside docs/specs/**/docs/adr/** in this diff."
+          fi
+
       - name: Check spec scope (hard)
         if: ${{ !cancelled() && steps.specs.outputs.count != '0' }}
         env:

--- a/.github/workflows/ai-sdlc-guards.yml
+++ b/.github/workflows/ai-sdlc-guards.yml
@@ -113,21 +113,21 @@ jobs:
         # A human glancing at this warning would have caught it immediately.
         run: |
           set -euo pipefail
-          outside=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- . ':!docs/specs/**' ':!docs/adr/**')
+          outside=$(git diff --name-only --diff-filter=ACMRD "$BASE_SHA" "$HEAD_SHA" -- . ':!docs/specs/**' ':!docs/adr/**')
           if [ -n "$outside" ]; then
-            echo "::warning::This PR touches docs/specs/** but also modifies files outside docs/specs/**/docs/adr/**. Often fine (a small incidental fix bundled in), but also the exact shape of an accidental cross-branch merge - double check these are intentional:"
+            echo "::warning::This PR touches docs/specs/** but also modifies files outside docs/specs/** and docs/adr/**. Often fine (a small incidental fix bundled in), but also the exact shape of an accidental cross-branch merge - double check these are intentional:"
             printf '%s\n' "$outside" | sed 's/^/  /'
             if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
               {
                 echo ""
-                echo "**Spec-branch scope warning:** this PR modifies files outside \`docs/specs/**\`/\`docs/adr/**\`:"
+                echo "**Spec-branch scope warning:** this PR modifies files outside \`docs/specs/**\` and \`docs/adr/**\`:"
                 echo '```'
                 printf '%s\n' "$outside"
                 echo '```'
               } >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            echo "Spec-branch scope check: no files outside docs/specs/**/docs/adr/** in this diff."
+            echo "Spec-branch scope check: no files outside docs/specs/** and docs/adr/** in this diff."
           fi
 
       - name: Check spec scope (hard)

--- a/scripts/ai-sdlc/workflow-model-vars.test.mjs
+++ b/scripts/ai-sdlc/workflow-model-vars.test.mjs
@@ -40,6 +40,11 @@ function stepBlockForRun(yamlText, scriptName) {
   while (startIdx > 0 && !/^\s*- name:/.test(lines[startIdx])) {
     startIdx--;
   }
+  assert.match(
+    lines[startIdx],
+    /^\s*- name:/,
+    `no "- name:" boundary found scanning back from the "run: node scripts/ai-sdlc/${scriptName}" line - would silently return an over-broad block spanning earlier steps`
+  );
   return lines.slice(startIdx, runIdx + 1).join('\n');
 }
 

--- a/scripts/ai-sdlc/workflow-model-vars.test.mjs
+++ b/scripts/ai-sdlc/workflow-model-vars.test.mjs
@@ -1,0 +1,81 @@
+// Regression guard for a real, previously-silent bug (2026-08-21): an
+// env-var-driven default in an .mjs script (LLM_DEFAULT_MODEL, IMPL_MODEL_*)
+// is NOT automatically populated from a same-named GitHub Actions repo
+// variable. Each consuming workflow STEP needs its own explicit
+// `env: KEY: ${{ vars.KEY }}` mapping, or setting the repo variable in
+// Settings silently does nothing - the script always falls back to its
+// hardcoded default. `LLM_DEFAULT_MODEL` shipped in llm-client.mjs without
+// that mapping ever being added to spec-agent.yml/adr-agent.yml; nothing
+// caught it until it was asked about directly. This file asserts the
+// mapping exists in the specific step that runs the consuming script, not
+// just somewhere in the file - a full YAML-semantics engine is overkill,
+// but a plain "is this file present" substring check would pass even if the
+// mapping were on the wrong step.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Returns the YAML lines for the step that runs `scriptName`, from that
+ * step's `- name:` line through its `run:` line (inclusive) - enough to
+ * regex-match against that step's own `env:` block without matching a
+ * same-named var mapped on a different, unrelated step in the same file.
+ *
+ * Matches only an actual `run:` line, not `.includes(scriptName)` anywhere -
+ * these workflow files have header comments mentioning a script by name
+ * (e.g. "generate-spec.mjs (450s)") well before the real step, which a bare
+ * substring search would match instead of the step itself.
+ */
+function stepBlockForRun(yamlText, scriptName) {
+  const lines = yamlText.split('\n');
+  const runPattern = new RegExp(`run:\\s*node\\s+scripts/ai-sdlc/${scriptName}\\b`);
+  const runIdx = lines.findIndex((l) => runPattern.test(l));
+  assert.notEqual(runIdx, -1, `no "run: node scripts/ai-sdlc/${scriptName}" line found`);
+  let startIdx = runIdx;
+  while (startIdx > 0 && !/^\s*- name:/.test(lines[startIdx])) {
+    startIdx--;
+  }
+  return lines.slice(startIdx, runIdx + 1).join('\n');
+}
+
+function readWorkflow(name) {
+  return readFileSync(join(REPO_ROOT, '.github/workflows', name), 'utf8');
+}
+
+test('spec-agent.yml wires LLM_DEFAULT_MODEL into the generate-spec.mjs step', () => {
+  const block = stepBlockForRun(readWorkflow('spec-agent.yml'), 'generate-spec.mjs');
+  assert.match(block, /LLM_DEFAULT_MODEL:\s*\$\{\{\s*vars\.LLM_DEFAULT_MODEL\s*\}\}/);
+});
+
+test('spec-agent.yml wires LLM_DEFAULT_MODEL into the verify-spec.mjs step', () => {
+  const block = stepBlockForRun(readWorkflow('spec-agent.yml'), 'verify-spec.mjs');
+  assert.match(block, /LLM_DEFAULT_MODEL:\s*\$\{\{\s*vars\.LLM_DEFAULT_MODEL\s*\}\}/);
+});
+
+test('adr-agent.yml wires LLM_DEFAULT_MODEL into the generate-adr.mjs step', () => {
+  const block = stepBlockForRun(readWorkflow('adr-agent.yml'), 'generate-adr.mjs');
+  assert.match(block, /LLM_DEFAULT_MODEL:\s*\$\{\{\s*vars\.LLM_DEFAULT_MODEL\s*\}\}/);
+});
+
+test('impl-agent.yml wires IMPL_MODEL_HIGH/_DEFAULT/_LOW into the generate-impl.mjs step', () => {
+  const block = stepBlockForRun(readWorkflow('impl-agent.yml'), 'generate-impl.mjs');
+  assert.match(block, /IMPL_MODEL_HIGH:\s*\$\{\{\s*vars\.IMPL_MODEL_HIGH\s*\}\}/);
+  assert.match(block, /IMPL_MODEL_DEFAULT:\s*\$\{\{\s*vars\.IMPL_MODEL_DEFAULT\s*\}\}/);
+  assert.match(block, /IMPL_MODEL_LOW:\s*\$\{\{\s*vars\.IMPL_MODEL_LOW\s*\}\}/);
+});
+
+// claude-review.yml's model selection is referenced directly inside the
+// `${{ }}` expression on the --model line itself, not via a step `env:`
+// mapping - `vars.*` is available in any `${{ }}` context in the file, so
+// there's no separate mapping step to check. A plain presence check is the
+// right level of rigor here.
+test('claude-review.yml references CLAUDE_REVIEW_MODEL_AUTO and _HUMAN repo variables', () => {
+  const yaml = readWorkflow('claude-review.yml');
+  assert.match(yaml, /vars\.CLAUDE_REVIEW_MODEL_AUTO/);
+  assert.match(yaml, /vars\.CLAUDE_REVIEW_MODEL_HUMAN/);
+});


### PR DESCRIPTION
Refs #381

Two guardrails, both prompted by real incidents from today's session:

1. **Advisory spec-branch diff-scope check** (`ai-sdlc-guards.yml`): flags — does not block — a spec/adr PR whose diff touches files outside `docs/specs/**`/`docs/adr/**`. Soft rather than hard, since #376 legitimately bundled a spec fix with an unrelated flaky-test rewrite in one PR — blocking on any extra file would be a false-positive machine. What it catches: a branch-switch mistake silently merged a whole other feature branch's files (7 unrelated cache-layer files) into PR #370's diff, caught only by manually running `gh pr diff --name-only`. Verified against both the contaminated commit range and the fixed one.

2. **`workflow-model-vars.test.mjs`**: regression guard for a separate bug found the same day — `LLM_DEFAULT_MODEL` was read by `llm-client.mjs` but never mapped from the repo variable into any workflow step's `env:`, so setting it in Settings would have silently done nothing. Asserts the mapping exists in the specific step that runs each consuming script. Verified to pass today and to actually fail when a mapping is removed.

Assisted-by: claude-opus-5 (agent)