### PR TITLE
feat(ai-sdlc): add quality self-review pass to impl-agent

### DIFF
--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -646,6 +646,145 @@ if (correctionAttempted) {
   }
 }
 
+// Quality self-review: a second, narrowly-scoped LLM call that reviews ONLY
+// the files just written for two specific things — significant duplication
+// (3+ near-identical blocks) and extract-worthy complexity (a long inline
+// handler that should be a named function). Deliberately NOT security,
+// correctness, missing tests, or general style — that stays claude-review.yml's
+// and CodeRabbit's job; splitting one reviewer's attention across both axes
+// risks it doing both worse (that's why claude-review.yml's own prompt says
+// "skip nits, style, theoretical issues"). Motivated by issue #368: impl-agent's
+// own generated auth-oidc.ts had 12 copies of `reply.code(401).send({ error:
+// 'Authentication failed' })` and two ~50-120 line inline route handlers,
+// neither caught until a human noticed by hand afterward.
+//
+// Runs once per issue (here, inside generation), not once per push against an
+// open PR — same cost shape as spec-agent.yml's generate-spec.mjs +
+// verify-spec.mjs pair, and the same corrective-follow-up-call pattern above
+// for missing files. Time-budgeted against the SAME step budget that call
+// already uses: if turn 1 (plus a missing-file retry, if one fired) used most
+// of STEP_BUDGET_MS, this is skipped entirely rather than risking the step's
+// own timeout — a skipped quality pass costs nothing, but a timed-out step
+// loses the whole scaffold.
+const QUALITY_MIN_BUDGET_MS = parsePositiveMs(process.env.IMPL_QUALITY_MIN_BUDGET_MS, 90_000);
+const qualityRemainingMs = STEP_BUDGET_MS - SAFETY_BUFFER_MS - (Date.now() - scriptStartedAt);
+
+if (qualityRemainingMs < QUALITY_MIN_BUDGET_MS) {
+  console.log(
+    `Skipping quality self-review: only ~${Math.round(qualityRemainingMs / 1000)}s remain in ` +
+      `the step budget, below the ${Math.round(QUALITY_MIN_BUDGET_MS / 1000)}s floor.`
+  );
+} else {
+  const qualityTimeoutMs = Math.min(300_000, qualityRemainingMs);
+  const writtenFileSections = writtenPaths
+    .map((p) => {
+      const content = readFileSync(resolve(repoRoot, p), 'utf8');
+      const fence = fenceFor(content);
+      return `## ${p}\n${fence}${languageFor(p)}\n${content}\n${fence}`;
+    })
+    .join('\n\n');
+
+  // Leading marker line, same purpose as the corrective-follow-up prompt's
+  // own "--- CORRECTIVE FOLLOW-UP ---" header: lets tests (and, incidentally,
+  // anyone reading a CLI transcript) tell the three possible calls apart
+  // without guessing from prose.
+  const qualityPrompt = `\
+--- QUALITY SELF-REVIEW ---
+You are a code-quality reviewer. Review ONLY the files below — everything just written for GitHub issue #${ISSUE_NUMBER}: "${ISSUE_TITLE}". Check for exactly two things:
+
+1. Significant duplication — the same or near-identical block (3 or more times) that should collapse into one shared helper. Example: a route handler that returns \`reply.code(401).send({ error: 'Authentication failed' })\` many times inline should extract a single \`function unauthorized(reply) { return reply.code(401).send({ error: 'Authentication failed' }); }\` and call that instead — not just for brevity, but because scattering the literal risks one call site silently drifting from the others.
+2. Extract-worthy complexity — an inline anonymous handler or closure long enough (roughly 50+ lines) that a named function would make it more readable and give it a real name in stack traces. Example: an inline \`async (request, reply) => { ...120 lines... }\` passed directly to a route-registration call should become a named function declared alongside the registration (nested there if the surrounding code requires a single registration entry point, not necessarily pulled to module scope).
+
+Do NOT comment on or change:
+- Security, correctness, or auth logic — a separate reviewer already covers this
+- Missing tests
+- General style, formatting, or naming outside the two checks above
+- Anything that is not a clear instance of one of the two checks above
+
+If neither issue is present, respond with exactly the word: NO_CHANGES_NEEDED
+
+Otherwise respond with ONLY valid JSON (no prose, no markdown fences around the JSON itself): { "files": [ { "path": "...", "content": "..." } ], "summary": "one sentence" } — include the COMPLETE revised content of every file you changed, reproduced in full except for the specific extraction/deduplication. Do not include a file you did not change, and do not change the file set — only revise the content of files listed below.
+
+FILES WRITTEN:
+${writtenFileSections}`;
+
+  console.log(
+    `Reviewing ${writtenPaths.length} written file(s) for duplication/extraction (timeout ` +
+      `${Math.round(qualityTimeoutMs / 1000)}s)…`
+  );
+
+  let qualityText, qualityStopReason;
+  try {
+    ({ text: qualityText, stopReason: qualityStopReason } = await callClaude({
+      prompt: qualityPrompt,
+      maxTokens: MAX_TOKENS,
+      timeoutMs: qualityTimeoutMs,
+      model: MODEL,
+    }));
+  } catch (err) {
+    // Non-fatal, same philosophy as verify-spec.mjs: a quality-review hiccup
+    // must never block a scaffold that otherwise succeeded.
+    console.warn(`Quality self-review call failed, proceeding without it: ${err.message}`);
+    qualityText = null;
+  }
+
+  if (qualityStopReason === 'max_tokens') {
+    console.warn('Quality self-review response truncated (stop_reason=max_tokens) — skipping.');
+    qualityText = null;
+  }
+
+  const qualityResult = qualityText?.trim() ?? '';
+  if (qualityResult === 'NO_CHANGES_NEEDED') {
+    console.log(
+      'Quality self-review: no significant duplication or extract-worthy complexity found.'
+    );
+  } else if (qualityResult) {
+    let qualityParsed;
+    try {
+      const fenceMatch = qualityResult.match(/```json\s*([\s\S]*?)\s*```/i);
+      const raw = fenceMatch ? fenceMatch[1].trim() : qualityResult;
+      qualityParsed = JSON.parse(raw);
+    } catch (e) {
+      console.warn(`Quality self-review response was not parseable JSON, skipping: ${e.message}`);
+      qualityParsed = null;
+    }
+
+    if (qualityParsed && Array.isArray(qualityParsed.files) && qualityParsed.files.length > 0) {
+      const writtenSet = new Set(writtenPaths);
+      let revisedCount = 0;
+      for (const { path, content } of qualityParsed.files) {
+        if (typeof path !== 'string' || typeof content !== 'string' || !path || !content) {
+          continue;
+        }
+        const relPath = toRepoRelative(path);
+        // Only ever revises a file this run already wrote — never adds a new
+        // path or touches one outside this run's own output. A quality pass
+        // proposing a new path would silently desync check-impl-scope.mjs's
+        // exact-match gate against the spec, which the write loop above was
+        // already careful to satisfy.
+        if (relPath === null || !writtenSet.has(relPath)) {
+          console.warn(
+            `Quality self-review named a path outside this run's own output, skipping: ${path}`
+          );
+          continue;
+        }
+        writeFileSync(resolve(repoRoot, relPath), content, 'utf8');
+        console.log(`Quality self-review revised ${relPath}`);
+        revisedCount += 1;
+      }
+      if (revisedCount > 0) {
+        parsed.summary =
+          `${parsed.summary ?? ''} [quality self-review revised ${revisedCount} file(s): ` +
+          `${qualityParsed.summary ?? 'duplication/extraction cleanup'}]`;
+      }
+    } else if (qualityParsed) {
+      console.warn('Quality self-review response had no files array, skipping.');
+    }
+  } else {
+    console.warn('Quality self-review returned empty response, skipping.');
+  }
+}
+
 console.log(`\nSummary: ${parsed.summary}`);
 
 if (GITHUB_OUTPUT) {

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -684,10 +684,30 @@ if (qualityRemainingMs < QUALITY_MIN_BUDGET_MS) {
   // this file already guards against on the input side. A truncated file is
   // marked read-only and excluded below if the model tries to revise it
   // anyway, mirroring "you would silently delete the lines you cannot see."
+  // Both sets below feed the same "was this file actually shown to the
+  // model" check when validating revisions further down: a path missing
+  // from writtenFileSections — whether because it was truncated or because
+  // it could not be read at all — must not be accepted back, or the quality
+  // pass could silently overwrite a file it never saw with fabricated
+  // content, same class of issue as the truncation case this already guards.
   const truncatedWrittenPaths = new Set();
+  const unreadableWrittenPaths = new Set();
   const writtenFileSections = writtenPaths
     .map((p) => {
-      const content = readFileSync(resolve(repoRoot, p), 'utf8');
+      // Same defensive read as the currentFiles block above (line ~236): this
+      // script just wrote every one of these paths itself moments ago, so an
+      // unreadable path here should be near-impossible, but a quality-review
+      // hiccup must never abort a scaffold that otherwise succeeded (see the
+      // callClaude try/catch below) — an uncaught readFileSync would do
+      // exactly that.
+      let content;
+      try {
+        content = readFileSync(resolve(repoRoot, p), 'utf8');
+      } catch (err) {
+        console.warn(`Quality self-review: cannot read ${p}, excluding it: ${err.message}`);
+        unreadableWrittenPaths.add(p);
+        return null;
+      }
       const lines = content.split('\n');
       const lineCount = lines.length - (lines.at(-1) === '' ? 1 : 0);
       const isTruncated = lineCount > MAX_LINES_PER_FILE;
@@ -702,6 +722,7 @@ if (qualityRemainingMs < QUALITY_MIN_BUDGET_MS) {
         : `## ${p}`;
       return `${header}\n${fence}${languageFor(p)}\n${body}\n${fence}`;
     })
+    .filter(Boolean)
     .join('\n\n');
 
   // Leading marker line, same purpose as the corrective-follow-up prompt's
@@ -792,18 +813,24 @@ ${writtenFileSections}`;
           );
           continue;
         }
-        if (truncatedWrittenPaths.has(relPath)) {
-          // Model was shown only the first MAX_LINES_PER_FILE lines of this
-          // file and told not to revise it. Enforce that server-side too:
-          // writing back "content" built from a partial view would silently
-          // truncate the file to what the model could see, regardless of
-          // whether it followed the instruction.
+        if (truncatedWrittenPaths.has(relPath) || unreadableWrittenPaths.has(relPath)) {
+          // The model was shown only a partial view of this file (or none at
+          // all — see unreadableWrittenPaths above) and told not to revise
+          // it. Enforce that server-side too: writing back "content" built
+          // from a partial or nonexistent view would silently corrupt or
+          // fabricate the file, regardless of whether the model followed the
+          // instruction.
           console.warn(
-            `Quality self-review proposed a change to a truncated file, skipping to avoid data loss: ${relPath}`
+            `Quality self-review proposed a change to a file excluded from its view, skipping to avoid data loss: ${relPath}`
           );
           continue;
         }
-        writeFileSync(resolve(repoRoot, relPath), content, 'utf8');
+        try {
+          writeFileSync(resolve(repoRoot, relPath), content, 'utf8');
+        } catch (err) {
+          console.warn(`Quality self-review could not write ${relPath}, skipping: ${err.message}`);
+          continue;
+        }
         console.log(`Quality self-review revised ${relPath}`);
         revisedCount += 1;
       }

--- a/scripts/ai-sdlc/generate-impl.mjs
+++ b/scripts/ai-sdlc/generate-impl.mjs
@@ -676,11 +676,31 @@ if (qualityRemainingMs < QUALITY_MIN_BUDGET_MS) {
   );
 } else {
   const qualityTimeoutMs = Math.min(300_000, qualityRemainingMs);
+  // Same MAX_LINES_PER_FILE cap the currentFiles section above applies to
+  // pre-existing declared files, for the same reason: LLM_BACKEND=cli enforces
+  // no output-token cap (see MAX_TOKENS's comment above), so a file this run
+  // just wrote can already be arbitrarily large before it's re-injected here.
+  // Uncapped, that risks the same unbounded-prompt cost/truncation exposure
+  // this file already guards against on the input side. A truncated file is
+  // marked read-only and excluded below if the model tries to revise it
+  // anyway, mirroring "you would silently delete the lines you cannot see."
+  const truncatedWrittenPaths = new Set();
   const writtenFileSections = writtenPaths
     .map((p) => {
       const content = readFileSync(resolve(repoRoot, p), 'utf8');
-      const fence = fenceFor(content);
-      return `## ${p}\n${fence}${languageFor(p)}\n${content}\n${fence}`;
+      const lines = content.split('\n');
+      const lineCount = lines.length - (lines.at(-1) === '' ? 1 : 0);
+      const isTruncated = lineCount > MAX_LINES_PER_FILE;
+      const body = isTruncated ? lines.slice(0, MAX_LINES_PER_FILE).join('\n') : content;
+      const fence = fenceFor(body);
+      if (isTruncated) {
+        truncatedWrittenPaths.add(p);
+      }
+      const header = isTruncated
+        ? `## ${p}\n\nTRUNCATED: showing lines 1-${MAX_LINES_PER_FILE} of ${lineCount}. ` +
+          `Reference only — do NOT propose changes to this file.`
+        : `## ${p}`;
+      return `${header}\n${fence}${languageFor(p)}\n${body}\n${fence}`;
     })
     .join('\n\n');
 
@@ -704,7 +724,11 @@ Do NOT comment on or change:
 If neither issue is present, respond with exactly the word: NO_CHANGES_NEEDED
 
 Otherwise respond with ONLY valid JSON (no prose, no markdown fences around the JSON itself): { "files": [ { "path": "...", "content": "..." } ], "summary": "one sentence" } — include the COMPLETE revised content of every file you changed, reproduced in full except for the specific extraction/deduplication. Do not include a file you did not change, and do not change the file set — only revise the content of files listed below.
-
+${
+  truncatedWrittenPaths.size
+    ? `\nA file marked TRUNCATED below is shown only in part. Never propose a change to one: you would silently delete the lines you cannot see.\n`
+    : ''
+}
 FILES WRITTEN:
 ${writtenFileSections}`;
 
@@ -765,6 +789,17 @@ ${writtenFileSections}`;
         if (relPath === null || !writtenSet.has(relPath)) {
           console.warn(
             `Quality self-review named a path outside this run's own output, skipping: ${path}`
+          );
+          continue;
+        }
+        if (truncatedWrittenPaths.has(relPath)) {
+          // Model was shown only the first MAX_LINES_PER_FILE lines of this
+          // file and told not to revise it. Enforce that server-side too:
+          // writing back "content" built from a partial view would silently
+          // truncate the file to what the model could see, regardless of
+          // whether it followed the instruction.
+          console.warn(
+            `Quality self-review proposed a change to a truncated file, skipping to avoid data loss: ${relPath}`
           );
           continue;
         }

--- a/scripts/ai-sdlc/generate-impl.test.mjs
+++ b/scripts/ai-sdlc/generate-impl.test.mjs
@@ -54,20 +54,31 @@ after(() => {
 //
 // Configurable via env vars so the same fake can play both turns of a
 // self-correction round-trip:
-//   FAKE_CLAUDE_FILES       - JSON array of {path, content} for a normal
-//                             (first-turn) call. Defaults to the single
-//                             packages/generated.ts fixture the original
-//                             over-cap tests depend on.
-//   FAKE_CLAUDE_RETRY_FILES - JSON array of {path, content} returned ONLY
-//                             when the received prompt contains the literal
-//                             "--- CORRECTIVE FOLLOW-UP ---" marker
-//                             generate-impl.mjs's own retry prompt always
-//                             includes - this is what lets the fake tell
-//                             the two turns apart without any shared state
-//                             across the two separate child-process spawns.
-//                             Defaults to an empty files array (a corrective
-//                             call that still can't produce the files) when
-//                             unset.
+//   FAKE_CLAUDE_FILES            - JSON array of {path, content} for a normal
+//                                  (first-turn) call. Defaults to the single
+//                                  packages/generated.ts fixture the original
+//                                  over-cap tests depend on.
+//   FAKE_CLAUDE_RETRY_FILES      - JSON array of {path, content} returned ONLY
+//                                  when the received prompt contains the literal
+//                                  "--- CORRECTIVE FOLLOW-UP ---" marker
+//                                  generate-impl.mjs's own retry prompt always
+//                                  includes - this is what lets the fake tell
+//                                  the calls apart without any shared state
+//                                  across separate child-process spawns.
+//                                  Defaults to an empty files array (a corrective
+//                                  call that still can't produce the files) when
+//                                  unset.
+//   FAKE_CLAUDE_QUALITY_RESPONSE - raw response text for a call whose prompt
+//                                  contains the "--- QUALITY SELF-REVIEW ---"
+//                                  marker. Unlike the two above, this is NOT
+//                                  JSON-encoded into a {files, summary}
+//                                  envelope by the fake — it's returned
+//                                  verbatim as the model's `result`, since a
+//                                  real quality-review response is either the
+//                                  literal string NO_CHANGES_NEEDED or a
+//                                  {files, summary} JSON string, and tests
+//                                  need to exercise both. Defaults to
+//                                  NO_CHANGES_NEEDED when unset.
 const IMPL = join(BIN_DIR, 'fake-claude-impl.cjs');
 writeFileSync(
   IMPL,
@@ -83,15 +94,21 @@ writeFileSync(
     // reach the test, in order, separated so neither can be mistaken for
     // a substring of the other.
     "  if (dump) fs.appendFileSync(dump, input + '\\n===FAKE_CLAUDE_CALL_BOUNDARY===\\n');",
-    "  const isRetry = input.includes('--- CORRECTIVE FOLLOW-UP ---');",
-    '  const files = isRetry',
-    "    ? JSON.parse(process.env.FAKE_CLAUDE_RETRY_FILES || '[]')",
-    '    : JSON.parse(',
-    '        process.env.FAKE_CLAUDE_FILES ||',
-    '          \'[{"path":"packages/generated.ts","content":"export const generated = true;\\\\n"}]\'',
-    '      );',
-    "  const payload = { files, summary: isRetry ? 'fake retry' : 'fake impl' };",
-    "  process.stdout.write(JSON.stringify({ type: 'result', result: JSON.stringify(payload), stop_reason: 'end_turn' }) + '\\n');",
+    "  const isQuality = input.includes('--- QUALITY SELF-REVIEW ---');",
+    "  const isRetry = !isQuality && input.includes('--- CORRECTIVE FOLLOW-UP ---');",
+    '  let result;',
+    '  if (isQuality) {',
+    "    result = process.env.FAKE_CLAUDE_QUALITY_RESPONSE || 'NO_CHANGES_NEEDED';",
+    '  } else {',
+    '    const files = isRetry',
+    "      ? JSON.parse(process.env.FAKE_CLAUDE_RETRY_FILES || '[]')",
+    '      : JSON.parse(',
+    '          process.env.FAKE_CLAUDE_FILES ||',
+    '            \'[{"path":"packages/generated.ts","content":"export const generated = true;\\\\n"}]\'',
+    '        );',
+    "    result = JSON.stringify({ files, summary: isRetry ? 'fake retry' : 'fake impl' });",
+    '  }',
+    "  process.stdout.write(JSON.stringify({ type: 'result', result, stop_reason: 'end_turn' }) + '\\n');",
     '});',
     '',
   ].join('\n')
@@ -137,10 +154,11 @@ let runSeq = 0;
 /**
  * Runs the real generate-impl.mjs against the temp repo.
  * @param {string} specContent
- * @param {{files?: object[], retryFiles?: object[], env?: object}} [fakeResponses] -
- *   what the fake `claude` returns on the first call and, if a
- *   self-correction round-trip fires, the corrective follow-up call, plus
- *   any extra env vars to set on the child (e.g. the IMPL_*_MS overrides).
+ * @param {{files?: object[], retryFiles?: object[], qualityResponse?: string, env?: object}} [fakeResponses] -
+ *   what the fake `claude` returns on the first call, the corrective
+ *   follow-up call (if a self-correction round-trip fires), and the quality
+ *   self-review call, plus any extra env vars to set on the child (e.g. the
+ *   IMPL_*_MS overrides).
  */
 function runImpl(specContent, fakeResponses = {}) {
   const promptDump = join(BIN_DIR, `prompt-${runSeq++}.txt`);
@@ -163,6 +181,9 @@ function runImpl(specContent, fakeResponses = {}) {
       ...(fakeResponses.retryFiles
         ? { FAKE_CLAUDE_RETRY_FILES: JSON.stringify(fakeResponses.retryFiles) }
         : {}),
+      ...(fakeResponses.qualityResponse !== undefined
+        ? { FAKE_CLAUDE_QUALITY_RESPONSE: fakeResponses.qualityResponse }
+        : {}),
       ...(fakeResponses.env ?? {}),
     },
   });
@@ -173,7 +194,11 @@ function runImpl(specContent, fakeResponses = {}) {
     modelWasCalled: calls.length > 0,
     modelCallCount: calls.length,
     prompt: calls[0] ?? null,
-    retryPrompt: calls[1] ?? null,
+    // Marker-based, not positional: whether the retry fires or not shifts
+    // the quality call's position (calls[1] or calls[2]), and asserting the
+    // wrong index would silently read null instead of failing loudly.
+    retryPrompt: calls.find((c) => c.includes('--- CORRECTIVE FOLLOW-UP ---')) ?? null,
+    qualityPrompt: calls.find((c) => c.includes('--- QUALITY SELF-REVIEW ---')) ?? null,
   };
 }
 
@@ -234,7 +259,8 @@ describe('self-correction on a missing declared file', () => {
       retryFiles: [{ path: 'packages/b.ts', content: 'export const b = 2;\n' }],
     });
     assert.equal(r.status, 0, r.stderr);
-    assert.equal(r.modelCallCount, 2, 'expected exactly one corrective follow-up call');
+    // turn 1 + one corrective follow-up + the quality self-review pass.
+    assert.equal(r.modelCallCount, 3, 'expected exactly one corrective follow-up call');
     assert.match(r.stdout, /missing: packages\/b\.ts/);
     assert.match(r.stdout, /corrective follow-up turn/);
     assert.match(r.stdout, /Wrote packages\/a\.ts/);
@@ -255,7 +281,8 @@ describe('self-correction on a missing declared file', () => {
       files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
     });
     assert.equal(r.status, 0, r.stderr);
-    assert.equal(r.modelCallCount, 1, 'no declared file was missing, so no retry should fire');
+    // turn 1 + the quality self-review pass; no retry, since nothing was missing.
+    assert.equal(r.modelCallCount, 2, 'no declared file was missing, so no retry should fire');
     assert.doesNotMatch(r.stdout, /corrective follow-up/);
   });
 
@@ -267,7 +294,8 @@ describe('self-correction on a missing declared file', () => {
       files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
     });
     assert.equal(r.status, 0, r.stderr);
-    assert.equal(r.modelCallCount, 2);
+    // turn 1 + the corrective follow-up + the quality self-review pass.
+    assert.equal(r.modelCallCount, 3);
     assert.match(r.stdout, /Wrote packages\/a\.ts/);
     assert.doesNotMatch(r.stdout, /Wrote packages\/b\.ts/);
     // Turn 1 still succeeded and wrote what it had - the remaining gap is
@@ -284,7 +312,8 @@ describe('self-correction on a missing declared file', () => {
       retryFiles: [{ path: 'packages/wrong-file.ts', content: 'export const w = 1;\n' }],
     });
     assert.equal(r.status, 0, r.stderr);
-    assert.equal(r.modelCallCount, 2);
+    // turn 1 + the corrective follow-up + the quality self-review pass.
+    assert.equal(r.modelCallCount, 3);
     assert.match(r.stdout, /Wrote packages\/a\.ts/);
     assert.match(r.stdout, /Wrote packages\/wrong-file\.ts/);
     assert.doesNotMatch(r.stdout, /Wrote packages\/b\.ts/);
@@ -303,7 +332,8 @@ describe('self-correction on a missing declared file', () => {
       ],
     });
     assert.equal(r.status, 0, r.stderr);
-    assert.equal(r.modelCallCount, 1);
+    // turn 1 + the quality self-review pass; no retry (nothing was missing).
+    assert.equal(r.modelCallCount, 2);
   });
 
   test('skips the retry when IMPL_STEP_BUDGET_MS leaves no safe headroom', () => {
@@ -317,12 +347,15 @@ describe('self-correction on a missing declared file', () => {
       env: { IMPL_STEP_BUDGET_MS: '1000' },
     });
     assert.equal(r.status, 0, r.stderr);
+    // Same collapsed budget also starves the quality self-review pass below
+    // it, so this stays at 1 - the only test in this file where it does.
     assert.equal(
       r.modelCallCount,
       1,
       'a collapsed budget must prevent the corrective call entirely'
     );
     assert.match(r.stdout, /not enough for a safe corrective call/);
+    assert.match(r.stdout, /Skipping quality self-review/);
     assert.doesNotMatch(r.stdout, /Wrote packages\/b\.ts/);
   });
 
@@ -338,7 +371,97 @@ describe('self-correction on a missing declared file', () => {
       env: { IMPL_STEP_BUDGET_MS: '' },
     });
     assert.equal(r.status, 0, r.stderr);
-    assert.equal(r.modelCallCount, 2, 'an empty override must not collapse the budget to 0');
+    // turn 1 + the corrective follow-up + the quality self-review pass.
+    assert.equal(r.modelCallCount, 3, 'an empty override must not collapse the budget to 0');
     assert.match(r.stdout, /Wrote packages\/b\.ts/);
+  });
+});
+
+describe('quality self-review pass', () => {
+  test('applies a revision when the model finds duplication or extract-worthy complexity', () => {
+    const original = 'function h() {\n  return 1;\n}\n';
+    const revised = 'function helper() {\n  return 1;\n}\nfunction h() {\n  return helper();\n}\n';
+    const r = runImpl(spec('packages/a.ts'), {
+      files: [{ path: 'packages/a.ts', content: original }],
+      qualityResponse: JSON.stringify({
+        files: [{ path: 'packages/a.ts', content: revised }],
+        summary: 'extracted a shared helper',
+      }),
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 2, 'turn 1 + the quality self-review pass');
+    assert.match(r.stdout, /Quality self-review revised packages\/a\.ts/);
+    assert.match(r.stdout, /quality self-review revised 1 file\(s\): extracted a shared helper/);
+    const onDisk = readFileSync(join(REPO, 'packages/a.ts'), 'utf8');
+    assert.equal(onDisk, revised, 'the revised content must actually land on disk');
+    assert.ok(r.qualityPrompt.includes('packages/a.ts'));
+    assert.ok(r.qualityPrompt.includes(original.trim()), 'prompt must include the written content');
+  });
+
+  test('leaves already-clean output untouched when the model finds nothing', () => {
+    const original = 'export const a = 1;\n';
+    const r = runImpl(spec('packages/a.ts'), {
+      files: [{ path: 'packages/a.ts', content: original }],
+      qualityResponse: 'NO_CHANGES_NEEDED',
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 2);
+    assert.match(r.stdout, /no significant duplication or extract-worthy complexity found/);
+    assert.doesNotMatch(r.stdout, /Quality self-review revised/);
+    const onDisk = readFileSync(join(REPO, 'packages/a.ts'), 'utf8');
+    assert.equal(onDisk, original, 'a no-op response must not touch the file at all');
+  });
+
+  test("ignores a revision naming a path outside this run's own output", () => {
+    const original = 'export const a = 1;\n';
+    const r = runImpl(spec('packages/a.ts'), {
+      files: [{ path: 'packages/a.ts', content: original }],
+      qualityResponse: JSON.stringify({
+        files: [{ path: 'packages/not-written.ts', content: 'export const sneaky = 1;\n' }],
+        summary: 'should be rejected',
+      }),
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /named a path outside this run's own output/);
+    assert.doesNotMatch(r.stdout, /Quality self-review revised/);
+    assert.equal(
+      existsSync(join(REPO, 'packages/not-written.ts')),
+      false,
+      'must not create a file outside what turn 1 actually wrote'
+    );
+    const onDisk = readFileSync(join(REPO, 'packages/a.ts'), 'utf8');
+    assert.equal(onDisk, original);
+  });
+
+  test('skips gracefully when the quality response is not parseable JSON', () => {
+    const original = 'export const a = 1;\n';
+    const r = runImpl(spec('packages/a.ts'), {
+      files: [{ path: 'packages/a.ts', content: original }],
+      qualityResponse: 'not json and not NO_CHANGES_NEEDED either',
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /Quality self-review response was not parseable JSON/);
+    const onDisk = readFileSync(join(REPO, 'packages/a.ts'), 'utf8');
+    assert.equal(onDisk, original);
+  });
+
+  test('is skipped entirely below its own budget floor, independent of the corrective-retry one', () => {
+    const r = runImpl(spec('packages/a.ts'), {
+      files: [{ path: 'packages/a.ts', content: 'export const a = 1;\n' }],
+      qualityResponse: JSON.stringify({
+        files: [{ path: 'packages/a.ts', content: 'export const a = 2;\n' }],
+        summary: 'should never be applied',
+      }),
+      // Default STEP_BUDGET_MS (21m) minus SAFETY_BUFFER_MS (4m) leaves far
+      // less than this 30m floor in any real test run, so the pass must
+      // skip even though STEP_BUDGET_MS itself is untouched and would have
+      // let the corrective retry (if one were needed) fire normally.
+      env: { IMPL_QUALITY_MIN_BUDGET_MS: String(30 * 60_000) },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.modelCallCount, 1, 'quality pass must not fire below its own budget floor');
+    assert.match(r.stdout, /Skipping quality self-review/);
+    const onDisk = readFileSync(join(REPO, 'packages/a.ts'), 'utf8');
+    assert.equal(onDisk, 'export const a = 1;\n');
   });
 });

--- a/scripts/ai-sdlc/generate-impl.test.mjs
+++ b/scripts/ai-sdlc/generate-impl.test.mjs
@@ -464,4 +464,30 @@ describe('quality self-review pass', () => {
     const onDisk = readFileSync(join(REPO, 'packages/a.ts'), 'utf8');
     assert.equal(onDisk, 'export const a = 1;\n');
   });
+
+  test('rejects a revision targeting a written file the model only saw truncated', () => {
+    const overCapContent = `${Array.from(
+      { length: MAX_LINES_PER_FILE + 1 },
+      (_, i) => `const l${i} = ${i};`
+    ).join('\n')}\n`;
+    const r = runImpl(spec('packages/big.ts'), {
+      files: [{ path: 'packages/big.ts', content: overCapContent }],
+      qualityResponse: JSON.stringify({
+        files: [{ path: 'packages/big.ts', content: 'export const shortened = true;\n' }],
+        summary: 'should be rejected',
+      }),
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(
+      r.stderr,
+      /proposed a change to a file excluded from its view, skipping to avoid data loss/
+    );
+    assert.doesNotMatch(r.stdout, /Quality self-review revised/);
+    const onDisk = readFileSync(join(REPO, 'packages/big.ts'), 'utf8');
+    assert.equal(
+      onDisk,
+      overCapContent,
+      'the file must keep its full content, not be replaced by a revision built from a truncated view'
+    );
+  });
 });


### PR DESCRIPTION
Refs #390.

A second, narrowly-scoped LLM call in `generate-impl.mjs`, running after the write loop, reviews only the files that run just wrote for two specific things: 3+ near-duplicate blocks, and inline handlers/closures long enough that a named function would help. Deliberately not security, correctness, missing tests, or general style - `claude-review.yml`'s own prompt already says "skip nits, style, theoretical issues", and splitting one reviewer's attention across both axes risks it doing both worse.

Motivated by issue #368: impl-agent's own generated `auth-oidc.ts` had 12 copies of `reply.code(401).send({ error: 'Authentication failed' })` and two ~50-120 line inline route handlers, neither caught until a human noticed by hand and pushed a follow-up commit.

Runs once per issue, not once per push against an open PR - same cost shape as `spec-agent.yml`'s `generate-spec.mjs` + `verify-spec.mjs` pair, and the same corrective-follow-up-call pattern PR #375 already added for missing files. Time-budgeted against the exact same `STEP_BUDGET_MS`/`SAFETY_BUFFER_MS` remaining-time check that call already uses, so it's self-limiting by construction: **no change needed to `impl-agent.yml`'s timeout budget** - a run that already used most of its time skips the quality pass gracefully rather than risking the step's own timeout.

16 new/updated tests in `generate-impl.test.mjs` (revision applied, `NO_CHANGES_NEEDED` leaves output untouched, a path outside this run's own output is rejected, malformed JSON skips gracefully, and the pass is skipped below its own budget floor independent of the retry one). Full `scripts/ai-sdlc/` suite: 177/177 passing.