### PR TITLE
fix: guard callViaCli against a delayed close event after timeout settle

### DIFF
--- a/scripts/ai-sdlc/llm-client.mjs
+++ b/scripts/ai-sdlc/llm-client.mjs
@@ -451,6 +451,28 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     // stop requiring manual transcript archaeology to diagnose.
     let latestVisibleText = null;
     const startedAt = Date.now();
+    // Set the instant any one of the three terminal handlers below (timeout,
+    // 'error', 'close') has settled the promise. All three guard on it and
+    // bail out before doing ANY work — including dumpCliTranscriptOnFailure —
+    // on a second firing.
+    //
+    // This exists because those three handlers race independently on the
+    // same child, and `child.kill('SIGKILL')` in the timeout handler is not
+    // synchronous with the child's actual death: on Windows, `claude` is
+    // spawned via `shell: true` (see the spawn() call below), so `child` is
+    // the intermediate cmd.exe wrapper, not the real process running under
+    // it — killing the wrapper does not kill that grandchild. Confirmed
+    // empirically (temporary instrumentation, since removed) that the
+    // 'close' event this file listens for can then arrive seconds after the
+    // timeout handler already rejected: it fires once the orphaned
+    // grandchild eventually exits on its own, not when SIGKILL was sent.
+    // Without this guard, that delayed 'close' still matches
+    // `code !== 0 || signal` (signal is 'SIGKILL') and calls
+    // dumpCliTranscriptOnFailure a second time, reading whatever
+    // AI_SDLC_CLI_TRANSCRIPT_PATH happens to be set to at that later,
+    // unrelated moment — corrupting a different call's transcript file. See
+    // #428.
+    let settled = false;
 
     function consumeLine(line) {
       if (!line.trim()) {
@@ -498,6 +520,10 @@ async function callViaCli({ prompt, timeoutMs, model }) {
     heartbeat.unref?.();
 
     const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       clearInterval(heartbeat);
       // Mirrors the close handler below: a complete NDJSON record can be
       // sitting in lineBuf without its trailing newline yet (the child's
@@ -541,12 +567,20 @@ async function callViaCli({ prompt, timeoutMs, model }) {
       stderr += d;
     });
     child.on('error', (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       clearTimeout(timer);
       clearInterval(heartbeat);
       dumpCliTranscriptOnFailure(stdout, stderr);
       reject(err);
     });
     child.on('close', (code, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       clearTimeout(timer);
       clearInterval(heartbeat);
       if (lineBuf.trim()) {

--- a/scripts/ai-sdlc/llm-client.test.mjs
+++ b/scripts/ai-sdlc/llm-client.test.mjs
@@ -79,6 +79,42 @@ writeFileSync(
     "  process.stdout.write('FAKE_STDOUT_MARKER: upstream billing failure detail');",
     '  process.exit(2);',
     '}',
+    // Reproduces, portably (POSIX and Windows alike), the shape that makes
+    // callViaCli's 'close' event arrive well after SIGKILL actually landed:
+    // a detached grandchild inherits this process's stdout/stderr pipe
+    // handles and keeps them open even once this process itself is killed,
+    // so the parent doesn't see EOF (and therefore no 'close') until that
+    // grandchild also exits. This is the same "immediate child dies, but
+    // something else still holds the pipe" shape as the real Windows
+    // shell:true wrapper (see llm-client.mjs's `settled` guard comment and
+    // #428) — engineered here with a short, controllable delay instead of
+    // relying on that platform-specific incidental timing.
+    "if (mode === 'orphan_survives_kill') {",
+    "  const cp = require('node:child_process');",
+    "  const delayMs = Number(process.env.FAKE_CLAUDE_ORPHAN_DELAY_MS || '300');",
+    '  const donePath = process.env.FAKE_CLAUDE_ORPHAN_DONE_FILE;',
+    '  const grandchild = cp.spawn(',
+    '    process.execPath,',
+    "    ['-e', `setTimeout(() => { try { require('fs').writeFileSync(${JSON.stringify(donePath)}, 'done'); } catch (e) {} process.exit(0); }, ${delayMs});`],",
+    "    { stdio: 'inherit', detached: true }",
+    '  );',
+    '  grandchild.unref();',
+    "  process.stdout.write(JSON.stringify({ type: 'system', subtype: 'thinking_tokens', estimated_tokens: 1 }) + '\\n');",
+    // On POSIX, callViaCli's real SIGKILL reaches this process directly and
+    // it dies well before this fires. This exists only as a safety net for
+    // when it does not — e.g. if callViaCli's kill only reaches an
+    // intermediate shell wrapper and not this actual process (the
+    // platform-specific mechanic #428 is about) — so this process is
+    // guaranteed to exit on its own and never leak, mirroring the existing
+    // 'hang' mode's self-exit fallback above. Deliberately the *same*
+    // delayMs as the grandchild's own exit (not a longer one): the pipe
+    // this process and the grandchild both hold open only closes once BOTH
+    // have exited, so this must not outlive the grandchild by much, or the
+    // donePath poll below would report "done" well before the pipe (and
+    // therefore the real delayed close) actually closes.
+    '  setTimeout(function () { process.exit(0); }, delayMs);',
+    '  return;',
+    '}',
     // stream-json shape: one or more NDJSON lines, the terminal one typed
     // "result" — mirrors the real CLI's `--output-format stream-json` output.
     "process.stdout.write(JSON.stringify({ type: 'system', subtype: 'thinking_tokens', estimated_tokens: 7 }) + '\\n');",
@@ -480,6 +516,92 @@ test('callViaCli never writes a transcript on success, even when AI_SDLC_CLI_TRA
     assert.equal(existsSync(transcriptPath), false);
   } finally {
     delete process.env.AI_SDLC_CLI_TRANSCRIPT_PATH;
+  }
+});
+
+test('callViaCli does not act on a delayed close event after the timeout has already settled (regression for #428)', async () => {
+  // #428: the timeout path kills the child and settles the promise
+  // synchronously, without waiting for the child's real 'close' event. On
+  // Windows, `claude` is spawned via shell:true, so the killed `child` is
+  // the cmd.exe wrapper, not the real process underneath it — killing it
+  // does not kill that grandchild, so the tracked child's 'close' event
+  // doesn't fire until the grandchild eventually exits on its own, well
+  // after the timeout promise already settled. When it does fire, it used
+  // to re-run the `code !== 0 || signal` branch and dump a transcript a
+  // second time, reading whatever AI_SDLC_CLI_TRANSCRIPT_PATH happened to
+  // be set to *at that later moment* — potentially a different, unrelated
+  // call's path.
+  //
+  // 'orphan_survives_kill' reproduces the same "immediate child dies but
+  // something else still holds the stdio pipe open" shape portably (POSIX
+  // and Windows alike) via a detached grandchild with a short, controllable
+  // delay, instead of depending on that platform-specific incidental
+  // timing.
+  const donePath = join(DIR, 'orphan-done.marker');
+  const transcriptOwn = join(DIR, 'transcript-race-own.txt');
+  const transcriptLater = join(DIR, 'transcript-race-later.txt');
+  rmSync(donePath, { force: true });
+  rmSync(transcriptOwn, { force: true });
+  rmSync(transcriptLater, { force: true });
+
+  process.env.FAKE_CLAUDE_MODE = 'orphan_survives_kill';
+  process.env.FAKE_CLAUDE_ENV_DUMP = '';
+  process.env.FAKE_CLAUDE_ORPHAN_DELAY_MS = '300';
+  process.env.FAKE_CLAUDE_ORPHAN_DONE_FILE = donePath;
+  process.env.AI_SDLC_CLI_TRANSCRIPT_PATH = transcriptOwn;
+
+  try {
+    // timeoutMs is well under the grandchild's 300ms delay, so the timeout
+    // path fires and kills the immediate child while the grandchild is
+    // still alive holding the stdout/stderr pipes open.
+    await assert.rejects(callClaude({ prompt: 'hi', maxTokens: 100, timeoutMs: 100 }), (err) => {
+      assert.match(err.message, /claude CLI timed out after 100ms/);
+      return true;
+    });
+
+    // The FIRST (real) terminal event's own side effects must be intact —
+    // the guard must not suppress legitimate work, only a second firing.
+    assert.equal(existsSync(transcriptOwn), true);
+
+    // Simulate a later, unrelated call setting its own transcript path —
+    // exactly what the next test(s) in this file do in the real suite.
+    process.env.AI_SDLC_CLI_TRANSCRIPT_PATH = transcriptLater;
+
+    // Poll deterministically for proof the orphaned grandchild has actually
+    // exited — and therefore the real, delayed 'close' event for the killed
+    // child has had every chance to fire — instead of sleeping a fixed
+    // guess and hoping it was long enough.
+    const deadline = Date.now() + 5000;
+    while (!existsSync(donePath) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    assert.equal(
+      existsSync(donePath),
+      true,
+      'the orphaned grandchild never exited — test harness is broken, not necessarily the fix'
+    );
+
+    // A brief grace period: fake-claude-impl's own self-destruct fallback
+    // (see the harness above) fires at the same delay as the grandchild, so
+    // this covers ordinary scheduling jitter between the two nearly
+    // simultaneous exits, plus the time for the now-closed pipe to actually
+    // propagate through Node's event loop as a 'close' event.
+    await new Promise((r) => setTimeout(r, 800));
+
+    // The fix under test: once the timeout path has settled the promise,
+    // the delayed 'close' that follows must be a complete no-op. Before the
+    // `settled` guard, this assertion failed intermittently depending on
+    // exactly when a later test's own AI_SDLC_CLI_TRANSCRIPT_PATH happened
+    // to be current.
+    assert.equal(
+      existsSync(transcriptLater),
+      false,
+      "a delayed close event after settle wrote into a later, unrelated call's transcript path"
+    );
+  } finally {
+    delete process.env.AI_SDLC_CLI_TRANSCRIPT_PATH;
+    delete process.env.FAKE_CLAUDE_ORPHAN_DELAY_MS;
+    delete process.env.FAKE_CLAUDE_ORPHAN_DONE_FILE;
   }
 });
 


### PR DESCRIPTION
## Summary
- `callViaCli`'s timeout, `error`, and `close` handlers raced independently on the same child; a delayed `close` after a timeout-triggered `SIGKILL` could re-invoke `dumpCliTranscriptOnFailure` using whatever `AI_SDLC_CLI_TRANSCRIPT_PATH` was current by then, corrupting a later, unrelated test/call's transcript file. Verified empirically with temporary instrumentation (see #428) before fixing.
- Adds a `settled` guard shared by all three handlers so only the first terminal event does any work; no change to which error wins or what's logged on the real first-event path.
- Adds a deterministic regression test using a portable (POSIX + Windows) fake-CLI mode that forces a delayed `close` via a detached grandchild holding the stdio pipe open, polling for a done-marker instead of guessing a sleep.

Closes #428

## Test plan
- [x] `node --test scripts/ai-sdlc/llm-client.test.mjs` — 38/38 pass
- [x] New regression test confirmed to fail on pre-fix code, pass on post-fix code
- [x] `node --test scripts/ai-sdlc/*.test.mjs` x20: before fix vs. after fix (see PR comment / commit for exact counts)
