### PR TITLE
impl(#368): SSO 2b/4: OIDC callback, account-linking, and session issuance (split from #353)

### DIFF
--- a/packages/backend/src/api/routes/auth-oidc.ts
+++ b/packages/backend/src/api/routes/auth-oidc.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { IServiceContainer } from '../../container/index.js';
 import {
   discoverIssuerValidated,
@@ -21,58 +21,19 @@ function getContainer(fastify: FastifyInstance): IServiceContainer {
   return (fastify as FastifyInstance & { container: IServiceContainer }).container;
 }
 
+// Every OIDC-flow rejection returns this exact generic message - deliberately, not just for
+// brevity. A cross-tenant email match, an expired token, and a tampered signature must all be
+// indistinguishable to the caller (ADR-0044); one shared helper makes that a structural
+// guarantee instead of a convention repeated at every call site.
+function unauthorized(reply: FastifyReply) {
+  return reply.code(401).send({ error: 'Authentication failed' });
+}
+
 export function oidcRoutes(fastify: FastifyInstance): void {
   fastify.get<{ Params: { tenantId: string } }>(
     '/api/v1/auth/oidc/:tenantId/login',
     { config: { public: true } },
-    async (request, reply) => {
-      const { tenantId } = request.params;
-      const idpConfig = await getContainer(fastify).db.oidcIdpConfigs.findByTenantId(tenantId);
-      if (!idpConfig) {
-        throw new AppError('SSO not configured', 404, 'NotFound');
-      }
-
-      // Never derive the redirect_uri from request.protocol/hostname — both
-      // are attacker-influenceable via the Host / X-Forwarded-* headers
-      // depending on proxy config, and a spoofed redirect_uri is
-      // security-relevant for an OIDC flow. Use the fixed, operator-set
-      // base URL instead.
-      if (!config.oidc.redirectBaseUrl) {
-        throw new ConfigurationError(
-          'OIDC_REDIRECT_BASE_URL must be configured to serve OIDC login for a tenant with SSO enabled',
-          'oidc-routes'
-        );
-      }
-
-      const redirectUri = `${config.oidc.redirectBaseUrl}/api/v1/auth/oidc/${tenantId}/callback`;
-      const issuer = await discoverIssuerValidated(idpConfig.issuerUrl);
-
-      // openid-client@5.7.1: class-based construction, not the v6 functional API.
-      const client = new issuer.Client({ client_id: idpConfig.clientId, response_types: ['code'] });
-      const state = generators.state();
-      const nonce = generators.nonce();
-      const codeVerifier = generators.codeVerifier();
-      const codeChallenge = generators.codeChallenge(codeVerifier);
-
-      const authUrl = client.authorizationUrl({
-        scope: 'openid email profile',
-        state,
-        nonce,
-        code_challenge: codeChallenge,
-        code_challenge_method: 'S256',
-        redirect_uri: redirectUri,
-      });
-
-      await storeOidcState(state, {
-        nonce,
-        codeVerifier,
-        redirectUri,
-        tenantId,
-        issuer: issuer.metadata.issuer,
-      });
-
-      return reply.redirect(authUrl);
-    }
+    handleOidcLogin
   );
 
   // #368 appends the callback handler here, inside this same oidcRoutes() function.
@@ -81,123 +42,181 @@ export function oidcRoutes(fastify: FastifyInstance): void {
     Querystring: { code?: string; state?: string; error?: string };
   }>(
     '/api/v1/auth/oidc/:tenantId/callback',
-    // The IdP redirects the browser here unauthenticated — same reason the login route
+    // The IdP redirects the browser here unauthenticated - same reason the login route
     // above carries this flag; without it the auth middleware rejects the request before
     // the handler ever runs (packages/backend/src/api/middleware/auth/middleware.ts).
     { config: { public: true } },
-    async (request, reply) => {
-      const { tenantId } = request.params;
-      const { code, state: stateParam, error: idpError } = request.query;
-
-      if (idpError || !code || !stateParam) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-
-      // Atomic consume: a replayed state value must fail on the second
-      // request, not merely be "checked" and left in place.
-      const statePayload = await consumeOidcState(stateParam);
-      if (!statePayload) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-      if (statePayload.tenantId !== tenantId) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-
-      const idpConfig = await getContainer(fastify).db.oidcIdpConfigs.findByTenantId(tenantId);
-      if (!idpConfig) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-
-      // discoverIssuerValidated() and client.callback() both throw on failure — SSRF
-      // rejection, discovery failure, or openid-client's own iss/aud/nonce/exp/signature
-      // validation inside callback() — and every such rejection must map to the same
-      // generic 401 (AC / test cases B-E, L-M), not an unhandled 500.
-      let claims: { email?: string; email_verified?: boolean; name?: unknown };
-      try {
-        const issuer = await discoverIssuerValidated(idpConfig.issuerUrl);
-        // Bind the callback to the same IdP the login step discovered (ADR-0044: the CSRF
-        // state is bound to the issuer, not just checked for existence). Without this, a
-        // tenant's IdP config could change between login and callback and the stored state
-        // would still be honored against a different issuer than the one the user actually
-        // authenticated with.
-        if (issuer.metadata.issuer !== statePayload.issuer) {
-          return reply.code(401).send({ error: 'Authentication failed' });
-        }
-        // openid-client@5.7.1: class-based construction, matching the login handler above.
-        const client = new issuer.Client({
-          client_id: idpConfig.clientId,
-          client_secret: idpConfig.clientSecret,
-          response_types: ['code'],
-        });
-
-        // openid-client validates iss/aud/nonce/exp/JWKS signature internally on callback()
-        const tokenSet = await client.callback(
-          statePayload.redirectUri,
-          { code },
-          { state: stateParam, nonce: statePayload.nonce, code_verifier: statePayload.codeVerifier }
-        );
-        claims = tokenSet.claims();
-      } catch {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-
-      if (claims.email_verified !== true) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-      if (!claims.email) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-      const email = claims.email;
-
-      if (!idpConfig.allowedDomains?.length) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-      // .toLowerCase() so the check isn't case-sensitive; split('@')[1] is still undefined
-      // for a malformed email with no '@', so the fail-closed check covers that too.
-      const emailDomain = email.split('@')[1]?.toLowerCase();
-      if (!emailDomain || !idpConfig.allowedDomains.includes(emailDomain)) {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-
-      const existingUser = await getContainer(fastify).db.users.findByEmail(email);
-      if (existingUser) {
-        const membership = await getContainer(fastify).db.organizationMembers.findMembership(
-          tenantId,
-          existingUser.id
-        );
-        if (!membership) {
-          return reply.code(401).send({ error: 'Authentication failed' });
-        }
-        return issueOidcCookie(fastify, reply, existingUser);
-      }
-
-      // users.create() + organizationMembers.createWithUser() must be atomic: if the
-      // membership insert fails or returns null after the user row is already committed, a
-      // later callback for this same email finds an orphaned global user with no membership
-      // anywhere, and the cross-tenant-reject branch above would then reject it forever.
-      // db.transaction(async tx => ...) is this codebase's established pattern for exactly
-      // this (see e.g. signup.service.ts) — throwing inside the callback on a null
-      // membership rolls back the user insert too, instead of returning 401 while leaving
-      // it committed.
-      let newUser: User;
-      try {
-        newUser = await getContainer(fastify).db.transaction(async (tx) => {
-          const user = await tx.users.create({
-            email,
-            name: typeof claims.name === 'string' ? claims.name : undefined,
-          });
-          const created = await tx.organizationMembers.createWithUser(tenantId, user.id, 'member');
-          if (!created) {
-            throw new Error('OIDC callback: membership creation returned null for a new user');
-          }
-          return user;
-        });
-      } catch {
-        return reply.code(401).send({ error: 'Authentication failed' });
-      }
-      return issueOidcCookie(fastify, reply, newUser);
-    }
+    handleOidcCallback
   );
+
+  async function handleOidcLogin(
+    request: FastifyRequest<{ Params: { tenantId: string } }>,
+    reply: FastifyReply
+  ) {
+    const { tenantId } = request.params;
+    const idpConfig = await getContainer(fastify).db.oidcIdpConfigs.findByTenantId(tenantId);
+    if (!idpConfig) {
+      throw new AppError('SSO not configured', 404, 'NotFound');
+    }
+
+    // Never derive the redirect_uri from request.protocol/hostname — both
+    // are attacker-influenceable via the Host / X-Forwarded-* headers
+    // depending on proxy config, and a spoofed redirect_uri is
+    // security-relevant for an OIDC flow. Use the fixed, operator-set
+    // base URL instead.
+    if (!config.oidc.redirectBaseUrl) {
+      throw new ConfigurationError(
+        'OIDC_REDIRECT_BASE_URL must be configured to serve OIDC login for a tenant with SSO enabled',
+        'oidc-routes'
+      );
+    }
+
+    const redirectUri = `${config.oidc.redirectBaseUrl}/api/v1/auth/oidc/${tenantId}/callback`;
+    const issuer = await discoverIssuerValidated(idpConfig.issuerUrl);
+
+    // openid-client@5.7.1: class-based construction, not the v6 functional API.
+    const client = new issuer.Client({ client_id: idpConfig.clientId, response_types: ['code'] });
+    const state = generators.state();
+    const nonce = generators.nonce();
+    const codeVerifier = generators.codeVerifier();
+    const codeChallenge = generators.codeChallenge(codeVerifier);
+
+    const authUrl = client.authorizationUrl({
+      scope: 'openid email profile',
+      state,
+      nonce,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      redirect_uri: redirectUri,
+    });
+
+    await storeOidcState(state, {
+      nonce,
+      codeVerifier,
+      redirectUri,
+      tenantId,
+      issuer: issuer.metadata.issuer,
+    });
+
+    return reply.redirect(authUrl);
+  }
+
+  async function handleOidcCallback(
+    request: FastifyRequest<{
+      Params: { tenantId: string };
+      Querystring: { code?: string; state?: string; error?: string };
+    }>,
+    reply: FastifyReply
+  ) {
+    const { tenantId } = request.params;
+    const { code, state: stateParam, error: idpError } = request.query;
+    const db = getContainer(fastify).db;
+
+    if (idpError || !code || !stateParam) {
+      return unauthorized(reply);
+    }
+
+    // Atomic consume: a replayed state value must fail on the second
+    // request, not merely be "checked" and left in place.
+    const statePayload = await consumeOidcState(stateParam);
+    if (!statePayload) {
+      return unauthorized(reply);
+    }
+    if (statePayload.tenantId !== tenantId) {
+      return unauthorized(reply);
+    }
+
+    const idpConfig = await db.oidcIdpConfigs.findByTenantId(tenantId);
+    if (!idpConfig) {
+      return unauthorized(reply);
+    }
+
+    // discoverIssuerValidated() and client.callback() both throw on failure — SSRF
+    // rejection, discovery failure, or openid-client's own iss/aud/nonce/exp/signature
+    // validation inside callback() — and every such rejection must map to the same
+    // generic 401 (AC / test cases B-E, L-M), not an unhandled 500.
+    let claims: { email?: string; email_verified?: boolean; name?: unknown };
+    try {
+      const issuer = await discoverIssuerValidated(idpConfig.issuerUrl);
+      // Bind the callback to the same IdP the login step discovered (ADR-0044: the CSRF
+      // state is bound to the issuer, not just checked for existence). Without this, a
+      // tenant's IdP config could change between login and callback and the stored state
+      // would still be honored against a different issuer than the one the user actually
+      // authenticated with.
+      if (issuer.metadata.issuer !== statePayload.issuer) {
+        return unauthorized(reply);
+      }
+      // openid-client@5.7.1: class-based construction, matching the login handler above.
+      const client = new issuer.Client({
+        client_id: idpConfig.clientId,
+        client_secret: idpConfig.clientSecret,
+        response_types: ['code'],
+      });
+
+      // openid-client validates iss/aud/nonce/exp/JWKS signature internally on callback()
+      const tokenSet = await client.callback(
+        statePayload.redirectUri,
+        { code },
+        { state: stateParam, nonce: statePayload.nonce, code_verifier: statePayload.codeVerifier }
+      );
+      claims = tokenSet.claims();
+    } catch {
+      return unauthorized(reply);
+    }
+
+    if (claims.email_verified !== true) {
+      return unauthorized(reply);
+    }
+    if (!claims.email) {
+      return unauthorized(reply);
+    }
+    const email = claims.email;
+
+    if (!idpConfig.allowedDomains?.length) {
+      return unauthorized(reply);
+    }
+    // .toLowerCase() so the check isn't case-sensitive; split('@')[1] is still undefined
+    // for a malformed email with no '@', so the fail-closed check covers that too.
+    const emailDomain = email.split('@')[1]?.toLowerCase();
+    if (!emailDomain || !idpConfig.allowedDomains.includes(emailDomain)) {
+      return unauthorized(reply);
+    }
+
+    const existingUser = await db.users.findByEmail(email);
+    if (existingUser) {
+      const membership = await db.organizationMembers.findMembership(tenantId, existingUser.id);
+      if (!membership) {
+        return unauthorized(reply);
+      }
+      return issueOidcCookie(fastify, reply, existingUser);
+    }
+
+    // users.create() + organizationMembers.createWithUser() must be atomic: if the
+    // membership insert fails or returns null after the user row is already committed, a
+    // later callback for this same email finds an orphaned global user with no membership
+    // anywhere, and the cross-tenant-reject branch above would then reject it forever.
+    // db.transaction(async tx => ...) is this codebase's established pattern for exactly
+    // this (see e.g. signup.service.ts) — throwing inside the callback on a null
+    // membership rolls back the user insert too, instead of returning 401 while leaving
+    // it committed.
+    let newUser: User;
+    try {
+      newUser = await db.transaction(async (tx) => {
+        const user = await tx.users.create({
+          email,
+          name: typeof claims.name === 'string' ? claims.name : undefined,
+        });
+        const created = await tx.organizationMembers.createWithUser(tenantId, user.id, 'member');
+        if (!created) {
+          throw new Error('OIDC callback: membership creation returned null for a new user');
+        }
+        return user;
+      });
+    } catch {
+      return unauthorized(reply);
+    }
+    return issueOidcCookie(fastify, reply, newUser);
+  }
 }
 
 // Cookie must match auth.ts exactly: name `refresh_token`, options built via

--- a/packages/backend/src/api/routes/auth-oidc.ts
+++ b/packages/backend/src/api/routes/auth-oidc.ts
@@ -1,8 +1,18 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 import type { IServiceContainer } from '../../container/index.js';
-import { discoverIssuerValidated, storeOidcState, generators } from '../services/oidc-service.js';
+import {
+  discoverIssuerValidated,
+  storeOidcState,
+  consumeOidcState,
+  generators,
+} from '../services/oidc-service.js';
 import { AppError, ConfigurationError } from '../middleware/error.js';
 import { config } from '../../config.js';
+import { generateAuthTokens } from '../utils/auth-tokens.js';
+import { buildRefreshCookieOptions } from '../utils/auth-cookies.js';
+import { sendSuccess } from '../utils/response.js';
+import { omitFields } from '../utils/resource.js';
+import type { User } from '../../db/types.js';
 
 // fastify.container is not globally typed anywhere in this codebase (server.ts
 // itself only reads it back via this same cast) — this local helper is #368's
@@ -66,4 +76,146 @@ export function oidcRoutes(fastify: FastifyInstance): void {
   );
 
   // #368 appends the callback handler here, inside this same oidcRoutes() function.
+  fastify.get<{
+    Params: { tenantId: string };
+    Querystring: { code?: string; state?: string; error?: string };
+  }>(
+    '/api/v1/auth/oidc/:tenantId/callback',
+    // The IdP redirects the browser here unauthenticated — same reason the login route
+    // above carries this flag; without it the auth middleware rejects the request before
+    // the handler ever runs (packages/backend/src/api/middleware/auth/middleware.ts).
+    { config: { public: true } },
+    async (request, reply) => {
+      const { tenantId } = request.params;
+      const { code, state: stateParam, error: idpError } = request.query;
+
+      if (idpError || !code || !stateParam) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+
+      // Atomic consume: a replayed state value must fail on the second
+      // request, not merely be "checked" and left in place.
+      const statePayload = await consumeOidcState(stateParam);
+      if (!statePayload) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+      if (statePayload.tenantId !== tenantId) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+
+      const idpConfig = await getContainer(fastify).db.oidcIdpConfigs.findByTenantId(tenantId);
+      if (!idpConfig) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+
+      // discoverIssuerValidated() and client.callback() both throw on failure — SSRF
+      // rejection, discovery failure, or openid-client's own iss/aud/nonce/exp/signature
+      // validation inside callback() — and every such rejection must map to the same
+      // generic 401 (AC / test cases B-E, L-M), not an unhandled 500.
+      let claims: { email?: string; email_verified?: boolean; name?: unknown };
+      try {
+        const issuer = await discoverIssuerValidated(idpConfig.issuerUrl);
+        // Bind the callback to the same IdP the login step discovered (ADR-0044: the CSRF
+        // state is bound to the issuer, not just checked for existence). Without this, a
+        // tenant's IdP config could change between login and callback and the stored state
+        // would still be honored against a different issuer than the one the user actually
+        // authenticated with.
+        if (issuer.metadata.issuer !== statePayload.issuer) {
+          return reply.code(401).send({ error: 'Authentication failed' });
+        }
+        // openid-client@5.7.1: class-based construction, matching the login handler above.
+        const client = new issuer.Client({
+          client_id: idpConfig.clientId,
+          client_secret: idpConfig.clientSecret,
+          response_types: ['code'],
+        });
+
+        // openid-client validates iss/aud/nonce/exp/JWKS signature internally on callback()
+        const tokenSet = await client.callback(
+          statePayload.redirectUri,
+          { code },
+          { state: stateParam, nonce: statePayload.nonce, code_verifier: statePayload.codeVerifier }
+        );
+        claims = tokenSet.claims();
+      } catch {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+
+      if (claims.email_verified !== true) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+      if (!claims.email) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+      const email = claims.email;
+
+      if (!idpConfig.allowedDomains?.length) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+      // .toLowerCase() so the check isn't case-sensitive; split('@')[1] is still undefined
+      // for a malformed email with no '@', so the fail-closed check covers that too.
+      const emailDomain = email.split('@')[1]?.toLowerCase();
+      if (!emailDomain || !idpConfig.allowedDomains.includes(emailDomain)) {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+
+      const existingUser = await getContainer(fastify).db.users.findByEmail(email);
+      if (existingUser) {
+        const membership = await getContainer(fastify).db.organizationMembers.findMembership(
+          tenantId,
+          existingUser.id
+        );
+        if (!membership) {
+          return reply.code(401).send({ error: 'Authentication failed' });
+        }
+        return issueOidcCookie(fastify, reply, existingUser);
+      }
+
+      // users.create() + organizationMembers.createWithUser() must be atomic: if the
+      // membership insert fails or returns null after the user row is already committed, a
+      // later callback for this same email finds an orphaned global user with no membership
+      // anywhere, and the cross-tenant-reject branch above would then reject it forever.
+      // db.transaction(async tx => ...) is this codebase's established pattern for exactly
+      // this (see e.g. signup.service.ts) — throwing inside the callback on a null
+      // membership rolls back the user insert too, instead of returning 401 while leaving
+      // it committed.
+      let newUser: User;
+      try {
+        newUser = await getContainer(fastify).db.transaction(async (tx) => {
+          const user = await tx.users.create({
+            email,
+            name: typeof claims.name === 'string' ? claims.name : undefined,
+          });
+          const created = await tx.organizationMembers.createWithUser(tenantId, user.id, 'member');
+          if (!created) {
+            throw new Error('OIDC callback: membership creation returned null for a new user');
+          }
+          return user;
+        });
+      } catch {
+        return reply.code(401).send({ error: 'Authentication failed' });
+      }
+      return issueOidcCookie(fastify, reply, newUser);
+    }
+  );
+}
+
+// Cookie must match auth.ts exactly: name `refresh_token`, options built via
+// buildRefreshCookieOptions() from packages/backend/src/api/utils/auth-cookies.ts. No
+// post-login frontend redirect destination is configured anywhere in this codebase yet, so
+// this mirrors the 200 JSON shape auth.ts's other session-issuing routes already return
+// (user + access_token + expires_in + token_type) instead of inventing a redirect target.
+async function issueOidcCookie(fastify: FastifyInstance, reply: FastifyReply, user: User) {
+  const tokens = generateAuthTokens(fastify, user);
+  reply.setCookie(
+    'refresh_token',
+    tokens.refresh_token,
+    buildRefreshCookieOptions(tokens.refresh_expires_in)
+  );
+  return sendSuccess(reply, {
+    user: omitFields(user, 'password_hash'),
+    access_token: tokens.access_token,
+    expires_in: tokens.expires_in,
+    token_type: tokens.token_type,
+  });
 }

--- a/packages/backend/src/api/routes/auth-oidc.ts
+++ b/packages/backend/src/api/routes/auth-oidc.ts
@@ -153,10 +153,14 @@ export function oidcRoutes(fastify: FastifyInstance): void {
         response_types: ['code'],
       });
 
-      // openid-client validates iss/aud/nonce/exp/JWKS signature internally on callback()
+      // openid-client validates iss/aud/nonce/exp/JWKS signature internally on callback().
+      // `state` must be echoed in `params` too, not just `checks` — openid-client@5.7.1's
+      // callback() throws "state missing from the response" when checks.state is set but
+      // params.state isn't (lib/client.js), which would 401 every real callback while
+      // leaving the fully-mocked unit tests green.
       const tokenSet = await client.callback(
         statePayload.redirectUri,
-        { code },
+        { code, state: stateParam },
         { state: stateParam, nonce: statePayload.nonce, code_verifier: statePayload.codeVerifier }
       );
       claims = tokenSet.claims();
@@ -167,7 +171,11 @@ export function oidcRoutes(fastify: FastifyInstance): void {
     if (claims.email_verified !== true) {
       return unauthorized(reply);
     }
-    if (!claims.email) {
+    // The ID token's claim shape is IdP-controlled, not just signature-verified — a
+    // truthy non-string `email` (e.g. a number or object) would pass `!claims.email`
+    // and then throw on .split() below, outside this try/catch, turning a bad claim
+    // into an unhandled 500 instead of the generic 401 every other rejection returns.
+    if (typeof claims.email !== 'string' || claims.email.length === 0) {
       return unauthorized(reply);
     }
     const email = claims.email;
@@ -176,9 +184,15 @@ export function oidcRoutes(fastify: FastifyInstance): void {
       return unauthorized(reply);
     }
     // .toLowerCase() so the check isn't case-sensitive; split('@')[1] is still undefined
-    // for a malformed email with no '@', so the fail-closed check covers that too.
+    // for a malformed email with no '@', so the fail-closed check covers that too. The
+    // configured domains themselves aren't guaranteed lowercase (admin-entered free
+    // text), so each is normalized at comparison time too — .includes() alone would
+    // silently reject a valid user against e.g. an allowedDomains entry of 'Corp.Example.Com'.
     const emailDomain = email.split('@')[1]?.toLowerCase();
-    if (!emailDomain || !idpConfig.allowedDomains.includes(emailDomain)) {
+    if (
+      !emailDomain ||
+      !idpConfig.allowedDomains.some((domain) => domain.toLowerCase() === emailDomain)
+    ) {
       return unauthorized(reply);
     }
 

--- a/packages/backend/src/api/services/oidc-service.ts
+++ b/packages/backend/src/api/services/oidc-service.ts
@@ -52,4 +52,17 @@ export async function storeOidcState(stateKey: string, payload: OidcStatePayload
   await getCacheService().set(`oidc:state:${stateKey}`, payload, STATE_TTL_SECONDS);
 }
 
+/**
+ * Atomically consume (read + delete in one round-trip) a stored CSRF state
+ * payload. Backed by `CacheService.getAndDelete` (#379), which goes straight
+ * to Redis's native GETDEL rather than checking the L1 memory cache first —
+ * checking L1 first would reintroduce the race this exists to prevent (two
+ * concurrent requests both observing a still-present L1 copy before either
+ * one deletes it). A `null` return means the state was never stored, already
+ * consumed, or expired — callers must treat all three identically.
+ */
+export async function consumeOidcState(stateKey: string): Promise<OidcStatePayload | null> {
+  return getCacheService().getAndDelete<OidcStatePayload>(`oidc:state:${stateKey}`);
+}
+
 export { generators };

--- a/packages/backend/tests/api/auth-oidc.test.ts
+++ b/packages/backend/tests/api/auth-oidc.test.ts
@@ -1,10 +1,11 @@
 /**
- * OIDC Login Initiation Tests (#367)
+ * OIDC Login Initiation + Callback Tests (#367 + #368)
  *
- * Route-level tests for `GET /api/v1/auth/oidc/:tenantId/login`. Builds its
- * own minimal Fastify instance and registers `oidcRoutes` directly — the
- * same pattern `tests/api/routes/signup.route.test.ts` uses — since
- * `server.ts` wiring is out of scope for this slice (see spec #367).
+ * Route-level tests for `GET /api/v1/auth/oidc/:tenantId/login` (#367) and
+ * `GET /api/v1/auth/oidc/:tenantId/callback` (#368). Builds its own minimal
+ * Fastify instance and registers `oidcRoutes` directly — the same pattern
+ * `tests/api/routes/signup.route.test.ts` uses — since `server.ts` wiring is
+ * out of scope for this slice (see spec #368).
  *
  * `openid-client`, the SSRF validator, the DNS-pinning helper, and the
  * cache singleton are all mocked at top level via `vi.mock`/`vi.hoisted`
@@ -12,14 +13,27 @@
  * declarations they're referenced from, or referencing them from inside
  * the hoisted factory hits the TDZ).
  *
- * `OIDC_REDIRECT_BASE_URL` is populated by `tests/setup-unit-env.ts` — the
- * route throws a `ConfigurationError` when it's unset, matching production
- * behavior for a deployment that hasn't configured it.
+ * `OIDC_REDIRECT_BASE_URL` and `JWT_SECRET` are populated by
+ * `tests/setup-unit-env.ts` — the login route throws a `ConfigurationError`
+ * rather than deriving `redirect_uri` from request headers when the former
+ * is unset; the callback route's session issuance needs a real JWT secret
+ * for `fastify.jwt.sign()` to work, so `@fastify/jwt` and `@fastify/cookie`
+ * are registered on the test server exactly like the real server does
+ * (`src/api/server.ts`) — omitting either makes `issueOidcCookie()` throw
+ * (`reply.setCookie is not a function` / `fastify.jwt.sign is not a
+ * function`), which the Fastify default error handler turns into an
+ * unhandled 500 on every cookie-issuing branch (happy path, state-reuse's
+ * first call, same-tenant link, new-user create) while leaving pure-401
+ * branches unaffected — precisely the four-test failure shape hit by the
+ * impl-agent run this file replaces.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
+import cookie from '@fastify/cookie';
+import jwt from '@fastify/jwt';
 import { oidcRoutes } from '../../src/api/routes/auth-oidc.js';
+import { config } from '../../src/config.js';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside the hoisted vi.mock factories below (a
@@ -27,15 +41,22 @@ import { oidcRoutes } from '../../src/api/routes/auth-oidc.js';
 // above regular imports/consts).
 // ---------------------------------------------------------------------------
 
-const { mockAuthorizationUrlFn, mockCacheService, mockPinHostnameToIp } = vi.hoisted(() => ({
-  mockAuthorizationUrlFn: vi.fn(),
-  mockCacheService: { get: vi.fn(), set: vi.fn().mockResolvedValue(undefined) },
-  mockPinHostnameToIp: vi.fn(),
-}));
+const { mockAuthorizationUrlFn, mockCacheService, mockPinHostnameToIp, mockCallbackFn } =
+  vi.hoisted(() => ({
+    mockAuthorizationUrlFn: vi.fn(),
+    mockCacheService: {
+      get: vi.fn(),
+      set: vi.fn().mockResolvedValue(undefined),
+      getAndDelete: vi.fn(),
+    },
+    mockPinHostnameToIp: vi.fn(),
+    mockCallbackFn: vi.fn(),
+  }));
 
 vi.mock('openid-client', () => {
   const MockClient = vi.fn().mockImplementation(() => ({
     authorizationUrl: mockAuthorizationUrlFn,
+    callback: mockCallbackFn,
   }));
   const mockIssuer = {
     metadata: {
@@ -84,10 +105,38 @@ const mockOidcIdpConfigs = {
   findByTenantId: vi.fn(),
 };
 
+const mockUsers = {
+  findByEmail: vi.fn(),
+  create: vi.fn(),
+};
+
+const mockOrganizationMembers = {
+  findMembership: vi.fn(),
+  createWithUser: vi.fn(),
+};
+
+// The new-user branch wraps its two calls in db.transaction(async tx => ...) — the mock
+// just invokes the callback with the same users/organizationMembers mocks as `tx`, so
+// mockUsers.create / mockOrganizationMembers.createWithUser assertions still work unchanged.
+const mockTransaction = vi.fn((callback: (tx: unknown) => unknown) =>
+  callback({ users: mockUsers, organizationMembers: mockOrganizationMembers })
+);
+
 async function buildServer(): Promise<FastifyInstance> {
   const server = Fastify();
+  // Mirrors src/api/server.ts's real plugin registration for the pieces the
+  // callback route's session issuance depends on (setCookie + jwt.sign) —
+  // a minimal server missing either turns every cookie-issuing branch into
+  // an unhandled 500 instead of the intended 2xx/401.
+  await server.register(cookie);
+  await server.register(jwt, { secret: config.jwt.secret });
   server.decorate('container', {
-    db: { oidcIdpConfigs: mockOidcIdpConfigs },
+    db: {
+      oidcIdpConfigs: mockOidcIdpConfigs,
+      users: mockUsers,
+      organizationMembers: mockOrganizationMembers,
+      transaction: mockTransaction,
+    },
   });
   oidcRoutes(server);
   await server.ready();
@@ -170,5 +219,400 @@ describe('GET /api/v1/auth/oidc/:tenantId/login', () => {
       '../../src/integrations/security/ssrf-validator.js'
     );
     expect(validateSSRFProtection).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/v1/auth/oidc/:tenantId/callback', () => {
+  let server: FastifyInstance;
+
+  const validPayload = {
+    nonce: 'mock-nonce',
+    codeVerifier: 'mock-verifier',
+    redirectUri: 'http://app/cb',
+    tenantId: 'tenant-abc',
+    issuer: 'https://idp.example.com',
+  };
+
+  const validConfig = {
+    issuerUrl: 'https://idp.example.com',
+    clientId: 'c',
+    clientSecret: 's',
+    allowedDomains: ['corp.example.com'],
+  };
+
+  const validTokenSet = {
+    claims: () => ({
+      email: 'alice@corp.example.com',
+      email_verified: true,
+      sub: 'sub-1',
+    }),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockPinHostnameToIp.mockResolvedValue({
+      ip: '93.184.216.34',
+      family: 4,
+      lookup: vi.fn(),
+    });
+    const { validateSSRFProtection } = await import(
+      '../../src/integrations/security/ssrf-validator.js'
+    );
+    vi.mocked(validateSSRFProtection).mockReturnValue(new URL('https://idp.example.com'));
+    server = await buildServer();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  // --- A: happy path ---------------------------------------------------
+
+  it('valid callback with email_verified:true for same-tenant member issues cookie', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue(validTokenSet);
+    mockUsers.findByEmail.mockResolvedValue({ id: 'user-1' });
+    mockOrganizationMembers.findMembership.mockResolvedValue({ id: 'mem-1' });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBeLessThan(400);
+    expect(res.headers['set-cookie']).toMatch(/refresh_token=/);
+  });
+
+  // --- B: tampered signature --------------------------------------------
+
+  it('returns 401 when openid-client throws on bad signature', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockRejectedValue(new Error('JWSSignatureVerificationFailed'));
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- C: expired ID token (same shape as B) -----------------------------
+
+  it('returns 401 when openid-client throws on an expired ID token', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockRejectedValue(new Error('RPError: id_token expired'));
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- D: wrong iss (same shape as B) -------------------------------------
+
+  it('returns 401 when openid-client throws on unexpected iss', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockRejectedValue(new Error('RPError: unexpected iss value'));
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- E: wrong aud (same shape as B) -------------------------------------
+
+  it('returns 401 when openid-client throws on unexpected aud', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockRejectedValue(new Error('RPError: aud mismatch'));
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- F: replayed state ---------------------------------------------------
+
+  it('returns 401 on second use of the same state (state consumed after first callback)', async () => {
+    mockCacheService.getAndDelete.mockResolvedValueOnce(validPayload).mockResolvedValueOnce(null);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue(validTokenSet);
+    mockUsers.findByEmail.mockResolvedValue({ id: 'user-1' });
+    mockOrganizationMembers.findMembership.mockResolvedValue({ id: 'mem-1' });
+
+    const first = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+    const second = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(first.statusCode).toBeLessThan(400);
+    expect(second.statusCode).toBe(401);
+    expect(mockCacheService.getAndDelete).toHaveBeenCalledTimes(2);
+  });
+
+  // --- G: email_verified false/absent (same shape as H) -------------------
+
+  it('returns 401 without any users repository call when email_verified is false', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue({
+      claims: () => ({ email: 'alice@corp.example.com', email_verified: false, sub: 'sub-1' }),
+    });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockUsers.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 without any users repository call when email_verified is absent', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue({
+      claims: () => ({ email: 'alice@corp.example.com', sub: 'sub-1' }),
+    });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockUsers.findByEmail).not.toHaveBeenCalled();
+  });
+
+  // --- H: allowedDomains fail-closed ---------------------------------------
+
+  it('returns 401 before any user lookup when allowedDomains is empty', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue({
+      ...validConfig,
+      allowedDomains: [],
+    });
+    mockCallbackFn.mockResolvedValue(validTokenSet);
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockUsers.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 before any user lookup when the email has no @ domain to match', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue({
+      claims: () => ({ email: 'not-an-email', email_verified: true, sub: 'sub-1' }),
+    });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockUsers.findByEmail).not.toHaveBeenCalled();
+  });
+
+  // --- I: cross-tenant match rejected --------------------------------------
+
+  it('returns 401 when email matches a user who has no membership in the requested tenant', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue({ ...validPayload, tenantId: 'tenant-abc' });
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue(validTokenSet); // email: alice@corp.example.com
+    mockUsers.findByEmail.mockResolvedValue({ id: 'user-1' });
+    mockOrganizationMembers.findMembership.mockResolvedValue(null); // not a member of this tenant
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).error).toBe('Authentication failed');
+    // Must not expose which tenant the user belongs to, and must not create
+    // a duplicate global user for an email that already exists.
+    expect(mockUsers.create).not.toHaveBeenCalled();
+  });
+
+  // --- J: same-tenant link (no new user row) -------------------------------
+
+  it('links the existing account when email matches a member of the requested tenant', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue(validTokenSet);
+    mockUsers.findByEmail.mockResolvedValue({ id: 'user-1' });
+    mockOrganizationMembers.findMembership.mockResolvedValue({ id: 'mem-1' });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBeLessThan(400);
+    expect(res.headers['set-cookie']).toMatch(/refresh_token=/);
+    // Proves the "link" branch reused the existing user row instead of the
+    // new-user-create branch.
+    expect(mockUsers.create).not.toHaveBeenCalled();
+    expect(mockOrganizationMembers.createWithUser).not.toHaveBeenCalled();
+  });
+
+  // --- K: no existing user creates a new user + membership -----------------
+
+  it('creates a new user and membership when no existing user matches the email', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue(validTokenSet);
+    mockUsers.findByEmail.mockResolvedValue(null);
+    mockUsers.create.mockResolvedValue({ id: 'new-user-1', email: 'alice@corp.example.com' });
+    mockOrganizationMembers.createWithUser.mockResolvedValue({ id: 'mem-new' });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBeLessThan(400);
+    expect(res.headers['set-cookie']).toMatch(/refresh_token=/);
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockUsers.create).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'alice@corp.example.com' })
+    );
+    expect(mockOrganizationMembers.createWithUser).toHaveBeenCalledWith(
+      'tenant-abc',
+      'new-user-1',
+      'member'
+    );
+  });
+
+  it('returns 401 and rolls back when membership creation returns null for a new user', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    mockCallbackFn.mockResolvedValue(validTokenSet);
+    mockUsers.findByEmail.mockResolvedValue(null);
+    mockUsers.create.mockResolvedValue({ id: 'new-user-1', email: 'alice@corp.example.com' });
+    mockOrganizationMembers.createWithUser.mockResolvedValue(null);
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- L: SSRF rejection on internal token_endpoint ------------------------
+
+  it('rejects when discovered token_endpoint resolves to an internal address', async () => {
+    const { validateSSRFProtection } = await import(
+      '../../src/integrations/security/ssrf-validator.js'
+    );
+    vi.mocked(validateSSRFProtection)
+      .mockReturnValueOnce(new URL('https://idp.example.com')) // issuerUrl passes
+      .mockImplementationOnce(() => {
+        throw new Error('SSRF: private address');
+      }); // token_endpoint fails
+
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockCallbackFn).not.toHaveBeenCalled();
+  });
+
+  // --- M: SSRF rejection on internal jwks_uri (same shape as L) ------------
+
+  it('rejects when discovered jwks_uri resolves to an internal address', async () => {
+    const { validateSSRFProtection } = await import(
+      '../../src/integrations/security/ssrf-validator.js'
+    );
+    vi.mocked(validateSSRFProtection)
+      .mockReturnValueOnce(new URL('https://idp.example.com')) // issuerUrl passes
+      .mockReturnValueOnce(new URL('https://idp.example.com/token')) // token_endpoint passes
+      .mockImplementationOnce(() => {
+        throw new Error('SSRF: private address');
+      }); // jwks_uri fails
+
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockCallbackFn).not.toHaveBeenCalled();
+  });
+
+  // --- N: issuer mismatch between state and re-discovery -------------------
+
+  it('returns 401 when the re-discovered issuer does not match the issuer stored in state', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue({
+      ...validPayload,
+      issuer: 'https://old-idp.example.com',
+    });
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    // discoverIssuerValidated resolves the mocked Issuer, whose metadata.issuer is
+    // 'https://idp.example.com' — does not match the state's 'https://old-idp.example.com'
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockCallbackFn).not.toHaveBeenCalled();
+  });
+
+  // --- Additional edge cases: missing query params / IdP error passthrough -
+
+  it('returns 401 without consuming state when the IdP redirects with an error param', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?error=access_denied',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockCacheService.getAndDelete).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for a tenant mismatch between the callback URL and the stored state', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue({ ...validPayload, tenantId: 'other-tenant' });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockOidcIdpConfigs.findByTenantId).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/tests/api/auth-oidc.test.ts
+++ b/packages/backend/tests/api/auth-oidc.test.ts
@@ -282,6 +282,16 @@ describe('GET /api/v1/auth/oidc/:tenantId/callback', () => {
 
     expect(res.statusCode).toBeLessThan(400);
     expect(res.headers['set-cookie']).toMatch(/refresh_token=/);
+    // Regression guard: openid-client@5.7.1's callback() throws "state missing from
+    // the response" when checks.state is set but params.state isn't (verified against
+    // node_modules/openid-client's actual lib/client.js) — mockCallbackFn being fully
+    // mocked means a statusCode assertion alone can't catch a dropped `state` in the
+    // params object, so assert on the actual call arguments too.
+    expect(mockCallbackFn).toHaveBeenCalledWith(
+      'http://app/cb',
+      expect.objectContaining({ code: 'c', state: 's' }),
+      expect.objectContaining({ state: 's' })
+    );
   });
 
   // --- B: tampered signature --------------------------------------------
@@ -401,6 +411,26 @@ describe('GET /api/v1/auth/oidc/:tenantId/callback', () => {
     expect(mockUsers.findByEmail).not.toHaveBeenCalled();
   });
 
+  it('returns 401 instead of a 500 when the email claim is a non-string truthy value', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue(validConfig);
+    // A truthy, non-empty, non-string claim (e.g. a malformed/malicious IdP response)
+    // passes a bare `!claims.email` check and would previously reach `.split('@')`
+    // outside the try/catch, throwing an unhandled 500 instead of the generic 401
+    // every other rejection in this handler returns.
+    mockCallbackFn.mockResolvedValue({
+      claims: () => ({ email: 12345, email_verified: true, sub: 'sub-1' }),
+    });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockUsers.findByEmail).not.toHaveBeenCalled();
+  });
+
   // --- H: allowedDomains fail-closed ---------------------------------------
 
   it('returns 401 before any user lookup when allowedDomains is empty', async () => {
@@ -434,6 +464,25 @@ describe('GET /api/v1/auth/oidc/:tenantId/callback', () => {
 
     expect(res.statusCode).toBe(401);
     expect(mockUsers.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it('links the account when allowedDomains has a mixed-case entry matching the lowercased email domain', async () => {
+    mockCacheService.getAndDelete.mockResolvedValue(validPayload);
+    mockOidcIdpConfigs.findByTenantId.mockResolvedValue({
+      ...validConfig,
+      allowedDomains: ['Corp.Example.Com'],
+    });
+    mockCallbackFn.mockResolvedValue(validTokenSet); // email: alice@corp.example.com
+    mockUsers.findByEmail.mockResolvedValue({ id: 'user-1' });
+    mockOrganizationMembers.findMembership.mockResolvedValue({ id: 'mem-1' });
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/auth/oidc/tenant-abc/callback?code=c&state=s',
+    });
+
+    expect(res.statusCode).toBeLessThan(400);
+    expect(res.headers['set-cookie']).toMatch(/refresh_token=/);
   });
 
   // --- I: cross-tenant match rejected --------------------------------------


### PR DESCRIPTION
Refs #368.

Replaces a failed impl-agent auto-generation attempt: all 3 declared files were written and `check-impl-scope.mjs` passed, but 4 of ~14 generated test cases failed with `AssertionError: expected 500 to be less than 400` on every cookie-issuing branch (happy path, second call of the state-reuse test, same-tenant link, new-user create), so Husky's pre-push hook blocked the push and the generated code never reached any branch. This PR hand-implements the spec directly against the merged code instead.

**Root cause of the 500s (diagnosed by rebuilding the test harness from scratch and running it for real, not guessed):** the route's session-issuing path calls `reply.setCookie()` and `fastify.jwt.sign()` (via `generateAuthTokens`), but a route-level test harness built as a minimal `Fastify()` instance has neither `@fastify/cookie` nor `@fastify/jwt` registered unless the test file explicitly does so. #367's own login-route test file (which this spec said to extend) never needed either plugin, since the login handler only redirects and writes to the cache. Extending that file's `buildServer()` with the callback route without also registering both plugins makes every branch that reaches `issueOidcCookie()` throw an unhandled `TypeError` (`reply.setCookie is not a function` / `fastify.jwt.sign is not a function`), which Fastify's default error handler turns into a 500 — exactly matching the 4 failing cases (all reach that path) versus the 10 passing ones (all return 401 before it). Fixed by registering `@fastify/cookie` and `@fastify/jwt` on the shared `buildServer()`, mirroring `src/api/server.ts`'s real plugin registration.

Spec assumptions verified against real code, no corrections needed this time (the previous correction pass already happened during spec review for #367/#368):
- Container keys `db.users` / `db.organizationMembers` with `findMembership(orgId, userId)` / `createWithUser(orgId, userId, role)` — confirmed in `factory.ts` and `organization-member.repository.ts`.
- `CacheService.getAndDelete` (#379) — confirmed merged, goes straight to Redis `GETDEL`, bypasses L1 read, matches spec semantics exactly.
- `openid-client@5.7.1` — confirmed `client.callback(redirectUri, params, checks, extras)` is the real v5 method signature.
- `UserInsert.password_hash` is already `string | null` (optional) — the spec's "ASSUMED compatible" new-user branch needed no schema change.

## What's implemented
- `consumeOidcState` in `oidc-service.ts` — atomic state consumption via `CacheService.getAndDelete`.
- Callback handler in `auth-oidc.ts` (`GET /api/v1/auth/oidc/:tenantId/callback`): CSRF state consumption + issuer re-validation, SSRF-gated discovery (reusing `discoverIssuerValidated`), strict `email_verified === true` check before any DB call, fail-closed `allowedDomains` (case-insensitive, malformed-email-safe), tenant-scoped account-linking per ADR-0044 Decision 1, and an atomic `db.transaction(...)` new-user + membership creation that rolls back on a null `createWithUser` conflict.

## Test plan
- [x] `packages/backend/tests/api/auth-oidc.test.ts` extended with all 14 spec test cases (A-N) plus a few extra edge cases (malformed email, missing email_verified, tenant-mismatch-in-state, IdP error passthrough) — 21 tests, all passing.
- [x] Full backend unit suite: `pnpm --filter @bugspotter/backend test:unit` — 127 files, 3166 tests, all passing.
- [x] `pnpm --filter @bugspotter/backend typecheck` — clean.
- [x] `eslint` + `prettier@3.6.2` — clean.