### PR TITLE
impl(#414): SSO - add GET /api/v1/auth/sso-status endpoint

### DIFF
--- a/packages/backend/src/api/routes/auth.ts
+++ b/packages/backend/src/api/routes/auth.ts
@@ -834,6 +834,14 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
    * Hub domain in saas mode (no request.organizationId) resolves to
    * false, matching the guard's own skip-on-hub-domain behavior at
    * /login and /register above.
+   *
+   * Unlike `assertSsoNotEnforced`, DB errors from `findByTenantId` here
+   * ARE caught and default to `enforceSso: false`. This is a status read
+   * the login page depends on before first paint (#408); the actual
+   * enforcement gate stays fail-closed at /login and /register
+   * regardless of what this endpoint reports, so defaulting to false
+   * here only risks showing password fields that a DB-down guard would
+   * then still reject — never a bypass.
    */
   fastify.get(
     '/api/v1/auth/sso-status',
@@ -842,12 +850,25 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
       config: { public: true },
     },
     async (request, reply) => {
-      const enforceSso =
-        process.env.DEPLOYMENT_MODE === 'saas'
-          ? request.organizationId
-            ? Boolean((await db.oidcIdpConfigs.findByTenantId(request.organizationId))?.enforceSso)
-            : false
-          : config.oidc.enforceSso;
+      let enforceSso: boolean;
+      if (process.env.DEPLOYMENT_MODE === 'saas') {
+        if (request.organizationId) {
+          try {
+            const idpConfig = await db.oidcIdpConfigs.findByTenantId(request.organizationId);
+            enforceSso = Boolean(idpConfig?.enforceSso);
+          } catch (err) {
+            request.log.error(
+              { err: err instanceof Error ? err.message : String(err) },
+              'sso-status: findByTenantId failed, defaulting to enforceSso: false'
+            );
+            enforceSso = false;
+          }
+        } else {
+          enforceSso = false;
+        }
+      } else {
+        enforceSso = config.oidc.enforceSso;
+      }
 
       return sendSuccess(reply, { enforceSso });
     }

--- a/packages/backend/src/api/routes/auth.ts
+++ b/packages/backend/src/api/routes/auth.ts
@@ -94,6 +94,34 @@ interface RefreshTokenBody {
 }
 
 /**
+ * Response schema for GET /api/v1/auth/sso-status. Kept local to this
+ * file (rather than promoted into
+ * packages/backend/src/api/schemas/auth-schema.ts) since it's a single
+ * small schema for one route, not shared — mirrors the shape of
+ * registrationStatusSchema in auth-schema.ts without adding a new file
+ * to this issue's declared scope.
+ */
+const ssoStatusSchema = {
+  response: {
+    200: {
+      type: 'object',
+      required: ['success', 'data', 'timestamp'],
+      properties: {
+        success: { type: 'boolean', enum: [true] },
+        data: {
+          type: 'object',
+          required: ['enforceSso'],
+          properties: {
+            enforceSso: { type: 'boolean' },
+          },
+        },
+        timestamp: { type: 'string', format: 'date-time' },
+      },
+    },
+  },
+} as const;
+
+/**
  * Generate a magic token for passwordless authentication
  * Used for demo users and email-based login links
  *
@@ -787,6 +815,41 @@ export function authRoutes(fastify: FastifyInstance, db: DatabaseClient) {
         requireInvitation: config.auth.requireInvitationToRegister,
         passwordResetEnabled: await isPasswordResetEnabledForRequest(request.organizationId),
       });
+    }
+  );
+
+  /**
+   * GET /api/v1/auth/sso-status
+   * Public endpoint — returns whether SSO is enforced (mandatory) for the
+   * tenant resolved from the request host/subdomain. The login page (#408)
+   * uses this to decide whether to hide the password fields before first
+   * paint, rather than showing them and letting a doomed password login
+   * fail against the SSO-enforcement guard.
+   *
+   * Resolution mirrors `assertSsoNotEnforced` (enforce-sso.ts, ADR-0044
+   * Decision 4): saas mode reads the tenant's oidc_idp_config row via
+   * `findByTenantId`, selfhosted mode reads OIDC_ENFORCE_SSO
+   * (config.oidc.enforceSso). This route resolves the same boolean
+   * instead of throwing — it's a status read, not a login-time gate.
+   * Hub domain in saas mode (no request.organizationId) resolves to
+   * false, matching the guard's own skip-on-hub-domain behavior at
+   * /login and /register above.
+   */
+  fastify.get(
+    '/api/v1/auth/sso-status',
+    {
+      schema: ssoStatusSchema,
+      config: { public: true },
+    },
+    async (request, reply) => {
+      const enforceSso =
+        process.env.DEPLOYMENT_MODE === 'saas'
+          ? request.organizationId
+            ? Boolean((await db.oidcIdpConfigs.findByTenantId(request.organizationId))?.enforceSso)
+            : false
+          : config.oidc.enforceSso;
+
+      return sendSuccess(reply, { enforceSso });
     }
   );
 }

--- a/packages/backend/tests/api/auth.test.ts
+++ b/packages/backend/tests/api/auth.test.ts
@@ -704,6 +704,30 @@ describe('Auth Routes', () => {
     });
   });
 
+  describe('GET /api/v1/auth/sso-status', () => {
+    it('should return enforceSso: false when SSO is not enforced (OIDC_ENFORCE_SSO unset)', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/auth/sso-status',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.success).toBe(true);
+      expect(json.data.enforceSso).toBe(false);
+    });
+
+    it('should be accessible without authentication', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/v1/auth/sso-status',
+      });
+
+      // No Authorization header — should still work (public endpoint)
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
   describe('POST /api/v1/auth/refresh', () => {
     beforeEach(async () => {
       await db.query('DELETE FROM users');
@@ -899,6 +923,21 @@ describe('Auth Routes', () => {
 
       expect(response.statusCode).toBe(200);
     });
+
+    it('reports enforceSso: true from GET /api/v1/auth/sso-status when OIDC_ENFORCE_SSO is set', async () => {
+      const ssoServer = await createServerWithSsoEnforced(db, true);
+      try {
+        const response = await ssoServer.inject({
+          method: 'GET',
+          url: '/api/v1/auth/sso-status',
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json().data.enforceSso).toBe(true);
+      } finally {
+        await ssoServer.close();
+      }
+    });
   });
 
   describe('POST /api/v1/auth/{login,register,magic-login} — SSO enforcement (saas mode)', () => {
@@ -1029,6 +1068,46 @@ describe('Auth Routes', () => {
       } finally {
         spy.mockRestore();
       }
+    });
+
+    it("Test I: GET /api/v1/auth/sso-status resolves enforceSso: true from the tenant's oidc_idp_config row on a host-resolved tenant", async () => {
+      const org = await db.organizations.create({
+        name: 'SSO Status Org',
+        subdomain: 'sso-status-org',
+      });
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockImplementation(async (tenantId) =>
+          tenantId === org.id ? ({ enforceSso: true } as never) : null
+        );
+
+      try {
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'GET',
+            url: '/api/v1/auth/sso-status',
+            headers: { host: `${org.subdomain}.bugspotter.io` },
+          })
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json().data.enforceSso).toBe(true);
+        expect(spy).toHaveBeenCalledWith(org.id);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('Test J: GET /api/v1/auth/sso-status resolves enforceSso: false on the hub domain (no host-resolved tenant)', async () => {
+      const response = await withDeploymentMode('saas', () =>
+        saasServer.inject({
+          method: 'GET',
+          url: '/api/v1/auth/sso-status',
+        })
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data.enforceSso).toBe(false);
     });
   });
 });

--- a/packages/backend/tests/api/auth.test.ts
+++ b/packages/backend/tests/api/auth.test.ts
@@ -1109,5 +1109,31 @@ describe('Auth Routes', () => {
       expect(response.statusCode).toBe(200);
       expect(response.json().data.enforceSso).toBe(false);
     });
+
+    it('Test K: GET /api/v1/auth/sso-status returns enforceSso: false (not 500) when findByTenantId throws', async () => {
+      const org = await db.organizations.create({
+        name: 'SSO Status Error Org',
+        subdomain: 'sso-status-error-org',
+      });
+      const spy = vi
+        .spyOn(db.oidcIdpConfigs, 'findByTenantId')
+        .mockRejectedValue(new Error('connection failure'));
+
+      try {
+        const response = await withDeploymentMode('saas', () =>
+          saasServer.inject({
+            method: 'GET',
+            url: '/api/v1/auth/sso-status',
+            headers: { host: `${org.subdomain}.bugspotter.io` },
+          })
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json().data.enforceSso).toBe(false);
+        expect(spy).toHaveBeenCalledWith(org.id);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
Refs #414.

Replaces a failed impl-agent auto-generation attempt: `impl-agent.yml` self-aborted (not a crash, a deliberate safe failure) because `packages/backend/tests/api/auth.test.ts` is 1034 lines on `main`, past what `generate-impl.mjs` will safely rewrite in full rather than risk silently truncating it. Same class of failure as #368 and #395, hand-implemented directly against the merged spec instead.

Spec: `docs/specs/0414-sso-add-get-api-v1-auth-sso-status-endpo.md` (from PR #415, 3 review rounds).

Adds `GET /api/v1/auth/sso-status` to `packages/backend/src/api/routes/auth.ts`, mirroring the existing `GET /api/v1/auth/registration-status` route's public/unauthenticated shape and `assertSsoNotEnforced`'s (`enforce-sso.ts`) saas-vs-selfhosted resolution logic, but returning the boolean instead of throwing. Adds Test I/Test J to the existing saas-mode SSO enforcement describe block plus a standalone `describe('GET /api/v1/auth/sso-status', ...)` block and one selfhosted-mode case, following the file's existing Test F/G/H convention.

## Test plan

- [x] `pnpm --filter @bugspotter/backend test tests/api/auth.test.ts` — 40/40 passing (real Postgres via testcontainers)
- [x] `pnpm --filter @bugspotter/backend test` — full suite, 288 files / 7006 tests passing
- [x] `pnpm --filter @bugspotter/backend typecheck` — clean