### PR TITLE
fix(tests): replace flaky wall-clock health-check timing assertions

### DIFF
--- a/packages/backend/tests/api/admin.test.ts
+++ b/packages/backend/tests/api/admin.test.ts
@@ -245,10 +245,15 @@ describe('Admin Routes', () => {
       expect(typeof json.data.services.redis.response_time).toBe('number');
       expect(typeof json.data.services.storage.response_time).toBe('number');
 
-      // Response times should be reasonable (< 1000ms for local services)
-      expect(json.data.services.database.response_time).toBeLessThan(1000);
-      expect(json.data.services.redis.response_time).toBeLessThan(1000);
-      expect(json.data.services.storage.response_time).toBeLessThan(1000);
+      // A non-negative sanity check on the timer, not an upper bound: an
+      // absolute-ms threshold here is CI-runner-load-dependent, not a
+      // property of the health-check logic itself - hit 1005ms and 1064ms
+      // on unrelated PRs the same day. This test's job (per its own name)
+      // is proving the field is present and numeric, already covered above;
+      // this just confirms it isn't a nonsense negative value.
+      expect(json.data.services.database.response_time).toBeGreaterThanOrEqual(0);
+      expect(json.data.services.redis.response_time).toBeGreaterThanOrEqual(0);
+      expect(json.data.services.storage.response_time).toBeGreaterThanOrEqual(0);
     });
 
     it('should include last_check timestamp for services', async () => {

--- a/packages/backend/tests/api/admin.test.ts
+++ b/packages/backend/tests/api/admin.test.ts
@@ -246,11 +246,11 @@ describe('Admin Routes', () => {
       expect(typeof json.data.services.storage.response_time).toBe('number');
 
       // A non-negative sanity check on the timer, not an upper bound: an
-      // absolute-ms threshold here is CI-runner-load-dependent, not a
-      // property of the health-check logic itself - hit 1005ms and 1064ms
-      // on unrelated PRs the same day. This test's job (per its own name)
-      // is proving the field is present and numeric, already covered above;
-      // this just confirms it isn't a nonsense negative value.
+      // absolute-ms threshold here is CI-runner-load-dependent and flakes,
+      // not a property of the health-check logic itself. This test's job
+      // (per its own name) is proving the field is present and numeric,
+      // already covered above; this just confirms it isn't a nonsense
+      // negative value, which can't flake.
       expect(json.data.services.database.response_time).toBeGreaterThanOrEqual(0);
       expect(json.data.services.redis.response_time).toBeGreaterThanOrEqual(0);
       expect(json.data.services.storage.response_time).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Refs #381

\`tests/api/admin.test.ts\`'s "should include service response times" test asserted database/redis/storage \`response_time\` is under 1000ms — hit 1005ms and 1064ms on two unrelated PRs (#379) the same day, both CI-load flukes, not real regressions (\`response_time\` is a genuine \`Date.now()\` delta in \`health-check-service.ts\`, so a hard upper bound tests infra speed under CI load, not the feature itself).

The test's own name says it's testing presence, already covered by the \`toHaveProperty\`/\`typeof\` assertions above. Replaced the upper bound with \`toBeGreaterThanOrEqual(0)\`, a deterministic sanity check on the timer that can't flake.

Assisted-by: claude-opus-5 (agent)