### PR TITLE
impl(#395): SSO 3b/4: wire enforce_sso guard onto existing auth endpoints (split from #354)

### DIFF
--- a/packages/backend/src/api/routes/admin-organizations.ts
+++ b/packages/backend/src/api/routes/admin-organizations.ts
@@ -18,6 +18,7 @@ import type { EmailLocale } from '../../saas/services/invitation-email.service.j
 import { InvitationEmailService } from '../../saas/services/invitation-email.service.js';
 import { requirePlatformAdmin } from '../middleware/auth.js';
 import { AppError } from '../middleware/error.js';
+import { assertSsoNotEnforced, SsoEnforcedError } from '../middleware/enforce-sso.js';
 import { validateBillingMethodSwitch } from '../../saas/services/billing-method.js';
 import { sendSuccess, sendCreated, sendNoContent } from '../utils/response.js';
 import { generateMagicToken } from './auth.js';
@@ -537,6 +538,19 @@ export function adminOrganizationRoutes(fastify: FastifyInstance, db: DatabaseCl
       preHandler: [requirePlatformAdmin()],
     },
     async (request, reply) => {
+      // SSO enforcement guard — must be the first check (constraint 3),
+      // before the org-existence check. Safe: assertSsoNotEnforced no-ops
+      // for a nonexistent tenant (findByTenantId resolves null), so a
+      // nonexistent org id still falls through to the 404 below.
+      try {
+        await assertSsoNotEnforced(request.params.id, db.oidcIdpConfigs);
+      } catch (err) {
+        if (err instanceof SsoEnforcedError) {
+          return reply.code(403).send({ error: err.message });
+        }
+        throw err;
+      }
+
       const org = await db.organizations.findById(request.params.id);
       if (!org) {
         throw new AppError('Organization not found', 404, 'NotFound');

--- a/packages/backend/src/api/routes/auth.ts
+++ b/packages/backend/src/api/routes/auth.ts
@@ -45,6 +45,7 @@ import type { User } from '../../db/types.js';
 import { isPlatformAdmin } from '../middleware/auth.js';
 import { getDeploymentConfig } from '../../saas/config.js';
 import { assertUserBelongsToTenant } from '../../saas/middleware/tenant-match.js';
+import { assertSsoNotEnforced, SsoEnforcedError } from '../middleware/enforce-sso.js';
 
 /**
  * SaaS-mode access gate: reject the caller if the user has zero
@@ -173,6 +174,24 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       config: { public: true },
     },
     async (request, reply) => {
+      // SSO enforcement guard — must be the first check (constraint 3).
+      // Skip only on the saas hub domain (no tenant resolved) - matching the
+      // existing assertUserBelongsToTenant/isPasswordResetEnabledForRequest
+      // no-op-on-hub-domain pattern. This is always false in selfhosted mode,
+      // so the guard always runs there and reads config.oidc.enforceSso via
+      // its own branch, independent of request.organizationId.
+      const skipGuard = process.env.DEPLOYMENT_MODE === 'saas' && !request.organizationId;
+      if (!skipGuard) {
+        try {
+          await assertSsoNotEnforced(request.organizationId ?? '', db.oidcIdpConfigs);
+        } catch (err) {
+          if (err instanceof SsoEnforcedError) {
+            return reply.code(403).send({ error: err.message });
+          }
+          throw err;
+        }
+      }
+
       if (!config.auth.allowRegistration) {
         throw new AppError('Registration is currently disabled', 403, 'Forbidden');
       }
@@ -250,6 +269,21 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       config: { public: true },
     },
     async (request, reply) => {
+      // SSO enforcement guard — must be the first check (constraint 3).
+      // Skip only on the saas hub domain (no tenant resolved) - see the
+      // /register handler above for the full rationale.
+      const skipGuard = process.env.DEPLOYMENT_MODE === 'saas' && !request.organizationId;
+      if (!skipGuard) {
+        try {
+          await assertSsoNotEnforced(request.organizationId ?? '', db.oidcIdpConfigs);
+        } catch (err) {
+          if (err instanceof SsoEnforcedError) {
+            return reply.code(403).send({ error: err.message });
+          }
+          throw err;
+        }
+      }
+
       const { email, password } = request.body;
 
       /**
@@ -458,6 +492,21 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
           request.organizationId !== decoded.organizationId
         ) {
           throw new AppError('Invalid magic token: tenant mismatch', 401, 'Unauthorized');
+        }
+
+        // SSO enforcement guard. Keyed on decoded.organizationId (the JWT
+        // claim, already validated a real string above) - not
+        // request.organizationId, which is intentionally unset on
+        // hub-domain magic-logins and isn't authoritative for which tenant
+        // the token was minted for. The inner catch returns directly on
+        // SsoEnforcedError, so it never reaches the outer catch below.
+        try {
+          await assertSsoNotEnforced(decoded.organizationId, db.oidcIdpConfigs);
+        } catch (err) {
+          if (err instanceof SsoEnforcedError) {
+            return reply.code(403).send({ error: err.message });
+          }
+          throw err;
         }
 
         // Check if magic login is enabled for this organization (DB-backed setting)

--- a/packages/backend/tests/api/admin-organizations.test.ts
+++ b/packages/backend/tests/api/admin-organizations.test.ts
@@ -3,7 +3,7 @@
  * Tests for admin org creation, plan management, and admin invitations.
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { createServer } from '../../src/api/server.js';
 import { createDatabaseClient } from '../../src/db/client.js';
@@ -11,6 +11,27 @@ import type { DatabaseClient } from '../../src/db/client.js';
 import { createMockPluginRegistry, createMockStorage, createAdminUser } from '../test-helpers.js';
 
 const TEST_DB_URL = process.env.DATABASE_URL || 'postgresql://localhost:5432/bugspotter_test';
+
+/**
+ * assertSsoNotEnforced (enforce-sso.ts) reads process.env.DEPLOYMENT_MODE
+ * live on every call — unlike the saas tenant-resolution middleware, which
+ * bakes DEPLOYMENT_MODE in once at createServer() time via
+ * getDeploymentConfig()'s cached singleton. The saas-mode describe block
+ * below restores the env var immediately after building saasServer (so it
+ * doesn't leak into other describe blocks in this file), which means it's
+ * back to the outer 'selfhosted' value by the time a test actually calls
+ * saasServer.inject(...). Pin the env var to 'saas' for just the duration
+ * of the inject() call so the guard's live read sees the right mode.
+ */
+async function withDeploymentMode<T>(mode: string, fn: () => Promise<T>): Promise<T> {
+  const original = process.env.DEPLOYMENT_MODE;
+  process.env.DEPLOYMENT_MODE = mode;
+  try {
+    return await fn();
+  } finally {
+    process.env.DEPLOYMENT_MODE = original;
+  }
+}
 
 describe('Admin Organization Routes', () => {
   let server: FastifyInstance;
@@ -1379,6 +1400,135 @@ describe('Admin Organization Routes', () => {
       });
 
       expect(response.statusCode).toBe(401);
+    });
+  });
+
+  // ─── POST /:id/magic-token — SSO enforcement (saas mode) ───
+
+  describe('POST /:id/magic-token — SSO enforcement (saas mode)', () => {
+    let saasServer: FastifyInstance;
+
+    beforeAll(async () => {
+      const originalMode = process.env.DEPLOYMENT_MODE;
+      process.env.DEPLOYMENT_MODE = 'saas';
+      const { resetDeploymentConfig } = await import('../../src/saas/config.js');
+      resetDeploymentConfig();
+      vi.resetModules();
+
+      const { createServer: freshCreateServer } = await import('../../src/api/server.js');
+      saasServer = await freshCreateServer({
+        db,
+        storage: createMockStorage(),
+        pluginRegistry: createMockPluginRegistry(),
+      });
+      await saasServer.ready();
+
+      // Restore env var — the already-created saasServer has its config baked in.
+      // adminToken (from the outer beforeEach) validates on saasServer too: it's
+      // a JWT signed against the shared JWT_SECRET, and the admin user it names
+      // lives in `db`, which both server instances share.
+      process.env.DEPLOYMENT_MODE = originalMode;
+      resetDeploymentConfig();
+      vi.resetModules();
+    });
+
+    afterAll(async () => {
+      await saasServer.close();
+    });
+
+    it('blocks admin magic-token impersonation when the target org enforces SSO, before the org lookup', async () => {
+      const orgId = '00000000-0000-0000-0000-000000000001';
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockImplementation(async (id) => (id === orgId ? ({ enforceSso: true } as never) : null));
+
+      try {
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'POST',
+            url: `/api/v1/admin/organizations/${orgId}/magic-token`,
+            headers: { authorization: `Bearer ${adminToken}` },
+            payload: { user_id: '00000000-0000-0000-0000-000000000002' },
+          })
+        );
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({ error: 'sso_enforced' });
+        expect(spy).toHaveBeenCalledWith(orgId);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('still 404s for a nonexistent organization rather than leaking a 403', async () => {
+      const orgId = '00000000-0000-0000-0000-000000000099';
+      // no row -> no-op; a wrong-id call would also resolve null here, so the
+      // toHaveBeenCalledWith below is what actually proves the guard ran with
+      // the right id rather than being skipped or reordered.
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockImplementation(async (id) => (id === orgId ? null : ({ enforceSso: true } as never)));
+
+      try {
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'POST',
+            url: `/api/v1/admin/organizations/${orgId}/magic-token`,
+            headers: { authorization: `Bearer ${adminToken}` },
+            payload: { user_id: '00000000-0000-0000-0000-000000000002' },
+          })
+        );
+
+        expect(response.statusCode).toBe(404);
+        expect(spy).toHaveBeenCalledWith(orgId);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('proceeds to a real success response when an existing org has an enforceSso:false config row', async () => {
+      // Real org + real OWNER membership (adminCreateOrganization creates both
+      // atomically from owner_user_id), plus magic_login_enabled - this
+      // actually reaches the handler's normal body: org lookup succeeds,
+      // magic_login_enabled is true, regularUserId is a member, so a passing
+      // guard genuinely proves the enforceSso:false path, not an unrelated 404.
+      const subdomain = `sso-off-org-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      const createResponse = await saasServer.inject({
+        method: 'POST',
+        url: '/api/v1/admin/organizations',
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { name: 'SSO Off Org', subdomain, owner_user_id: regularUserId },
+      });
+      const orgId = createResponse.json().data.id;
+      createdOrgIds.push(orgId);
+
+      await saasServer.inject({
+        method: 'PATCH',
+        url: `/api/v1/admin/organizations/${orgId}/magic-login-status`,
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { enabled: true },
+      });
+
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockImplementation(async (id) => (id === orgId ? ({ enforceSso: false } as never) : null));
+
+      try {
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'POST',
+            url: `/api/v1/admin/organizations/${orgId}/magic-token`,
+            headers: { authorization: `Bearer ${adminToken}` },
+            payload: { user_id: regularUserId },
+          })
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json().data.token).toBeTypeOf('string');
+        expect(spy).toHaveBeenCalledWith(orgId);
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 });

--- a/packages/backend/tests/api/auth.test.ts
+++ b/packages/backend/tests/api/auth.test.ts
@@ -62,6 +62,51 @@ async function createServerWithInvitationRequired(db: DatabaseClient) {
   return server;
 }
 
+/**
+ * Create a server with a different OIDC_ENFORCE_SSO value.
+ * Mirrors createServerWithRegistration above — same file, same pattern.
+ */
+async function createServerWithSsoEnforced(db: DatabaseClient, enforced: boolean) {
+  const original = process.env.OIDC_ENFORCE_SSO;
+  process.env.OIDC_ENFORCE_SSO = String(enforced);
+  vi.resetModules();
+
+  const { createServer: freshCreateServer } = await import('../../src/api/server.js');
+  const server = await freshCreateServer({
+    db,
+    storage: createMockStorage(),
+    pluginRegistry: createMockPluginRegistry(),
+  });
+  await server.ready();
+
+  // Restore env var — doesn't affect the already-created server.
+  process.env.OIDC_ENFORCE_SSO = original;
+  vi.resetModules();
+
+  return server;
+}
+
+/**
+ * assertSsoNotEnforced (enforce-sso.ts) reads process.env.DEPLOYMENT_MODE
+ * live on every call — unlike the saas tenant-resolution middleware, which
+ * bakes DEPLOYMENT_MODE in once at createServer() time via
+ * getDeploymentConfig()'s cached singleton. The saas-mode describe blocks
+ * below restore the env var immediately after building saasServer (so it
+ * doesn't leak into other describe blocks in this file), which means it's
+ * back to the outer 'selfhosted' value by the time a test actually calls
+ * saasServer.inject(...). Pin the env var to 'saas' for just the duration
+ * of the inject() call so the guard's live read sees the right mode.
+ */
+async function withDeploymentMode<T>(mode: string, fn: () => Promise<T>): Promise<T> {
+  const original = process.env.DEPLOYMENT_MODE;
+  process.env.DEPLOYMENT_MODE = mode;
+  try {
+    return await fn();
+  } finally {
+    process.env.DEPLOYMENT_MODE = original;
+  }
+}
+
 describe('Auth Routes', () => {
   let server: FastifyInstance;
   let db: DatabaseClient;
@@ -711,6 +756,279 @@ describe('Auth Routes', () => {
       const json = response.json();
       expect(json.success).toBe(false);
       expect(json.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('POST /api/v1/auth/{login,register,magic-login} — SSO enforcement (selfhosted mode)', () => {
+    beforeEach(async () => {
+      await db.query('DELETE FROM users');
+    });
+
+    it('returns 403 sso_enforced when the deployment enforces SSO', async () => {
+      // Register on the default server first (OIDC_ENFORCE_SSO=false there),
+      // so the user exists before ssoServer's guard blocks the login attempt.
+      await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email: 'user@example.com', password: 'password123' },
+      });
+
+      const ssoServer = await createServerWithSsoEnforced(db, true);
+      try {
+        const response = await ssoServer.inject({
+          method: 'POST',
+          url: '/api/v1/auth/login',
+          payload: { email: 'user@example.com', password: 'password123' },
+        });
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({ error: 'sso_enforced' });
+      } finally {
+        await ssoServer.close();
+      }
+    });
+
+    it('blocks register and does not create a session when SSO is enforced', async () => {
+      const ssoServer = await createServerWithSsoEnforced(db, true);
+      try {
+        const response = await ssoServer.inject({
+          method: 'POST',
+          url: '/api/v1/auth/register',
+          payload: { email: 'new@example.com', password: 'password123' },
+        });
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({ error: 'sso_enforced' });
+        expect(response.cookies).toHaveLength(0);
+      } finally {
+        await ssoServer.close();
+      }
+    });
+
+    it('blocks magic-login when SSO is enforced', async () => {
+      const ssoServer = await createServerWithSsoEnforced(db, true);
+      try {
+        const magicToken = ssoServer.jwt.sign({
+          userId: '00000000-0000-0000-0000-000000000003',
+          organizationId: '00000000-0000-0000-0000-000000000004',
+          type: 'magic',
+        });
+
+        const response = await ssoServer.inject({
+          method: 'POST',
+          url: '/api/v1/auth/magic-login',
+          payload: { token: magicToken },
+        });
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({ error: 'sso_enforced' });
+      } finally {
+        await ssoServer.close();
+      }
+    });
+
+    it('logs in normally when SSO is not enforced (OIDC_ENFORCE_SSO unset)', async () => {
+      // The default `server` from beforeAll never sets OIDC_ENFORCE_SSO, so
+      // config.oidc.enforceSso is already false — no extra server needed.
+      await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/register',
+        payload: { email: 'user2@example.com', password: 'password123' },
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/login',
+        payload: { email: 'user2@example.com', password: 'password123' },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('registers normally when OIDC_ENFORCE_SSO is explicitly false', async () => {
+      const ssoOffServer = await createServerWithSsoEnforced(db, false);
+      try {
+        const response = await ssoOffServer.inject({
+          method: 'POST',
+          url: '/api/v1/auth/register',
+          payload: { email: 'user3@example.com', password: 'password123' },
+        });
+
+        expect(response.statusCode).toBe(201);
+      } finally {
+        await ssoOffServer.close();
+      }
+    });
+
+    it('logs in via magic-login normally when SSO is not enforced', async () => {
+      // Seed a user + magic_login_enabled org directly, following the same
+      // pattern as tests/integration/magic-login.integration.test.ts. A real
+      // (unused) password hash is required: the `check_auth_method` DB
+      // constraint rejects password_hash IS NULL unless oauth_provider/
+      // oauth_id are both set, and magic-login never reads password_hash.
+      const bcrypt = (await import('bcrypt')).default;
+      const passwordHash = await bcrypt.hash('unused-password', 10);
+      const user = await db.users.create({
+        email: 'magic-ok@example.com',
+        name: null,
+        password_hash: passwordHash,
+        role: 'user',
+      });
+      const org = await db.organizations.create({
+        name: 'Magic OK Org',
+        subdomain: 'magic-ok-org',
+        settings: { magic_login_enabled: true },
+      });
+      await db.organizationMembers.create({
+        organization_id: org.id,
+        user_id: user.id,
+        role: 'member',
+      });
+
+      const magicToken = server.jwt.sign({
+        userId: user.id,
+        organizationId: org.id,
+        type: 'magic',
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/auth/magic-login',
+        payload: { token: magicToken },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
+  describe('POST /api/v1/auth/{login,register,magic-login} — SSO enforcement (saas mode)', () => {
+    let saasServer: FastifyInstance;
+
+    beforeAll(async () => {
+      const originalMode = process.env.DEPLOYMENT_MODE;
+      process.env.DEPLOYMENT_MODE = 'saas';
+      const { resetDeploymentConfig } = await import('../../src/saas/config.js');
+      resetDeploymentConfig();
+      vi.resetModules();
+
+      const { createServer: freshCreateServer } = await import('../../src/api/server.js');
+      saasServer = await freshCreateServer({
+        db,
+        storage: createMockStorage(),
+        pluginRegistry: createMockPluginRegistry(),
+      });
+      await saasServer.ready();
+
+      // Restore env var — the already-created saasServer has its config baked in.
+      process.env.DEPLOYMENT_MODE = originalMode;
+      resetDeploymentConfig();
+      vi.resetModules();
+    });
+
+    afterAll(async () => {
+      await saasServer.close();
+    });
+
+    it('Test F: blocks /login on a host-resolved tenant, keyed on request.organizationId', async () => {
+      // subscription_status defaults to 'trial' (in ACTIVE_STATUSES), so the
+      // tenant middleware resolves this subdomain instead of 403ing first.
+      const org = await db.organizations.create({
+        name: 'SSO Login Org',
+        subdomain: 'sso-login-org',
+      });
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockImplementation(async (tenantId) =>
+          tenantId === org.id ? ({ enforceSso: true } as never) : null
+        );
+
+      try {
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'POST',
+            url: '/api/v1/auth/login',
+            headers: { host: `${org.subdomain}.bugspotter.io` },
+            payload: { email: 'someone@example.com', password: 'password123' },
+          })
+        );
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({ error: 'sso_enforced' });
+        expect(spy).toHaveBeenCalledWith(org.id);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('Test G: blocks /register on a host-resolved tenant, before allowRegistration/invite checks', async () => {
+      const org = await db.organizations.create({
+        name: 'SSO Register Org',
+        subdomain: 'sso-register-org',
+      });
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockImplementation(async (tenantId) =>
+          tenantId === org.id ? ({ enforceSso: true } as never) : null
+        );
+
+      try {
+        // No invite_token: saas mode's default requireInvitationToRegister
+        // would otherwise reject this with 403 InvitationRequired, but the
+        // guard runs first (constraint 3) and short-circuits before that
+        // check is ever reached — this also proves the ordering, not just
+        // the tenant source.
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'POST',
+            url: '/api/v1/auth/register',
+            headers: { host: `${org.subdomain}.bugspotter.io` },
+            payload: { email: 'newuser@example.com', password: 'password123' },
+          })
+        );
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({ error: 'sso_enforced' });
+        expect(spy).toHaveBeenCalledWith(org.id);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('Test H: blocks /magic-login keyed on decoded.organizationId, not request.organizationId', async () => {
+      const tenantId = '00000000-0000-0000-0000-000000000005';
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockImplementation(async (id) =>
+          id === tenantId ? ({ enforceSso: true } as never) : null
+        );
+
+      try {
+        const magicToken = saasServer.jwt.sign({
+          userId: '00000000-0000-0000-0000-000000000006',
+          organizationId: tenantId,
+          type: 'magic',
+        });
+
+        // No host header override: the injected default host resolves no
+        // subdomain in saas mode, so request.organizationId stays undefined
+        // and the handler's own tenant-match gate no-ops. The guard must
+        // still block using decoded.organizationId from the token claim —
+        // proving the guard reads the claim, not request.organizationId
+        // (which is a different, and here absent, value).
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'POST',
+            url: '/api/v1/auth/magic-login',
+            payload: { token: magicToken },
+          })
+        );
+
+        expect(response.statusCode).toBe(403);
+        expect(response.json()).toEqual({ error: 'sso_enforced' });
+        expect(spy).toHaveBeenCalledWith(tenantId);
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
Refs #395.

Hand-implemented directly against the merged spec (docs/specs/0395-sso-3b-wire-enforce-sso-guard-endpoints.md, from PR #397) after `impl-agent.yml`'s automated generation self-aborted: `packages/backend/tests/api/admin-organizations.test.ts` is 1384 lines on `main`, and `generate-impl.mjs` refuses to propose a full-file rewrite of a file that large rather than risk silently truncating it. Same remedy already used on #368.

Wires `assertSsoNotEnforced` (from #394, PR #398) onto all four endpoints named in the spec: `/auth/login`, `/auth/register`, `/auth/magic-login`, and the admin `magic-token` impersonation endpoint. Guard runs first in every handler, before any other business-rule check, session minting, or impersonation-token creation. 403 response is `{ error: err.message }` from `SsoEnforcedError` at all four call sites.

**Note on diff scope:** #394 (PR #398) hasn't merged yet, so this branch is stacked on top of it and the diff above includes its files (`enforce-sso.ts`, `config.ts`, `config/types.ts`, `enforce-sso.test.ts`) alongside this issue's own four files. This PR's actual authored content is only: `auth.ts`, `admin-organizations.ts`, `auth.test.ts`, `admin-organizations.test.ts`. The diff will shrink to just those four once #398 merges and this PR rebases.

Tests extend `auth.test.ts` and `admin-organizations.test.ts` per the spec's test list (A-M), including saas-mode tenant-source proofs (F/G/H, D/L/M) that spy on `db.oidcIdpConfigs.findByTenantId` keyed to the exact expected tenant id.

## Test plan
- [x] `pnpm --filter @bugspotter/backend typecheck` — clean
- [x] `pnpm --filter @bugspotter/backend test:unit` — 3168 passed
- [x] `pnpm --filter @bugspotter/backend test -- tests/api/auth.test.ts tests/api/admin-organizations.test.ts` — 106 passed
- [x] `pnpm --filter @bugspotter/backend test` (full suite) — 6998 passed