### PR TITLE
debug: temporary workflow to test grep classification on a real runner

### DIFF
--- a/.github/workflows/debug-grep-classification.yml
+++ b/.github/workflows/debug-grep-classification.yml
@@ -1,0 +1,85 @@
+name: Debug - grep classification on real runner
+
+# Temporary diagnostic workflow investigating a real, unexplained failure:
+# deploy-api.yml's network-error classification (grep -qE against ssh's own
+# "ssh: connect to host X port Y: Connection timed out" message) has twice
+# failed to detect that exact text on a real ubuntu-latest runner
+# (2026-08-22), while every local reproduction of the identical byte
+# sequence (verified via raw API log bytes - xxd showed clean ASCII, a
+# single trailing 0a, no \r, no hidden characters) matches correctly. This
+# workflow reproduces the classification logic in isolation, on the actual
+# failing environment, with no secrets and no host access, to find out
+# whether the real runner's shell/grep genuinely behaves differently or
+# whether something else in the real deploy step is responsible. Delete
+# once the question is answered either way.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test-classification:
+    name: Test classification logic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Environment info
+        run: |
+          echo "bash: $BASH_VERSION"
+          grep --version | head -1
+          echo "LANG=$LANG LC_ALL=$LC_ALL LC_CTYPE=$LC_CTYPE"
+          locale 2>&1 || true
+
+      - name: Test 1 - hardcoded string, old ($-anchored) pattern
+        run: |
+          SSH_OUTPUT="ssh: connect to host *** port 22: Connection timed out"
+          PATTERN='^ssh: connect to host .* port [0-9]+: (Connection timed out|Connection refused|No route to host|Network is unreachable)$|^ssh: Could not resolve hostname '
+          if printf '%s' "$SSH_OUTPUT" | grep -qE "$PATTERN"; then
+            echo "RESULT: MATCHED"
+          else
+            echo "RESULT: NO MATCH"
+          fi
+
+      - name: Test 2 - hardcoded string, new (no end-anchor) pattern
+        run: |
+          SSH_OUTPUT="ssh: connect to host *** port 22: Connection timed out"
+          PATTERN='^ssh: connect to host .* port [0-9]+: (Connection timed out|Connection refused|No route to host|Network is unreachable)|^ssh: Could not resolve hostname '
+          if printf '%s' "$SSH_OUTPUT" | grep -qE "$PATTERN"; then
+            echo "RESULT: MATCHED"
+          else
+            echo "RESULT: NO MATCH"
+          fi
+
+      - name: Test 3 - real command substitution capture, like the actual deploy step
+        run: |
+          fake_ssh() {
+            echo "ssh: connect to host *** port 22: Connection timed out" >&2
+            return 255
+          }
+          SSH_EXIT=0
+          SSH_OUTPUT=$(fake_ssh 2>&1) || SSH_EXIT=$?
+          printf '%s\n' "$SSH_OUTPUT"
+          echo "SSH_EXIT=$SSH_EXIT"
+          printf '%s' "$SSH_OUTPUT" | od -c | tail -5
+          PATTERN='^ssh: connect to host .* port [0-9]+: (Connection timed out|Connection refused|No route to host|Network is unreachable)$|^ssh: Could not resolve hostname '
+          if [ "$SSH_EXIT" -eq 255 ] && printf '%s' "$SSH_OUTPUT" | grep -qE "$PATTERN"; then
+            echo "RESULT: MATCHED"
+          else
+            echo "RESULT: NO MATCH"
+          fi
+
+      - name: Test 4 - a real ssh binary actually attempting a doomed connection
+        run: |
+          SSH_EXIT=0
+          SSH_OUTPUT=$(ssh -o BatchMode=yes -o ConnectTimeout=3 -o StrictHostKeyChecking=no \
+            nonexistent-user@192.0.2.1 "echo hi" 2>&1) || SSH_EXIT=$?
+          printf '%s\n' "$SSH_OUTPUT"
+          echo "SSH_EXIT=$SSH_EXIT"
+          printf '%s' "$SSH_OUTPUT" | od -c
+          PATTERN='^ssh: connect to host .* port [0-9]+: (Connection timed out|Connection refused|No route to host|Network is unreachable)$|^ssh: Could not resolve hostname '
+          if [ "$SSH_EXIT" -eq 255 ] && printf '%s' "$SSH_OUTPUT" | grep -qE "$PATTERN"; then
+            echo "RESULT: MATCHED"
+          else
+            echo "RESULT: NO MATCH"
+          fi


### PR DESCRIPTION
Refs #309

Investigating the deploy-api.yml failure from earlier today: the network-error classification (\`grep -qE\` against ssh's own connection-timeout message) has twice failed to detect that exact text on a real \`ubuntu-latest\` runner, while every local reproduction — including a byte-for-byte check against the raw API log via \`xxd\` — matches correctly and shows no hidden characters.

This is a temporary, throwaway diagnostic workflow (no secrets, no host access) that runs the classification logic in isolation on the actual runner environment, including a test against a real \`ssh\` binary attempting a doomed connection, to see whether the real environment genuinely behaves differently.

**\`workflow_dispatch\` only works for workflows present on the default branch**, so this needs to merge before I can actually run it — asking for your call on merging this one, since it's outside the "investigate" scope I already have. I'll delete this file once the question is answered either way.

Assisted-by: claude-opus-5 (agent)